### PR TITLE
remove unnecessary method

### DIFF
--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -213,16 +213,6 @@ void report_error(FormatFunc func, int error_code,
 }
 }  // namespace
 
-namespace internal {
-
-// This method is used to preserve binary compatibility with fmt 3.0.
-// It can be removed in 4.0.
-FMT_FUNC void format_system_error(
-  Writer &out, int error_code, StringRef message) FMT_NOEXCEPT {
-  fmt::format_system_error(out, error_code, message);
-}
-}  // namespace internal
-
 FMT_FUNC void SystemError::init(
     int err_code, CStringRef format_str, ArgList args) {
   error_code_ = err_code;


### PR DESCRIPTION
Since the 4.0 release is almost there, that function should be removed as described in the comment.