### PR TITLE
fixes MSVC compiler warning bloat (Visual Studio 2017, latest updates)

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2655,7 +2655,7 @@ void basic_writer<Range>::write_padded(
   if (width <= size)
     return f(reserve(size));
   auto &&it = reserve(width);
-  char_type fill = spec.fill();
+  char_type fill = static_cast<char_type>(spec.fill());
   std::size_t padding = width - size;
   if (spec.align() == ALIGN_RIGHT) {
     it = std::fill_n(it, padding, fill);


### PR DESCRIPTION
Hi,

first, thanks for the great library. I am currently porting my own software to Windows and it turned out that MSVC/VS2017 is complaining a lot in my code (99% of the build output is `fmt` lib related).

It turned out that I could track it down to the following change of this PR.

There might be surely another way (I didn't dig too deep into the template-voodoo of this project), such as the template-ification of `align_spec`, so that in line 1144 (`wchar_t fill_;`) would be more generic.  But I'd like to get your feedback, and probably an early merge, so that I do not need to manually patch locally.

Best regards,
Christian Parpart.