### PR TITLE
Support Unicode filenames on Windows

### DIFF
--- a/fmt/posix.cc
+++ b/fmt/posix.cc
@@ -64,8 +64,9 @@ inline std::size_t convert_rwcount(std::size_t count) { return count; }
 
 std::FILE* u8fopen(fmt::CStringRef filename, fmt::CStringRef mode) {
 #ifdef _WIN32
-  fmt::UTF8ToUTF16 conv(filename.c_str());
-  return FMT_SYSTEM(_wfopen(conv.c_str(), modebuff));
+  fmt::UTF8ToUTF16 nconv(filename.c_str());
+  fmt::UTF8ToUTF16 mconv(filename.c_str());
+  return FMT_SYSTEM(_wfopen(nconv.c_str(), mconv.c_str()));
 #else
   return FMT_SYSTEM(fopen(filename.c_str(), mode.c_str()));
 #endif

--- a/fmt/posix.cc
+++ b/fmt/posix.cc
@@ -65,7 +65,7 @@ inline std::size_t convert_rwcount(std::size_t count) { return count; }
 std::FILE* u8fopen(fmt::CStringRef filename, fmt::CStringRef mode) {
 #ifdef _WIN32
   fmt::UTF8ToUTF16 nconv(filename.c_str());
-  fmt::UTF8ToUTF16 mconv(filename.c_str());
+  fmt::UTF8ToUTF16 mconv(mode.c_str());
   return FMT_SYSTEM(_wfopen(nconv.c_str(), mconv.c_str()));
 #else
   return FMT_SYSTEM(fopen(filename.c_str(), mode.c_str()));

--- a/fmt/posix.cc
+++ b/fmt/posix.cc
@@ -88,7 +88,7 @@ int u8open(fmt::CStringRef filename, int flags, int mode) {
     FMT_THROW(fmt::WindowsError(::GetLastError(), 
       "couldn't convert filename to native encoding"));
   int fd = -1;
-  FMT_POSIX_CALL(wsopen_s(&fd, namebuff, flags, _SH_DENYNO, mode));
+  FMT_SYSTEM(_wsopen_s(&fd, namebuff, flags, _SH_DENYNO, mode));
   return fd;
 #else
   return FMT_POSIX_CALL(open(filename, flags, mode));


### PR DESCRIPTION
This change allows to open files with UTF-8 encoded strings on Windows (no codepage nonsense). 
Although I am not quite familiar with testing methods used here and therefore have no clue why it fails checks.