### PR TITLE
Fix #433 for FreeBSD 12

### DIFF
--- a/test/posix-mock-test.cc
+++ b/test/posix-mock-test.cc
@@ -476,7 +476,7 @@ LocaleType newlocale(int category_mask, const char *locale, LocaleType base) {
   return LocaleMock::instance->newlocale(category_mask, locale, base);
 }
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || (defined(__FreeBSD__) && __FreeBSD_version < 1200002)
 typedef int FreeLocaleResult;
 #else
 typedef void FreeLocaleResult;

--- a/test/posix-mock.h
+++ b/test/posix-mock.h
@@ -14,6 +14,7 @@
 #ifdef _WIN32
 # include <windows.h>
 #else
+# include <sys/param.h>  // for FreeBSD version
 # include <sys/types.h>  // for ssize_t
 #endif
 


### PR DESCRIPTION
The fix for #433 is correct for FreeBSD versions less than 12.

FreeBSD 12 changed the type of freelocale to the type defined by POSIX. Check the FreeBSD version when building for FreeBSD.