### PR TITLE
fix(Clang CodeGen): remove warnings

### DIFF
--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -70,11 +70,6 @@
 # pragma warning(disable: 4996)
 #endif
 
-#ifdef __c2__
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wunused-function"
-#endif
-
 // Dummy implementations of strerror_r and strerror_s called if corresponding
 // system functions are not available.
 static inline fmt::internal::Null<> strerror_r(int, char *, ...) {
@@ -83,10 +78,6 @@ static inline fmt::internal::Null<> strerror_r(int, char *, ...) {
 static inline fmt::internal::Null<> strerror_s(char *, std::size_t, ...) {
   return fmt::internal::Null<>();
 }
-
-#ifdef __c2__
-# pragma clang diagnostic pop
-#endif
 
 namespace fmt {
 
@@ -189,8 +180,9 @@ int safe_strerror(
       : error_code_(err_code), buffer_(buf), buffer_size_(buf_size) {}
 
     int run() {
-      // Suppress a warning about unused strerror_r.
+      // Suppress a warning about unused strerror_r and strerror_s.
       strerror_r(0, FMT_NULL, "");
+      strerror_s(FMT_NULL, 0, "");
       return handle(strerror_r(error_code_, buffer_, buffer_size_));
     }
   };

--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -70,6 +70,11 @@
 # pragma warning(disable: 4996)
 #endif
 
+#ifdef __c2__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunused-function"
+#endif
+
 // Dummy implementations of strerror_r and strerror_s called if corresponding
 // system functions are not available.
 static inline fmt::internal::Null<> strerror_r(int, char *, ...) {
@@ -78,6 +83,10 @@ static inline fmt::internal::Null<> strerror_r(int, char *, ...) {
 static inline fmt::internal::Null<> strerror_s(char *, std::size_t, ...) {
   return fmt::internal::Null<>();
 }
+
+#ifdef __c2__
+# pragma clang diagnostic pop
+#endif
 
 namespace fmt {
 
@@ -159,12 +168,21 @@ int safe_strerror(
             ERANGE : result;
     }
 
+#ifdef __c2__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
     // Fallback to strerror if strerror_r and strerror_s are not available.
     int fallback(internal::Null<>) {
       errno = 0;
       buffer_ = strerror(error_code_);
       return errno;
     }
+
+#ifdef __c2__
+# pragma clang diagnostic pop
+#endif
 
    public:
     StrError(int err_code, char *&buf, std::size_t buf_size)

--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -72,10 +72,10 @@
 
 // Dummy implementations of strerror_r and strerror_s called if corresponding
 // system functions are not available.
-static inline fmt::internal::Null<> strerror_r(int, char *, ...) {
+FMT_MAYBE_UNUSED static inline fmt::internal::Null<> strerror_r(int, char *, ...) {
   return fmt::internal::Null<>();
 }
-static inline fmt::internal::Null<> strerror_s(char *, std::size_t, ...) {
+FMT_MAYBE_UNUSED static inline fmt::internal::Null<> strerror_s(char *, std::size_t, ...) {
   return fmt::internal::Null<>();
 }
 
@@ -180,9 +180,6 @@ int safe_strerror(
       : error_code_(err_code), buffer_(buf), buffer_size_(buf_size) {}
 
     int run() {
-      // Suppress a warning about unused strerror_r and strerror_s.
-      strerror_r(0, FMT_NULL, "");
-      strerror_s(FMT_NULL, 0, "");
       return handle(strerror_r(error_code_, buffer_, buffer_size_));
     }
   };

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -153,6 +153,23 @@ typedef __int64          intmax_t;
 # define FMT_HAS_CPP_ATTRIBUTE(x) 0
 #endif
 
+#if FMT_HAS_CPP_ATTRIBUTE(maybe_unused)
+# define FMT_HAS_CXX17_ATTRIBUTE_MAYBE_UNUSED
+// VC++ 1910 support /std: option and that will set _MSVC_LANG macro
+// Clang with Microsoft CodeGen doesn't define _MSVC_LANG macro
+#elif defined(_MSVC_LANG) && _MSVC_LANG > 201402
+# define FMT_HAS_CXX17_ATTRIBUTE_MAYBE_UNUSED
+#endif
+
+#ifdef FMT_HAS_CXX17_ATTRIBUTE_MAYBE_UNUSED
+# define FMT_MAYBE_UNUSED [[maybe_unused]]
+// g++/clang++ also support [[gnu::unused]]. However, we don't use it.
+#elif defined(__GNUC__)
+# define FMT_MAYBE_UNUSED __attribute__((unused))
+#else
+#define FMT_MAYBE_UNUSED
+#endif
+
 // Use the compiler's attribute noreturn
 #if defined(__MINGW32__) || defined(__MINGW64__)
 # define FMT_NORETURN __attribute__((noreturn))

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -335,7 +335,10 @@ typedef __int64          intmax_t;
 
 namespace fmt {
 namespace internal {
-# pragma intrinsic(_BitScanReverse)
+// avoid Clang with Microsoft CodeGen's -Wunknown-pragmas warning
+# ifndef __clang__
+#  pragma intrinsic(_BitScanReverse)
+# endif
 inline uint32_t clz(uint32_t x) {
   unsigned long r = 0;
   _BitScanReverse(&r, x);
@@ -349,7 +352,8 @@ inline uint32_t clz(uint32_t x) {
 }
 # define FMT_BUILTIN_CLZ(n) fmt::internal::clz(n)
 
-# ifdef _WIN64
+// avoid Clang with Microsoft CodeGen's -Wunknown-pragmas warning
+# if defined(_WIN64) && !defined(__clang__)
 #  pragma intrinsic(_BitScanReverse64)
 # endif
 


### PR DESCRIPTION
```
./fmt/fmt/format.h(308,10): warning : unknown pragma ignored [-Wunknown-pragmas]
# pragma intrinsic(_BitScanReverse)
         ^
1 warning generated.
format.cc In file included from fmt\fmt\format.cc:28:
fmt\fmt/format.h(308,10): warning : unknown pragma ignored [-Wunknown-pragmas]
# pragma intrinsic(_BitScanReverse)
         ^
fmt\fmt\format.cc(165,17): warning : 'strerror' is deprecated: This
function or variable may be unsafe. Consider using strerror_s instead.
To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for
details. [-Wdeprecated-declarations]
      buffer_ = strerror(error_code_);
                ^
C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\string.h(178,24) :  note: 'strerror' has been explicitly marked deprecated here
_ACRTIMP char* __cdecl strerror(
                       ^
fmt\fmt\format.cc(78,37): warning : unused function 'strerror_s' [-Wunused-function]
static inline fmt::internal::Null<> strerror_s(char *, std::size_t, ...) {
                                    ^
3 warnings generated.
```
