### PR TITLE
Using FMT_NULLPTR instead of literal 0

### DIFF
--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -171,7 +171,7 @@ int safe_strerror(
       : error_code_(err_code), buffer_(buf), buffer_size_(buf_size) {}
 
     int run() {
-      strerror_r(0, 0, "");  // Suppress a warning about unused strerror_r.
+      strerror_r(0, FMT_NULLPTR, "");  // Suppress a warning about unused strerror_r.
       return handle(strerror_r(error_code_, buffer_, buffer_size_));
     }
   };
@@ -312,7 +312,7 @@ FMT_FUNC internal::UTF8ToUTF16::UTF8ToUTF16(StringRef s) {
     FMT_THROW(WindowsError(ERROR_INVALID_PARAMETER, ERROR_MSG));
   int s_size = static_cast<int>(s.size());
   int length = MultiByteToWideChar(
-      CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size, 0, 0);
+      CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size, FMT_NULLPTR, 0);
   if (length == 0)
     FMT_THROW(WindowsError(GetLastError(), ERROR_MSG));
   buffer_.resize(length + 1);
@@ -334,12 +334,12 @@ FMT_FUNC int internal::UTF16ToUTF8::convert(WStringRef s) {
   if (s.size() > INT_MAX)
     return ERROR_INVALID_PARAMETER;
   int s_size = static_cast<int>(s.size());
-  int length = WideCharToMultiByte(CP_UTF8, 0, s.data(), s_size, 0, 0, 0, 0);
+  int length = WideCharToMultiByte(CP_UTF8, 0, s.data(), s_size, FMT_NULLPTR, 0, FMT_NULLPTR, FMT_NULLPTR);
   if (length == 0)
     return GetLastError();
   buffer_.resize(length + 1);
   length = WideCharToMultiByte(
-    CP_UTF8, 0, s.data(), s_size, &buffer_[0], length, 0, 0);
+    CP_UTF8, 0, s.data(), s_size, &buffer_[0], length, FMT_NULLPTR, FMT_NULLPTR);
   if (length == 0)
     return GetLastError();
   buffer_[length] = 0;
@@ -363,8 +363,8 @@ FMT_FUNC void internal::format_windows_error(
     for (;;) {
       wchar_t *system_message = &buffer[0];
       int result = FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                                  0, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                                  system_message, static_cast<uint32_t>(buffer.size()), 0);
+                                  FMT_NULLPTR, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                                  system_message, static_cast<uint32_t>(buffer.size()), FMT_NULLPTR);
       if (result != 0) {
         UTF16ToUTF8 utf8_message;
         if (utf8_message.convert(system_message) == ERROR_SUCCESS) {
@@ -408,7 +408,7 @@ void internal::ArgMap<Char>::init(const ArgList &args) {
   if (!map_.empty())
     return;
   typedef internal::NamedArg<Char> NamedArg;
-  const NamedArg *named_arg = 0;
+  const NamedArg *named_arg = FMT_NULLPTR;
   bool use_values =
       args.type(ArgList::MAX_PACKED_ARGS - 1) == internal::Arg::NONE;
   if (use_values) {

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -214,6 +214,16 @@ typedef __int64          intmax_t;
 # endif
 #endif
 
+#ifndef FMT_NULLPTR
+# if FMT_HAS_FEATURE(cxx_nullptr) || \
+   (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || \
+   FMT_MSC_VER >= 1600
+#  define FMT_NULLPTR nullptr
+# else
+#  define FMT_NULLPTR NULL
+# endif
+#endif
+
 // A macro to disallow the copy constructor and operator= functions
 // This should be used in the private: declarations for a class
 #ifndef FMT_USE_DELETED_FUNCTIONS
@@ -618,7 +628,7 @@ class Buffer {
   std::size_t size_;
   std::size_t capacity_;
 
-  Buffer(T *ptr = 0, std::size_t capacity = 0)
+  Buffer(T *ptr = FMT_NULLPTR, std::size_t capacity = 0)
     : ptr_(ptr), size_(0), capacity_(capacity) {}
 
   /**
@@ -748,7 +758,7 @@ void MemoryBuffer<T, SIZE, Allocator>::grow(std::size_t size) {
   std::size_t new_capacity = this->capacity_ + this->capacity_ / 2;
   if (size > new_capacity)
       new_capacity = size;
-  T *new_ptr = this->allocate(new_capacity);
+  T *new_ptr = this->allocate(new_capacity, FMT_NULLPTR);
   // The following code doesn't throw, so the raw pointer above doesn't leak.
   std::uninitialized_copy(this->ptr_, this->ptr_ + this->size_,
                           make_ptr(new_ptr, new_capacity));
@@ -770,7 +780,7 @@ class FixedBuffer : public fmt::Buffer<Char> {
   FixedBuffer(Char *array, std::size_t size) : fmt::Buffer<Char>(array, size) {}
 
  protected:
-  FMT_API void grow(std::size_t size);
+  FMT_API void grow(std::size_t size) FMT_OVERRIDE;
 };
 
 template <typename Char>
@@ -1867,7 +1877,7 @@ class ArgMap {
       if (it->first == name)
         return &it->second;
     }
-    return 0;
+    return FMT_NULLPTR;
   }
 };
 
@@ -1896,7 +1906,7 @@ class ArgFormatterBase : public ArgVisitor<Impl, void> {
   }
 
   void write(const char *value) {
-    Arg::StringValue<char> str = {value, value != 0 ? std::strlen(value) : 0};
+    Arg::StringValue<char> str = {value, value != FMT_NULLPTR ? std::strlen(value) : 0};
     writer_.write_str(str, spec_);
   }
 
@@ -2972,7 +2982,7 @@ void BasicWriter<Char>::write_double(T value, const FormatSpec &spec) {
   // Format using snprintf.
   Char fill = internal::CharTraits<Char>::cast(spec.fill());
   unsigned n = 0;
-  Char *start = 0;
+  Char *start = FMT_NULLPTR;
   for (;;) {
     std::size_t buffer_size = buffer_.capacity() - offset;
 #if FMT_MSC_VER
@@ -3578,7 +3588,7 @@ inline internal::Arg BasicFormatter<Char, AF>::get_arg(
 
 template <typename Char, typename AF>
 inline internal::Arg BasicFormatter<Char, AF>::parse_arg_index(const Char *&s) {
-  const char *error = 0;
+  const char *error = FMT_NULLPTR;
   internal::Arg arg = *s < '0' || *s > '9' ?
         next_arg(error) : get_arg(internal::parse_nonnegative_int(s), error);
   if (error) {
@@ -3596,7 +3606,7 @@ inline internal::Arg BasicFormatter<Char, AF>::parse_arg_name(const Char *&s) {
   do {
     c = *++s;
   } while (internal::is_name_start(c) || ('0' <= c && c <= '9'));
-  const char *error = 0;
+  const char *error = FMT_NULLPTR;
   internal::Arg arg = get_arg(BasicStringRef<Char>(start, s - start), error);
   if (error)
     FMT_THROW(FormatError(error));

--- a/fmt/posix.cc
+++ b/fmt/posix.cc
@@ -79,7 +79,7 @@ void fmt::BufferedFile::close() {
   if (!file_)
     return;
   int result = FMT_SYSTEM(fclose(file_));
-  file_ = 0;
+  file_ = FMT_NULLPTR;
   if (result != 0)
     FMT_THROW(SystemError(errno, "cannot close file"));
 }

--- a/fmt/posix.h
+++ b/fmt/posix.h
@@ -88,7 +88,7 @@ class BufferedFile {
 
  public:
   // Constructs a BufferedFile object which doesn't represent any file.
-  BufferedFile() FMT_NOEXCEPT : file_(0) {}
+  BufferedFile() FMT_NOEXCEPT : file_(FMT_NULLPTR) {}
 
   // Destroys the object closing the file it represents if any.
   ~BufferedFile() FMT_NOEXCEPT;
@@ -110,7 +110,7 @@ public:
 
   // A "move constructor" for moving from an lvalue.
   BufferedFile(BufferedFile &f) FMT_NOEXCEPT : file_(f.file_) {
-    f.file_ = 0;
+    f.file_ = FMT_NULLPTR;
   }
 
   // A "move assignment operator" for moving from a temporary.
@@ -124,7 +124,7 @@ public:
   BufferedFile &operator=(BufferedFile &other) {
     close();
     file_ = other.file_;
-    other.file_ = 0;
+    other.file_ = FMT_NULLPTR;
     return *this;
   }
 
@@ -132,7 +132,7 @@ public:
   //   BufferedFile file = BufferedFile(...);
   operator Proxy() FMT_NOEXCEPT {
     Proxy p = {file_};
-    file_ = 0;
+    file_ = FMT_NULLPTR;
     return p;
   }
 
@@ -142,13 +142,13 @@ public:
 
  public:
   BufferedFile(BufferedFile &&other) FMT_NOEXCEPT : file_(other.file_) {
-    other.file_ = 0;
+    other.file_ = FMT_NULLPTR;
   }
 
   BufferedFile& operator=(BufferedFile &&other) {
     close();
     file_ = other.file_;
-    other.file_ = 0;
+    other.file_ = FMT_NULLPTR;
     return *this;
   }
 #endif
@@ -336,7 +336,7 @@ class Locale {
  public:
   typedef locale_t Type;
 
-  Locale() : locale_(newlocale(LC_NUMERIC_MASK, "C", NULL)) {
+  Locale() : locale_(newlocale(LC_NUMERIC_MASK, "C", FMT_NULLPTR)) {
     if (!locale_)
       FMT_THROW(fmt::SystemError(errno, "cannot create locale"));
   }
@@ -347,7 +347,7 @@ class Locale {
   // Converts string to floating-point number and advances str past the end
   // of the parsed input.
   double strtod(const char *&str) const {
-    char *end = 0;
+    char *end = FMT_NULLPTR;
     double result = strtod_l(str, &end, locale_);
     str = end;
     return result;

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -341,7 +341,7 @@ template <typename Char, typename AF>
 internal::Arg PrintfFormatter<Char, AF>::get_arg(const Char *s,
                                                  unsigned arg_index) {
   (void)s;
-  const char *error = 0;
+  const char *error = FMT_NULLPTR;
   internal::Arg arg = arg_index == std::numeric_limits<unsigned>::max() ?
     next_arg(error) : FormatterBase::get_arg(arg_index - 1, error);
   if (error)

--- a/fmt/string.h
+++ b/fmt/string.h
@@ -23,7 +23,7 @@ class StringBuffer : public Buffer<Char> {
   std::basic_string<Char> data_;
 
  protected:
-  virtual void grow(std::size_t size) {
+  virtual void grow(std::size_t size) FMT_OVERRIDE {
     data_.resize(size);
     this->ptr_ = &data_[0];
     this->capacity_ = size;
@@ -35,7 +35,7 @@ class StringBuffer : public Buffer<Char> {
     data_.resize(this->size_);
     str.swap(data_);
     this->capacity_ = this->size_ = 0;
-    this->ptr_ = 0;
+    this->ptr_ = FMT_NULLPTR;
   }
 };
 }  // namespace internal

--- a/fmt/time.h
+++ b/fmt/time.h
@@ -75,7 +75,7 @@ inline std::tm localtime(std::time_t time) {
       return handle(localtime_r(&time_, &tm_));
     }
 
-    bool handle(std::tm* tm) { return tm != 0; }
+    bool handle(std::tm* tm) { return tm != FMT_NULLPTR; }
 
     bool handle(internal::Null<>) {
       using namespace fmt::internal;
@@ -87,8 +87,8 @@ inline std::tm localtime(std::time_t time) {
     bool fallback(internal::Null<>) {
       using namespace fmt::internal;
       std::tm* tm = std::localtime(&time_);
-      if (tm != 0) tm_ = *tm;
-      return tm != 0;
+      if (tm != FMT_NULLPTR) tm_ = *tm;
+      return tm != FMT_NULLPTR;
     }
   };
   LocalTime lt(time);
@@ -112,7 +112,7 @@ inline std::tm gmtime(std::time_t time) {
       return handle(gmtime_r(&time_, &tm_));
     }
 
-    bool handle(std::tm* tm) { return tm != 0; }
+    bool handle(std::tm* tm) { return tm != FMT_NULLPTR; }
 
     bool handle(internal::Null<>) {
       using namespace fmt::internal;
@@ -123,8 +123,8 @@ inline std::tm gmtime(std::time_t time) {
 
     bool fallback(internal::Null<>) {
       std::tm* tm = std::gmtime(&time_);
-      if (tm != 0) tm_ = *tm;
-      return tm != 0;
+      if (tm != FMT_NULLPTR) tm_ = *tm;
+      return tm != FMT_NULLPTR;
     }
   };
   GMTime gt(time);

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -250,7 +250,7 @@ TEST(WriterTest, Allocator) {
   std::size_t size =
       static_cast<std::size_t>(1.5 * fmt::internal::INLINE_BUFFER_SIZE);
   std::vector<char> mem(size);
-  EXPECT_CALL(alloc, allocate(size)).WillOnce(testing::Return(&mem[0]));
+  EXPECT_CALL(alloc, allocate(size, 0)).WillOnce(testing::Return(&mem[0]));
   for (int i = 0; i < fmt::internal::INLINE_BUFFER_SIZE + 1; ++i)
     w << '*';
   EXPECT_CALL(alloc, deallocate(&mem[0], size));

--- a/test/mock-allocator.h
+++ b/test/mock-allocator.h
@@ -36,7 +36,7 @@ class MockAllocator {
   MockAllocator() {}
   MockAllocator(const MockAllocator &) {}
   typedef T value_type;
-  MOCK_METHOD1_T(allocate, T* (std::size_t n));
+  MOCK_METHOD2_T(allocate, T* (std::size_t n, const T* h));
   MOCK_METHOD2_T(deallocate, void (T* p, std::size_t n));
 };
 
@@ -78,7 +78,7 @@ class AllocatorRef {
 
   Allocator *get() const { return alloc_; }
 
-  value_type* allocate(std::size_t n) { return alloc_->allocate(n); }
+  value_type* allocate(std::size_t n,  const value_type* h) { return alloc_->allocate(n, h); }
   void deallocate(value_type* p, std::size_t n) { alloc_->deallocate(p, n); }
 };
 

--- a/test/util-test.cc
+++ b/test/util-test.cc
@@ -83,8 +83,8 @@ void CheckForwarding(
   // Check if value_type is properly defined.
   AllocatorRef< MockAllocator<int> >::value_type *ptr = &mem;
   // Check forwarding.
-  EXPECT_CALL(alloc, allocate(42)).WillOnce(Return(ptr));
-  ref.allocate(42);
+  EXPECT_CALL(alloc, allocate(42, 0)).WillOnce(Return(ptr));
+  ref.allocate(42, 0);
   EXPECT_CALL(alloc, deallocate(ptr, 42));
   ref.deallocate(ptr, 42);
 }
@@ -339,7 +339,7 @@ TEST(MemoryBufferTest, Grow) {
   EXPECT_EQ(10u, buffer.capacity());
   int mem[20];
   mem[7] = 0xdead;
-  EXPECT_CALL(alloc, allocate(20)).WillOnce(Return(mem));
+  EXPECT_CALL(alloc, allocate(20, 0)).WillOnce(Return(mem));
   buffer.grow(20);
   EXPECT_EQ(20u, buffer.capacity());
   // Check if size elements have been copied
@@ -360,7 +360,7 @@ TEST(MemoryBufferTest, Allocator) {
     MemoryBuffer<char, 10, TestAllocator> buffer2((TestAllocator(&alloc)));
     EXPECT_EQ(&alloc, buffer2.get_allocator().get());
     std::size_t size = 2 * fmt::internal::INLINE_BUFFER_SIZE;
-    EXPECT_CALL(alloc, allocate(size)).WillOnce(Return(&mem));
+    EXPECT_CALL(alloc, allocate(size, 0)).WillOnce(Return(&mem));
     buffer2.reserve(size);
     EXPECT_CALL(alloc, deallocate(&mem, size));
   }
@@ -373,13 +373,13 @@ TEST(MemoryBufferTest, ExceptionInDeallocate) {
   std::size_t size = 2 * fmt::internal::INLINE_BUFFER_SIZE;
   std::vector<char> mem(size);
   {
-    EXPECT_CALL(alloc, allocate(size)).WillOnce(Return(&mem[0]));
+    EXPECT_CALL(alloc, allocate(size, 0)).WillOnce(Return(&mem[0]));
     buffer.resize(size);
     std::fill(&buffer[0], &buffer[0] + size, 'x');
   }
   std::vector<char> mem2(2 * size);
   {
-    EXPECT_CALL(alloc, allocate(2 * size)).WillOnce(Return(&mem2[0]));
+    EXPECT_CALL(alloc, allocate(2 * size, 0)).WillOnce(Return(&mem2[0]));
     std::exception e;
     EXPECT_CALL(alloc, deallocate(&mem[0], size)).WillOnce(testing::Throw(e));
     EXPECT_THROW(buffer.reserve(2 * size), std::exception);


### PR DESCRIPTION
Based on [issue 408](https://github.com/fmtlib/fmt/issues/408)

I've added FMT_NULLPTR macro (similar to other emulated language features there) that would expand to NULL or nullptr if available, as gcc isn't happy even with NULL in some cases.

Also added a couple of FMT_OVERRIDE where necessary.
