### PR TITLE
Mark the whole class FormatError as FMT_API

### DIFF
--- a/fmt/format.h
+++ b/fmt/format.h
@@ -710,12 +710,12 @@ typedef BasicCStringRef<char> CStringRef;
 typedef BasicCStringRef<wchar_t> WCStringRef;
 
 /** A formatting error such as invalid format string. */
-class FormatError : public std::runtime_error {
+class FMT_API FormatError : public std::runtime_error {
  public:
   explicit FormatError(CStringRef message)
   : std::runtime_error(message.c_str()) {}
   FormatError(const FormatError &ferr) : std::runtime_error(ferr) {}
-  FMT_API ~FormatError() FMT_DTOR_NOEXCEPT FMT_OVERRIDE;
+  ~FormatError() FMT_DTOR_NOEXCEPT FMT_OVERRIDE;
 };
 
 namespace internal {


### PR DESCRIPTION
Else on windows across DLLs the vtable is not visible which causes linking error