### PR TITLE
Add concat and concat_separated

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -4087,11 +4087,8 @@ void format_arg(fmt::BasicFormatter<Char, ArgFormatter> &f,
 }
 
 struct ArgConcatNoSeparator {
-    template<typename ArgFormatter>
-    void add_separator(fmt::BasicFormatter<char, ArgFormatter>&) const {}
-
-    template<typename ArgFormatter>
-    void add_separator(fmt::BasicFormatter<wchar_t, ArgFormatter>&) const {}
+    template<typename T>
+    void add_separator(T&) const {}
 };
 
 template<typename Char>

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -4093,7 +4093,6 @@ struct ArgConcatNoSeparator
 template<typename Char>
 struct ArgConcatSeparator {
     BasicCStringRef<Char> sep;
-    //ArgConcatSeparator<Char>(const BasicCStringRef<Char> &sep): sep(sep) {}
 };
 
 template<typename Separator, typename ...Args>

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1604,6 +1604,30 @@ TEST(FormatTest, JoinArg) {
 #endif
 }
 
+TEST(FormatTest, ConcatArg) {
+    using fmt::concat;
+    EXPECT_EQ("123", format("{}", concat(1,2,3)));
+    EXPECT_EQ("()", format("({})", concat()));
+    EXPECT_EQ("(001002003)", format("({:03})", concat(1,2,3)));
+    EXPECT_EQ("(1 hello world 2)", format("({})", concat(1," hello"," world ", 2)));
+    EXPECT_EQ("(1 hello world 2)", format("({}{})", concat(1," hello"," world "), 2));
+    EXPECT_EQ("(+01.20+03.40)", format("({:+06.2f})", concat(1.2f, 3.4f)));
+
+    EXPECT_EQ(L"(1, 2, 3)", format(L"({})", concat(1, L", ", 2, L", ", 3)));
+}
+
+TEST(FormatTest, ConcatSeparatedArg) {
+    using fmt::concat_separated;
+    EXPECT_EQ("(1, 2, 3)", format("({})", concat_separated(", ", 1,2,3)));
+    EXPECT_EQ("()", format("({})", concat_separated(", ")));
+    EXPECT_EQ("(001, 002, 003)", format("({:03})", concat_separated(", ", 1,2,3)));
+    EXPECT_EQ("(1 hello world 2)", format("({})", concat_separated(" ", 1,"hello","world", 2)));
+    EXPECT_EQ("(1 hello world 2)", format("({} {})", concat_separated(" ", 1,"hello","world"), 2));
+    EXPECT_EQ("(+01.20, +03.40)", format("({:+06.2f})", concat_separated(", ", 1.2f, 3.4f)));
+
+    EXPECT_EQ(L"(1, 2, 3)", format(L"({})", concat_separated(L", ", 1, 2, 3)));
+}
+
 template <typename T>
 std::string str(const T &value) {
   return fmt::format("{}", value);


### PR DESCRIPTION
Concat simply concatenates all arguments and will replace a single placeholder
with the concatenation. Example:
format("({})", concat("hello ", "world")) will result in "(hello world)"

concat_separated concatenates all arguments with a separator between them.
Example: format("({})", concat(", ", 1, 2, 3)) will result in "(1, 2, 3)"

<!---
Please make sure you've followed the guidelines outlined in the CONTRIBUTING.rst file.
--->
