### PR TITLE
Allow compiling and using as DLL in windows

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -732,7 +732,8 @@ class Buffer {
 template <typename T>
 template <typename U>
 void Buffer<T>::append(const U *begin, const U *end) {
-  std::size_t new_size = size_ + internal::to_unsigned(end - begin);
+  FMT_ASSERT(end >= begin, "negative value");
+  std::size_t new_size = size_ + (end - begin);
   if (new_size > capacity_)
     grow(new_size);
   std::uninitialized_copy(begin, end,

--- a/fmt/ostream.h
+++ b/fmt/ostream.h
@@ -67,7 +67,7 @@ struct ConvertToIntImpl<T, true> {
 };
 
 // Write the content of w to os.
-void write(std::ostream &os, Writer &w);
+FMT_API void write(std::ostream &os, Writer &w);
 
 #if FMT_HAS_DECLTYPE_INCOMPLETE_RETURN_TYPES
 template<typename T>

--- a/fmt/posix.h
+++ b/fmt/posix.h
@@ -91,7 +91,7 @@ class BufferedFile {
   BufferedFile() FMT_NOEXCEPT : file_(FMT_NULL) {}
 
   // Destroys the object closing the file it represents if any.
-  ~BufferedFile() FMT_NOEXCEPT;
+  FMT_API ~BufferedFile() FMT_NOEXCEPT;
 
 #if !FMT_USE_RVALUE_REFERENCES
   // Emulate a move constructor and a move assignment operator if rvalue
@@ -154,17 +154,17 @@ public:
 #endif
 
   // Opens a file.
-  BufferedFile(CStringRef filename, CStringRef mode);
+  FMT_API BufferedFile(CStringRef filename, CStringRef mode);
 
   // Closes the file.
-  void close();
+  FMT_API void close();
 
   // Returns the pointer to a FILE object representing this file.
   FILE *get() const FMT_NOEXCEPT { return file_; }
 
   // We place parentheses around fileno to workaround a bug in some versions
   // of MinGW that define fileno as a macro.
-  int (fileno)() const;
+  FMT_API int (fileno)() const;
 
   void print(CStringRef format_str, const ArgList &args) {
     fmt::print(file_, format_str, args);
@@ -197,7 +197,7 @@ class File {
   File() FMT_NOEXCEPT : fd_(-1) {}
 
   // Opens a file and constructs a File object representing this file.
-  File(CStringRef path, int oflag);
+  FMT_API File(CStringRef path, int oflag);
 
 #if !FMT_USE_RVALUE_REFERENCES
   // Emulate a move constructor and a move assignment operator if rvalue
@@ -260,43 +260,43 @@ class File {
 #endif
 
   // Destroys the object closing the file it represents if any.
-  ~File() FMT_NOEXCEPT;
+  FMT_API ~File() FMT_NOEXCEPT;
 
   // Returns the file descriptor.
   int descriptor() const FMT_NOEXCEPT { return fd_; }
 
   // Closes the file.
-  void close();
+  FMT_API void close();
 
   // Returns the file size. The size has signed type for consistency with
   // stat::st_size.
-  LongLong size() const;
+  FMT_API LongLong size() const;
 
   // Attempts to read count bytes from the file into the specified buffer.
-  std::size_t read(void *buffer, std::size_t count);
+  FMT_API std::size_t read(void *buffer, std::size_t count);
 
   // Attempts to write count bytes from the specified buffer to the file.
-  std::size_t write(const void *buffer, std::size_t count);
+  FMT_API std::size_t write(const void *buffer, std::size_t count);
 
   // Duplicates a file descriptor with the dup function and returns
   // the duplicate as a file object.
-  static File dup(int fd);
+  FMT_API static File dup(int fd);
 
   // Makes fd be the copy of this file descriptor, closing fd first if
   // necessary.
-  void dup2(int fd);
+  FMT_API void dup2(int fd);
 
   // Makes fd be the copy of this file descriptor, closing fd first if
   // necessary.
-  void dup2(int fd, ErrorCode &ec) FMT_NOEXCEPT;
+  FMT_API void dup2(int fd, ErrorCode &ec) FMT_NOEXCEPT;
 
   // Creates a pipe setting up read_end and write_end file objects for reading
   // and writing respectively.
-  static void pipe(File &read_end, File &write_end);
+  FMT_API static void pipe(File &read_end, File &write_end);
 
   // Creates a BufferedFile object associated with this file and detaches
   // this File object from the file.
-  BufferedFile fdopen(const char *mode);
+  FMT_API BufferedFile fdopen(const char *mode);
 };
 
 // Returns the memory page size.

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -62,21 +62,21 @@ class IsZeroInt : public ArgVisitor<IsZeroInt, bool> {
 };
 
 // returns the default type for format specific "%s"
-class DefaultType : public ArgVisitor<DefaultType, wchar_t> {
+class DefaultType : public ArgVisitor<DefaultType, char> {
  public:
-  wchar_t visit_char(int) { return 'c'; }
+  char visit_char(int) { return 'c'; }
 
-  wchar_t visit_bool(bool) { return 's'; }
+  char visit_bool(bool) { return 's'; }
 
-  wchar_t visit_pointer(const void *) { return 'p'; }
-
-  template <typename T>
-  wchar_t visit_any_int(T) { return 'd'; }
+  char visit_pointer(const void *) { return 'p'; }
 
   template <typename T>
-  wchar_t visit_any_double(T) { return 'g'; }
+  char visit_any_int(T) { return 'd'; }
 
-  wchar_t visit_unhandled_arg() { return 's'; }
+  template <typename T>
+  char visit_any_double(T) { return 'g'; }
+
+  char visit_unhandled_arg() { return 's'; }
 };
 
 template <typename T, typename U>
@@ -495,9 +495,7 @@ void PrintfFormatter<Char, AF>::format(BasicCStringRef<Char> format_str) {
 
     if (spec.type_ == 's') {
       // set the format type to the default if 's' is specified
-
-      // Avoid warning for wchar_t
-      spec.type_ = char(internal::DefaultType().visit(arg));
+      spec.type_ = internal::DefaultType().visit(arg);
     }
 
     if (arg.type <= Arg::LAST_INTEGER_TYPE) {

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -336,7 +336,7 @@ class PrintfFormatter : private internal::FormatterBase {
     : FormatterBase(al), writer_(w) {}
 
   /** Formats stored arguments and writes the output to the writer. */
-  FMT_API void format(BasicCStringRef<Char> format_str);
+  void format(BasicCStringRef<Char> format_str);
 };
 
 template <typename Char, typename AF>
@@ -495,7 +495,9 @@ void PrintfFormatter<Char, AF>::format(BasicCStringRef<Char> format_str) {
 
     if (spec.type_ == 's') {
       // set the format type to the default if 's' is specified
-      spec.type_ = internal::DefaultType().visit(arg);
+
+      // Avoid warning for wchar_t
+      spec.type_ = char(internal::DefaultType().visit(arg));
     }
 
     if (arg.type <= Arg::LAST_INTEGER_TYPE) {

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -26,6 +26,7 @@
  */
 
 #define FMT_NOEXCEPT
+#undef FMT_SHARED
 #include "test-assert.h"
 
 // Include *.cc instead of *.h to test implementation-specific stuff.

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1556,8 +1556,8 @@ TEST(FormatTest, JoinArg) {
   using fmt::join;
   int v1[3] = { 1, 2, 3 };
   std::vector<float> v2;
-  v2.push_back(1.2);
-  v2.push_back(3.4);
+  v2.push_back(1.2f);
+  v2.push_back(3.4f);
 
   EXPECT_EQ("(1, 2, 3)", format("({})", join(v1 + 0, v1 + 3, ", ")));
   EXPECT_EQ("(1)", format("({})", join(v1 + 0, v1 + 1, ", ")));

--- a/test/time-test.cc
+++ b/test/time-test.cc
@@ -6,6 +6,9 @@
 
  For the license information refer to format.h.
  */
+#ifdef WIN32
+#define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include "gmock/gmock.h"
 #include "fmt/time.h"


### PR DESCRIPTION
Removes warnings and errors when compiling in VS 2015 with BUILD_SHARED_LIBS set to "ON".

