### PR TITLE
Fix VS2017 string_view support

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -663,7 +663,8 @@ class basic_arg {
 template <typename Char, typename ErrorHandler = internal::error_handler>
 class basic_parse_context : private ErrorHandler {
  private:
-  basic_string_view<Char> format_str_;
+  typename basic_string_view<Char>::iterator begin_;
+  typename basic_string_view<Char>::iterator end_;
   int next_arg_id_;
 
  public:
@@ -672,20 +673,21 @@ class basic_parse_context : private ErrorHandler {
 
   explicit FMT_CONSTEXPR basic_parse_context(
       basic_string_view<Char> format_str, ErrorHandler eh = ErrorHandler())
-    : ErrorHandler(eh), format_str_(format_str), next_arg_id_(0) {}
+    : ErrorHandler(eh), begin_(format_str.begin()), end_(format_str.end()),
+      next_arg_id_(0) {}
 
   // Returns an iterator to the beginning of the format string range being
   // parsed.
   FMT_CONSTEXPR iterator begin() const FMT_NOEXCEPT {
-    return format_str_.begin();
+    return begin_;
   }
 
   // Returns an iterator past the end of the format string range being parsed.
-  FMT_CONSTEXPR iterator end() const FMT_NOEXCEPT { return format_str_.end(); }
+  FMT_CONSTEXPR iterator end() const FMT_NOEXCEPT { return end_; }
 
   // Advances the begin iterator to ``it``.
   FMT_CONSTEXPR void advance_to(iterator it) {
-    format_str_.remove_prefix(it - begin());
+    begin_ = it;
   }
 
   // Returns the next argument index.

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -567,7 +567,7 @@ template <typename Char>
 class null_terminating_iterator;
 
 template <typename Char>
-FMT_CONSTEXPR_DECL const Char *pointer_from(null_terminating_iterator<Char> it);
+FMT_CONSTEXPR_DECL typename null_terminating_iterator<Char>::pointer pointer_from(null_terminating_iterator<Char> it);
 
 // An iterator that produces a null terminator on *end. This simplifies parsing
 // and allows comparing the performance of processing a null-terminated string
@@ -577,20 +577,20 @@ class null_terminating_iterator {
  public:
   typedef std::ptrdiff_t difference_type;
   typedef Char value_type;
-  typedef const Char* pointer;
+  typedef typename basic_string_view<Char>::iterator pointer;
   typedef const Char& reference;
   typedef std::random_access_iterator_tag iterator_category;
 
   null_terminating_iterator() : ptr_(0), end_(0) {}
 
-  FMT_CONSTEXPR null_terminating_iterator(const Char *ptr, const Char *end)
+  FMT_CONSTEXPR null_terminating_iterator(pointer ptr, pointer end)
     : ptr_(ptr), end_(end) {}
 
   template <typename Range>
   FMT_CONSTEXPR explicit null_terminating_iterator(const Range &r)
     : ptr_(r.begin()), end_(r.end()) {}
 
-  null_terminating_iterator &operator=(const Char *ptr) {
+  null_terminating_iterator &operator=(pointer ptr) {
     assert(ptr <= end_);
     ptr_ = ptr;
     return *this;
@@ -642,19 +642,19 @@ class null_terminating_iterator {
     return ptr_ >= other.ptr_;
   }
 
-  friend FMT_CONSTEXPR_DECL const Char *pointer_from<Char>(
+  friend FMT_CONSTEXPR_DECL typename null_terminating_iterator<Char>::pointer pointer_from<Char>(
       null_terminating_iterator it);
 
  private:
-  const Char *ptr_;
-  const Char *end_;
+  pointer ptr_;
+  pointer end_;
 };
 
 template <typename T>
 FMT_CONSTEXPR const T *pointer_from(const T *p) { return p; }
 
 template <typename Char>
-FMT_CONSTEXPR const Char *pointer_from(null_terminating_iterator<Char> it) {
+FMT_CONSTEXPR typename null_terminating_iterator<Char>::pointer pointer_from(null_terminating_iterator<Char> it) {
   return it.ptr_;
 }
 
@@ -1783,7 +1783,7 @@ FMT_CONSTEXPR Iterator parse_arg_id(Iterator it, IDHandler &&handler) {
   do {
     c = *++it;
   } while (is_name_start(c) || ('0' <= c && c <= '9'));
-  handler(basic_string_view<char_type>(pointer_from(start), it - start));
+  handler(basic_string_view<char_type>(&*pointer_from(start), it - start));
   return it;
 }
 


### PR DESCRIPTION
I've tried to address #657 here by encapsulating the iterator type.

I'm not sure if it's the best possible approach, but at least it works.

Note: cmake scripts really should be updated to add `/std:c++latest` compiler option to enable the "real" VS17 string_view - right now this path is not tested, which is presumably why this issue was not identified earlier.