### PR TITLE
Fix Visual Studio 2017 new warning (C4244: 'argument': conversion fro…

### DIFF
--- a/fmt/ostream.h
+++ b/fmt/ostream.h
@@ -38,7 +38,7 @@ class FormatBuf : public std::basic_streambuf<Char> {
 
   int_type overflow(int_type ch = traits_type::eof()) FMT_OVERRIDE {
     if (!traits_type::eq_int_type(ch, traits_type::eof()))
-      buffer_.push_back(ch);
+      buffer_.push_back(static_cast<Char>(ch));
     return ch;
   }
 


### PR DESCRIPTION
…m 'int' to 'const char', possible loss of data)

<!---
Please make sure you've followed the guidelines outlined in the CONTRIBUTING.rst file.
--->
