### PR TITLE
Update format.h to remove C4574 error on MSVC 14.2

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -45,7 +45,7 @@
 // The fmt library version in the form major * 10000 + minor * 100 + patch.
 #define FMT_VERSION 40001
 
-#ifdef _SECURE_SCL
+#if defined _SECURE_SCL && _SECURE_SCL
 # define FMT_SECURE_SCL _SECURE_SCL
 #else
 # define FMT_SECURE_SCL 0


### PR DESCRIPTION
Similar to the Pullrequest #539, `_SECURE_SCL` caused the same  `warning C4574: '_SECURE_SCL' is defined to be '0': did you mean to use '#if _SECURE_SCL'`.  `_SECURE_SCL` is defined in the `MSVC/14.10.25017/include/yvals.h` by Microsoft itself