### PR TITLE
Fix missing intrinsic when included from C++/CLI

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -289,7 +289,7 @@ typedef __int64          intmax_t;
 // otherwise support __builtin_clz and __builtin_clzll, so
 // only define FMT_BUILTIN_CLZ using the MSVC intrinsics
 // if the clz and clzll builtins are not available.
-#if FMT_MSC_VER && !defined(FMT_BUILTIN_CLZLL)
+#if FMT_MSC_VER && !defined(FMT_BUILTIN_CLZLL) && !defined(_MANAGED)
 # include <intrin.h>  // _BitScanReverse, _BitScanReverse64
 
 namespace fmt {


### PR DESCRIPTION
Managed C++ code doesn't have the _BitScanReverse* intrinsics, we must use the fallback code for count_digits etc.