### PR TITLE
Added support for "namespace encapsulation" for fmt library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ CMakeCache.txt
 CMakeFiles
 Makefile
 run-msbuild.bat
+.vs
+.vscode

--- a/fmt/CMakeLists.txt
+++ b/fmt/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Define the fmt library, its includes and the needed defines.
 # *.cc are added to FMT_HEADERS for the header-only configuration.
-set(FMT_HEADERS container.h format.h format.cc ostream.h ostream.cc printf.h
+set(FMT_HEADERS container.h custom_namespace.h format.h format.cc ostream.h ostream.cc printf.h
                 printf.cc string.h time.h)
 if (HAVE_OPEN)
   set(FMT_HEADERS ${FMT_HEADERS} posix.h)

--- a/fmt/container.h
+++ b/fmt/container.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  Formatting library for C++ - standard container utilities
 
  Copyright (c) 2012 - 2016, Victor Zverovich
@@ -11,6 +11,8 @@
 #define FMT_CONTAINER_H_
 
 #include "format.h"
+
+FMT_CUSTOM_NAMESPACE_BEGIN
 
 namespace fmt {
 
@@ -78,5 +80,7 @@ class BasicContainerWriter
 };
 
 } // namespace fmt
+
+FMT_CUSTOM_NAMESPACE_END
 
 #endif  // FMT_CONTAINER_H_

--- a/fmt/custom_namespace.h
+++ b/fmt/custom_namespace.h
@@ -1,0 +1,101 @@
+﻿/*
+Formatting library for C++
+
+Copyright (c) 2012 - 2016, Victor Zverovich
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef FMT_CUSTOM_NAMESPACE_H_
+#define FMT_CUSTOM_NAMESPACE_H_
+
+/*
+This file adds support for using fmt library defining a custom namespace in your code
+to avoid conflicting with other fmt library versions or 'encapsulate' the implementation
+you are using inside another namespace.
+
+Those four macros below provide this feature:
+
+- FMT_CUSTOM_NAMESPACE - 1 if you want a custom namespace prefix, 0 otherwise
+- FMT_CUSTOM_NAMESPACE_USING_NAMESPACE - the 'using namespace CUSTOM_NAMESPACE;' used into fmt source code, and
+MUST terminate with a semicolon. It also could be used by your application if needed (but it's not recommended);
+- FMT_CUSTOM_NAMESPACE_PREFIX - the 'CUSTOM_NAMESPACE' namespace prefix for the encapsulation namespace;
+- FMT_CUSTOM_NAMESPACE_BEGIN - the 'namespace CUSTOM_NAMESPACE {' namespace begin for the encapsulation namespace;
+- FMT_CUSTOM_NAMESPACE_END - the '} // namespace CUSTOM_NAMESPACE' namespace end for the encapsulation namespace;
+
+Please note that you could use more than one namespace nested, as the example below:
+
+#define FMT_CUSTOM_NAMESPACE                      1
+#define FMT_CUSTOM_NAMESPACE_USING_NAMESPACE      using namespace my_cpp_library::formatting_libraries;
+#define FMT_CUSTOM_NAMESPACE_PREFIX               my_cpp_library::formatting_libraries
+#define FMT_CUSTOM_NAMESPACE_BEGIN                namespace my_cpp_library { namespace formatting_libraries {
+#define FMT_CUSTOM_NAMESPACE_END                  } }
+
+Then, in your code, you use this fmt in following way:
+
+#include <fmt/format.h>
+#include <iostream>
+
+template <typename ... args>
+std::string format_some_string(char const * mask, args && ... argsv)
+{
+	my_cpp_library::formatting_libraries::fmt::MemoryWriter writer;
+
+	writer.write(mask, std::forward<args>(argsv) ...);
+	
+	return writer.str();
+}
+
+int main(int argc, char ** argv)
+{
+	std::cout << format_some_string("{} from somewhere", "Hello") << std::endl;
+
+	return 0;
+}
+
+Below, the macro definition you could adjust for your needs, please pay attention to example above to show
+how to change the final fmt library namespace.
+*/
+
+#define FMT_CUSTOM_NAMESPACE                      0
+#define FMT_CUSTOM_NAMESPACE_USING_NAMESPACE      // using namespace my_cpp_library::formatting_libraries;
+#define FMT_CUSTOM_NAMESPACE_PREFIX               // my_cpp_library::formatting_libraries
+#define FMT_CUSTOM_NAMESPACE_BEGIN                // namespace my_cpp_library { namespace formatting_libraries {
+#define FMT_CUSTOM_NAMESPACE_END                  // } }
+
+/*
+If you doesn't define FMT_CUSTOM_NAMESPACE to 1, bad things happen, so we disable custom namespaces defined
+above, to allow build tests and unit tests pass without any false negatives...
+*/
+
+#if (FMT_CUSTOM_NAMESPACE != 1)
+# undef  FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+# define FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+# undef  FMT_CUSTOM_NAMESPACE_PREFIX
+# define FMT_CUSTOM_NAMESPACE_PREFIX
+# undef  FMT_CUSTOM_NAMESPACE_BEGIN
+# define FMT_CUSTOM_NAMESPACE_BEGIN
+# undef  FMT_CUSTOM_NAMESPACE_END
+# define FMT_CUSTOM_NAMESPACE_END
+#endif
+
+#endif // FMT_CUSTOM_NAMESPACE_H_

--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -73,13 +73,15 @@
 // Dummy implementations of strerror_r and strerror_s called if corresponding
 // system functions are not available.
 FMT_MAYBE_UNUSED
-static inline fmt::internal::Null<> strerror_r(int, char *, ...) {
-  return fmt::internal::Null<>();
+static inline FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::Null<> strerror_r(int, char *, ...) {
+  return FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::Null<>();
 }
 FMT_MAYBE_UNUSED
-static inline fmt::internal::Null<> strerror_s(char *, std::size_t, ...) {
-  return fmt::internal::Null<>();
+static inline FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::Null<> strerror_s(char *, std::size_t, ...) {
+  return FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::Null<>();
 }
+
+FMT_CUSTOM_NAMESPACE_BEGIN
 
 namespace fmt {
 
@@ -489,6 +491,8 @@ template FMT_API int internal::CharTraits<wchar_t>::format_float(
 #endif  // FMT_HEADER_ONLY
 
 }  // namespace fmt
+
+FMT_CUSTOM_NAMESPACE_END
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -28,6 +28,8 @@
 #ifndef FMT_FORMAT_H_
 #define FMT_FORMAT_H_
 
+#include "custom_namespace.h"
+
 #define FMT_INCLUDE
 #include <cassert>
 #include <clocale>
@@ -355,6 +357,12 @@ typedef __int64          intmax_t;
 // if the clz and clzll builtins are not available.
 #if FMT_MSC_VER && !defined(FMT_BUILTIN_CLZLL) && !defined(_MANAGED)
 # include <intrin.h>  // _BitScanReverse, _BitScanReverse64
+# define FMT_HAS_MSVC_INTRINSICS
+#endif
+
+FMT_CUSTOM_NAMESPACE_BEGIN
+
+#ifdef FMT_HAS_MSVC_INTRINSICS
 
 namespace fmt {
 namespace internal {
@@ -401,8 +409,8 @@ inline uint32_t clzll(uint64_t x) {
   return 63 - r;
 }
 # define FMT_BUILTIN_CLZLL(n) fmt::internal::clzll(n)
-}
-}
+} // namespace internal
+} // namespace fmt
 #endif
 
 namespace fmt {
@@ -426,8 +434,10 @@ inline DummyInt _isnan(...) { return DummyInt(); }
 // warnings.
 template <typename T>
 inline T const_check(T value) { return value; }
-}
+}  // namespace internal
 }  // namespace fmt
+
+FMT_CUSTOM_NAMESPACE_END
 
 namespace std {
 // Standard permits specialization of std::numeric_limits. This specialization
@@ -435,15 +445,15 @@ namespace std {
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48891
 // and the same for isnan and signbit.
 template <>
-class numeric_limits<fmt::internal::DummyInt> :
+class numeric_limits<FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::DummyInt> :
     public std::numeric_limits<int> {
  public:
   // Portable version of isinf.
   template <typename T>
   static bool isinfinity(T x) {
-    using namespace fmt::internal;
+    using namespace FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal;
     // The resolution "priority" is:
-    // isinf macro > std::isinf > ::isinf > fmt::internal::isinf
+    // isinf macro > std::isinf > ::isinf > FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::isinf
     if (const_check(sizeof(isinf(x)) == sizeof(bool) ||
                     sizeof(isinf(x)) == sizeof(int))) {
       return isinf(x) != 0;
@@ -454,7 +464,7 @@ class numeric_limits<fmt::internal::DummyInt> :
   // Portable version of isnan.
   template <typename T>
   static bool isnotanumber(T x) {
-    using namespace fmt::internal;
+    using namespace FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal;
     if (const_check(sizeof(isnan(x)) == sizeof(bool) ||
                     sizeof(isnan(x)) == sizeof(int))) {
       return isnan(x) != 0;
@@ -464,7 +474,7 @@ class numeric_limits<fmt::internal::DummyInt> :
 
   // Portable version of signbit.
   static bool isnegative(double x) {
-    using namespace fmt::internal;
+    using namespace FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal;
     if (const_check(sizeof(signbit(x)) == sizeof(bool) ||
                     sizeof(signbit(x)) == sizeof(int))) {
       return signbit(x) != 0;
@@ -478,6 +488,8 @@ class numeric_limits<fmt::internal::DummyInt> :
   }
 };
 }  // namespace std
+
+FMT_CUSTOM_NAMESPACE_BEGIN
 
 namespace fmt {
 
@@ -2427,35 +2439,35 @@ inline uint64_t make_type(FMT_GEN15(FMT_ARG_TYPE_DEFAULT)) {
 # define FMT_MAKE_ARG_TYPE(n) T##n
 # define FMT_MAKE_ARG(n) const T##n &v##n
 # define FMT_ASSIGN_char(n) \
-  arr[n] = fmt::internal::MakeValue< fmt::BasicFormatter<char> >(v##n)
+  arr[n] = FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::MakeValue< fmt::BasicFormatter<char> >(v##n)
 # define FMT_ASSIGN_wchar_t(n) \
-  arr[n] = fmt::internal::MakeValue< fmt::BasicFormatter<wchar_t> >(v##n)
+  arr[n] = FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::MakeValue< fmt::BasicFormatter<wchar_t> >(v##n)
 
 #if FMT_USE_VARIADIC_TEMPLATES
 // Defines a variadic function returning void.
 # define FMT_VARIADIC_VOID(func, arg_type) \
   template <typename... Args> \
   void func(arg_type arg0, const Args & ... args) { \
-    typedef fmt::internal::ArgArray<sizeof...(Args)> ArgArray; \
+    typedef FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::ArgArray<sizeof...(Args)> ArgArray; \
     typename ArgArray::Type array{ \
-      ArgArray::template make<fmt::BasicFormatter<Char> >(args)...}; \
-    func(arg0, fmt::ArgList(fmt::internal::make_type(args...), array)); \
+      ArgArray::template make<FMT_CUSTOM_NAMESPACE_PREFIX::fmt::BasicFormatter<Char> >(args)...}; \
+    func(arg0, fmt::ArgList(FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::make_type(args...), array)); \
   }
 
 // Defines a variadic constructor.
 # define FMT_VARIADIC_CTOR(ctor, func, arg0_type, arg1_type) \
   template <typename... Args> \
   ctor(arg0_type arg0, arg1_type arg1, const Args & ... args) { \
-    typedef fmt::internal::ArgArray<sizeof...(Args)> ArgArray; \
+    typedef FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::ArgArray<sizeof...(Args)> ArgArray; \
     typename ArgArray::Type array{ \
-      ArgArray::template make<fmt::BasicFormatter<Char> >(args)...}; \
-    func(arg0, arg1, fmt::ArgList(fmt::internal::make_type(args...), array)); \
+      ArgArray::template make<FMT_CUSTOM_NAMESPACE_PREFIX::fmt::BasicFormatter<Char> >(args)...}; \
+    func(arg0, arg1, fmt::ArgList(FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::make_type(args...), array)); \
   }
 
 #else
 
 # define FMT_MAKE_REF(n) \
-  fmt::internal::MakeValue< fmt::BasicFormatter<Char> >(v##n)
+  FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::MakeValue< FMT_CUSTOM_NAMESPACE_PREFIX::fmt::BasicFormatter<Char> >(v##n)
 # define FMT_MAKE_REF2(n) v##n
 
 // Defines a wrapper for a function taking one argument of type arg_type
@@ -2463,14 +2475,14 @@ inline uint64_t make_type(FMT_GEN15(FMT_ARG_TYPE_DEFAULT)) {
 # define FMT_WRAP1(func, arg_type, n) \
   template <FMT_GEN(n, FMT_MAKE_TEMPLATE_ARG)> \
   inline void func(arg_type arg1, FMT_GEN(n, FMT_MAKE_ARG)) { \
-    const fmt::internal::ArgArray<n>::Type array = {FMT_GEN(n, FMT_MAKE_REF)}; \
-    func(arg1, fmt::ArgList( \
-      fmt::internal::make_type(FMT_GEN(n, FMT_MAKE_REF2)), array)); \
+    const FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::ArgArray<n>::Type array = {FMT_GEN(n, FMT_MAKE_REF)}; \
+    func(arg1, FMT_CUSTOM_NAMESPACE_PREFIX::fmt::ArgList( \
+      FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::make_type(FMT_GEN(n, FMT_MAKE_REF2)), array)); \
   }
 
 // Emulates a variadic function returning void on a pre-C++11 compiler.
 # define FMT_VARIADIC_VOID(func, arg_type) \
-  inline void func(arg_type arg) { func(arg, fmt::ArgList()); } \
+  inline void func(arg_type arg) { func(arg, FMT_CUSTOM_NAMESPACE_PREFIX::fmt::ArgList()); } \
   FMT_WRAP1(func, arg_type, 1) FMT_WRAP1(func, arg_type, 2) \
   FMT_WRAP1(func, arg_type, 3) FMT_WRAP1(func, arg_type, 4) \
   FMT_WRAP1(func, arg_type, 5) FMT_WRAP1(func, arg_type, 6) \
@@ -2480,9 +2492,9 @@ inline uint64_t make_type(FMT_GEN15(FMT_ARG_TYPE_DEFAULT)) {
 # define FMT_CTOR(ctor, func, arg0_type, arg1_type, n) \
   template <FMT_GEN(n, FMT_MAKE_TEMPLATE_ARG)> \
   ctor(arg0_type arg0, arg1_type arg1, FMT_GEN(n, FMT_MAKE_ARG)) { \
-    const fmt::internal::ArgArray<n>::Type array = {FMT_GEN(n, FMT_MAKE_REF)}; \
-    func(arg0, arg1, fmt::ArgList( \
-      fmt::internal::make_type(FMT_GEN(n, FMT_MAKE_REF2)), array)); \
+    const FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::ArgArray<n>::Type array = {FMT_GEN(n, FMT_MAKE_REF)}; \
+    func(arg0, arg1, FMT_CUSTOM_NAMESPACE_PREFIX::fmt::ArgList( \
+      FMT_CUSTOM_NAMESPACE_PREFIX::fmt::internal::make_type(FMT_GEN(n, FMT_MAKE_REF2)), array)); \
   }
 
 // Emulates a variadic constructor on a pre-C++11 compiler.
@@ -3605,7 +3617,7 @@ template <typename Char>
 void arg(StringRef, const internal::NamedArg<Char>&) FMT_DELETED_OR_UNDEFINED;
 template <typename Char>
 void arg(WStringRef, const internal::NamedArg<Char>&) FMT_DELETED_OR_UNDEFINED;
-}
+} // namespace fmt
 
 #if FMT_GCC_VERSION
 // Use the system_header pragma to suppress warnings about variadic macros
@@ -3717,9 +3729,9 @@ void arg(WStringRef, const internal::NamedArg<Char>&) FMT_DELETED_OR_UNDEFINED;
 #define FMT_VARIADIC_CONST_W(ReturnType, func, ...) \
   FMT_VARIADIC_(const, wchar_t, ReturnType, func, return func, __VA_ARGS__)
 
-#define FMT_CAPTURE_ARG_(id, index) ::fmt::arg(#id, id)
+#define FMT_CAPTURE_ARG_(id, index) FMT_CUSTOM_NAMESPACE_PREFIX::fmt::arg(#id, id)
 
-#define FMT_CAPTURE_ARG_W_(id, index) ::fmt::arg(L###id, id)
+#define FMT_CAPTURE_ARG_W_(id, index) FMT_CUSTOM_NAMESPACE_PREFIX::fmt::arg(L###id, id)
 
 /**
   \rst
@@ -4149,6 +4161,8 @@ operator"" _a(const wchar_t *s, std::size_t) { return {s}; }
 } // inline namespace literals
 } // namespace fmt
 #endif // FMT_USE_USER_DEFINED_LITERALS
+
+FMT_CUSTOM_NAMESPACE_END
 
 // Restore warnings.
 #if FMT_GCC_VERSION >= 406

--- a/fmt/ostream.cc
+++ b/fmt/ostream.cc
@@ -9,6 +9,8 @@
 
 #include "ostream.h"
 
+FMT_CUSTOM_NAMESPACE_BEGIN
+
 namespace fmt {
 
 namespace internal {
@@ -33,3 +35,5 @@ FMT_FUNC void print(std::ostream &os, CStringRef format_str, ArgList args) {
   internal::write(os, w);
 }
 }  // namespace fmt
+
+FMT_CUSTOM_NAMESPACE_END

--- a/fmt/ostream.h
+++ b/fmt/ostream.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  Formatting library for C++ - std::ostream support
 
  Copyright (c) 2012 - 2016, Victor Zverovich
@@ -12,6 +12,8 @@
 
 #include "format.h"
 #include <ostream>
+
+FMT_CUSTOM_NAMESPACE_BEGIN
 
 namespace fmt {
 
@@ -100,6 +102,8 @@ void format_arg(BasicFormatter<Char, ArgFormatter_> &f,
 FMT_API void print(std::ostream &os, CStringRef format_str, ArgList args);
 FMT_VARIADIC(void, print, std::ostream &, CStringRef)
 }  // namespace fmt
+
+FMT_CUSTOM_NAMESPACE_END
 
 #ifdef FMT_HEADER_ONLY
 # include "ostream.cc"

--- a/fmt/posix.cc
+++ b/fmt/posix.cc
@@ -48,6 +48,8 @@
 # undef fileno
 #endif
 
+FMT_CUSTOM_NAMESPACE_BEGIN
+
 namespace {
 #ifdef _WIN32
 // Return type of read and write functions.
@@ -239,3 +241,5 @@ long fmt::getpagesize() {
   return size;
 #endif
 }
+
+FMT_CUSTOM_NAMESPACE_END

--- a/fmt/posix.h
+++ b/fmt/posix.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  A C++ interface to POSIX functions.
 
  Copyright (c) 2012 - 2016, Victor Zverovich
@@ -63,6 +63,8 @@
 #endif
 
 #define FMT_RETRY(result, expression) FMT_RETRY_VAL(result, expression, -1)
+
+FMT_CUSTOM_NAMESPACE_BEGIN
 
 namespace fmt {
 
@@ -355,6 +357,8 @@ class Locale {
 };
 #endif  // FMT_LOCALE
 }  // namespace fmt
+
+FMT_CUSTOM_NAMESPACE_END
 
 #if !FMT_USE_RVALUE_REFERENCES
 namespace std {

--- a/fmt/printf.cc
+++ b/fmt/printf.cc
@@ -10,6 +10,8 @@
 #include "format.h"
 #include "printf.h"
 
+FMT_CUSTOM_NAMESPACE_BEGIN
+
 namespace fmt {
 
 template <typename Char>
@@ -30,3 +32,5 @@ template void PrintfFormatter<wchar_t>::format(WCStringRef format);
 #endif  // FMT_HEADER_ONLY
 
 }  // namespace fmt
+
+FMT_CUSTOM_NAMESPACE_END

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  Formatting library for C++
 
  Copyright (c) 2012 - 2016, Victor Zverovich
@@ -14,6 +14,8 @@
 #include <limits>     // std::numeric_limits
 
 #include "ostream.h"
+
+FMT_CUSTOM_NAMESPACE_BEGIN
 
 namespace fmt {
 namespace internal {
@@ -595,6 +597,8 @@ inline int fprintf(std::ostream &os, CStringRef format_str, ArgList args) {
 }
 FMT_VARIADIC(int, fprintf, std::ostream &, CStringRef)
 }  // namespace fmt
+
+FMT_CUSTOM_NAMESPACE_END
 
 #ifdef FMT_HEADER_ONLY
 # include "printf.cc"

--- a/fmt/string.h
+++ b/fmt/string.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  Formatting library for C++ - string utilities
 
  Copyright (c) 2012 - 2016, Victor Zverovich
@@ -15,6 +15,8 @@
 #define FMT_STRING_H_
 
 #include "format.h"
+
+FMT_CUSTOM_NAMESPACE_BEGIN
 
 namespace fmt {
 
@@ -143,6 +145,8 @@ std::wstring to_wstring(const T &value) {
   w << value;
   return w.str();
 }
-}
+} // namespace fmt
+
+FMT_CUSTOM_NAMESPACE_END
 
 #endif  // FMT_STRING_H_

--- a/fmt/time.h
+++ b/fmt/time.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  Formatting library for C++ - time formatting
 
  Copyright (c) 2012 - 2016, Victor Zverovich
@@ -18,6 +18,8 @@
 # pragma warning(disable: 4702)  // unreachable code
 # pragma warning(disable: 4996)  // "deprecated" functions
 #endif
+
+FMT_CUSTOM_NAMESPACE_BEGIN
 
 namespace fmt {
 template <typename ArgFormatter>
@@ -135,6 +137,8 @@ inline std::tm gmtime(std::time_t time) {
   return std::tm();
 }
 } //namespace fmt
+
+FMT_CUSTOM_NAMESPACE_END
 
 #ifdef _MSC_VER
 # pragma warning(pop)

--- a/test/assert-test.cc
+++ b/test/assert-test.cc
@@ -28,6 +28,8 @@
 #include "fmt/format.h"
 #include "gtest/gtest.h"
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 #if GTEST_HAS_DEATH_TEST
 # define EXPECT_DEBUG_DEATH_IF_SUPPORTED(statement, regex) \
     EXPECT_DEBUG_DEATH(statement, regex)

--- a/test/container-test.cc
+++ b/test/container-test.cc
@@ -10,6 +10,8 @@
 #include "fmt/container.h"
 #include "gtest/gtest.h"
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 using fmt::internal::ContainerBuffer;
 
 TEST(ContainerBufferTest, Empty) {

--- a/test/custom-formatter-test.cc
+++ b/test/custom-formatter-test.cc
@@ -10,6 +10,8 @@
 #include "fmt/printf.h"
 #include "gtest-extra.h"
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 using fmt::BasicPrintfArgFormatter;
 
 // A custom argument formatter that doesn't print `-` for floating-point values

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -33,6 +33,8 @@
 #include "fmt/format.cc"
 #include "fmt/printf.cc"
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 #include <algorithm>
 #include <cstring>
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -49,6 +49,10 @@ struct LocaleMock {
   MOCK_METHOD0(localeconv, lconv *());
 } *LocaleMock::instance;
 
+#include "fmt/custom_namespace.h"
+
+FMT_CUSTOM_NAMESPACE_BEGIN
+
 namespace fmt {
 namespace std {
 using namespace ::std;
@@ -56,10 +60,14 @@ lconv *localeconv() {
   return LocaleMock::instance ?
         LocaleMock::instance->localeconv() : ::std::localeconv();
 }
-}
-}
+} // namespace std
+} // namespace fmt
+
+FMT_CUSTOM_NAMESPACE_END
 
 #include "fmt/format.h"
+
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
 
 #include "util.h"
 #include "mock-allocator.h"

--- a/test/gtest-extra-test.cc
+++ b/test/gtest-extra-test.cc
@@ -38,6 +38,8 @@
 
 #include "util.h"
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 using testing::internal::scoped_ptr;
 
 namespace {
@@ -262,17 +264,29 @@ TEST(ExpectTest, EXPECT_THROW_MSG) {
       "  Actual: test");
 }
 
+#if (FMT_CUSTOM_NAMESPACE == 1)
+#define FMT_COMPILER_STRINGFY_(x)					#x
+#define FMT_COMPILER_STRINGFY(x)					FMT_COMPILER_STRINGFY_(x)
+#define EXPECT_CUSTOM_NAMESPACE_PREFIX				FMT_COMPILER_STRINGFY(FMT_CUSTOM_NAMESPACE_PREFIX)
+#else
+#define EXPECT_CUSTOM_NAMESPACE_PREFIX				""
+#endif
+
+#define EXPECT_SYSTEM_ERROR_THROW_EXCEPTION_MESSAGE	"Expected: throw_exception() throws an exception of " \
+													"type " EXPECT_CUSTOM_NAMESPACE_PREFIX "::fmt::SystemError.\n  Actual: it throws a different type."
+
+#define EXPECT_SYSTEM_ERROR_DO_NOTHING_MESSAGE		"Expected: do_nothing() throws an exception of type " EXPECT_CUSTOM_NAMESPACE_PREFIX "::fmt::SystemError.\n" \
+													"  Actual: it throws nothing."
+
 // Tests EXPECT_SYSTEM_ERROR.
 TEST(ExpectTest, EXPECT_SYSTEM_ERROR) {
   EXPECT_SYSTEM_ERROR(throw_system_error(), EDOM, "test");
   EXPECT_NONFATAL_FAILURE(
       EXPECT_SYSTEM_ERROR(throw_exception(), EDOM, "test"),
-      "Expected: throw_exception() throws an exception of "
-      "type fmt::SystemError.\n  Actual: it throws a different type.");
+	  EXPECT_SYSTEM_ERROR_THROW_EXCEPTION_MESSAGE);
   EXPECT_NONFATAL_FAILURE(
       EXPECT_SYSTEM_ERROR(do_nothing(), EDOM, "test"),
-      "Expected: do_nothing() throws an exception of type fmt::SystemError.\n"
-      "  Actual: it throws nothing.");
+	  EXPECT_SYSTEM_ERROR_DO_NOTHING_MESSAGE);
   EXPECT_NONFATAL_FAILURE(
       EXPECT_SYSTEM_ERROR(throw_system_error(), EDOM, "other"),
       fmt::format(

--- a/test/gtest-extra.cc
+++ b/test/gtest-extra.cc
@@ -29,6 +29,8 @@
 
 #if FMT_USE_FILE_DESCRIPTORS
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 using fmt::File;
 
 void OutputRedirect::flush() {

--- a/test/gtest-extra.h
+++ b/test/gtest-extra.h
@@ -81,10 +81,10 @@
   FMT_TEST_THROW_(statement, expected_exception, \
       expected_message, GTEST_NONFATAL_FAILURE_)
 
-std::string format_system_error(int error_code, fmt::StringRef message);
+std::string format_system_error(int error_code, FMT_CUSTOM_NAMESPACE_PREFIX::fmt::StringRef message);
 
 #define EXPECT_SYSTEM_ERROR(statement, error_code, message) \
-  EXPECT_THROW_MSG(statement, fmt::SystemError, \
+  EXPECT_THROW_MSG(statement, FMT_CUSTOM_NAMESPACE_PREFIX::fmt::SystemError, \
       format_system_error(error_code, message))
 
 #if FMT_USE_FILE_DESCRIPTORS
@@ -94,8 +94,8 @@ std::string format_system_error(int error_code, fmt::StringRef message);
 class OutputRedirect {
  private:
   FILE *file_;
-  fmt::File original_;  // Original file passed to redirector.
-  fmt::File read_end_;  // Read end of the pipe where the output is redirected.
+  FMT_CUSTOM_NAMESPACE_PREFIX::fmt::File original_;  // Original file passed to redirector.
+  FMT_CUSTOM_NAMESPACE_PREFIX::fmt::File read_end_;  // Read end of the pipe where the output is redirected.
 
   GTEST_DISALLOW_COPY_AND_ASSIGN_(OutputRedirect);
 
@@ -165,7 +165,7 @@ class SuppressAssert {
   EXPECT_SYSTEM_ERROR(SUPPRESS_ASSERT(statement), error_code, message)
 
 // Attempts to read count characters from a file.
-std::string read(fmt::File &f, std::size_t count);
+std::string read(FMT_CUSTOM_NAMESPACE_PREFIX::fmt::File &f, std::size_t count);
 
 #define EXPECT_READ(file, expected_content) \
   EXPECT_EQ(expected_content, read(file, std::strlen(expected_content)))

--- a/test/macro-test.cc
+++ b/test/macro-test.cc
@@ -31,6 +31,8 @@
 #define FMT_USE_VARIADIC_TEMPLATES 0
 #include "fmt/format.h"
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 #define IDENTITY(x) x
 
 TEST(UtilTest, Gen) {

--- a/test/ostream-test.cc
+++ b/test/ostream-test.cc
@@ -32,6 +32,8 @@
 #include "gtest-extra.h"
 #include "util.h"
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 using fmt::format;
 using fmt::FormatError;
 

--- a/test/posix-mock-test.cc
+++ b/test/posix-mock-test.cc
@@ -31,6 +31,8 @@
 #include "posix-mock.h"
 #include "fmt/posix.cc"
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 #include <errno.h>
 #include <fcntl.h>
 #include <climits>

--- a/test/posix-test.cc
+++ b/test/posix-test.cc
@@ -32,6 +32,8 @@
 #include "gtest-extra.h"
 #include "util.h"
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 #ifdef fileno
 # undef fileno
 #endif

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -34,6 +34,8 @@
 #include "gtest-extra.h"
 #include "util.h"
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 using fmt::format;
 using fmt::FormatError;
 

--- a/test/string-test.cc
+++ b/test/string-test.cc
@@ -10,6 +10,8 @@
 #include "fmt/string.h"
 #include "gtest/gtest.h"
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 using fmt::internal::StringBuffer;
 
 TEST(StringBufferTest, Empty) {

--- a/test/time-test.cc
+++ b/test/time-test.cc
@@ -13,6 +13,8 @@
 #include "gmock/gmock.h"
 #include "fmt/time.h"
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 TEST(TimeTest, Format) {
   std::tm tm = std::tm();
   tm.tm_year = 116;

--- a/test/util-test.cc
+++ b/test/util-test.cc
@@ -51,6 +51,8 @@
 
 #undef max
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 using fmt::StringRef;
 using fmt::internal::Arg;
 using fmt::Buffer;

--- a/test/util.cc
+++ b/test/util.cc
@@ -28,6 +28,8 @@
 #include "util.h"
 #include <cstring>
 
+FMT_CUSTOM_NAMESPACE_USING_NAMESPACE
+
 void increment(char *s) {
   for (int i = static_cast<int>(std::strlen(s)) - 1; i >= 0; --i) {
     if (s[i] != '9') {

--- a/test/util.h
+++ b/test/util.h
@@ -55,7 +55,7 @@ std::string get_system_error(int error_code);
 extern const char *const FILE_CONTENT;
 
 // Opens a buffered file for reading.
-fmt::BufferedFile open_buffered_file(FILE **fp = 0);
+FMT_CUSTOM_NAMESPACE_PREFIX::fmt::BufferedFile open_buffered_file(FILE **fp = 0);
 
 inline FILE *safe_fopen(const char *filename, const char *mode) {
 #if defined(_WIN32) && !defined(__MINGW32__)


### PR DESCRIPTION
Added support for "namespace encapsulation" (better explained as a custom namespace prefix) for fmt library, using the new header file custom_namespace.h

This file adds support for using fmt library defining a custom namespace in your code
to avoid conflicting with other fmt library versions or 'encapsulate' the implementation
you are using inside another namespace.

```
#include <fmt/format.h>
#include <iostream>

template <typename ... args>
std::string format_some_string(char const * mask, args && ... argsv)
{
	my_cpp_library::formatting_libraries::fmt::MemoryWriter writer;

	writer.write(mask, std::forward<args>(argsv) ...);
	
	return writer.str();
}

int main(int argc, char ** argv)
{
	std::cout << format_some_string("{} from somewhere", "Hello") << std::endl;

	return 0;
}
```

<!---
Please make sure you've followed the guidelines outlined in the CONTRIBUTING.rst file.
--->
