### PR TITLE
Don't bring Arg struct into global namespace

### DIFF
--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -455,9 +455,9 @@ void internal::FixedBuffer<Char>::grow(std::size_t) {
   FMT_THROW(std::runtime_error("buffer overflow"));
 }
 
-FMT_FUNC Arg internal::FormatterBase::do_get_arg(
+FMT_FUNC fmt::internal::Arg internal::FormatterBase::do_get_arg(
     unsigned arg_index, const char *&error) {
-  Arg arg = args_[arg_index];
+  fmt::internal::Arg arg = args_[arg_index];
   switch (arg.type) {
   case Arg::NONE:
     error = "argument index out of range";


### PR DESCRIPTION
This fixes compiling fmtlib in header-only mode when user code also has
something called 'Arg' defined: the using in format.cc brings fmt::internal::Arg into the global namespace. This change means that the Arg struct is referred to with its full namespace.
