### PR TITLE
Fix warnings when with master project set to hidden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if (POLICY CMP0048) # Version variables
 endif ()
 
 if (POLICY CMP0063) # Visibility
-  cmake_policy(SET CMP0063 OLD)
+  cmake_policy(SET CMP0063 NEW)
 endif (POLICY CMP0063)
 
 # Determine if fmt is built as a subproject (using add_subdirectory)


### PR DESCRIPTION
Setting the `OLD` version of [this policy](https://cmake.org/cmake/help/latest/policy/CMP0063.html) (or even if it is unset and CMake minimum_version is set below 3.3, which it is) does the wrong thing; it causes GCC to spew a mass of warnings if you try to use fmt from a project that has set hidden symbols. Setting this to `NEW` fixes the issue.

Patch to 4.x because both policy statements are missing from master.