### PR TITLE
Added variadic versions for Format that act as a proxy for providing an initialiser list to a BasicFormatter

### DIFF
--- a/format-test.cc
+++ b/format-test.cc
@@ -1485,19 +1485,12 @@ TEST(StrTest, Convert) {
   EXPECT_EQ("2012-12-9", s);
 }
 
-#if FMT_USE_INITIALIZER_LIST
-template<typename... Args>
-inline std::string Format(const StringRef &format, const Args & ... args) {
-  Writer w;
-  fmt::BasicFormatter<char> f(w, format.c_str(), {args...});
-  return fmt::str(f);
-}
-
+#if FMT_USE_INITIALIZER_LIST && FMT_USE_VARIADIC_TEMPLATES
 TEST(FormatTest, Variadic) {
-  Writer w;
-  EXPECT_EQ("Hello, world!1", str(Format("Hello, {}!{}", "world", 1)));
+  EXPECT_EQ("Hello, world!1", Format("Hello, {}!{}", "world", 1));
+  EXPECT_EQ(L"Hello, world!1", Format(L"Hello, {}!{}", L"world", 1));
 }
-#endif  // FMT_USE_INITIALIZER_LIST
+#endif  // FMT_USE_INITIALIZER_LIST && FMT_USE_VARIADIC_TEMPLATES
 
 int main(int argc, char **argv) {
 #ifdef _WIN32

--- a/format.h
+++ b/format.h
@@ -61,6 +61,12 @@
        (FMT_GCC_VERSION >= 404 && __cplusplus >= 201103) || _MSC_VER >= 1800)
 #endif
 
+#ifndef FMT_USE_VARIADIC_TEMPLATES
+# define FMT_USE_VARIADIC_TEMPLATES \
+   (__has_feature(cxx_variadic_templates) || \
+       (FMT_GCC_VERSION >= 404 && __cplusplus >= 201103) || _MSC_VER >= 1800)
+#endif
+
 #if FMT_USE_INITIALIZER_LIST
 # include <initializer_list>
 #endif
@@ -1491,6 +1497,23 @@ inline Formatter<ColorWriter> PrintColored(Color c, StringRef format) {
   Formatter<ColorWriter> f(format, ColorWriter(c));
   return f;
 }
+
+#if FMT_USE_INITIALIZER_LIST && FMT_USE_VARIADIC_TEMPLATES
+template<typename... Args>
+std::string Format(const StringRef &format, const Args & ... args) {
+  Writer w;
+  BasicFormatter<char> f(w, format.c_str(), { args... });
+  return fmt::str(f);
+}
+
+template<typename... Args>
+std::wstring Format(const WStringRef &format, const Args & ... args) {
+  WWriter w;
+  BasicFormatter<wchar_t> f(w, format.c_str(), { args... });
+  return fmt::str(f);
+}
+#endif  // FMT_USE_INITIALIZER_LIST && FMT_USE_VARIADIC_TEMPLATES
+
 }
 
 #if _MSC_VER


### PR DESCRIPTION
Updated the Variadic test to use these new functions and verified that the tests passed.

See https://github.com/vitaut/format/issues/25
