### PR TITLE
Suppress Clang's warning on zero as a null pointer

### DIFF
--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -121,7 +121,7 @@ typedef void (*FormatFunc)(Writer &, int, StringRef);
 // Buffer should be at least of size 1.
 int safe_strerror(
     int error_code, char *&buffer, std::size_t buffer_size) FMT_NOEXCEPT {
-  FMT_ASSERT(buffer != 0 && buffer_size != 0, "invalid buffer");
+  FMT_ASSERT(buffer != FMT_NULL && buffer_size != 0, "invalid buffer");
 
   class StrError {
    private:


### PR DESCRIPTION
This suppresses the Clang warning `-Wzero-as-null-pointer-constant` by using `FMT_NULL` instead of `0`:

```
fmt/format.cc:124:24: error: zero as null pointer
                      constant [-Werror,-Wzero-as-null-pointer-constant]
  FMT_ASSERT(buffer != 0 && buffer_size != 0, "invalid buffer");
                       ^
                       nullptr
```