### PR TITLE
Fix Android not being detected with latest NDK toolchain

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -2916,7 +2916,7 @@ void BasicWriter<Char>::write_int(T value, Spec spec) {
   case 'n': {
     unsigned num_digits = internal::count_digits(abs_value);
     fmt::StringRef sep = "";
-#ifndef ANDROID
+#if !(defined(ANDROID) || defined(__ANDROID__))
     sep = internal::thousands_sep(std::localeconv());
 #endif
     unsigned size = static_cast<unsigned>(


### PR DESCRIPTION
When using the NDK 13b toolchain standalone or with CMake, ANDROID is not defined,
but __ANDROID__ is defined instead.

I can't say for sure that is and will always be the case, but it works for me, and I have some unofficial sources: http://stackoverflow.com/a/15335544 and http://markmail.org/message/5ekhfztchs45lz3n#query:+page:1+mid:jfqgzrmwm37uyrt6+state:results

<!---
Please make sure you've followed the guidelines outlined in the CONTRIBUTING.rst file.
--->
