### PR TITLE
Create doc/html directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin/
 /_CPack_Packages
 /doc/doxyxml
 /doc/html
+!/doc/html
 virtualenv
 /Testing
 /install_manifest.txt


### PR DESCRIPTION
The html directory must exist before the documentation can be built, or
else `make` reports the following error:

    CMake Error at doc/cmake_install.cmake:31 (file):
      file INSTALL cannot find "/Users/jeff/pkg/fmtlib/fmt/doc/html".
    Call Stack (most recent call first):
      cmake_install.cmake:33 (include)

    make: *** [install] Error 1

This commit is just a work-around; I don't know enough CMake to update the build, but it probably should just create the html directory automatically if necessary.