### PR TITLE
v3 v4 transition helper

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -25,6 +25,11 @@
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// transition helper
+#ifdef FMT_FORMAT_PROVIDE_PRINTF
+#include "printf.h"
+#endif
+
 #ifndef FMT_FORMAT_H_
 #define FMT_FORMAT_H_
 


### PR DESCRIPTION
i'd like to propose the following (ugly) helper: we're using v3 in several projects, but the transition from v3 to v4 was not straight-forward as printf functionality was moved out of format.h into a separate header.
this hack helps us to update to v4 without immediately changing all of our product code, but allows us to incrementally adapt the includes.