### PR TITLE
CMakeLists: Use GNUInstallDirs to set install location

### DIFF
--- a/fmt/CMakeLists.txt
+++ b/fmt/CMakeLists.txt
@@ -49,8 +49,9 @@ endif ()
 
 # Install targets.
 if (FMT_INSTALL)
+  include(GNUInstallDirs)
   include(CMakePackageConfigHelpers)
-  set(FMT_CMAKE_DIR lib/cmake/fmt CACHE STRING
+  set(FMT_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/fmt CACHE STRING
     "Installation directory for cmake files, relative to ${CMAKE_INSTALL_PREFIX}.")
   set(version_config ${PROJECT_BINARY_DIR}/fmt-config-version.cmake)
   set(project_config ${PROJECT_BINARY_DIR}/fmt-config.cmake)
@@ -61,8 +62,11 @@ if (FMT_INSTALL)
     set(INSTALL_TARGETS ${INSTALL_TARGETS} fmt-header-only)
   endif ()
 
-  set(FMT_LIB_DIR lib CACHE STRING
+  set(FMT_LIB_DIR ${CMAKE_INSTALL_LIBDIR} CACHE STRING
     "Installation directory for libraries, relative to ${CMAKE_INSTALL_PREFIX}.")
+
+  set(FMT_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR}/fmt CACHE STRING
+    "Installation directory for include files, relative to ${CMAKE_INSTALL_PREFIX}.")
 
   # Generate the version, config and target files into the build directory.
   write_basic_package_version_file(
@@ -86,5 +90,5 @@ if (FMT_INSTALL)
   # Install the library and headers.
   install(TARGETS ${INSTALL_TARGETS} EXPORT ${targets_export_name}
           DESTINATION ${FMT_LIB_DIR})
-  install(FILES ${FMT_HEADERS} DESTINATION include/fmt)
+  install(FILES ${FMT_HEADERS} DESTINATION ${FMT_INC_DIR})
 endif ()


### PR DESCRIPTION
CMake's GNUInstallDirs knows where particular Linux architectures and
distributions want to have their libraries installed. In particular,
Debian-derived "multi-arch" distributions keep their libraries in triplet
sudirectories under /lib. Other "bi-arch" distributions keep 64-bit
libraries in /lib64.

Including GNUInstallDirs and using CMAKE_INSTALL_LIBDIR and
CMAKE_INSTALL_INCLUDEDIR means that fmt's libraries and header files are
installed in the correct locations.

Tested with OpenEmbedded and on Debian GNU/Linux 9 (the special naming only
applies when installing in /usr.)

I would hope that GNUInstallDirs does something sensible on Windows, but I haven't tested it.
