### PR TITLE
Make format work with C++17 std::string_view

### DIFF
--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -151,16 +151,31 @@ TEST(StringRefTest, Ctor) {
 
   EXPECT_STREQ("defg", StringRef(std::string("defg")).data());
   EXPECT_EQ(4u, StringRef(std::string("defg")).size());
+
+#if FMT_HAS_STRING_VIEW
+  EXPECT_STREQ("hijk", StringRef(std::string_view("hijk")).data());
+  EXPECT_EQ(4u, StringRef(std::string_view("hijk")).size());
+#endif
 }
 
 TEST(StringRefTest, ConvertToString) {
   std::string s = StringRef("abc").to_string();
   EXPECT_EQ("abc", s);
+
+#if FMT_HAS_STRING_VIEW
+  StringRef str_ref("defg");
+  std::string_view sv = static_cast<std::string_view>(str_ref);
+  EXPECT_EQ("defg", sv);
+#endif
 }
 
 TEST(CStringRefTest, Ctor) {
   EXPECT_STREQ("abc", CStringRef("abc").c_str());
   EXPECT_STREQ("defg", CStringRef(std::string("defg")).c_str());
+
+#if FMT_HAS_STRING_VIEW
+  EXPECT_STREQ("hijk", CStringRef(std::string_view("hijk")).c_str());
+#endif
 }
 
 #if FMT_USE_TYPE_TRAITS
@@ -1377,6 +1392,12 @@ TEST(FormatterTest, FormatStringRef) {
 TEST(FormatterTest, FormatCStringRef) {
   EXPECT_EQ("test", format("{0}", CStringRef("test")));
 }
+
+#if FMT_HAS_STRING_VIEW
+TEST(FormatterTest, FormatStringView) {
+  EXPECT_EQ("test", format("{0}", std::string_view("test")));
+}
+#endif
 
 void format_arg(fmt::BasicFormatter<char> &f, const char *, const Date &d) {
   f.writer() << d.year() << '-' << d.month() << '-' << d.day();


### PR DESCRIPTION
Enable `std::string_view` to work with format when compiling with C++17.

Change log:

+ `fmt::StringRef` is constructible from `std::string_view`.
+ `fmt::StringRef` is convertible to `std::string_view` (only explicitly)[1].
+ `fmt::format` accepts `std::string_view` as an argument for the argument list.

[1] This is open to debate. Should it be an implicit conversion, or should it not exist at all? The argument in favor of it is that `std::string_view` is now the common string reference, and all other string implementations could take advantage of it by providing a conversion to it. A counter-argument would be that fmtlib prefers `fmt::StringRef` as the common string reference.