### PR TITLE
Fix user-defined literal detection for Intel C++ compiler (#311)

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -105,7 +105,7 @@ typedef __int64          intmax_t;
 # define FMT_ICC_VERSION __ICL
 #endif
 
-#if defined(__clang__) && !defined(__INTEL_COMPILER)
+#if defined(__clang__) && !defined(FMT_ICC_VERSION)
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wdocumentation"
 #endif
@@ -3915,7 +3915,7 @@ operator"" _a(const wchar_t *s, std::size_t) { return {s}; }
 # pragma GCC diagnostic pop
 #endif
 
-#if defined(__clang__) && !defined(__INTEL_COMPILER)
+#if defined(__clang__) && !defined(FMT_ICC_VERSION)
 # pragma clang diagnostic pop
 #endif
 

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -99,6 +99,12 @@ typedef __int64          intmax_t;
 # define FMT_GCC_EXTENSION
 #endif
 
+#if defined(__INTEL_COMPILER)
+# define FMT_ICC_VERSION __INTEL_COMPILER
+#elif defined(__ICL)
+# define FMT_ICC_VERSION __ICL
+#endif
+
 #if defined(__clang__) && !defined(__INTEL_COMPILER)
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wdocumentation"
@@ -212,10 +218,12 @@ typedef __int64          intmax_t;
 // All compilers which support UDLs also support variadic templates. This
 // makes the fmt::literals implementation easier. However, an explicit check
 // for variadic templates is added here just in case.
+// For Intel's compiler both it and the system gcc/msc must support UDLs.
 # define FMT_USE_USER_DEFINED_LITERALS \
    FMT_USE_VARIADIC_TEMPLATES && FMT_USE_RVALUE_REFERENCES && \
    (FMT_HAS_FEATURE(cxx_user_literals) || \
-       (FMT_GCC_VERSION >= 407 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1900)
+       (FMT_GCC_VERSION >= 407 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1900) && \
+   (!defined(FMT_ICC_VERSION) || FMT_ICC_VERSION >= 1500)
 #endif
 
 #ifndef FMT_ASSERT

--- a/support/cmake/cxx11.cmake
+++ b/support/cmake/cxx11.cmake
@@ -63,4 +63,11 @@ check_cxx_source_compiles("
   class C { void operator=(const C&); };
   int main() { static_assert(!std::is_copy_assignable<C>::value, \"\"); }"
   SUPPORTS_TYPE_TRAITS)
+
+# Check if user-defined literals are available
+check_cxx_source_compiles("
+  void operator\"\" _udl(long double);
+  int main() {}"
+  SUPPORTS_USER_DEFINED_LITERALS)
+
 set(CMAKE_REQUIRED_FLAGS )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -123,7 +123,11 @@ if (FMT_PEDANTIC)
     "${CMAKE_CURRENT_SOURCE_DIR}/compile-test"
     "${CMAKE_CURRENT_BINARY_DIR}/compile-test"
     --build-generator ${CMAKE_GENERATOR}
-    --build-makeprogram ${CMAKE_MAKE_PROGRAM})
+    --build-makeprogram ${CMAKE_MAKE_PROGRAM}
+    --build-options 
+    "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+    "-DCPP11_FLAG=${CPP11_FLAG}"
+    "-DSUPPORTS_USER_DEFINED_LITERALS=${SUPPORTS_USER_DEFINED_LITERALS}")
 
   # test if the targets are findable from the build directory
   add_test(find-package-test ${CMAKE_CTEST_COMMAND}

--- a/test/compile-test/CMakeLists.txt
+++ b/test/compile-test/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 2.8)
 
 include(CheckCXXSourceCompiles)
 set(CMAKE_REQUIRED_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+set(CMAKE_REQUIRED_FLAGS ${CPP11_FLAG})
 
 function (generate_source result fragment)
   set(${result} "
@@ -57,3 +58,14 @@ expect_compile_error("fmt::MemoryWriter() << fmt::pad(42, 5, L' ');")
 expect_compile_error("fmt::format(\"{}\", L'a';")
 
 expect_compile_error("FMT_STATIC_ASSERT(0 > 1, \"oops\");")
+
+# Make sure that compiler features detected in the header
+# match the features detected in CMake.
+if (SUPPORTS_USER_DEFINED_LITERALS)
+  set(supports_udl 1)
+else ()
+  set(supports_udl 0)
+endif ()
+expect_compile("#if FMT_USE_USER_DEFINED_LITERALS != ${supports_udl}
+                # error
+                #endif")


### PR DESCRIPTION
Fixes #311.

The `FMT_USE_USER_DEFINED_LITERALS` check is beginning to resemble a dumpster fire, but as per Intel's [C++11 feature notes](https://software.intel.com/en-us/articles/c0x-features-supported-by-intel-c-compiler) both the system compiler (gcc/msc) and icc itself must support the given feature:

> On Windows: when using Intel C++ compiler with Visual Studio 2010* or 2012*, the C++11 features supported by Visual C++ 2010/2012 are enabled by default. Use "/Qstd=c++11" to turn on the support for all other cases.
> On Linux or Mac OS X: the C++11 features supported by gcc on the path are enabled by default. Use "-std=c++11" to turn on the support for all other cases.

To make sure the UDL detection still works on any compiler I added a new compile test which checks that the feature detection in the header matches the one in CMake. `CMAKE_CXX_COMPILER` and `CPP11_FLAG` are passed to `compile-test` to ensure the same configuration.

Tested and working with Intel C++ 14.0-16.0 on Linux and 16.0 on Windows.