### PR TITLE
Added an overload taking string literals to BasicStringRef

### DIFF
--- a/format.h
+++ b/format.h
@@ -172,7 +172,14 @@ class BasicStringRef {
     If *size* is zero, which is the default, the size is computed
     automatically.
    */
-  BasicStringRef(const Char *s, std::size_t size = 0) : data_(s), size_(size) {}
+  BasicStringRef(const Char* const& s, std::size_t size = 0) : data_(s), size_(size) {}
+
+  /**
+   Constructs a string reference object from a C string literal,
+   if its size is determinable at compile time.
+   */
+  template <std::size_t N>
+  BasicStringRef(const Char (&s) [N]) : data_(s), size_(N) {}
 
   /**
     Constructs a string reference from an `std::string` object.


### PR DESCRIPTION
This patch allows constructing `BasicStringRef` from a string literal, the size of which is known at compile time. Note that I had to change the constructor taking a `const char*` to take a `const &` to `const char*`, in order to disable the decaying of string literals to pointers.
