### PR TITLE
Fix compilation on Android.

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -2812,7 +2812,10 @@ void BasicWriter<Char>::write_int(T value, Spec spec) {
   }
   case 'n': {
     unsigned num_digits = internal::count_digits(abs_value);
-    fmt::StringRef sep = internal::thousands_sep(std::localeconv());
+    fmt::StringRef sep = "";
+#ifndef ANDROID
+    sep = internal::thousands_sep(std::localeconv());
+#endif
     unsigned size = static_cast<unsigned>(
           num_digits + sep.size() * ((num_digits - 1) / 3));
     CharPtr p = prepare_int_buffer(size, spec, prefix, prefix_size) + 1;


### PR DESCRIPTION
The pull request fixes the compilation error on Android's NDK.

```
spdlog/fmt/bundled/format.h:3263: error: undefined reference to 'localeconv'
```