### PR TITLE
FMT_USE_CPP11 option pollutes build flags with '-std=c++11'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,9 @@ option(FMT_PEDANTIC "Enable extra warnings and expensive tests." OFF)
 option(FMT_DOC "Generate the doc target." ${MASTER_PROJECT})
 option(FMT_INSTALL "Generate the install target." ${MASTER_PROJECT})
 option(FMT_TEST "Generate the test target." ${MASTER_PROJECT})
-option(FMT_USE_CPP11 "Enable the addition of C++11 compiler flags." ON)
+if (MASTER_PROJECT)
+   option(FMT_USE_CPP11 "Enable the addition of C++11 compiler flags." ON)
+endif()
 
 project(FMT)
 


### PR DESCRIPTION
When included (with add_subdirectory), `FMT_USE_CPP11` option pollutes build flags with `-std=c++11`.  If master project has `set(CMAKE_CXX_STANDARD 14)` , then compilation flags become `-std=c++11 -std=gnu++14`.

Enable `FMT_USE_CPP11` by default only when `MASTER_PROJECT` is `ON`, otherwise inherit from master project.