### PR TITLE
Fix a few bugs related to compile tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -137,8 +137,10 @@ if (FMT_PEDANTIC)
     "${CMAKE_CURRENT_BINARY_DIR}/find-package-test"
     --build-generator ${CMAKE_GENERATOR}
     --build-makeprogram ${CMAKE_MAKE_PROGRAM}
-    --build-options "-DFMT_DIR=${PROJECT_BINARY_DIR}"
-                    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+    --build-options
+    "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+    "-DFMT_DIR=${PROJECT_BINARY_DIR}"
+    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 
   # test if the targets are findable when add_subdirectory is used
   add_test(add-subdirectory-test ${CMAKE_CTEST_COMMAND}
@@ -148,5 +150,7 @@ if (FMT_PEDANTIC)
     "${CMAKE_CURRENT_BINARY_DIR}/add-subdirectory-test"
     --build-generator ${CMAKE_GENERATOR}
     --build-makeprogram ${CMAKE_MAKE_PROGRAM}
-    --build-options "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+    --build-options
+    "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 endif ()

--- a/test/compile-test/CMakeLists.txt
+++ b/test/compile-test/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_REQUIRED_FLAGS ${CPP11_FLAG})
 function (generate_source result fragment)
   set(${result} "
   #define FMT_HEADER_ONLY 1
-  #include \"fmt/format.h\"
+  #include \"fmt/posix.h\"
   int main() {
     ${fragment}
   }
@@ -63,6 +63,7 @@ expect_compile_error("fmt::MemoryWriter() << fmt::pad(42, 5, L' ');")
 # Formatting a wide character with a narrow format string is forbidden.
 expect_compile_error("fmt::format(\"{}\", L'a';")
 
+expect_compile("FMT_STATIC_ASSERT(true, \"this should never happen\");")
 expect_compile_error("FMT_STATIC_ASSERT(0 > 1, \"oops\");")
 
 # Make sure that compiler features detected in the header

--- a/test/compile-test/CMakeLists.txt
+++ b/test/compile-test/CMakeLists.txt
@@ -20,22 +20,28 @@ function (expect_compile code)
   generate_source(source "${code}")
   check_cxx_source_compiles("${source}" compiles)
   if (NOT compiles)
-    message(FATAL_ERROR "Compile error for: ${code}")
+    set(error_msg "Compile error for: ${code}")
   endif ()
   # Unset the CMake cache variable compiles. Otherwise the compile test will
   # just use cached information next time it runs.
   unset(compiles CACHE)
+  if (error_msg)
+    message(FATAL_ERROR ${error_msg})
+  endif ()
 endfunction ()
 
 function (expect_compile_error code)
   generate_source(source "${code}")
   check_cxx_source_compiles("${source}" compiles)
   if (compiles)
-    message(FATAL_ERROR "No compile error for: ${code}")
+    set(error_msg "No compile error for: ${code}")
   endif ()
   # Unset the CMake cache variable compiles. Otherwise the compile test will
   # just use cached information next time it runs.
   unset(compiles CACHE)
+  if (error_msg)
+    message(FATAL_ERROR ${error_msg})
+  endif ()
 endfunction ()
 
 # check if the source file skeleton compiles


### PR DESCRIPTION
I noticed some compile test bugs while working on #312 (but these bugs aren't actually specific to Intel's compiler).

1. In `expect_compile` and `expect_compile_error` the cache variable was not always unset because `message(FATAL_ERROR)` exits immediately. Even if a test was fixed it would appear broken until the cache was reset manually.

2.  The expected-to-fail `FMT_STATIC_ASSERT` test was failing for the wrong reason: missing macro instead of the actual static assert.

3.  If the main project was configured with a non-default compiler, `find-package-test` failed with linker errors because `ctest --build-and-test` would still use the system default.