### PR TITLE
Fix warnings on gcc and clang

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1075,7 +1075,7 @@ class basic_format_args {
 struct format_args: basic_format_args<context> {
   template <typename ...Args>
   format_args(Args && ... arg)
-  : basic_format_args<context>(std::forward<Args>(arg)...) {};
+  : basic_format_args<context>(std::forward<Args>(arg)...) {}
 };
 typedef basic_format_args<wcontext> wformat_args;
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -157,7 +157,7 @@
 #endif
 
 // A workaround for gcc 4.4 that doesn't support union members with ctors.
-#if FMT_GCC_VERSION && FMT_GCC_VERSION <= 404
+#if (FMT_GCC_VERSION && FMT_GCC_VERSION <= 404) && !defined(__clang__)
 # define FMT_UNION struct
 #else
 # define FMT_UNION union


### PR DESCRIPTION
First commit fixes a `-Wpedantic` warning when compiling gcc and clang.
Second commit defines `FMT_UNION` as `union` rather than `struct` on clang.