### PR TITLE
Don't include the world with WIN32_LEAN_AND_MEAN

### DIFF
--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -41,6 +41,9 @@
 #endif
 
 #if FMT_USE_WINDOWS_H
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # if defined(NOMINMAX) || defined(FMT_WIN_MINMAX)
 #  include <windows.h>
 # else

--- a/fmt/posix.cc
+++ b/fmt/posix.cc
@@ -21,6 +21,9 @@
 #ifndef _WIN32
 # include <unistd.h>
 #else
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <windows.h>
 # include <io.h>
 


### PR DESCRIPTION
This PR reduces the size of what `windows.h` will include by using the define `WIN32_LEAN_AND_MEAN`.

In fact it also help to prevent bad order of inclusion because some header files in Windows need to be include in a good order and that can cause some problems when you use fmt without looking for what it is including.