### PR TITLE
Hack to get `char` and `byte` to play well

### DIFF
--- a/format.cc
+++ b/format.cc
@@ -432,7 +432,7 @@ class fmt::internal::ArgFormatter :
 
   void visit_char(int value) {
     if (spec_.type_ && spec_.type_ != 'c')
-      fmt::internal::ReportUnknownType(spec_.type_, "char");
+      return visit_any_int(value);
     typedef typename fmt::BasicWriter<Char>::CharPtr CharPtr;
     CharPtr out = CharPtr();
     if (spec_.width_ > 1) {

--- a/format.h
+++ b/format.h
@@ -571,8 +571,10 @@ struct Arg {
     // Integer types should go first,
     INT, UINT, LONG_LONG, ULONG_LONG, LAST_INTEGER_TYPE = ULONG_LONG,
     // followed by floating-point types.
-    DOUBLE, LONG_DOUBLE, LAST_NUMERIC_TYPE = LONG_DOUBLE,
-    CHAR, STRING, WSTRING, POINTER, CUSTOM
+    DOUBLE, LONG_DOUBLE, 
+	// fringe number hybrid type
+	CHAR, LAST_NUMERIC_TYPE = CHAR,
+	STRING, WSTRING, POINTER, CUSTOM,
   };
   Type type;
 


### PR DESCRIPTION
This hack isn't great, but it fixes the problem. I don't like
being a problem-only kinda guy, so I'm submitting a patch.

Personally I think that cppformat shouldn't be so pedantic. It
seems like if there is a natural conversion from the source to the
destination format, then it should be performed.

Resolves #55
