### PR TITLE
printf("%.f") should use zero precision, not default precision

### DIFF
--- a/fmt/ostream.h
+++ b/fmt/ostream.h
@@ -90,8 +90,8 @@ public:
 }  // namespace internal
 
 // Formats a value.
-template <typename Char, typename ArgFormatter_, typename T>
-void format_arg(BasicFormatter<Char, ArgFormatter_> &f,
+template <typename ArgFormatter_, typename T, typename Char=typename ArgFormatter_::Char>
+void format_arg(UserFormatter<ArgFormatter_> &f,
                 const Char *&format_str, const T &value) {
   internal::MemoryBuffer<Char, internal::INLINE_BUFFER_SIZE> buffer;
 

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -439,6 +439,8 @@ void PrintfFormatter<Char, AF>::format(BasicCStringRef<Char> format_str) {
       } else if (*s == '*') {
         ++s;
         spec.precision_ = internal::PrecisionHandler().visit(get_arg(s));
+      } else {
+          spec.precision_ = 0;
       }
     }
 

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -290,7 +290,7 @@ class BasicPrintfArgFormatter :
 
   /** Formats an argument of a custom (user-defined) type. */
   void visit_custom(internal::Arg::CustomValue c) {
-    BasicFormatter<Char> formatter(ArgList(), this->writer());
+    UserFormatter<BasicPrintfArgFormatter> formatter(*this);
     const Char format_str[] = {'}', 0};
     const Char *format = format_str;
     c.format(&formatter, c.value, &format);
@@ -308,7 +308,7 @@ class PrintfArgFormatter :
 };
 
 /** This template formats data and writes the output to a writer. */
-template <typename Char, typename ArgFormatter = PrintfArgFormatter<Char> >
+template <typename Char, typename AF = PrintfArgFormatter<Char> >
 class PrintfFormatter : private internal::FormatterBase {
  private:
   BasicWriter<Char> &writer_;
@@ -325,6 +325,7 @@ class PrintfFormatter : private internal::FormatterBase {
   unsigned parse_header(const Char *&s, FormatSpec &spec);
 
  public:
+  typedef AF ArgFormatter;
   /**
    \rst
    Constructs a ``PrintfFormatter`` object. References to the arguments and

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -440,7 +440,7 @@ void PrintfFormatter<Char, AF>::format(BasicCStringRef<Char> format_str) {
         ++s;
         spec.precision_ = internal::PrecisionHandler().visit(get_arg(s));
       } else {
-          spec.precision_ = 0;
+        spec.precision_ = 0;
       }
     }
 

--- a/fmt/time.h
+++ b/fmt/time.h
@@ -21,7 +21,7 @@
 
 namespace fmt {
 template <typename ArgFormatter>
-void format_arg(BasicFormatter<char, ArgFormatter> &f,
+void format_arg(UserFormatter<ArgFormatter> &f,
                 const char *&format_str, const std::tm &tm) {
   if (*format_str == ':')
     ++format_str;

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -401,6 +401,9 @@ TEST(PrintfTest, LongLong) {
 
 TEST(PrintfTest, Float) {
   EXPECT_PRINTF("392.650000", "%f", 392.65);
+  EXPECT_PRINTF("392.65", "%.2f", 392.65);
+  EXPECT_PRINTF("392.6", "%.1f", 392.65);
+  EXPECT_PRINTF("392", "%.f", 392.65);
   EXPECT_PRINTF("392.650000", "%F", 392.65);
   EXPECT_PRINTF("392.65", "%s", 392.65);
   char buffer[BUFFER_SIZE];

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -403,7 +403,7 @@ TEST(PrintfTest, Float) {
   EXPECT_PRINTF("392.650000", "%f", 392.65);
   EXPECT_PRINTF("392.65", "%.2f", 392.65);
   EXPECT_PRINTF("392.6", "%.1f", 392.65);
-  EXPECT_PRINTF("392", "%.f", 392.65);
+  EXPECT_PRINTF("393", "%.f", 392.65);
   EXPECT_PRINTF("392.650000", "%F", 392.65);
   EXPECT_PRINTF("392.65", "%s", 392.65);
   char buffer[BUFFER_SIZE];


### PR DESCRIPTION
Really minor change to make fmt::printf better conform to the man page when omitting the optional precision digit

An optional period, `.', followed by an optional digit string giving a precision which specifies the number of digits to appear after the decimal point, for e and f formats, or the maximum number of bytes to be printed from a string; if the digit string is missing, the precision is treated as zero;