### PR TITLE
Use allocator_traits if available.

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -200,6 +200,12 @@ typedef __int64          intmax_t;
 # endif
 #endif
 
+#if __cplusplus >= 201103L || FMT_MSC_VER >= 1700
+# define FMT_USE_ALLOCATOR_TRAITS 1
+#else
+# define FMT_USE_ALLOCATOR_TRAITS 0
+#endif
+
 // Check if exceptions are disabled.
 #if defined(__GNUC__) && !defined(__EXCEPTIONS)
 # define FMT_EXCEPTIONS 0
@@ -869,7 +875,12 @@ void MemoryBuffer<T, SIZE, Allocator>::grow(std::size_t size) {
   std::size_t new_capacity = this->capacity_ + this->capacity_ / 2;
   if (size > new_capacity)
       new_capacity = size;
+#if FMT_USE_ALLOCATOR_TRAITS
+  T *new_ptr =
+      std::allocator_traits<Allocator>::allocate(*this, new_capacity, FMT_NULL);
+#else
   T *new_ptr = this->allocate(new_capacity, FMT_NULL);
+#endif
   // The following code doesn't throw, so the raw pointer above doesn't leak.
   std::uninitialized_copy(this->ptr_, this->ptr_ + this->size_,
                           make_ptr(new_ptr, new_capacity));

--- a/test/mock-allocator.h
+++ b/test/mock-allocator.h
@@ -36,7 +36,7 @@ class MockAllocator {
   MockAllocator() {}
   MockAllocator(const MockAllocator &) {}
   typedef T value_type;
-  MOCK_METHOD2_T(allocate, T *(std::size_t n, const T *h));
+  MOCK_METHOD2_T(allocate, T *(std::size_t n, const void *h));
   MOCK_METHOD2_T(deallocate, void (T *p, std::size_t n));
 };
 
@@ -78,8 +78,12 @@ class AllocatorRef {
 
   Allocator *get() const { return alloc_; }
 
-  value_type *allocate(std::size_t n,  const value_type *h) {
+  value_type *allocate(std::size_t n,  const void *h) {
+#if FMT_USE_ALLOCATOR_TRAITS
+    return std::allocator_traits<Allocator>::allocate(*alloc_, n, h);
+#else
     return alloc_->allocate(n, h);
+#endif
   }
   void deallocate(value_type *p, std::size_t n) { alloc_->deallocate(p, n); }
 };


### PR DESCRIPTION
This is to avoid using functionality deprecated in C++17. Addresses #579.