### PR TITLE
Remove unnecessary "fmt/" prefix inside fmt directory

### DIFF
--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -25,8 +25,8 @@
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "fmt/format.h"
-#include "fmt/printf.h"
+#include "format.h"
+#include "printf.h"
 
 #include <string.h>
 

--- a/fmt/ostream.cc
+++ b/fmt/ostream.cc
@@ -7,7 +7,7 @@
  For the license information refer to format.h.
  */
 
-#include "fmt/ostream.h"
+#include "ostream.h"
 
 namespace fmt {
 

--- a/fmt/ostream.h
+++ b/fmt/ostream.h
@@ -10,7 +10,7 @@
 #ifndef FMT_OSTREAM_H_
 #define FMT_OSTREAM_H_
 
-#include "fmt/format.h"
+#include "format.h"
 #include <ostream>
 
 namespace fmt {

--- a/fmt/posix.cc
+++ b/fmt/posix.cc
@@ -12,7 +12,7 @@
 # define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include "fmt/posix.h"
+#include "posix.h"
 
 #include <limits.h>
 #include <sys/types.h>

--- a/fmt/posix.h
+++ b/fmt/posix.h
@@ -27,7 +27,7 @@
 # include <xlocale.h>  // for LC_NUMERIC_MASK on OS X
 #endif
 
-#include "fmt/format.h"
+#include "format.h"
 
 #ifndef FMT_POSIX
 # if defined(_WIN32) && !defined(__MINGW32__)

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -13,7 +13,7 @@
 #include <algorithm>  // std::fill_n
 #include <limits>     // std::numeric_limits
 
-#include "fmt/ostream.h"
+#include "ostream.h"
 
 namespace fmt {
 namespace internal {

--- a/fmt/string.h
+++ b/fmt/string.h
@@ -10,7 +10,7 @@
 #ifndef FMT_STRING_H_
 #define FMT_STRING_H_
 
-#include "fmt/format.h"
+#include "format.h"
 
 namespace fmt {
 

--- a/fmt/time.h
+++ b/fmt/time.h
@@ -10,7 +10,7 @@
 #ifndef FMT_TIME_H_
 #define FMT_TIME_H_
 
-#include "fmt/format.h"
+#include "format.h"
 #include <ctime>
 
 namespace fmt {


### PR DESCRIPTION
I suggest removing "fmt/" prefix in *.h, *.cc files inside fmt directory. Consider someone using fmt library as a git submodule or third-party library and has format.h helper file with direct referencing: 

#include "../../modules/fmt/fmt/format.h"
#include "../../modules/fmt/fmt/ostream.h"

Nevertheless I put explicit relative path to format.h and ostream.h I need to add include_directories("modules/fmt") anywhere I use my format.h helper, because ostream.h contins the following inside:

#include "fmt/format.h"

and I believe it could be easily replaced without any side effects with  

#include "format.h"