### PR TITLE
Explicitly cast int -> char to prevent conversion warnings

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -742,7 +742,7 @@ template <typename T>
 template <typename U>
 void Buffer<T>::append(const U *begin, const U *end) {
   FMT_ASSERT(end >= begin, "negative value");
-  std::size_t new_size = size_ + (end - begin);
+  std::size_t new_size = size_ + static_cast<std::size_t>(end - begin);
   if (new_size > capacity_)
     grow(new_size);
   std::uninitialized_copy(begin, end,

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -110,7 +110,7 @@ class ArgConverter : public ArgVisitor<ArgConverter<T>, void> {
       visit_any_int(value);
   }
 
-  void visit_char(char value) {
+  void visit_char(int value) {
     if (type_ != 's')
       visit_any_int(value);
   }


### PR DESCRIPTION
This prevents integer conversion warnings so the library can be compiled with GCC and `-Wconversion` enabled (also `-Werror -Wall -Wextra -pedantic`, but I think the offender was `-Wconversion`) as "discussed" in #552.

Note this change makes possible to build fmt with these flags, but **the unit tests cannot be compiled, googletest triggers a lot of conversion warnings**.