### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/include/fmt/posix.h
+++ b/include/fmt/posix.h
@@ -353,7 +353,7 @@ class File {
 long getpagesize();
 
 #if (defined(LC_NUMERIC_MASK) || defined(_MSC_VER)) && \
-    !defined(__ANDROID__) && !defined(__CYGWIN__)
+    !defined(__ANDROID__) && !defined(__CYGWIN__) && !defined(__OpenBSD__)
 # define FMT_LOCALE
 #endif
 


### PR DESCRIPTION
OpenBSD lacks `strtod_l`, so the `Locale` class won't compile. Looking around, this problem has apparently occurred in other environments as well (#388, #345), so I fixed it the same way they were fixed: by appending ` && !defined(__OpenBSD__)` to the preprocessor condition gating the definition of the `FMT_LOCALE` macro.