### PR TITLE
remove 'FMT_CPPFORMAT' CMake option

### DIFF
--- a/fmt/CMakeLists.txt
+++ b/fmt/CMakeLists.txt
@@ -10,12 +10,6 @@ endif ()
 add_library(fmt ${FMT_SOURCES} ${FMT_HEADERS} ../README.rst ../ChangeLog.rst)
 add_library(fmt::fmt ALIAS fmt)
 
-option(FMT_CPPFORMAT "Build cppformat library for backward compatibility." OFF)
-if (FMT_CPPFORMAT)
-  message(WARNING "The cppformat library is deprecated, use fmt instead.")
-  add_library(cppformat ${FMT_SOURCES} ${FMT_HEADERS})
-endif ()
-
 # Starting with cmake 3.1 the CXX_STANDARD property can be used instead.
 # Note: Don't make -std=c++11 public or interface, since it breaks projects
 # that use C++14.
@@ -93,7 +87,4 @@ if (FMT_INSTALL)
   install(TARGETS ${INSTALL_TARGETS} EXPORT ${targets_export_name}
           DESTINATION ${FMT_LIB_DIR})
   install(FILES ${FMT_HEADERS} DESTINATION include/fmt)
-  if (FMT_CPPFORMAT)
-    install(TARGETS cppformat DESTINATION ${FMT_LIB_DIR})
-  endif ()
 endif ()


### PR DESCRIPTION
Another backward compatibility thing removed before 4.0 release.