### PR TITLE
Fix FormatBuf implementation (#491)

### DIFF
--- a/test/ostream-test.cc
+++ b/test/ostream-test.cc
@@ -191,3 +191,24 @@ TEST(OStreamTest, WriteToOStreamMaxSize) {
   } while (size != 0);
   fmt::internal::write(os, w);
 }
+
+struct Xs {
+  const size_t size;
+  const std::string s;
+  Xs() : size(200), s(size, 'x') {}
+};
+
+inline std::ostream& operator<<(std::ostream& os, Xs const& xs) {
+  return os << xs.s;
+}
+
+TEST(OStreamTest, FormatBuf1) {
+  Xs xs;
+  fmt::MemoryWriter w;
+  int n = fmt::internal::INLINE_BUFFER_SIZE / xs.size + 1;
+  for (int i = 0; i < n; ++i)
+    w << xs;
+  EXPECT_EQ(w.size(), size_t(n * xs.size));
+  w << xs;
+  EXPECT_EQ(w.size(), size_t((n + 1) * xs.size));
+}

--- a/test/ostream-test.cc
+++ b/test/ostream-test.cc
@@ -192,6 +192,7 @@ TEST(OStreamTest, WriteToOStreamMaxSize) {
   fmt::internal::write(os, w);
 }
 
+#if __cplusplus >= 201103L
 struct Xs {
   const size_t size;
   const std::string s;
@@ -212,3 +213,4 @@ TEST(OStreamTest, FormatBuf1) {
   w << xs;
   EXPECT_EQ(w.size(), size_t((n + 1) * xs.size));
 }
+#endif


### PR DESCRIPTION
Fixes #491 (and probably #480) Before, the put-area of the custom streambuf
implementation was (sometimes) incorrectly extended beyond the writeable buffer.
The new implementation is in some cases not as efficient as the old, but avoids
to write into uninitialized memory.