### PR TITLE
Stop newer CMake's from warning about OLD policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ message(STATUS "CMake version: ${CMAKE_VERSION}")
 cmake_minimum_required(VERSION 2.8.12)
 
 if (POLICY CMP0048) # Version variables
-  cmake_policy(SET CMP0048 OLD)
+  cmake_policy(SET CMP0048 NEW)
 endif ()
 
 if (POLICY CMP0063) # Visibility


### PR DESCRIPTION
Fmt sets the `FMT_VERSION` variables after project(), so the NEW option here is safe. Currently including Fmt causes newer versions of CMake to throw warnings. (This problem was fixed in Fmt master)