### PR TITLE
Extend ArgLists to support serialization/deserialization in third-party components

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -1377,10 +1377,7 @@ class ArgList {
   };
 
   internal::Arg::Type type(unsigned index) const {
-    unsigned shift = index * 4;
-    uint64_t mask = 0xf;
-    return static_cast<internal::Arg::Type>(
-          (types_ & (mask << shift)) >> shift);
+    return type(types_, index);
   }
 
   template <typename Char>
@@ -1396,6 +1393,8 @@ class ArgList {
   : types_(types), values_(values) {}
   ArgList(ULongLong types, const internal::Arg *args)
   : types_(types), args_(args) {}
+
+  uint64_t types() const { return types_; }
 
   /** Returns the argument at specified index. */
   internal::Arg operator[](unsigned index) const {
@@ -1421,6 +1420,13 @@ class ArgList {
         return args_[i];
     }
     return args_[index];
+  }
+
+  static internal::Arg::Type type(uint64_t types, unsigned index) {
+    unsigned shift = index * 4;
+    uint64_t mask = 0xf;
+    return static_cast<internal::Arg::Type>(
+          (types & (mask << shift)) >> shift);
   }
 };
 


### PR DESCRIPTION
I removed CustomValue.size overhead in my PR and keep only types() accessors in ArgList