### PR TITLE
Fix unreachable code warning when signbit returns bool

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -444,8 +444,7 @@ class numeric_limits<fmt::internal::DummyInt> :
     using namespace fmt::internal;
     // The resolution "priority" is:
     // isinf macro > std::isinf > ::isinf > fmt::internal::isinf
-    if (const_check(sizeof(isinf(x)) == sizeof(bool) ||
-                    sizeof(isinf(x)) == sizeof(int))) {
+    if (const_check(sizeof(isinf(x)) != sizeof(fmt::internal::DummyInt))) {
       return isinf(x) != 0;
     }
     return !_finite(static_cast<double>(x));
@@ -455,8 +454,7 @@ class numeric_limits<fmt::internal::DummyInt> :
   template <typename T>
   static bool isnotanumber(T x) {
     using namespace fmt::internal;
-    if (const_check(sizeof(isnan(x)) == sizeof(bool) ||
-                    sizeof(isnan(x)) == sizeof(int))) {
+    if (const_check(sizeof(isnan(x)) != sizeof(fmt::internal::DummyInt))) {
       return isnan(x) != 0;
     }
     return _isnan(static_cast<double>(x)) != 0;
@@ -465,8 +463,7 @@ class numeric_limits<fmt::internal::DummyInt> :
   // Portable version of signbit.
   static bool isnegative(double x) {
     using namespace fmt::internal;
-    if (const_check(sizeof(signbit(x)) == sizeof(bool) ||
-                    sizeof(signbit(x)) == sizeof(int))) {
+    if (const_check(sizeof(signbit(x)) != sizeof(fmt::internal::DummyInt))) {
       return signbit(x) != 0;
     }
     if (x < 0) return true;


### PR DESCRIPTION
Fixes the following warning:
```
warning: will never be executed [-Wunreachable-code]
                    sizeof(signbit(x)) == sizeof(int))) {
                    ^~~~~~~~~~~~~~~~~~
```

