### PR TITLE
printf: Add support for glibc's %m format

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -162,7 +162,9 @@ The following functions use `printf format string syntax
 <http://pubs.opengroup.org/onlinepubs/009695399/functions/fprintf.html>`_ with
 the POSIX extension for positional arguments. Unlike their standard
 counterparts, the ``fmt`` functions are type-safe and throw an exception if an
-argument type doesn't match its format specification.
+argument type doesn't match its format specification. They also support the
+glibc '%m' extension to output the string corresponding to the error code
+in errno.
 
 .. doxygenfunction:: printf(CStringRef, ArgList)
 

--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -385,7 +385,10 @@ FMT_FUNC void format_system_error(
       char *system_message = &buffer[0];
       int result = safe_strerror(error_code, system_message, buffer.size());
       if (result == 0) {
-        out << message << ": " << system_message;
+	  if (message.size())
+	    out << message << ": " << system_message;
+	  else
+	    out << system_message;
         return;
       }
       if (result != ERANGE)

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1105,7 +1105,7 @@ template <typename T>
 void check_unknown_types(
     const T &value, const char *types, const char *type_name) {
   char format_str[BUFFER_SIZE], message[BUFFER_SIZE];
-  const char *special = ".0123456789}";
+  const char *special = ".0123456789}m";
   for (int i = CHAR_MIN; i <= CHAR_MAX; ++i) {
     char c = static_cast<char>(i);
     if (std::strchr(types, c) || std::strchr(special, c) || !c) continue;

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -476,6 +476,21 @@ TEST(PrintfTest, Enum) {
   EXPECT_PRINTF("42", "%d", A);
 }
 
+TEST(PrintfTest, ErrnoPreserved) {
+  errno = ENOENT;
+  EXPECT_PRINTF_NO_ARG("testing 1 2 3", "testing 1 2 3");
+  EXPECT_EQ(errno, ENOENT);
+
+  EXPECT_PRINTF("42", "%d", 42);
+  EXPECT_EQ(errno, ENOENT);
+
+  EXPECT_PRINTF(" Hello", "%6s", "Hello");
+  EXPECT_EQ(errno, ENOENT);
+
+  EXPECT_PRINTF_NO_ARG("No such file or directory", "%m");
+  EXPECT_EQ(errno, ENOENT);
+}
+
 TEST(PrintfTest, ErrorMessage) {
   errno = ENOENT;
 

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -51,6 +51,10 @@ std::string make_positional(fmt::StringRef format) {
     << "format: " << format; \
   EXPECT_EQ(expected_output, fmt::sprintf(make_positional(format), arg))
 
+#define EXPECT_PRINTF_NO_ARG(expected_output, format) \
+  EXPECT_EQ(expected_output, fmt::sprintf(format)) \
+    << "format: " << format;
+
 TEST(PrintfTest, NoArgs) {
   EXPECT_EQ("test", fmt::sprintf("test"));
 }
@@ -470,6 +474,18 @@ enum E { A = 42 };
 
 TEST(PrintfTest, Enum) {
   EXPECT_PRINTF("42", "%d", A);
+}
+
+TEST(PrintfTest, ErrorMessage) {
+  errno = ENOENT;
+
+  EXPECT_PRINTF_NO_ARG("No such file or directory", "%m");
+  EXPECT_PRINTF_NO_ARG("No such file or directory     ", "%-30m");
+  EXPECT_PRINTF_NO_ARG("     No such file or directory", "%30m");
+
+  EXPECT_PRINTF_NO_ARG(L"No such file or directory", L"%m");
+  EXPECT_PRINTF_NO_ARG(L"No such file or directory     ", L"%-30m");
+  EXPECT_PRINTF_NO_ARG(L"     No such file or directory", L"%30m");
 }
 
 #if FMT_USE_FILE_DESCRIPTORS


### PR DESCRIPTION
glibc's printf family of functions support '%m' to emit the error string
that corresponds to the current value of errno. It has no corresponding
argument.

In order to take advantage of safe_strerror, PrintfFormatter::format calls
format_system_error, which has been modified to not emit the separator if
the message prefix is empty.

'm' needs to be added to the list of special characters in format-test.cc's
check_unknown_types since it would otherwise always be valid in the format
string.
