### PR TITLE
MSVC improvements and data truncation cleanup.

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -73,7 +73,8 @@
 # endif
 #endif
 
-#if FMT_HAS_FEATURE(cxx_explicit_conversions)
+#if FMT_HAS_FEATURE(cxx_explicit_conversions) || \
+    FMT_MSC_VER >= 1800
 # define FMT_EXPLICIT explicit
 #else
 # define FMT_EXPLICIT
@@ -986,8 +987,17 @@ class format_arg_store {
 
   friend class basic_format_args<Context>;
 
+  static FMT_CONSTEXPR uint64_t get_types() {
+    return IS_PACKED ? internal::get_types<Context, Args...>()
+                : -static_cast<int64_t>(NUM_ARGS);
+  }
+
  public:
+#if FMT_USE_CONSTEXPR
+  static constexpr uint64_t TYPES = get_types();
+#else
   static const uint64_t TYPES;
+#endif
 
 #if FMT_GCC_VERSION && FMT_GCC_VERSION <= 405
   // Workaround an array initialization bug in gcc 4.5 and earlier.
@@ -1000,10 +1010,10 @@ class format_arg_store {
 #endif
 };
 
+#if !FMT_USE_CONSTEXPR
 template <typename Context, typename ...Args>
-const uint64_t format_arg_store<Context, Args...>::TYPES = IS_PACKED ?
-    internal::get_types<Context, Args...>() :
-    -static_cast<int64_t>(NUM_ARGS);
+const uint64_t format_arg_store<Context, Args...>::TYPES = get_types();
+#endif
 
 /**
   \rst

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1381,13 +1381,13 @@ class float_type_checker : private ErrorHandler {
   }
 };
 
-template <typename ErrorHandler>
+template <typename ErrorHandler, typename CharType>
 class char_specs_checker : public ErrorHandler {
  private:
-  char type_;
+  CharType type_;
 
  public:
-  FMT_CONSTEXPR char_specs_checker(char type, ErrorHandler eh)
+  FMT_CONSTEXPR char_specs_checker(CharType type, ErrorHandler eh)
     : ErrorHandler(eh), type_(type) {}
 
   FMT_CONSTEXPR void on_int() {
@@ -3110,8 +3110,10 @@ struct formatter<
             type_spec, internal::int_type_checker<decltype(eh)>(eh));
       break;
     case internal::char_type:
-      handle_char_specs(specs_, internal::char_specs_checker<decltype(eh)>(
-                          type_spec, eh));
+      handle_char_specs(
+          specs_,
+          internal::char_specs_checker<decltype(eh), decltype(type_spec)>(
+              type_spec, eh));
       break;
     case internal::double_type:
     case internal::long_double_type:


### PR DESCRIPTION
MSVC is timid about evaluating constexpr functions unless it has to, so the "TYPES" variables end up in read-write memory even though the optimizer removes the initializer. Making TYPES constexpr causes MSVC to try harder to initialize these variables at compile time, which also ends up completely removing the (named) variable from the final compiled binary.
Fixed a data truncation warning being reported in ostream-test.