### PR TITLE
Add FMT_OVERRIDE macro to allow specifying overriding functions

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -194,6 +194,17 @@ typedef __int64          intmax_t;
 # endif
 #endif
 
+#ifndef FMT_OVERRIDE
+# if FMT_USE_OVERRIDE || FMT_HAS_FEATURE(cxx_override) || \
+   (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || \
+   FMT_MSC_VER >= 1900
+#  define FMT_OVERRIDE override
+# else
+#  define FMT_OVERRIDE
+# endif
+#endif
+
+
 // A macro to disallow the copy constructor and operator= functions
 // This should be used in the private: declarations for a class
 #ifndef FMT_USE_DELETED_FUNCTIONS
@@ -678,7 +689,7 @@ class MemoryBuffer : private Allocator, public Buffer<T> {
   }
 
  protected:
-  void grow(std::size_t size);
+  void grow(std::size_t size) FMT_OVERRIDE;
 
  public:
   explicit MemoryBuffer(const Allocator &alloc = Allocator())


### PR DESCRIPTION
in c++11 compilers

Also use it where the compiler warns.