### PR TITLE
Second try

### DIFF
--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -33,7 +33,7 @@
 #include <cctype>
 
 #include <cmath>
-#include <cstdarg>
+
 #include <cstddef>  // for std::ptrdiff_t
 
 

--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -99,31 +99,6 @@ const char fmt::internal::BasicData<T>::DIGITS[] =
     "6061626364656667686970717273747576777879"
     "8081828384858687888990919293949596979899";
 
-#define FMT_POWERS_OF_10(factor) \
-  factor * 10, \
-  factor * 100, \
-  factor * 1000, \
-  factor * 10000, \
-  factor * 100000, \
-  factor * 1000000, \
-  factor * 10000000, \
-  factor * 100000000, \
-  factor * 1000000000
-
-template <typename T>
-const uint32_t fmt::internal::BasicData<T>::POWERS_OF_10_32[] = {
-  0, FMT_POWERS_OF_10(1)
-};
-
-template <typename T>
-const uint64_t fmt::internal::BasicData<T>::POWERS_OF_10_64[] = {
-  0,
-  FMT_POWERS_OF_10(1),
-  FMT_POWERS_OF_10(fmt::ULongLong(1000000000)),
-  // Multiply several constants instead of using a single long long constant
-  // to avoid warnings about C++98 not supporting long long.
-  fmt::ULongLong(1000000000) * fmt::ULongLong(1000000000) * 10
-};
 
 FMT_FUNC void fmt::internal::report_unknown_type(char code, const char *type) {
   (void)type;

--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -26,7 +26,7 @@
  */
 
 #include "fmt/format.h"
-#include "printf.h"
+#include "fmt/printf.h"
 
 #include <string.h>
 
@@ -38,8 +38,6 @@
 
 
 namespace fmt {
-
-
 namespace internal {
 
 // This method is used to preserve binary compatibility with fmt 3.0.
@@ -313,10 +311,6 @@ FMT_FUNC void fmt::print_colored(Color c, CStringRef format, ArgList args) {
 }
 
 
-
-
-
-
 #ifndef FMT_HEADER_ONLY
 
 template struct fmt::internal::BasicData<void>;
@@ -326,7 +320,6 @@ template struct fmt::internal::BasicData<void>;
 template void fmt::internal::FixedBuffer<char>::grow(std::size_t);
 
 template void fmt::internal::ArgMap<char>::init(const fmt::ArgList &args);
-
 
 template int fmt::internal::CharTraits<char>::format_float(
     char *buffer, std::size_t size, const char *format,
@@ -341,7 +334,6 @@ template int fmt::internal::CharTraits<char>::format_float(
 template void fmt::internal::FixedBuffer<wchar_t>::grow(std::size_t);
 
 template void fmt::internal::ArgMap<wchar_t>::init(const fmt::ArgList &args);
-
 
 template int fmt::internal::CharTraits<wchar_t>::format_float(
     wchar_t *buffer, std::size_t size, const wchar_t *format,

--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -26,336 +26,19 @@
  */
 
 #include "fmt/format.h"
+#include "printf.h"
 
 #include <string.h>
 
 #include <cctype>
-#include <cerrno>
-#include <climits>
+
 #include <cmath>
 #include <cstdarg>
 #include <cstddef>  // for std::ptrdiff_t
 
-#if defined(_WIN32) && defined(__MINGW32__)
-# include <cstring>
-#endif
-
-#if FMT_USE_WINDOWS_H
-# if defined(NOMINMAX) || defined(FMT_WIN_MINMAX)
-#  include <windows.h>
-# else
-#  define NOMINMAX
-#  include <windows.h>
-#  undef NOMINMAX
-# endif
-#endif
-
-using fmt::internal::Arg;
-
-#if FMT_EXCEPTIONS
-# define FMT_TRY try
-# define FMT_CATCH(x) catch (x)
-#else
-# define FMT_TRY if (true)
-# define FMT_CATCH(x) if (false)
-#endif
-
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable: 4127)  // conditional expression is constant
-# pragma warning(disable: 4702)  // unreachable code
-// Disable deprecation warning for strerror. The latter is not called but
-// MSVC fails to detect it.
-# pragma warning(disable: 4996)
-#endif
-
-// Dummy implementations of strerror_r and strerror_s called if corresponding
-// system functions are not available.
-static inline fmt::internal::Null<> strerror_r(int, char *, ...) {
-  return fmt::internal::Null<>();
-}
-static inline fmt::internal::Null<> strerror_s(char *, std::size_t, ...) {
-  return fmt::internal::Null<>();
-}
 
 namespace fmt {
-namespace {
 
-#ifndef _MSC_VER
-# define FMT_SNPRINTF snprintf
-#else  // _MSC_VER
-inline int fmt_snprintf(char *buffer, size_t size, const char *format, ...) {
-  va_list args;
-  va_start(args, format);
-  int result = vsnprintf_s(buffer, size, _TRUNCATE, format, args);
-  va_end(args);
-  return result;
-}
-# define FMT_SNPRINTF fmt_snprintf
-#endif  // _MSC_VER
-
-#if defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
-# define FMT_SWPRINTF snwprintf
-#else
-# define FMT_SWPRINTF swprintf
-#endif // defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
-
-// Checks if a value fits in int - used to avoid warnings about comparing
-// signed and unsigned integers.
-template <bool IsSigned>
-struct IntChecker {
-  template <typename T>
-  static bool fits_in_int(T value) {
-    unsigned max = INT_MAX;
-    return value <= max;
-  }
-  static bool fits_in_int(bool) { return true; }
-};
-
-template <>
-struct IntChecker<true> {
-  template <typename T>
-  static bool fits_in_int(T value) {
-    return value >= INT_MIN && value <= INT_MAX;
-  }
-  static bool fits_in_int(int) { return true; }
-};
-
-const char RESET_COLOR[] = "\x1b[0m";
-
-typedef void (*FormatFunc)(Writer &, int, StringRef);
-
-// Portable thread-safe version of strerror.
-// Sets buffer to point to a string describing the error code.
-// This can be either a pointer to a string stored in buffer,
-// or a pointer to some static immutable string.
-// Returns one of the following values:
-//   0      - success
-//   ERANGE - buffer is not large enough to store the error message
-//   other  - failure
-// Buffer should be at least of size 1.
-int safe_strerror(
-    int error_code, char *&buffer, std::size_t buffer_size) FMT_NOEXCEPT {
-  FMT_ASSERT(buffer != 0 && buffer_size != 0, "invalid buffer");
-
-  class StrError {
-   private:
-    int error_code_;
-    char *&buffer_;
-    std::size_t buffer_size_;
-
-    // A noop assignment operator to avoid bogus warnings.
-    void operator=(const StrError &) {}
-
-    // Handle the result of XSI-compliant version of strerror_r.
-    int handle(int result) {
-      // glibc versions before 2.13 return result in errno.
-      return result == -1 ? errno : result;
-    }
-
-    // Handle the result of GNU-specific version of strerror_r.
-    int handle(char *message) {
-      // If the buffer is full then the message is probably truncated.
-      if (message == buffer_ && strlen(buffer_) == buffer_size_ - 1)
-        return ERANGE;
-      buffer_ = message;
-      return 0;
-    }
-
-    // Handle the case when strerror_r is not available.
-    int handle(internal::Null<>) {
-      return fallback(strerror_s(buffer_, buffer_size_, error_code_));
-    }
-
-    // Fallback to strerror_s when strerror_r is not available.
-    int fallback(int result) {
-      // If the buffer is full then the message is probably truncated.
-      return result == 0 && strlen(buffer_) == buffer_size_ - 1 ?
-            ERANGE : result;
-    }
-
-    // Fallback to strerror if strerror_r and strerror_s are not available.
-    int fallback(internal::Null<>) {
-      errno = 0;
-      buffer_ = strerror(error_code_);
-      return errno;
-    }
-
-   public:
-    StrError(int err_code, char *&buf, std::size_t buf_size)
-      : error_code_(err_code), buffer_(buf), buffer_size_(buf_size) {}
-
-    int run() {
-      strerror_r(0, 0, "");  // Suppress a warning about unused strerror_r.
-      return handle(strerror_r(error_code_, buffer_, buffer_size_));
-    }
-  };
-  return StrError(error_code, buffer, buffer_size).run();
-}
-
-void format_error_code(Writer &out, int error_code,
-                       StringRef message) FMT_NOEXCEPT {
-  // Report error code making sure that the output fits into
-  // INLINE_BUFFER_SIZE to avoid dynamic memory allocation and potential
-  // bad_alloc.
-  out.clear();
-  static const char SEP[] = ": ";
-  static const char ERROR_STR[] = "error ";
-  // Subtract 2 to account for terminating null characters in SEP and ERROR_STR.
-  std::size_t error_code_size = sizeof(SEP) + sizeof(ERROR_STR) - 2;
-  typedef internal::IntTraits<int>::MainType MainType;
-  MainType abs_value = static_cast<MainType>(error_code);
-  if (internal::is_negative(error_code)) {
-    abs_value = 0 - abs_value;
-    ++error_code_size;
-  }
-  error_code_size += internal::count_digits(abs_value);
-  if (message.size() <= internal::INLINE_BUFFER_SIZE - error_code_size)
-    out << message << SEP;
-  out << ERROR_STR << error_code;
-  assert(out.size() <= internal::INLINE_BUFFER_SIZE);
-}
-
-void report_error(FormatFunc func, int error_code,
-                  StringRef message) FMT_NOEXCEPT {
-  MemoryWriter full_message;
-  func(full_message, error_code, message);
-  // Use Writer::data instead of Writer::c_str to avoid potential memory
-  // allocation.
-  std::fwrite(full_message.data(), full_message.size(), 1, stderr);
-  std::fputc('\n', stderr);
-}
-
-// IsZeroInt::visit(arg) returns true iff arg is a zero integer.
-class IsZeroInt : public ArgVisitor<IsZeroInt, bool> {
- public:
-  template <typename T>
-  bool visit_any_int(T value) { return value == 0; }
-};
-
-// Checks if an argument is a valid printf width specifier and sets
-// left alignment if it is negative.
-class WidthHandler : public ArgVisitor<WidthHandler, unsigned> {
- private:
-  FormatSpec &spec_;
-
-  FMT_DISALLOW_COPY_AND_ASSIGN(WidthHandler);
-
- public:
-  explicit WidthHandler(FormatSpec &spec) : spec_(spec) {}
-
-  void report_unhandled_arg() {
-    FMT_THROW(FormatError("width is not integer"));
-  }
-
-  template <typename T>
-  unsigned visit_any_int(T value) {
-    typedef typename internal::IntTraits<T>::MainType UnsignedType;
-    UnsignedType width = static_cast<UnsignedType>(value);
-    if (internal::is_negative(value)) {
-      spec_.align_ = ALIGN_LEFT;
-      width = 0 - width;
-    }
-    if (width > INT_MAX)
-      FMT_THROW(FormatError("number is too big"));
-    return static_cast<unsigned>(width);
-  }
-};
-
-class PrecisionHandler : public ArgVisitor<PrecisionHandler, int> {
- public:
-  void report_unhandled_arg() {
-    FMT_THROW(FormatError("precision is not integer"));
-  }
-
-  template <typename T>
-  int visit_any_int(T value) {
-    if (!IntChecker<std::numeric_limits<T>::is_signed>::fits_in_int(value))
-      FMT_THROW(FormatError("number is too big"));
-    return static_cast<int>(value);
-  }
-};
-
-template <typename T, typename U>
-struct is_same {
-  enum { value = 0 };
-};
-
-template <typename T>
-struct is_same<T, T> {
-  enum { value = 1 };
-};
-
-// An argument visitor that converts an integer argument to T for printf,
-// if T is an integral type. If T is void, the argument is converted to
-// corresponding signed or unsigned type depending on the type specifier:
-// 'd' and 'i' - signed, other - unsigned)
-template <typename T = void>
-class ArgConverter : public ArgVisitor<ArgConverter<T>, void> {
- private:
-  internal::Arg &arg_;
-  wchar_t type_;
-
-  FMT_DISALLOW_COPY_AND_ASSIGN(ArgConverter);
-
- public:
-  ArgConverter(internal::Arg &arg, wchar_t type)
-    : arg_(arg), type_(type) {}
-
-  void visit_bool(bool value) {
-    if (type_ != 's')
-      visit_any_int(value);
-  }
-
-  template <typename U>
-  void visit_any_int(U value) {
-    bool is_signed = type_ == 'd' || type_ == 'i';
-    using internal::Arg;
-    typedef typename internal::Conditional<
-        is_same<T, void>::value, U, T>::type TargetType;
-    if (sizeof(TargetType) <= sizeof(int)) {
-      // Extra casts are used to silence warnings.
-      if (is_signed) {
-        arg_.type = Arg::INT;
-        arg_.int_value = static_cast<int>(static_cast<TargetType>(value));
-      } else {
-        arg_.type = Arg::UINT;
-        typedef typename internal::MakeUnsigned<TargetType>::Type Unsigned;
-        arg_.uint_value = static_cast<unsigned>(static_cast<Unsigned>(value));
-      }
-    } else {
-      if (is_signed) {
-        arg_.type = Arg::LONG_LONG;
-        // glibc's printf doesn't sign extend arguments of smaller types:
-        //   std::printf("%lld", -42);  // prints "4294967254"
-        // but we don't have to do the same because it's a UB.
-        arg_.long_long_value = static_cast<LongLong>(value);
-      } else {
-        arg_.type = Arg::ULONG_LONG;
-        arg_.ulong_long_value =
-            static_cast<typename internal::MakeUnsigned<U>::Type>(value);
-      }
-    }
-  }
-};
-
-// Converts an integer argument to char for printf.
-class CharConverter : public ArgVisitor<CharConverter, void> {
- private:
-  internal::Arg &arg_;
-
-  FMT_DISALLOW_COPY_AND_ASSIGN(CharConverter);
-
- public:
-  explicit CharConverter(internal::Arg &arg) : arg_(arg) {}
-
-  template <typename T>
-  void visit_any_int(T value) {
-    arg_.type = internal::Arg::CHAR;
-    arg_.int_value = static_cast<char>(value);
-  }
-};
-}  // namespace
 
 namespace internal {
 
@@ -366,75 +49,9 @@ FMT_FUNC void format_system_error(
   fmt::format_system_error(out, error_code, message);
 }
 
-template <typename Char>
-class PrintfArgFormatter :
-    public ArgFormatterBase<PrintfArgFormatter<Char>, Char> {
-
-  void write_null_pointer() {
-    this->spec().type_ = 0;
-    this->write("(nil)");
-  }
-
-  typedef ArgFormatterBase<PrintfArgFormatter<Char>, Char> Base;
-
- public:
-  PrintfArgFormatter(BasicWriter<Char> &w, FormatSpec &s)
-  : ArgFormatterBase<PrintfArgFormatter<Char>, Char>(w, s) {}
-
-  void visit_bool(bool value) {
-    FormatSpec &fmt_spec = this->spec();
-    if (fmt_spec.type_ != 's')
-      return this->visit_any_int(value);
-    fmt_spec.type_ = 0;
-    this->write(value);
-  }
-
-  void visit_char(int value) {
-    const FormatSpec &fmt_spec = this->spec();
-    BasicWriter<Char> &w = this->writer();
-    if (fmt_spec.type_ && fmt_spec.type_ != 'c')
-      w.write_int(value, fmt_spec);
-    typedef typename BasicWriter<Char>::CharPtr CharPtr;
-    CharPtr out = CharPtr();
-    if (fmt_spec.width_ > 1) {
-      Char fill = ' ';
-      out = w.grow_buffer(fmt_spec.width_);
-      if (fmt_spec.align_ != ALIGN_LEFT) {
-        std::fill_n(out, fmt_spec.width_ - 1, fill);
-        out += fmt_spec.width_ - 1;
-      } else {
-        std::fill_n(out + 1, fmt_spec.width_ - 1, fill);
-      }
-    } else {
-      out = w.grow_buffer(1);
-    }
-    *out = static_cast<Char>(value);
-  }
-
-  void visit_cstring(const char *value) {
-    if (value)
-      Base::visit_cstring(value);
-    else if (this->spec().type_ == 'p')
-      write_null_pointer();
-    else
-      this->write("(null)");
-  }
-
-  void visit_pointer(const void *value) {
-    if (value)
-      return Base::visit_pointer(value);
-    this->spec().type_ = 0;
-    write_null_pointer();
-  }
-
-  void visit_custom(Arg::CustomValue c) {
-    BasicFormatter<Char> formatter(ArgList(), this->writer());
-    const Char format_str[] = {'}', 0};
-    const Char *format = format_str;
-    c.format(&formatter, c.value, &format);
-  }
-};
 }  // namespace internal
+
+
 }  // namespace fmt
 
 FMT_FUNC void fmt::SystemError::init(
@@ -686,177 +303,7 @@ FMT_FUNC Arg fmt::internal::FormatterBase::do_get_arg(
   return arg;
 }
 
-template <typename Char>
-void fmt::internal::PrintfFormatter<Char>::parse_flags(
-    FormatSpec &spec, const Char *&s) {
-  for (;;) {
-    switch (*s++) {
-      case '-':
-        spec.align_ = ALIGN_LEFT;
-        break;
-      case '+':
-        spec.flags_ |= SIGN_FLAG | PLUS_FLAG;
-        break;
-      case '0':
-        spec.fill_ = '0';
-        break;
-      case ' ':
-        spec.flags_ |= SIGN_FLAG;
-        break;
-      case '#':
-        spec.flags_ |= HASH_FLAG;
-        break;
-      default:
-        --s;
-        return;
-    }
-  }
-}
 
-template <typename Char>
-Arg fmt::internal::PrintfFormatter<Char>::get_arg(
-    const Char *s, unsigned arg_index) {
-  (void)s;
-  const char *error = 0;
-  Arg arg = arg_index == UINT_MAX ?
-    next_arg(error) : FormatterBase::get_arg(arg_index - 1, error);
-  if (error)
-    FMT_THROW(FormatError(!*s ? "invalid format string" : error));
-  return arg;
-}
-
-template <typename Char>
-unsigned fmt::internal::PrintfFormatter<Char>::parse_header(
-  const Char *&s, FormatSpec &spec) {
-  unsigned arg_index = UINT_MAX;
-  Char c = *s;
-  if (c >= '0' && c <= '9') {
-    // Parse an argument index (if followed by '$') or a width possibly
-    // preceded with '0' flag(s).
-    unsigned value = parse_nonnegative_int(s);
-    if (*s == '$') {  // value is an argument index
-      ++s;
-      arg_index = value;
-    } else {
-      if (c == '0')
-        spec.fill_ = '0';
-      if (value != 0) {
-        // Nonzero value means that we parsed width and don't need to
-        // parse it or flags again, so return now.
-        spec.width_ = value;
-        return arg_index;
-      }
-    }
-  }
-  parse_flags(spec, s);
-  // Parse width.
-  if (*s >= '0' && *s <= '9') {
-    spec.width_ = parse_nonnegative_int(s);
-  } else if (*s == '*') {
-    ++s;
-    spec.width_ = WidthHandler(spec).visit(get_arg(s));
-  }
-  return arg_index;
-}
-
-template <typename Char>
-void fmt::internal::PrintfFormatter<Char>::format(
-    BasicWriter<Char> &writer, BasicCStringRef<Char> format_str) {
-  const Char *start = format_str.c_str();
-  const Char *s = start;
-  while (*s) {
-    Char c = *s++;
-    if (c != '%') continue;
-    if (*s == c) {
-      write(writer, start, s);
-      start = ++s;
-      continue;
-    }
-    write(writer, start, s - 1);
-
-    FormatSpec spec;
-    spec.align_ = ALIGN_RIGHT;
-
-    // Parse argument index, flags and width.
-    unsigned arg_index = parse_header(s, spec);
-
-    // Parse precision.
-    if (*s == '.') {
-      ++s;
-      if ('0' <= *s && *s <= '9') {
-        spec.precision_ = static_cast<int>(parse_nonnegative_int(s));
-      } else if (*s == '*') {
-        ++s;
-        spec.precision_ = PrecisionHandler().visit(get_arg(s));
-      }
-    }
-
-    Arg arg = get_arg(s, arg_index);
-    if (spec.flag(HASH_FLAG) && IsZeroInt().visit(arg))
-      spec.flags_ &= ~to_unsigned<int>(HASH_FLAG);
-    if (spec.fill_ == '0') {
-      if (arg.type <= Arg::LAST_NUMERIC_TYPE)
-        spec.align_ = ALIGN_NUMERIC;
-      else
-        spec.fill_ = ' ';  // Ignore '0' flag for non-numeric types.
-    }
-
-    // Parse length and convert the argument to the required type.
-    switch (*s++) {
-    case 'h':
-      if (*s == 'h')
-        ArgConverter<signed char>(arg, *++s).visit(arg);
-      else
-        ArgConverter<short>(arg, *s).visit(arg);
-      break;
-    case 'l':
-      if (*s == 'l')
-        ArgConverter<fmt::LongLong>(arg, *++s).visit(arg);
-      else
-        ArgConverter<long>(arg, *s).visit(arg);
-      break;
-    case 'j':
-      ArgConverter<intmax_t>(arg, *s).visit(arg);
-      break;
-    case 'z':
-      ArgConverter<std::size_t>(arg, *s).visit(arg);
-      break;
-    case 't':
-      ArgConverter<std::ptrdiff_t>(arg, *s).visit(arg);
-      break;
-    case 'L':
-      // printf produces garbage when 'L' is omitted for long double, no
-      // need to do the same.
-      break;
-    default:
-      --s;
-      ArgConverter<void>(arg, *s).visit(arg);
-    }
-
-    // Parse type.
-    if (!*s)
-      FMT_THROW(FormatError("invalid format string"));
-    spec.type_ = static_cast<char>(*s++);
-    if (arg.type <= Arg::LAST_INTEGER_TYPE) {
-      // Normalize type.
-      switch (spec.type_) {
-      case 'i': case 'u':
-        spec.type_ = 'd';
-        break;
-      case 'c':
-        // TODO: handle wchar_t
-        CharConverter(arg).visit(arg);
-        break;
-      }
-    }
-
-    start = s;
-
-    // Format argument.
-    internal::PrintfArgFormatter<Char>(writer, spec).visit(arg);
-  }
-  write(writer, start, s);
-}
 
 FMT_FUNC void fmt::report_system_error(
     int error_code, fmt::StringRef message) FMT_NOEXCEPT {
@@ -890,12 +337,10 @@ FMT_FUNC void fmt::print_colored(Color c, CStringRef format, ArgList args) {
   std::fputs(RESET_COLOR, stdout);
 }
 
-FMT_FUNC int fmt::fprintf(std::FILE *f, CStringRef format, ArgList args) {
-  MemoryWriter w;
-  printf(w, format, args);
-  std::size_t size = w.size();
-  return std::fwrite(w.data(), 1, size, f) < size ? -1 : static_cast<int>(size);
-}
+
+
+
+
 
 #ifndef FMT_HEADER_ONLY
 
@@ -907,8 +352,6 @@ template void fmt::internal::FixedBuffer<char>::grow(std::size_t);
 
 template void fmt::internal::ArgMap<char>::init(const fmt::ArgList &args);
 
-template void fmt::internal::PrintfFormatter<char>::format(
-  BasicWriter<char> &writer, CStringRef format);
 
 template int fmt::internal::CharTraits<char>::format_float(
     char *buffer, std::size_t size, const char *format,
@@ -924,8 +367,6 @@ template void fmt::internal::FixedBuffer<wchar_t>::grow(std::size_t);
 
 template void fmt::internal::ArgMap<wchar_t>::init(const fmt::ArgList &args);
 
-template void fmt::internal::PrintfFormatter<wchar_t>::format(
-    BasicWriter<wchar_t> &writer, WCStringRef format);
 
 template int fmt::internal::CharTraits<wchar_t>::format_float(
     wchar_t *buffer, std::size_t size, const wchar_t *format,

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -1987,7 +1987,7 @@ class FormatterBase {
  */
 template <typename Impl, typename Char>
 class BasicArgFormatter : public internal::ArgFormatterBase<Impl, Char> {
-private:
+ private:
   BasicFormatter<Char, Impl> &formatter_;
   const Char *format_;
 

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -237,7 +237,7 @@ typedef __int64          intmax_t;
 # define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
 #endif
 
-// Some compilers masquerade as both MSVC and GCC-likes or 
+// Some compilers masquerade as both MSVC and GCC-likes or
 // otherwise support __builtin_clz and __builtin_clzll, so
 // only define FMT_BUILTIN_CLZ using the MSVC intrinsics
 // if the clz and clzll builtins are not available.
@@ -253,7 +253,7 @@ inline uint32_t clz(uint32_t x) {
 
   assert(x != 0);
   // Static analysis complains about using uninitialized data
-  // "r", but the only way that can happen is if "x" is 0, 
+  // "r", but the only way that can happen is if "x" is 0,
   // which the callers guarantee to not happen.
 # pragma warning(suppress: 6102)
   return 31 - r;
@@ -279,7 +279,7 @@ inline uint32_t clzll(uint64_t x) {
 
   assert(x != 0);
   // Static analysis complains about using uninitialized data
-  // "r", but the only way that can happen is if "x" is 0, 
+  // "r", but the only way that can happen is if "x" is 0,
   // which the callers guarantee to not happen.
 # pragma warning(suppress: 6102)
   return 63 - r;
@@ -1296,7 +1296,7 @@ public:
   MakeArg() {
     type = Arg::NONE;
   }
-  
+
   template <typename T>
   MakeArg(const T &value)
   : Arg(MakeValue<Formatter>(value)) {
@@ -1318,8 +1318,6 @@ class RuntimeError : public std::runtime_error {
   RuntimeError() : std::runtime_error("") {}
 };
 
-template <typename Char>
-class PrintfArgFormatter;
 
 template <typename Char>
 class ArgMap;
@@ -1938,25 +1936,6 @@ class FormatterBase {
   }
 };
 
-// A printf formatter.
-template <typename Char>
-class PrintfFormatter : private FormatterBase {
- private:
-  void parse_flags(FormatSpec &spec, const Char *&s);
-
-  // Returns the argument with specified index or, if arg_index is equal
-  // to the maximum unsigned value, the next argument.
-  Arg get_arg(const Char *s,
-      unsigned arg_index = (std::numeric_limits<unsigned>::max)());
-
-  // Parses argument index, flags and width and returns the argument index.
-  unsigned parse_header(const Char *&s, FormatSpec &spec);
-
- public:
-  explicit PrintfFormatter(const ArgList &args) : FormatterBase(args) {}
-  FMT_API void format(BasicWriter<Char> &writer,
-                      BasicCStringRef<Char> format_str);
-};
 }  // namespace internal
 
 /**
@@ -1978,11 +1957,11 @@ class PrintfFormatter : private FormatterBase {
  */
 template <typename Impl, typename Char>
 class BasicArgFormatter : public internal::ArgFormatterBase<Impl, Char> {
- private:
+private:
   BasicFormatter<Char, Impl> &formatter_;
   const Char *format_;
 
- public:
+public:
   /**
     \rst
     Constructs an argument formatter object.
@@ -1991,10 +1970,10 @@ class BasicArgFormatter : public internal::ArgFormatterBase<Impl, Char> {
     to the part of the format string being parsed for custom argument types.
     \endrst
    */
-  BasicArgFormatter(BasicFormatter<Char, Impl> &formatter,
-                    FormatSpec &spec, const Char *fmt)
-  : internal::ArgFormatterBase<Impl, Char>(formatter.writer(), spec),
-    formatter_(formatter), format_(fmt) {}
+  BasicArgFormatter(BasicFormatter<Char, Impl> &formatter, FormatSpec &spec,
+                    const Char *fmt)
+      : internal::ArgFormatterBase<Impl, Char>(formatter.writer(), spec),
+        formatter_(formatter), format_(fmt) {}
 
   /** Formats argument of a custom (user-defined) type. */
   void visit_custom(internal::Arg::CustomValue c) {
@@ -2091,7 +2070,7 @@ struct ArgArray;
 template <unsigned N>
 struct ArgArray<N, true/*IsPacked*/> {
   typedef Value Type[N > 0 ? N : 1];
-  
+
   template <typename Formatter, typename T>
   static Value make(const T &value) {
 #ifdef __clang__
@@ -2287,7 +2266,7 @@ class SystemError : public internal::RuntimeError {
   Formats an error returned by an operating system or a language runtime,
   for example a file opening error, and writes it to *out* in the following
   form:
-   
+
   .. parsed-literal::
      *<message>*: *<system-message>*
 
@@ -2300,6 +2279,11 @@ class SystemError : public internal::RuntimeError {
  */
 FMT_API void format_system_error(fmt::Writer &out, int error_code,
                                  fmt::StringRef message) FMT_NOEXCEPT;
+
+
+namespace internal{
+template <typename Impl, typename Char> class PrintfArgFormatter;
+}
 
 /**
   \rst
@@ -2405,8 +2389,7 @@ class BasicWriter {
   // pointer as std::ostream does, cast it to const void*.
   // Do not implement!
   void operator<<(typename internal::WCharHelper<wchar_t, Char>::Unsupported);
-  void operator<<(
-      typename internal::WCharHelper<const wchar_t *, Char>::Unsupported);
+  void operator<<(typename internal::WCharHelper<const wchar_t *, Char>::Unsupported);
 
   // Appends floating-point length specifier to the format string.
   // The second argument is only used for overload resolution.
@@ -2420,7 +2403,8 @@ class BasicWriter {
   template <typename Impl, typename Char_>
   friend class internal::ArgFormatterBase;
 
-  friend class internal::PrintfArgFormatter<Char>;
+  template <typename Impl, typename Char_>
+  friend class internal::PrintfArgFormatter;
 
  protected:
   /**
@@ -3187,55 +3171,7 @@ FMT_API void print(std::FILE *f, CStringRef format_str, ArgList args);
  */
 FMT_API void print(CStringRef format_str, ArgList args);
 
-template <typename Char>
-void printf(BasicWriter<Char> &w, BasicCStringRef<Char> format, ArgList args) {
-  internal::PrintfFormatter<Char>(args).format(w, format);
-}
 
-/**
-  \rst
-  Formats arguments and returns the result as a string.
-
-  **Example**::
-
-    std::string message = fmt::sprintf("The answer is %d", 42);
-  \endrst
-*/
-inline std::string sprintf(CStringRef format, ArgList args) {
-  MemoryWriter w;
-  printf(w, format, args);
-  return w.str();
-}
-
-inline std::wstring sprintf(WCStringRef format, ArgList args) {
-  WMemoryWriter w;
-  printf(w, format, args);
-  return w.str();
-}
-
-/**
-  \rst
-  Prints formatted data to the file *f*.
-
-  **Example**::
-
-    fmt::fprintf(stderr, "Don't %s!", "panic");
-  \endrst
- */
-FMT_API int fprintf(std::FILE *f, CStringRef format, ArgList args);
-
-/**
-  \rst
-  Prints formatted data to ``stdout``.
-
-  **Example**::
-
-    fmt::printf("Elapsed time: %.2f seconds", 1.23);
-  \endrst
- */
-inline int printf(CStringRef format, ArgList args) {
-  return fprintf(stdout, format, args);
-}
 
 /**
   Fast integer formatter.
@@ -3504,10 +3440,7 @@ FMT_VARIADIC(void, print, CStringRef)
 FMT_VARIADIC(void, print, std::FILE *, CStringRef)
 
 FMT_VARIADIC(void, print_colored, Color, CStringRef)
-FMT_VARIADIC(std::string, sprintf, CStringRef)
-FMT_VARIADIC_W(std::wstring, sprintf, WCStringRef)
-FMT_VARIADIC(int, printf, CStringRef)
-FMT_VARIADIC(int, fprintf, std::FILE *, CStringRef)
+
 
 namespace internal {
 template <typename Char>
@@ -3597,8 +3530,8 @@ inline internal::Arg BasicFormatter<Char, AF>::parse_arg_name(const Char *&s) {
   return arg;
 }
 
-template <typename Char, typename ArgFormatter>
-const Char *BasicFormatter<Char, ArgFormatter>::format(
+template <typename Char, typename ArgFormatter_Type>
+const Char *BasicFormatter<Char, ArgFormatter_Type>::format(
     const Char *&format_str, const internal::Arg &arg) {
   using internal::Arg;
   const Char *s = format_str;
@@ -3763,7 +3696,7 @@ const Char *BasicFormatter<Char, ArgFormatter>::format(
     FMT_THROW(FormatError("missing '}' in format string"));
 
   // Format argument.
-  ArgFormatter(*this, spec, s - 1).visit(arg);
+  ArgFormatter_Type(*this, spec, s - 1).visit(arg);
   return s;
 }
 

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -836,15 +836,45 @@ struct FMT_API BasicData {
   static const char DIGITS[];
 };
 
-#ifndef FMT_USE_EXTERN_TEMPLATES
-// Clang doesn't have a feature check for extern templates so we check
-// for variadic templates which were introduced in the same version.
-# define FMT_USE_EXTERN_TEMPLATES (__clang__ && FMT_USE_VARIADIC_TEMPLATES)
-#endif
+#define FMT_POWERS_OF_10(factor) \
+  factor * 10, \
+  factor * 100, \
+  factor * 1000, \
+  factor * 10000, \
+  factor * 100000, \
+  factor * 1000000, \
+  factor * 10000000, \
+  factor * 100000000, \
+  factor * 1000000000
 
-#if FMT_USE_EXTERN_TEMPLATES
-extern template struct BasicData<void>;
-#endif
+template <typename T>
+const uint32_t BasicData<T>::POWERS_OF_10_32[] = {
+  0, FMT_POWERS_OF_10(1)
+};
+
+template <typename T>
+const uint64_t fmt::internal::BasicData<T>::POWERS_OF_10_64[] = {
+  0,
+  FMT_POWERS_OF_10(1),
+  FMT_POWERS_OF_10(fmt::ULongLong(1000000000)),
+  // Multiply several constants instead of using a single long long constant
+  // to avoid warnings about C++98 not supporting long long.
+  fmt::ULongLong(1000000000) * fmt::ULongLong(1000000000) * 10
+};
+
+
+
+/// After the changes for 335, cland reported unedefined references to
+/// BasicData<void>, so I put their definitions in the header.
+// #ifndef FMT_USE_EXTERN_TEMPLATES
+// // Clang doesn't have a feature check for extern templates so we check
+// // for variadic templates which were introduced in the same version.
+// # define FMT_USE_EXTERN_TEMPLATES (__clang__ && FMT_USE_VARIADIC_TEMPLATES)
+// #endif
+
+// #if FMT_USE_EXTERN_TEMPLATES
+// extern template struct BasicData<void>;
+// #endif
 
 typedef BasicData<> Data;
 

--- a/fmt/ostream.cc
+++ b/fmt/ostream.cc
@@ -26,7 +26,7 @@
  */
 
 #include "fmt/ostream.h"
-
+#include "fmt/printf.h"
 namespace fmt {
 
 namespace {
@@ -54,7 +54,7 @@ FMT_FUNC void print(std::ostream &os, CStringRef format_str, ArgList args) {
 
 FMT_FUNC int fprintf(std::ostream &os, CStringRef format, ArgList args) {
   MemoryWriter w;
-  printf(w, format, args);
+  fmt::printf(w, format, args);
   write(os, w);
   return static_cast<int>(w.size());
 }

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -1,0 +1,710 @@
+/*
+ Formatting library for C++
+
+ Copyright (c) 2012 - 2016, Victor Zverovich
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FMT_PRINTF_H_
+#define FMT_PRINTF_H_
+
+
+#include "format.h"
+#include <climits>
+#include <cerrno>
+
+
+
+#if defined(_WIN32) && defined(__MINGW32__)
+# include <cstring>
+#endif
+
+#if FMT_USE_WINDOWS_H
+# if defined(NOMINMAX) || defined(FMT_WIN_MINMAX)
+#  include <windows.h>
+# else
+#  define NOMINMAX
+#  include <windows.h>
+#  undef NOMINMAX
+# endif
+#endif
+
+using fmt::internal::Arg;
+
+#if FMT_EXCEPTIONS
+# define FMT_TRY try
+# define FMT_CATCH(x) catch (x)
+#else
+# define FMT_TRY if (true)
+# define FMT_CATCH(x) if (false)
+#endif
+
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable: 4127)  // conditional expression is constant
+# pragma warning(disable: 4702)  // unreachable code
+// Disable deprecation warning for strerror. The latter is not called but
+// MSVC fails to detect it.
+# pragma warning(disable: 4996)
+#endif
+
+// Dummy implementations of strerror_r and strerror_s called if corresponding
+// system functions are not available.
+static inline fmt::internal::Null<> strerror_r(int, char *, ...) {
+  return fmt::internal::Null<>();
+}
+static inline fmt::internal::Null<> strerror_s(char *, std::size_t, ...) {
+  return fmt::internal::Null<>();
+}
+
+namespace fmt {
+namespace internal {
+
+template <typename Char> class DefaultPrintfArgFormatter;
+
+template <typename CharType,
+          typename PFAF = fmt::internal::DefaultPrintfArgFormatter<CharType> >
+class PrintfFormatter;
+
+template <typename Impl, typename CharT>
+class PrintfArgFormatter : public internal::ArgFormatterBase<Impl, CharT> {
+
+private:
+  void write_null_pointer() {
+    this->spec().type_ = 0;
+    this->write("(nil)");
+  }
+
+public:
+  PrintfArgFormatter(BasicWriter<CharT> &w, FormatSpec &s)
+    : internal::ArgFormatterBase<Impl, CharT>(w, s) {}
+
+  void visit_bool(bool value) {
+    FormatSpec &fmt_spec = this->spec();
+    if (fmt_spec.type_ != 's')
+      return this->visit_any_int(value);
+    fmt_spec.type_ = 0;
+    this->write(value);
+  }
+
+  void visit_char(int value) {
+    const FormatSpec &fmt_spec = this->spec();
+    BasicWriter<CharT> &w = this->writer();
+    if (fmt_spec.type_ && fmt_spec.type_ != 'c')
+      w.write_int(value, fmt_spec);
+    typedef typename BasicWriter<CharT>::CharPtr CharPtr;
+    CharPtr out = CharPtr();
+    if (fmt_spec.width_ > 1) {
+      CharT fill = ' ';
+      out = w.grow_buffer(fmt_spec.width_);
+      if (fmt_spec.align_ != ALIGN_LEFT) {
+        std::fill_n(out, fmt_spec.width_ - 1, fill);
+        out += fmt_spec.width_ - 1;
+      } else {
+        std::fill_n(out + 1, fmt_spec.width_ - 1, fill);
+      }
+    } else {
+      out = w.grow_buffer(1);
+    }
+    *out = static_cast<CharT>(value);
+  }
+
+  typedef ArgFormatterBase<Impl, CharT> Base;
+  void visit_cstring(const char *value) {
+    if (value)
+      Base::visit_cstring(value);
+    else if (this->spec().type_ == 'p')
+      write_null_pointer();
+    else
+      this->write("(null)");
+  }
+
+  void visit_pointer(const void *value) {
+    if (value)
+      return Base::visit_pointer(value);
+    this->spec().type_ = 0;
+    write_null_pointer();
+  }
+
+  void visit_custom(Arg::CustomValue c) {
+    BasicFormatter<CharT> formatter(ArgList(), this->writer());
+    const CharT format_str[] = {'}', 0};
+    const CharT *format = format_str;
+    c.format(&formatter, c.value, &format);
+  }
+};
+
+/** The default printf argument formatter. */
+template <typename CharT>
+class DefaultPrintfArgFormatter
+    : public PrintfArgFormatter<DefaultPrintfArgFormatter<CharT>, CharT> {
+public:
+  /** Constructs an argument formatter object. */
+  DefaultPrintfArgFormatter(BasicWriter<CharT> &w, FormatSpec &spec)
+    : PrintfArgFormatter<DefaultPrintfArgFormatter<CharT>, CharT>(w, spec) {}
+};
+
+ template <typename Char, typename PrintfArgFormatterT>
+   class PrintfFormatter : private FormatterBase {
+ private:
+  void parse_flags(FormatSpec &spec, const Char *&s);
+
+  // Returns the argument with specified index or, if arg_index is equal
+  // to the maximum unsigned value, the next argument.
+  Arg get_arg(const Char *s,
+      unsigned arg_index = (std::numeric_limits<unsigned>::max)());
+
+  // Parses argument index, flags and width and returns the argument index.
+  unsigned parse_header(const Char *&s, FormatSpec &spec);
+
+public:
+  explicit PrintfFormatter(const ArgList &args) : FormatterBase(args) {}
+  FMT_API void format(BasicWriter<Char> &writer,
+                      BasicCStringRef<Char> format_str);
+};
+
+
+}
+
+template <typename Char>
+inline void printf(BasicWriter<Char> &w, BasicCStringRef<Char> format, ArgList args) {
+  internal::PrintfFormatter<Char>(args).format(w, format);
+}
+
+
+/**
+  \rst
+  Formats arguments and returns the result as a string.
+
+  **Example**::
+
+    std::string message = fmt::sprintf("The answer is %d", 42);
+  \endrst
+*/
+inline std::string sprintf(CStringRef format, ArgList args) {
+	MemoryWriter w;
+	printf(w, format, args);
+	return w.str();
+}
+
+inline  std::wstring sprintf(WCStringRef format, ArgList args) {
+  WMemoryWriter w;
+  printf(w, format, args);
+  return w.str();
+}
+
+
+/**
+  \rst
+  Prints formatted data to the file *f*.
+
+  **Example**::
+
+    fmt::fprintf(stderr, "Don't %s!", "panic");
+  \endrst
+ */
+inline FMT_API int fprintf(std::FILE *f, CStringRef format, ArgList args);
+
+/**
+  \rst
+  Prints formatted data to ``stdout``.
+
+  **Example**::
+
+    fmt::printf("Elapsed time: %.2f seconds", 1.23);
+  \endrst
+ */
+inline  int printf(CStringRef format, ArgList args) {
+  return fprintf(stdout, format, args);
+}
+
+FMT_VARIADIC(std::string, sprintf, CStringRef)
+FMT_VARIADIC_W(std::wstring, sprintf, WCStringRef)
+FMT_VARIADIC(int, printf, CStringRef)
+FMT_VARIADIC(int, fprintf, std::FILE *, CStringRef)
+
+FMT_FUNC int fprintf(std::FILE *f, CStringRef format, ArgList args) {
+  MemoryWriter w;
+  printf(w, format, args);
+  std::size_t size = w.size();
+  return std::fwrite(w.data(), 1, size, f) < size ? -1 : static_cast<int>(size);
+}
+
+
+#ifndef _MSC_VER
+# define FMT_SNPRINTF snprintf
+#else  // _MSC_VER
+inline int fmt_snprintf(char *buffer, size_t size, const char *format, ...) {
+  va_list args;
+  va_start(args, format);
+  int result = vsnprintf_s(buffer, size, _TRUNCATE, format, args);
+  va_end(args);
+  return result;
+}
+# define FMT_SNPRINTF fmt_snprintf
+#endif  // _MSC_VER
+
+#if defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
+# define FMT_SWPRINTF snwprintf
+#else
+# define FMT_SWPRINTF swprintf
+#endif // defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
+
+// Checks if a value fits in int - used to avoid warnings about comparing
+// signed and unsigned integers.
+template <bool IsSigned>
+struct IntChecker {
+  template <typename T>
+  static bool fits_in_int(T value) {
+    unsigned max = INT_MAX;
+    return value <= max;
+  }
+  static bool fits_in_int(bool) { return true; }
+};
+
+template <>
+struct IntChecker<true> {
+  template <typename T>
+  static bool fits_in_int(T value) {
+    return value >= INT_MIN && value <= INT_MAX;
+  }
+  static bool fits_in_int(int) { return true; }
+};
+
+const char RESET_COLOR[] = "\x1b[0m";
+
+typedef void (*FormatFunc)(Writer &, int, StringRef);
+
+// Portable thread-safe version of strerror.
+// Sets buffer to point to a string describing the error code.
+// This can be either a pointer to a string stored in buffer,
+// or a pointer to some static immutable string.
+// Returns one of the following values:
+//   0      - success
+//   ERANGE - buffer is not large enough to store the error message
+//   other  - failure
+// Buffer should be at least of size 1.
+///GAS :take out of header!
+inline int safe_strerror(
+    int error_code, char *&buffer, std::size_t buffer_size) FMT_NOEXCEPT {
+  FMT_ASSERT(buffer != 0 && buffer_size != 0, "invalid buffer");
+
+  class StrError {
+   private:
+    int error_code_;
+    char *&buffer_;
+    std::size_t buffer_size_;
+
+    // A noop assignment operator to avoid bogus warnings.
+    void operator=(const StrError &) {}
+
+    // Handle the result of XSI-compliant version of strerror_r.
+    int handle(int result) {
+      // glibc versions before 2.13 return result in errno.
+      return result == -1 ? errno : result;
+    }
+
+    // Handle the result of GNU-specific version of strerror_r.
+    int handle(char *message) {
+      // If the buffer is full then the message is probably truncated.
+      if (message == buffer_ && strlen(buffer_) == buffer_size_ - 1)
+        return ERANGE;
+      buffer_ = message;
+      return 0;
+    }
+
+    // Handle the case when strerror_r is not available.
+    int handle(internal::Null<>) {
+      return fallback(strerror_s(buffer_, buffer_size_, error_code_));
+    }
+
+    // Fallback to strerror_s when strerror_r is not available.
+    int fallback(int result) {
+      // If the buffer is full then the message is probably truncated.
+      return result == 0 && strlen(buffer_) == buffer_size_ - 1 ?
+            ERANGE : result;
+    }
+
+    // Fallback to strerror if strerror_r and strerror_s are not available.
+    int fallback(internal::Null<>) {
+      errno = 0;
+      buffer_ = strerror(error_code_);
+      return errno;
+    }
+
+   public:
+    StrError(int err_code, char *&buf, std::size_t buf_size)
+      : error_code_(err_code), buffer_(buf), buffer_size_(buf_size) {}
+
+    int run() {
+      strerror_r(0, 0, "");  // Suppress a warning about unused strerror_r.
+      return handle(strerror_r(error_code_, buffer_, buffer_size_));
+    }
+  };
+  return StrError(error_code, buffer, buffer_size).run();
+}
+
+inline void format_error_code(Writer &out, int error_code,
+                       StringRef message) FMT_NOEXCEPT {
+  // Report error code making sure that the output fits into
+  // INLINE_BUFFER_SIZE to avoid dynamic memory allocation and potential
+  // bad_alloc.
+  out.clear();
+  static const char SEP[] = ": ";
+  static const char ERROR_STR[] = "error ";
+  // Subtract 2 to account for terminating null characters in SEP and ERROR_STR.
+  std::size_t error_code_size = sizeof(SEP) + sizeof(ERROR_STR) - 2;
+  typedef internal::IntTraits<int>::MainType MainType;
+  MainType abs_value = static_cast<MainType>(error_code);
+  if (internal::is_negative(error_code)) {
+    abs_value = 0 - abs_value;
+    ++error_code_size;
+  }
+  error_code_size += internal::count_digits(abs_value);
+  if (message.size() <= internal::INLINE_BUFFER_SIZE - error_code_size)
+    out << message << SEP;
+  out << ERROR_STR << error_code;
+  assert(out.size() <= internal::INLINE_BUFFER_SIZE);
+}
+
+inline void report_error(FormatFunc func, int error_code,
+                  StringRef message) FMT_NOEXCEPT {
+  MemoryWriter full_message;
+  func(full_message, error_code, message);
+  // Use Writer::data instead of Writer::c_str to avoid potential memory
+  // allocation.
+  std::fwrite(full_message.data(), full_message.size(), 1, stderr);
+  std::fputc('\n', stderr);
+}
+
+// IsZeroInt::visit(arg) returns true iff arg is a zero integer.
+class IsZeroInt : public ArgVisitor<IsZeroInt, bool> {
+ public:
+  template <typename T>
+  bool visit_any_int(T value) { return value == 0; }
+};
+
+// Checks if an argument is a valid printf width specifier and sets
+// left alignment if it is negative.
+class WidthHandler : public ArgVisitor<WidthHandler, unsigned> {
+ private:
+  FormatSpec &spec_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(WidthHandler);
+
+ public:
+  explicit WidthHandler(FormatSpec &spec) : spec_(spec) {}
+
+  void report_unhandled_arg() {
+    FMT_THROW(FormatError("width is not integer"));
+  }
+
+  template <typename T>
+  unsigned visit_any_int(T value) {
+    typedef typename internal::IntTraits<T>::MainType UnsignedType;
+    UnsignedType width = static_cast<UnsignedType>(value);
+    if (internal::is_negative(value)) {
+      spec_.align_ = ALIGN_LEFT;
+      width = 0 - width;
+    }
+    if (width > INT_MAX)
+      FMT_THROW(FormatError("number is too big"));
+    return static_cast<unsigned>(width);
+  }
+};
+
+class PrecisionHandler : public ArgVisitor<PrecisionHandler, int> {
+ public:
+  void report_unhandled_arg() {
+    FMT_THROW(FormatError("precision is not integer"));
+  }
+
+  template <typename T>
+  int visit_any_int(T value) {
+    if (!IntChecker<std::numeric_limits<T>::is_signed>::fits_in_int(value))
+      FMT_THROW(FormatError("number is too big"));
+    return static_cast<int>(value);
+  }
+};
+
+template <typename T, typename U>
+struct is_same {
+  enum { value = 0 };
+};
+
+template <typename T>
+struct is_same<T, T> {
+  enum { value = 1 };
+};
+
+// An argument visitor that converts an integer argument to T for printf,
+// if T is an integral type. If T is void, the argument is converted to
+// corresponding signed or unsigned type depending on the type specifier:
+// 'd' and 'i' - signed, other - unsigned)
+template <typename T = void>
+class ArgConverter : public ArgVisitor<ArgConverter<T>, void> {
+ private:
+  internal::Arg &arg_;
+  wchar_t type_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(ArgConverter);
+
+ public:
+  ArgConverter(internal::Arg &arg, wchar_t type)
+    : arg_(arg), type_(type) {}
+
+  void visit_bool(bool value) {
+    if (type_ != 's')
+      visit_any_int(value);
+  }
+
+  template <typename U>
+  void visit_any_int(U value) {
+    bool is_signed = type_ == 'd' || type_ == 'i';
+    using internal::Arg;
+    typedef typename internal::Conditional<
+        is_same<T, void>::value, U, T>::type TargetType;
+    if (sizeof(TargetType) <= sizeof(int)) {
+      // Extra casts are used to silence warnings.
+      if (is_signed) {
+        arg_.type = Arg::INT;
+        arg_.int_value = static_cast<int>(static_cast<TargetType>(value));
+      } else {
+        arg_.type = Arg::UINT;
+        typedef typename internal::MakeUnsigned<TargetType>::Type Unsigned;
+        arg_.uint_value = static_cast<unsigned>(static_cast<Unsigned>(value));
+      }
+    } else {
+      if (is_signed) {
+        arg_.type = Arg::LONG_LONG;
+        // glibc's printf doesn't sign extend arguments of smaller types:
+        //   std::printf("%lld", -42);  // prints "4294967254"
+        // but we don't have to do the same because it's a UB.
+        arg_.long_long_value = static_cast<LongLong>(value);
+      } else {
+        arg_.type = Arg::ULONG_LONG;
+        arg_.ulong_long_value =
+            static_cast<typename internal::MakeUnsigned<U>::Type>(value);
+      }
+    }
+  }
+};
+
+// Converts an integer argument to char for printf.
+class CharConverter : public ArgVisitor<CharConverter, void> {
+ private:
+  internal::Arg &arg_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(CharConverter);
+
+ public:
+  explicit CharConverter(internal::Arg &arg) : arg_(arg) {}
+
+  template <typename T>
+  void visit_any_int(T value) {
+    arg_.type = internal::Arg::CHAR;
+    arg_.int_value = static_cast<char>(value);
+  }
+};
+
+template <typename Char, typename PAF>
+void fmt::internal::PrintfFormatter<Char, PAF>::format(
+    BasicWriter<Char> &writer, BasicCStringRef<Char> format_str) {
+  const Char *start = format_str.c_str();
+  const Char *s = start;
+  while (*s) {
+    Char c = *s++;
+    if (c != '%') continue;
+    if (*s == c) {
+      write(writer, start, s);
+      start = ++s;
+      continue;
+    }
+    write(writer, start, s - 1);
+
+    FormatSpec spec;
+    spec.align_ = ALIGN_RIGHT;
+
+    // Parse argument index, flags and width.
+    unsigned arg_index = parse_header(s, spec);
+
+    // Parse precision.
+    if (*s == '.') {
+      ++s;
+      if ('0' <= *s && *s <= '9') {
+        spec.precision_ = static_cast<int>(parse_nonnegative_int(s));
+      } else if (*s == '*') {
+        ++s;
+        spec.precision_ = PrecisionHandler().visit(get_arg(s));
+      }
+    }
+
+    Arg arg = get_arg(s, arg_index);
+    if (spec.flag(HASH_FLAG) && IsZeroInt().visit(arg))
+      spec.flags_ &= ~to_unsigned<int>(HASH_FLAG);
+    if (spec.fill_ == '0') {
+      if (arg.type <= Arg::LAST_NUMERIC_TYPE)
+        spec.align_ = ALIGN_NUMERIC;
+      else
+        spec.fill_ = ' ';  // Ignore '0' flag for non-numeric types.
+    }
+
+    // Parse length and convert the argument to the required type.
+    switch (*s++) {
+    case 'h':
+      if (*s == 'h')
+        ArgConverter<signed char>(arg, *++s).visit(arg);
+      else
+        ArgConverter<short>(arg, *s).visit(arg);
+      break;
+    case 'l':
+      if (*s == 'l')
+        ArgConverter<fmt::LongLong>(arg, *++s).visit(arg);
+      else
+        ArgConverter<long>(arg, *s).visit(arg);
+      break;
+    case 'j':
+      ArgConverter<intmax_t>(arg, *s).visit(arg);
+      break;
+    case 'z':
+      ArgConverter<std::size_t>(arg, *s).visit(arg);
+      break;
+    case 't':
+      ArgConverter<std::ptrdiff_t>(arg, *s).visit(arg);
+      break;
+    case 'L':
+      // printf produces garbage when 'L' is omitted for long double, no
+      // need to do the same.
+      break;
+    default:
+      --s;
+      ArgConverter<void>(arg, *s).visit(arg);
+    }
+
+    // Parse type.
+    if (!*s)
+      FMT_THROW(FormatError("invalid format string"));
+    spec.type_ = static_cast<char>(*s++);
+    if (arg.type <= Arg::LAST_INTEGER_TYPE) {
+      // Normalize type.
+      switch (spec.type_) {
+      case 'i': case 'u':
+        spec.type_ = 'd';
+        break;
+      case 'c':
+        // TODO: handle wchar_t
+        CharConverter(arg).visit(arg);
+        break;
+      }
+    }
+
+    start = s;
+
+    // Format argument.
+    PAF(writer, spec).visit(arg);
+  }
+  write(writer, start, s);
+}
+
+template void fmt::internal::PrintfFormatter<char>::format(
+  BasicWriter<char> &writer, CStringRef format);
+
+template void fmt::internal::PrintfFormatter<wchar_t>::format(
+    BasicWriter<wchar_t> &writer, WCStringRef format);
+
+}
+
+template <typename Char, typename PAF>
+void fmt::internal::PrintfFormatter<Char,PAF>::parse_flags(
+    FormatSpec &spec, const Char *&s) {
+  for (;;) {
+    switch (*s++) {
+      case '-':
+        spec.align_ = ALIGN_LEFT;
+        break;
+      case '+':
+        spec.flags_ |= SIGN_FLAG | PLUS_FLAG;
+        break;
+      case '0':
+        spec.fill_ = '0';
+        break;
+      case ' ':
+        spec.flags_ |= SIGN_FLAG;
+        break;
+      case '#':
+        spec.flags_ |= HASH_FLAG;
+        break;
+      default:
+        --s;
+        return;
+    }
+  }
+}
+
+template <typename Char, typename PAF>
+Arg fmt::internal::PrintfFormatter<Char,PAF>::get_arg(
+    const Char *s, unsigned arg_index) {
+  (void)s;
+  const char *error = 0;
+  Arg arg = arg_index == UINT_MAX ?
+    next_arg(error) : FormatterBase::get_arg(arg_index - 1, error);
+  if (error)
+    FMT_THROW(FormatError(!*s ? "invalid format string" : error));
+  return arg;
+}
+
+template <typename Char, typename PAF>
+unsigned fmt::internal::PrintfFormatter<Char, PAF>::parse_header(
+  const Char *&s, FormatSpec &spec) {
+  unsigned arg_index = UINT_MAX;
+  Char c = *s;
+  if (c >= '0' && c <= '9') {
+    // Parse an argument index (if followed by '$') or a width possibly
+    // preceded with '0' flag(s).
+    unsigned value = parse_nonnegative_int(s);
+    if (*s == '$') {  // value is an argument index
+      ++s;
+      arg_index = value;
+    } else {
+      if (c == '0')
+        spec.fill_ = '0';
+      if (value != 0) {
+        // Nonzero value means that we parsed width and don't need to
+        // parse it or flags again, so return now.
+        spec.width_ = value;
+        return arg_index;
+      }
+    }
+  }
+  parse_flags(spec, s);
+  // Parse width.
+  if (*s >= '0' && *s <= '9') {
+    spec.width_ = parse_nonnegative_int(s);
+  } else if (*s == '*') {
+    ++s;
+    spec.width_ = WidthHandler(spec).visit(get_arg(s));
+  }
+  return arg_index;
+}
+
+#endif

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -81,11 +81,11 @@ static inline fmt::internal::Null<> strerror_s(char *, std::size_t, ...) {
 namespace fmt {
 namespace internal {
 
-template <typename Char> class DefaultPrintfArgFormatter;
+// template <typename Char> class DefaultPrintfArgFormatter;
 
-template <typename CharT,
-          typename PFAF = fmt::internal::DefaultPrintfArgFormatter<CharT> >
-class PrintfFormatter;
+// template <typename CharT,
+// 		  typename PFAF = fmt::internal::DefaultPrintfArgFormatter<CharT> >
+// class PrintfFormatter;
 
 template <typename Impl, typename CharT>
 class PrintfArgFormatter : public internal::ArgFormatterBase<Impl, CharT> {
@@ -165,8 +165,9 @@ public:
     : PrintfArgFormatter<DefaultPrintfArgFormatter<CharT>, CharT>(w, spec) {}
 };
 
- template <typename Char, typename PrintfArgFormatterT>
-   class PrintfFormatter : private FormatterBase {
+ template <typename Char,
+		   typename PrintfArgFormatterT = fmt::internal::DefaultPrintfArgFormatter<Char> >
+ class PrintfFormatter : private FormatterBase {
  private:
   void parse_flags(FormatSpec &spec, const Char *&s);
 

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -33,6 +33,7 @@
 #include <climits>
 #include <cerrno>
 
+#include <cstdarg>//< Only for windows?
 
 
 #if defined(_WIN32) && defined(__MINGW32__)

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -33,7 +33,7 @@
 #include <climits>
 #include <cerrno>
 
-#include <cstdarg>//< Only for windows?
+#include <cstdarg>
 
 
 #if defined(_WIN32) && defined(__MINGW32__)
@@ -80,12 +80,6 @@ static inline fmt::internal::Null<> strerror_s(char *, std::size_t, ...) {
 
 namespace fmt {
 namespace internal {
-
-// template <typename Char> class DefaultPrintfArgFormatter;
-
-// template <typename CharT,
-// 		  typename PFAF = fmt::internal::DefaultPrintfArgFormatter<CharT> >
-// class PrintfFormatter;
 
 template <typename Impl, typename CharT>
 class PrintfArgFormatter : public internal::ArgFormatterBase<Impl, CharT> {

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -83,8 +83,8 @@ namespace internal {
 
 template <typename Char> class DefaultPrintfArgFormatter;
 
-template <typename CharType,
-          typename PFAF = fmt::internal::DefaultPrintfArgFormatter<CharType> >
+template <typename CharT,
+          typename PFAF = fmt::internal::DefaultPrintfArgFormatter<CharT> >
 class PrintfFormatter;
 
 template <typename Impl, typename CharT>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,7 @@ add_fmt_test(printf-test)
 add_fmt_test(string-test)
 add_fmt_test(util-test mock-allocator.h)
 add_fmt_test(macro-test)
+add_fmt_test(custom-formatter-test)
 
 # Enable stricter options for one test to make sure that the header is free of
 # warnings.
@@ -129,7 +130,7 @@ if (FMT_PEDANTIC)
     "${CMAKE_CURRENT_BINARY_DIR}/compile-test"
     --build-generator ${CMAKE_GENERATOR}
     --build-makeprogram ${CMAKE_MAKE_PROGRAM}
-    --build-options 
+    --build-options
     "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
     "-DCPP11_FLAG=${CPP11_FLAG}"
     "-DSUPPORTS_USER_DEFINED_LITERALS=${SUPPORTS_USER_DEFINED_LITERALS}")

--- a/test/custom-formatter-test.cc
+++ b/test/custom-formatter-test.cc
@@ -1,0 +1,98 @@
+/*
+ printf tests.
+
+ Copyright (c) 2012-2014, Victor Zverovich
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fmt/format.h"
+#include "fmt/printf.h"
+#include "gtest-extra.h"
+
+#include <iostream>
+
+
+// A custom argument formatter that doesn't print `-` for floating-point values
+// rounded to 0.
+class CustomArgFormatter :
+  public fmt::BasicArgFormatter<CustomArgFormatter, char>  {
+  public:
+  CustomArgFormatter(fmt::BasicFormatter<char, CustomArgFormatter> &f,
+                         fmt::FormatSpec &s, const char *fmt)
+    : fmt::BasicArgFormatter<CustomArgFormatter, char>(f, s, fmt) {}
+
+  void visit_double(double value) {
+    if (round(value * pow(10, spec().precision())) == 0)
+      value = 0;
+    fmt::BasicArgFormatter<CustomArgFormatter, char>::visit_double(value);
+  }
+};
+
+
+// A custom argument formatter that doesn't print `-` for floating-point values
+// rounded to 0.
+class CustomPAF : public fmt::internal::PrintfArgFormatter<CustomPAF, char>
+{
+public:
+  CustomPAF(fmt::BasicWriter<char> &writer, fmt::FormatSpec &spec):
+	  fmt::internal::PrintfArgFormatter<CustomPAF, char>(writer, spec) {}
+
+  void visit_double(double value) {
+    if (round(value * pow(10, spec().precision())) == 0)
+      value = 0;
+    fmt::internal::PrintfArgFormatter< CustomPAF, char>::visit_double(value);
+  }
+};
+
+std::string custom_format(const char *format_str, fmt::ArgList args) {
+  fmt::MemoryWriter writer;
+  // Pass custom argument formatter as a template arg to BasicFormatter.
+  fmt::BasicFormatter<char, CustomArgFormatter> formatter(args, writer);
+  formatter.format(format_str);
+  return writer.str();
+}
+FMT_VARIADIC(std::string, custom_format, const char *)
+
+
+std::string printfer(const char* fstr, fmt::ArgList args){
+  fmt::MemoryWriter writer;
+  fmt::internal::PrintfFormatter< char, CustomPAF > pfer( args);
+  pfer.format(writer, fstr);
+   return writer.str();
+}
+FMT_VARIADIC(std::string, printfer, const char*);
+
+
+
+// Makes format string argument positional.
+std::string make_positional(fmt::StringRef format) {
+  std::string s(format.to_string());
+  s.replace(s.find('%'), 1, "%1$");
+  return s;
+}
+
+
+TEST(custom, foo){
+	EXPECT_EQ("0.00", custom_format("{:.2f}", -.00001));
+	EXPECT_EQ("0.00", printfer("%.2f", -.00001));
+}

--- a/test/custom-formatter-test.cc
+++ b/test/custom-formatter-test.cc
@@ -29,9 +29,6 @@
 #include "fmt/printf.h"
 #include "gtest-extra.h"
 
-#include <iostream>
-
-
 // A custom argument formatter that doesn't print `-` for floating-point values
 // rounded to 0.
 class CustomArgFormatter :
@@ -81,15 +78,6 @@ std::string printfer(const char* fstr, fmt::ArgList args){
    return writer.str();
 }
 FMT_VARIADIC(std::string, printfer, const char*);
-
-
-
-// Makes format string argument positional.
-std::string make_positional(fmt::StringRef format) {
-  std::string s(format.to_string());
-  s.replace(s.find('%'), 1, "%1$");
-  return s;
-}
 
 
 TEST(custom, foo){

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -29,6 +29,7 @@
 #include <climits>
 #include <cstring>
 
+#include "fmt/printf.h"
 #include "fmt/format.h"
 #include "gtest-extra.h"
 #include "util.h"


### PR DESCRIPTION
I saw that my previous pull request failed to build for OSX.  I was able to reproduce and fix the problem using clang to compile, so I'm trying again.

I put the PrintfArgFormatting changes into one commit, and make the clang error fixes in another.  Clang gave undefined symbol errors for the BasicData<void> on the header only tests, so I stopped defining those externally.  

I will admit to being unsure of the fixes, so please make any improvements/corrections, or let me know what you need me to change.

- printf.h created and placed PrintfArgFormat ting classes in this file.
- Created a DefaultPrintfArgFormatter, analagous to the ArgFormatter class for the python-style formatter.
- Added another template parameter to PrintfArgFormatter, enabling customisation of the PrintfArgFormatter through subclassing, as with the BasicArgFormatter.
- Created a very simple unit test for the new functionality in custom-formatterer-test.cc

I hope the changes are acceptable.  Once we wrap up this issue, I think PrintfArgFormatter should probably come out of internal, but I thought I'd leave that for a next step.

Looking forward to your feedback.
