### PR TITLE
quotes for string support.

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -165,13 +165,15 @@ void for_each(Tuple &&tup, F &&f) {
 
 template<typename Arg>
 FMT_CONSTEXPR const char* format_str_quoted(bool add_space, const Arg&, 
-    typename std::enable_if<!is_like_std_string<typename  std::decay<Arg>::type>::value>::type* = nullptr) {
+  typename std::enable_if<
+    !is_like_std_string<typename std::decay<Arg>::type>::value>::type* = nullptr) {
   return add_space ? " {}" : "{}";
 }
 
 template<typename Arg>
 FMT_CONSTEXPR const char* format_str_quoted(bool add_space, const Arg&, 
-    typename std::enable_if<is_like_std_string<typename  std::decay<Arg>::type>::value>::type* = nullptr) {
+  typename std::enable_if<
+    is_like_std_string<typename std::decay<Arg>::type>::value>::type* = nullptr) {
   return add_space ? " \"{}\"" : "\"{}\"";
 }
 
@@ -212,7 +214,10 @@ private:
         }
         internal::copy(formatting.delimiter, out);
       }
-      format_to(out, internal::format_str_quoted((formatting.add_delimiter_spaces && i > 0), v), v);
+      format_to(out,
+                internal::format_str_quoted(
+                    (formatting.add_delimiter_spaces && i > 0), v),
+                v);
       ++i;
     }
 
@@ -275,7 +280,10 @@ struct formatter<RangeT, Char,
         }
         internal::copy(formatting.delimiter, out);
       }
-      format_to(out, internal::format_str_quoted((formatting.add_delimiter_spaces && i > 0), *it), *it);
+      format_to(out,
+                internal::format_str_quoted(
+                    (formatting.add_delimiter_spaces && i > 0), *it),
+                *it);
       if (++i > formatting.range_length_limit) {
         format_to(out, " ... <other elements>");
         break;

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -32,7 +32,7 @@ TEST(RangesTest, FormatVector2) {
 
 TEST(RangesTest, FormatMap) {
   std::map<std::string, int32_t> simap{{"one", 1}, {"two", 2}};
-  EXPECT_EQ("{(one, 1), (two, 2)}", fmt::format("{}", simap));
+  EXPECT_EQ("{(\"one\", 1), (\"two\", 2)}", fmt::format("{}", simap));
 }
 
 TEST(RangesTest, FormatPair) {
@@ -41,9 +41,9 @@ TEST(RangesTest, FormatPair) {
 }
 
 TEST(RangesTest, FormatTuple) {
-  std::tuple<int64_t, float, std::string> tu1{42, 3.14159265358979f,
-                                              "this is tuple"};
-  EXPECT_EQ("(42, 3.14159, this is tuple)", fmt::format("{}", tu1));
+  std::tuple<int64_t, float, std::string, char> tu1{42, 3.14159265358979f,
+                                              "this is tuple", 'i'};
+  EXPECT_EQ("(42, 3.14159, \"this is tuple\", 'i')", fmt::format("{}", tu1));
 }
 
 /// Check if  'if constexpr' is supported.
@@ -81,7 +81,7 @@ struct tuple_element<N, my_struct> {
 
 TEST(RangesTest, FormatStruct) {
   my_struct mst{13, "my struct"};
-  EXPECT_EQ("(13, my struct)", fmt::format("{}", mst));
+  EXPECT_EQ("(13, \"my struct\")", fmt::format("{}", mst));
 }
 
 #endif  // (__cplusplus > 201402L) || (defined(_MSVC_LANG) && _MSVC_LANG >


### PR DESCRIPTION
std::string and types like it are now printed in double quotes "str".
chars are now printed in single quotes 'A'.

```cpp
#include <tuple>
#include <vector>
#include <string_view>

#define FMT_HEADER_ONLY
#include <fmt/ranges.h>

int main() {
    std::tuple tup = {1, '1', "10", std::string("20"), std::string_view{"30"}};
    fmt::print("{}\n", tup); // (1, '1', "10", "20", "30")

    std::vector vec = {'1', '2'};
    fmt::print("{}\n", vec); // {'1', '2'}

    std::vector vec2 = {"2", "3"};
    fmt::print("{}\n", vec2); // {"2", "3"}
}
```