### PR TITLE
Fix linker errors using fmt as shared library in MSVC

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -405,7 +405,7 @@ struct error_handler {
   FMT_CONSTEXPR error_handler(const error_handler &) {}
 
   // This function is intentionally not constexpr to give a compile-time error.
-  void on_error(const char *message);
+  FMT_API void on_error(const char *message);
 };
 
 // Formatting of wide characters and strings into a narrow output is disallowed:

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -905,7 +905,7 @@ class add_thousands_sep {
 };
 
 template <typename Char>
-Char thousands_sep(locale_provider *lp);
+FMT_API Char thousands_sep(locale_provider *lp);
 
 // Formats a decimal unsigned integer value writing into buffer.
 // thousands_sep is a functor that is called after writing each char to

--- a/src/format.cc
+++ b/src/format.cc
@@ -13,7 +13,7 @@ template struct internal::basic_data<void>;
 
 // Explicit instantiations for char.
 
-template char internal::thousands_sep(locale_provider *lp);
+template FMT_API char internal::thousands_sep(locale_provider *lp);
 
 template void basic_fixed_buffer<char>::grow(std::size_t);
 
@@ -30,7 +30,7 @@ template FMT_API int internal::char_traits<char>::format_float(
 
 // Explicit instantiations for wchar_t.
 
-template wchar_t internal::thousands_sep(locale_provider *lp);
+template FMT_API wchar_t internal::thousands_sep(locale_provider *lp);
 
 template void basic_fixed_buffer<wchar_t>::grow(std::size_t);
 


### PR DESCRIPTION
When using fmt as a shared library with FMT_SHARED in MSVC, I got linker errors for the library consuming fmt.
Two definitions could not be found:
- `fmt::internal::error_handler::on_error(const char *message)`
- `char fmt::internal::thousands_sep(locale_provider *lp)`

Since those definitions are hidden in `format-inl.h` I added `FMT_API` macros to make the functions part of the DLL interface.
