### PR TITLE
Added support for custom types with 'toString' function

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -629,7 +629,6 @@ inline typename std::enable_if<
 
 template <typename C, typename T, typename Char = typename C::char_type>
 inline typename std::enable_if<
-    !std::is_same<decltype(sizeof(&T::toString)), size_t>::value &&
     !convert_to_int<T, Char>::value &&
     !std::is_convertible<T, basic_string_view<Char>>::value &&
     !std::is_convertible<T, std::basic_string<Char>>::value,
@@ -640,7 +639,7 @@ template <typename C, typename T>
 inline typename std::enable_if<
     std::is_same<decltype(sizeof(&T::toString)), size_t>::value,
     typed_value<C, string_type>>::type
-  make_value(const T& val) {return static_cast<basic_string_view<typename C::char_type>>(val.toString());}
+  make_value(T& val) {return static_cast<basic_string_view<typename C::char_type>>(val.toString());}
 
 template <typename C, typename T>
 typed_value<C, name_arg_type>

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -629,11 +629,18 @@ inline typename std::enable_if<
 
 template <typename C, typename T, typename Char = typename C::char_type>
 inline typename std::enable_if<
+    !std::is_same<decltype(sizeof(&T::toString)), size_t>::value &&
     !convert_to_int<T, Char>::value &&
     !std::is_convertible<T, basic_string_view<Char>>::value &&
     !std::is_convertible<T, std::basic_string<Char>>::value,
     typed_value<C, custom_type>>::type
   make_value(const T &val) { return val; }
+
+template <typename C, typename T>
+inline typename std::enable_if<
+    std::is_same<decltype(sizeof(&T::toString)), size_t>::value,
+    typed_value<C, string_type>>::type
+  make_value(const T& val) {return static_cast<basic_string_view<typename C::char_type>>(val.toString());}
 
 template <typename C, typename T>
 typed_value<C, name_arg_type>


### PR DESCRIPTION
Customizing output for user-defined types doesn't work as documented, and relying on ostream is not the best option, so this enables java-like toString function to format classes.

I feel like this is more understandable and easier to implement for the users.