### PR TITLE
Add std::basic_string allocator support to StringRef, StringBuffer and relatives

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -440,7 +440,8 @@ class BasicFormatter;
 
 /**
   \rst
-  A string reference. It can be constructed from a C string or ``std::string``.
+  A string reference. It can be constructed from a C string or
+  ``std::basic_string``.
 
   You can use one of the following typedefs for common character types:
 
@@ -483,19 +484,24 @@ class BasicStringRef {
 
   /**
     \rst
-    Constructs a string reference from an ``std::string`` object.
+    Constructs a string reference from a ``std::basic_string`` object.
     \endrst
    */
-  BasicStringRef(const std::basic_string<Char> &s)
+  template <typename Allocator>
+  BasicStringRef(
+      const std::basic_string<Char, std::char_traits<Char>, Allocator> &s)
   : data_(s.c_str()), size_(s.size()) {}
 
   /**
     \rst
-    Converts a string reference to an ``std::string`` object.
+    Converts a string reference to a ``std::basic_string`` object.
     \endrst
    */
-  std::basic_string<Char> to_string() const {
-    return std::basic_string<Char>(data_, size_);
+  template <typename Allocator = std::allocator<Char> >
+  std::basic_string<Char, std::char_traits<Char>, Allocator>
+  to_string(const Allocator &allocator = Allocator()) const {
+    return std::basic_string<Char, std::char_traits<Char>, Allocator>(
+               data_, size_, allocator);
   }
 
   /** Returns a pointer to the string data. */
@@ -539,7 +545,7 @@ typedef BasicStringRef<wchar_t> WStringRef;
 /**
   \rst
   A reference to a null terminated string. It can be constructed from a C
-  string or ``std::string``.
+  string or ``std::basic_string``.
 
   You can use one of the following typedefs for common character types:
 
@@ -572,10 +578,13 @@ class BasicCStringRef {
 
   /**
     \rst
-    Constructs a string reference from an ``std::string`` object.
+    Constructs a string reference from a ``std::basic_string`` object.
     \endrst
    */
-  BasicCStringRef(const std::basic_string<Char> &s) : data_(s.c_str()) {}
+  template <typename Allocator>
+  BasicCStringRef(
+      const std::basic_string<Char, std::char_traits<Char>, Allocator> &s)
+  : data_(s.c_str()) {}
 
   /** Returns the pointer to a C string. */
   const Char *c_str() const { return data_; }
@@ -2567,11 +2576,14 @@ class BasicWriter {
 
   /**
     \rst
-    Returns the content of the output buffer as an `std::string`.
+    Returns the content of the output buffer as a `std::basic_string`.
     \endrst
    */
-  std::basic_string<Char> str() const {
-    return std::basic_string<Char>(&buffer_[0], buffer_.size());
+  template <typename Allocator = std::allocator<Char> >
+  std::basic_string<Char, std::char_traits<Char>, Allocator> str(
+      const Allocator &allocator = Allocator()) const {
+    return std::basic_string<Char, std::char_traits<Char>, Allocator>(
+               &buffer_[0], buffer_.size(), allocator);
   }
 
   /**

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -494,14 +494,11 @@ class BasicStringRef {
 
   /**
     \rst
-    Converts a string reference to a ``std::basic_string`` object.
+    Converts a string reference to an ``std::string`` object.
     \endrst
    */
-  template <typename Allocator = std::allocator<Char> >
-  std::basic_string<Char, std::char_traits<Char>, Allocator>
-  to_string(const Allocator &allocator = Allocator()) const {
-    return std::basic_string<Char, std::char_traits<Char>, Allocator>(
-               data_, size_, allocator);
+  std::basic_string<Char> to_string() const {
+    return std::basic_string<Char>(data_, size_);
   }
 
   /** Returns a pointer to the string data. */
@@ -2576,14 +2573,11 @@ class BasicWriter {
 
   /**
     \rst
-    Returns the content of the output buffer as a `std::basic_string`.
+    Returns the content of the output buffer as an `std::string`.
     \endrst
    */
-  template <typename Allocator = std::allocator<Char> >
-  std::basic_string<Char, std::char_traits<Char>, Allocator> str(
-      const Allocator &allocator = Allocator()) const {
-    return std::basic_string<Char, std::char_traits<Char>, Allocator>(
-               &buffer_[0], buffer_.size(), allocator);
+  std::basic_string<Char> str() const {
+    return std::basic_string<Char>(&buffer_[0], buffer_.size());
   }
 
   /**

--- a/fmt/string.h
+++ b/fmt/string.h
@@ -20,10 +20,10 @@ namespace internal {
 template <typename Char, typename Allocator = std::allocator<Char> >
 class StringBuffer : public Buffer<Char> {
  public:
-  typedef std::basic_string<Char, std::char_traits<Char>, Allocator> string_type;
+  typedef std::basic_string<Char, std::char_traits<Char>, Allocator> StringType;
 
  private:
-  string_type data_;
+  StringType data_;
 
  protected:
   virtual void grow(std::size_t size) FMT_OVERRIDE {
@@ -37,7 +37,7 @@ class StringBuffer : public Buffer<Char> {
   : data_(allocator) {}
 
   // Moves the data to ``str`` clearing the buffer.
-  void move_to(string_type &str) {
+  void move_to(StringType &str) {
     data_.resize(this->size_);
     str.swap(data_);
     this->capacity_ = this->size_ = 0;
@@ -49,7 +49,7 @@ class StringBuffer : public Buffer<Char> {
 /**
   \rst
   This class template provides operations for formatting and writing data
-  into a character stream. The output is stored in ``std::basic_string``
+  into a character stream. The output is stored in a ``std::basic_string``
   that grows dynamically.
 
   You can use one of the following typedefs for common character types


### PR DESCRIPTION
## `std::basic_string` allocator support
Modified the constructors of `BasicStringRef` and `BasicCStringRef` to accept `std::basic_string`s with any allocator. Also modified and `BasicWriter.str()` to accept custom allocator parameter. This allows the following code to work:
```c++
using scalable_string = std::basic_string<char, std::char_traits<char>, scalable_allocator<char> >;
fmt::MemoryWriter writer;
writer << "Hello from " << scalable_string{"fmtlib"} << '\n';
const scalable_string result_str = writer.str<scalable_allocator<char> >();
```

Modified `StringBuffer` and `BasicStringWriter` to accept custom allocator template parameters for the internal string and the `move_to` parameter.