### PR TITLE
Changing ArgArray template argument from unsigned to size_t

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -2214,10 +2214,10 @@ inline uint64_t make_type(const T &arg) {
   return MakeValue< BasicFormatter<char> >::type(arg);
 }
 
-template <unsigned N, bool/*IsPacked*/= (N < ArgList::MAX_PACKED_ARGS)>
+template <std::size_t N, bool/*IsPacked*/= (N < ArgList::MAX_PACKED_ARGS)>
 struct ArgArray;
 
-template <unsigned N>
+template <std::size_t N>
 struct ArgArray<N, true/*IsPacked*/> {
   typedef Value Type[N > 0 ? N : 1];
 
@@ -2235,7 +2235,7 @@ struct ArgArray<N, true/*IsPacked*/> {
   }
 };
 
-template <unsigned N>
+template <std::size_t N>
 struct ArgArray<N, false/*IsPacked*/> {
   typedef Arg Type[N + 1]; // +1 for the list end Arg::NONE
 


### PR DESCRIPTION
Each instantiation of ArgArray template uses sizeof operator, which returns a std::size_t value. GCC 7.1 warns about invalid conversion (error: conversion to ‘unsigned int’ from ‘long unsigned int’ may alter its value [-Werror=conversion]).
