### PR TITLE
Add default copy constructor to SystemError

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -2405,6 +2405,7 @@ class SystemError : public internal::RuntimeError {
   SystemError(int error_code, CStringRef message) {
     init(error_code, message, ArgList());
   }
+  SystemError(const SystemError&) = default;
   FMT_VARIADIC_CTOR(SystemError, init, int, CStringRef)
 
   FMT_API ~SystemError() FMT_DTOR_NOEXCEPT;

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -253,13 +253,10 @@ typedef __int64          intmax_t;
 #ifndef FMT_DEFAULTED_COPY_CTOR
 # if FMT_USE_DEFAULTED_FUNCTIONS || FMT_HAS_FEATURE(cxx_defaulted_functions) || \
    (FMT_GCC_VERSION >= 404 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1800
-#  define FMT_DEFAULTED  = default
 #  define FMT_DEFAULTED_COPY_CTOR(TypeName) \
-    TypeName(const TypeName&) = default
+    TypeName(const TypeName&) = default;
 # else
-#  define FMT_DEFAULTED  {}
-#  define FMT_DEFAULTED_COPY_CTOR(TypeName) \
-    TypeName(const TypeName&) {}
+#  define FMT_DEFAULTED_COPY_CTOR(TypeName)
 # endif
 #endif
 
@@ -2422,7 +2419,7 @@ class SystemError : public internal::RuntimeError {
   SystemError(int error_code, CStringRef message) {
     init(error_code, message, ArgList());
   }
-  FMT_DEFAULTED_COPY_CTOR(SystemError);
+  FMT_DEFAULTED_COPY_CTOR(SystemError)
   FMT_VARIADIC_CTOR(SystemError, init, int, CStringRef)
 
   FMT_API ~SystemError() FMT_DTOR_NOEXCEPT;

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -246,6 +246,23 @@ typedef __int64          intmax_t;
     TypeName& operator=(const TypeName&)
 #endif
 
+#ifndef FMT_USE_DEFAULTED_FUNCTIONS
+# define FMT_USE_DEFAULTED_FUNCTIONS 0
+#endif
+
+#ifndef FMT_DEFAULTED_COPY_CTOR
+# if FMT_USE_DEFAULTED_FUNCTIONS || FMT_HAS_FEATURE(cxx_defaulted_functions) || \
+   (FMT_GCC_VERSION >= 404 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1800
+#  define FMT_DEFAULTED  = default
+#  define FMT_DEFAULTED_COPY_CTOR(TypeName) \
+    TypeName(const TypeName&) = default
+# else
+#  define FMT_DEFAULTED  {}
+#  define FMT_DEFAULTED_COPY_CTOR(TypeName) \
+    TypeName(const TypeName&) {}
+# endif
+#endif
+
 #ifndef FMT_USE_USER_DEFINED_LITERALS
 // All compilers which support UDLs also support variadic templates. This
 // makes the fmt::literals implementation easier. However, an explicit check
@@ -2405,7 +2422,7 @@ class SystemError : public internal::RuntimeError {
   SystemError(int error_code, CStringRef message) {
     init(error_code, message, ArgList());
   }
-  SystemError(const SystemError&) = default;
+  FMT_DEFAULTED_COPY_CTOR(SystemError);
   FMT_VARIADIC_CTOR(SystemError, init, int, CStringRef)
 
   FMT_API ~SystemError() FMT_DTOR_NOEXCEPT;


### PR DESCRIPTION
This PR fixes 
```fmt/format.h:2387:3: error: definition of implicit copy constructor for 'SystemError' is deprecated because it has a user-declared destructor [-Werror,-Wdeprecated]   ~SystemError() FMT_DTOR_NOEXCEPT;``` 
in clang-3.9