### PR TITLE
Suppress warning about missing noreturn attribute

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -923,7 +923,7 @@ struct IntTraits {
     TypeSelector<std::numeric_limits<T>::digits <= 32>::Type MainType;
 };
 
-#if FMT_HAS_GXX_CXX11
+#if FMT_HAS_CPP_ATTRIBUTE(noreturn)
 FMT_API [[noreturn]] void report_unknown_type(char code, const char *type);
 #else
 FMT_API void report_unknown_type(char code, const char *type);

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -139,6 +139,15 @@ typedef __int64          intmax_t;
 # define FMT_HAS_CPP_ATTRIBUTE(x) 0
 #endif
 
+// Use the compiler's attribute noreturn
+#if defined(__MINGW32__) || defined(__MINGW64__)
+# define FMT_NORETURN __attribute__((noreturn))
+#elif FMT_HAS_CPP_ATTRIBUTE(noreturn)
+# define FMT_NORETURN [[noreturn]]
+#else
+# define FMT_NORETURN
+#endif
+
 #ifndef FMT_USE_VARIADIC_TEMPLATES
 // Variadic templates are available in GCC since version 4.4
 // (http://gcc.gnu.org/projects/cxx0x.html) and in Visual C++
@@ -923,11 +932,7 @@ struct IntTraits {
     TypeSelector<std::numeric_limits<T>::digits <= 32>::Type MainType;
 };
 
-#if FMT_HAS_CPP_ATTRIBUTE(noreturn)
-FMT_API [[noreturn]] void report_unknown_type(char code, const char *type);
-#else
-FMT_API void report_unknown_type(char code, const char *type);
-#endif
+FMT_API FMT_NORETURN void report_unknown_type(char code, const char *type);
 
 // Static data is placed in this class template to allow header-only
 // configuration.

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -923,7 +923,11 @@ struct IntTraits {
     TypeSelector<std::numeric_limits<T>::digits <= 32>::Type MainType;
 };
 
+#if FMT_HAS_GXX_CXX11
+FMT_API [[noreturn]] void report_unknown_type(char code, const char *type);
+#else
 FMT_API void report_unknown_type(char code, const char *type);
+#endif
 
 // Static data is placed in this class template to allow header-only
 // configuration.


### PR DESCRIPTION
Adding `[[noreturn]]` to `report_unknown_type` suppresses the Clang/GCC `-Wmissing-noreturn` warning:

Clang outputs:

    .../fmt/fmt/format.cc:294:74: warning:
          function 'report_unknown_type' could be declared with
          attribute 'noreturn' [-Wmissing-noreturn]
      ...code, const char *type) {
                                 ^

GCC outputs:

    .../fmt/fmt/format.cc:294:74: warning: function might be candidate for
        attribute 'noreturn' [-Wsuggest-attribute=noreturn]
      ...code, const char *type) {
                                 ^

<!---
Please make sure you've followed the guidelines outlined in the CONTRIBUTING.rst file.
--->
