### PR TITLE
Fix Linux compilation with -fno-exceptions

### DIFF
--- a/fmt/posix.cc
+++ b/fmt/posix.cc
@@ -72,7 +72,7 @@ fmt::BufferedFile::BufferedFile(
     fmt::CStringRef filename, fmt::CStringRef mode) {
   FMT_RETRY_VAL(file_, FMT_SYSTEM(fopen(filename.c_str(), mode.c_str())), 0);
   if (!file_)
-    throw SystemError(errno, "cannot open file {}", filename);
+    FMT_THROW(SystemError(errno, "cannot open file {}", filename));
 }
 
 void fmt::BufferedFile::close() {
@@ -81,7 +81,7 @@ void fmt::BufferedFile::close() {
   int result = FMT_SYSTEM(fclose(file_));
   file_ = 0;
   if (result != 0)
-    throw SystemError(errno, "cannot close file");
+    FMT_THROW(SystemError(errno, "cannot close file"));
 }
 
 // A macro used to prevent expansion of fileno on broken versions of MinGW.
@@ -90,7 +90,7 @@ void fmt::BufferedFile::close() {
 int fmt::BufferedFile::fileno() const {
   int fd = FMT_POSIX_CALL(fileno FMT_ARGS(file_));
   if (fd == -1)
-    throw SystemError(errno, "cannot get file descriptor");
+    FMT_THROW(SystemError(errno, "cannot get file descriptor"));
   return fd;
 }
 
@@ -103,7 +103,7 @@ fmt::File::File(fmt::CStringRef path, int oflag) {
   FMT_RETRY(fd_, FMT_POSIX_CALL(open(path.c_str(), oflag, mode)));
 #endif
   if (fd_ == -1)
-    throw SystemError(errno, "cannot open file {}", path);
+    FMT_THROW(SystemError(errno, "cannot open file {}", path));
 }
 
 fmt::File::~File() FMT_NOEXCEPT {
@@ -121,7 +121,7 @@ void fmt::File::close() {
   int result = FMT_POSIX_CALL(close(fd_));
   fd_ = -1;
   if (result != 0)
-    throw SystemError(errno, "cannot close file");
+    FMT_THROW(SystemError(errno, "cannot close file"));
 }
 
 fmt::LongLong fmt::File::size() const {
@@ -143,7 +143,7 @@ fmt::LongLong fmt::File::size() const {
   typedef struct stat Stat;
   Stat file_stat = Stat();
   if (FMT_POSIX_CALL(fstat(fd_, &file_stat)) == -1)
-    throw SystemError(errno, "cannot get file attributes");
+    FMT_THROW(SystemError(errno, "cannot get file attributes"));
   FMT_STATIC_ASSERT(sizeof(fmt::LongLong) >= sizeof(file_stat.st_size),
       "return type of File::size is not large enough");
   return file_stat.st_size;
@@ -154,7 +154,7 @@ std::size_t fmt::File::read(void *buffer, std::size_t count) {
   RWResult result = 0;
   FMT_RETRY(result, FMT_POSIX_CALL(read(fd_, buffer, convert_rwcount(count))));
   if (result < 0)
-    throw SystemError(errno, "cannot read from file");
+    FMT_THROW(SystemError(errno, "cannot read from file"));
   return internal::to_unsigned(result);
 }
 
@@ -162,7 +162,7 @@ std::size_t fmt::File::write(const void *buffer, std::size_t count) {
   RWResult result = 0;
   FMT_RETRY(result, FMT_POSIX_CALL(write(fd_, buffer, convert_rwcount(count))));
   if (result < 0)
-    throw SystemError(errno, "cannot write to file");
+    FMT_THROW(SystemError(errno, "cannot write to file"));
   return internal::to_unsigned(result);
 }
 
@@ -171,7 +171,7 @@ fmt::File fmt::File::dup(int fd) {
   // http://pubs.opengroup.org/onlinepubs/009695399/functions/dup.html
   int new_fd = FMT_POSIX_CALL(dup(fd));
   if (new_fd == -1)
-    throw SystemError(errno, "cannot duplicate file descriptor {}", fd);
+    FMT_THROW(SystemError(errno, "cannot duplicate file descriptor {}", fd));
   return File(new_fd);
 }
 
@@ -179,8 +179,8 @@ void fmt::File::dup2(int fd) {
   int result = 0;
   FMT_RETRY(result, FMT_POSIX_CALL(dup2(fd_, fd)));
   if (result == -1) {
-    throw SystemError(errno,
-      "cannot duplicate file descriptor {} to {}", fd_, fd);
+    FMT_THROW(SystemError(errno,
+      "cannot duplicate file descriptor {} to {}", fd_, fd));
   }
 }
 
@@ -207,7 +207,7 @@ void fmt::File::pipe(File &read_end, File &write_end) {
   int result = FMT_POSIX_CALL(pipe(fds));
 #endif
   if (result != 0)
-    throw SystemError(errno, "cannot create pipe");
+    FMT_THROW(SystemError(errno, "cannot create pipe"));
   // The following assignments don't throw because read_fd and write_fd
   // are closed.
   read_end = File(fds[0]);
@@ -218,7 +218,7 @@ fmt::BufferedFile fmt::File::fdopen(const char *mode) {
   // Don't retry as fdopen doesn't return EINTR.
   FILE *f = FMT_POSIX_CALL(fdopen(fd_, mode));
   if (!f)
-    throw SystemError(errno, "cannot associate stream with file descriptor");
+    FMT_THROW(SystemError(errno, "cannot associate stream with file descriptor"));
   BufferedFile file(f);
   fd_ = -1;
   return file;
@@ -232,7 +232,7 @@ long fmt::getpagesize() {
 #else
   long size = FMT_POSIX_CALL(sysconf(_SC_PAGESIZE));
   if (size < 0)
-    throw SystemError(errno, "cannot get memory page size");
+    FMT_THROW(SystemError(errno, "cannot get memory page size"));
   return size;
 #endif
 }

--- a/fmt/posix.h
+++ b/fmt/posix.h
@@ -338,7 +338,7 @@ class Locale {
 
   Locale() : locale_(newlocale(LC_NUMERIC_MASK, "C", NULL)) {
     if (!locale_)
-      throw fmt::SystemError(errno, "cannot create locale");
+      FMT_THROW(fmt::SystemError(errno, "cannot create locale"));
   }
   ~Locale() { freelocale(locale_); }
 


### PR DESCRIPTION
In some places `throw` was used instead of `FMT_THROW` which caused the compilation to fail when exceptions are disabled.
I didn't change this in the tests but only in the library itself which might be used by projects that are compiled without exceptions.