### PR TITLE
Fix building with clang in header-only mode

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -841,7 +841,7 @@ struct FMT_API BasicData {
 # define FMT_USE_EXTERN_TEMPLATES (__clang__ && FMT_USE_VARIADIC_TEMPLATES)
 #endif
 
-#if FMT_USE_EXTERN_TEMPLATES
+#if FMT_USE_EXTERN_TEMPLATES && !defined(FMT_HEADER_ONLY)
 extern template struct BasicData<void>;
 #endif
 


### PR DESCRIPTION
Building under a recent clang compiler causes the use of an extern
template for the BasicData struct. However, the only instantiation of
that structure in format.cc is only done if FMT_HEADER_ONLY is not
defined. This causes the build to fail in C++11 or C++14 mode.
Therefore, only declare the BasicData template as extern if
FMT_HEADER_ONLY is not defined.