### PR TITLE
Fix grow size during Array<>::append

### DIFF
--- a/format.h
+++ b/format.h
@@ -315,7 +315,7 @@ template <typename T, std::size_t SIZE>
 void Array<T, SIZE>::append(const T *begin, const T *end) {
   std::ptrdiff_t num_elements = end - begin;
   if (size_ + num_elements > capacity_)
-    Grow(num_elements);
+    Grow(size_ + num_elements);
   std::copy(begin, end, CheckPtr(ptr_, capacity_) + size_);
   size_ += num_elements;
 }


### PR DESCRIPTION
When the resulting array must grow during append, one must make sure
that the new elements _plus_ the current elements fit the new array
size.
