### PR TITLE
Don't export the -std=c++11 flag from the fmt target

### DIFF
--- a/fmt/CMakeLists.txt
+++ b/fmt/CMakeLists.txt
@@ -16,7 +16,9 @@ if (FMT_CPPFORMAT)
 endif ()
 
 # Starting with cmake 3.1 the CXX_STANDARD property can be used instead.
-target_compile_options(fmt PUBLIC ${CPP11_FLAG})
+# Note: Don't make -std=c++11 public or interface, since it breaks projects
+# that use C++14.
+target_compile_options(fmt PRIVATE ${CPP11_FLAG})
 if (FMT_PEDANTIC)
   target_compile_options(fmt PRIVATE ${PEDANTIC_COMPILE_FLAGS})
 endif ()


### PR DESCRIPTION
Currently the `fmt` CMake target exports `-std=c++11` as part of its interface; Meaning any project that links to `fmt` has the `-std=c++11` added to its compilation. However this will override the `-std=<ver>` flag provided by that project. This breaks projects that use C++14 or C++1z. In general I think it's bad style for projects to force a specific dialect, or any compile flags, upon its users. 

This patch fixes the issue by making `-std=c++11` a private flag of `fmt`. This prevent it from infecting downstream users.