### PR TITLE
Renamed enum color to colors.

### DIFF
--- a/include/fmt/colors.h
+++ b/include/fmt/colors.h
@@ -16,6 +16,8 @@
 
 FMT_BEGIN_NAMESPACE
 
+enum class colors : uint32_t;
+
 // rgb is a struct for red, green and blue colors.
 // We use rgb as name because some editors will show it as color direct in the
 // editor.
@@ -25,6 +27,8 @@ struct rgb {
     : r(r_), g(g_), b(b_) {}
   FMT_CONSTEXPR_DECL rgb(uint32_t hex) 
       : r((hex >> 16) & 0xFF), g((hex >> 8) & 0xFF), b((hex) & 0xFF) {}
+  FMT_CONSTEXPR_DECL rgb(colors hex) 
+      : r((uint32_t(hex) >> 16) & 0xFF), g((uint32_t(hex) >> 8) & 0xFF), b(uint32_t(hex) & 0xFF) {}
   uint8_t r;
   uint8_t g;
   uint8_t b;
@@ -40,7 +44,7 @@ FMT_CONSTEXPR inline void to_esc(uint8_t c, char out[], int offset) {
 
 } // namespace internal
 
-FMT_FUNC void vprint_rgb(rgb fd, string_view format, format_args args) {
+inline void vprint_rgb(rgb fd, string_view format, format_args args) {
   char escape_fd[] = "\x1b[38;2;000;000;000m";
   static FMT_CONSTEXPR_DECL const char RESET_COLOR[] = "\x1b[0m";
   internal::to_esc(fd.r, escape_fd, 7);
@@ -52,7 +56,7 @@ FMT_FUNC void vprint_rgb(rgb fd, string_view format, format_args args) {
   std::fputs(RESET_COLOR, stdout);
 }
 
-FMT_FUNC void vprint_rgb(rgb fd, rgb bg, string_view format, format_args args) {
+inline void vprint_rgb(rgb fd, rgb bg, string_view format, format_args args) {
   char escape_fd[] = "\x1b[38;2;000;000;000m"; // foreground color
   char escape_bg[] = "\x1b[48;2;000;000;000m"; // background color
   static FMT_CONSTEXPR_DECL const char RESET_COLOR[] = "\x1b[0m";
@@ -87,7 +91,7 @@ inline void print(rgb fd, rgb bg, string_view format_str, const Args & ... args)
   vprint_rgb(fd, bg, format_str, make_format_args(args...));
 }
 
-enum class color : uint32_t {
+enum class colors : uint32_t {
   alice_blue              = 0xF0F8FF, // rgb(240,248,255) 
   antique_white           = 0xFAEBD7, // rgb(250,235,215) 
   aqua                    = 0x00FFFF, // rgb(0,255,255)   

--- a/include/fmt/colors.h
+++ b/include/fmt/colors.h
@@ -36,7 +36,7 @@ struct rgb {
 
 namespace internal {
 
-FMT_CONSTEXPR inline void to_esc(uint8_t c, char out[], int offset) {
+FMT_CONSTEXPR void to_esc(uint8_t c, char out[], int offset) {
   out[offset + 0] = static_cast<char>('0' + c / 100);
   out[offset + 1] = static_cast<char>('0' + c / 10 % 10);
   out[offset + 2] = static_cast<char>('0' + c % 10);
@@ -72,17 +72,6 @@ inline void vprint_rgb(rgb fd, rgb bg, string_view format, format_args args) {
   std::fputs(escape_bg, stdout);
   vprint(format, args);
   std::fputs(RESET_COLOR, stdout);
-}
-
-/**
-  Formats a string and prints it to stdout using ANSI escape sequences to
-  specify foreground color 'fd'.
-  Example:
-    fmt::print_rgb(fmt::color::red, "Elapsed time: {0:.2f} seconds", 1.23);
- */
-template <typename... Args>
-inline void print_rgb(rgb fd, string_view format_str, const Args & ... args) {
-  vprint_rgb(fd, format_str, make_format_args(args...));
 }
 
 /**

--- a/include/fmt/colors.h
+++ b/include/fmt/colors.h
@@ -16,7 +16,7 @@
 
 FMT_BEGIN_NAMESPACE
 
-enum class colors : uint32_t;
+enum class color : uint32_t;
 
 // rgb is a struct for red, green and blue colors.
 // We use rgb as name because some editors will show it as color direct in the
@@ -27,7 +27,7 @@ struct rgb {
     : r(r_), g(g_), b(b_) {}
   FMT_CONSTEXPR_DECL rgb(uint32_t hex) 
       : r((hex >> 16) & 0xFF), g((hex >> 8) & 0xFF), b((hex) & 0xFF) {}
-  FMT_CONSTEXPR_DECL rgb(colors hex) 
+  FMT_CONSTEXPR_DECL rgb(color hex) 
       : r((uint32_t(hex) >> 16) & 0xFF), g((uint32_t(hex) >> 8) & 0xFF), b(uint32_t(hex) & 0xFF) {}
   uint8_t r;
   uint8_t g;
@@ -74,24 +74,40 @@ inline void vprint_rgb(rgb fd, rgb bg, string_view format, format_args args) {
   std::fputs(RESET_COLOR, stdout);
 }
 
+/**
+  Formats a string and prints it to stdout using ANSI escape sequences to
+  specify foreground color 'fd'.
+  Example:
+    fmt::print_rgb(fmt::color::red, "Elapsed time: {0:.2f} seconds", 1.23);
+ */
 template <typename... Args>
 inline void print_rgb(rgb fd, string_view format_str, const Args & ... args) {
   vprint_rgb(fd, format_str, make_format_args(args...));
 }
 
-// rgb foreground color
+/**
+  Formats a string and prints it to stdout using ANSI escape sequences to
+  specify foreground color 'fd'.
+  Example:
+    fmt::print(fmt::color::red, "Elapsed time: {0:.2f} seconds", 1.23);
+ */
 template <typename... Args>
 inline void print(rgb fd, string_view format_str, const Args & ... args) {
   vprint_rgb(fd, format_str, make_format_args(args...));
 }
 
-// rgb foreground color and background color
+/**
+  Formats a string and prints it to stdout using ANSI escape sequences to
+  specify foreground color 'fd' and background color 'bg'.
+  Example:
+    fmt::print(fmt::color::red, fmt::color::black, "Elapsed time: {0:.2f} seconds", 1.23);
+ */
 template <typename... Args>
 inline void print(rgb fd, rgb bg, string_view format_str, const Args & ... args) {
   vprint_rgb(fd, bg, format_str, make_format_args(args...));
 }
 
-enum class colors : uint32_t {
+enum class color : uint32_t {
   alice_blue              = 0xF0F8FF, // rgb(240,248,255) 
   antique_white           = 0xFAEBD7, // rgb(250,235,215) 
   aqua                    = 0x00FFFF, // rgb(0,255,255)   
@@ -233,7 +249,7 @@ enum class colors : uint32_t {
   white_smoke             = 0xF5F5F5, // rgb(245,245,245) 
   yellow                  = 0xFFFF00, // rgb(255,255,0)   
   yellow_green            = 0x9ACD32, // rgb(154,205,50)  
-};  // enum class colors
+};  // enum class color
 
 FMT_END_NAMESPACE
 

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1181,29 +1181,6 @@ inline internal::named_arg<T, wchar_t> arg(wstring_view name, const T &arg) {
 template <typename S, typename T, typename Char>
 void arg(S, internal::named_arg<T, Char>) FMT_DELETED;
 
-enum color { black, red, green, yellow, blue, magenta, cyan, white };
-
-FMT_API void vprint_colored(color c, string_view format, format_args args);
-FMT_API void vprint_colored(color c, wstring_view format, wformat_args args);
-
-/**
-  Formats a string and prints it to stdout using ANSI escape sequences to
-  specify color (experimental).
-  Example:
-    fmt::print_colored(fmt::RED, "Elapsed time: {0:.2f} seconds", 1.23);
- */
-template <typename... Args>
-inline void print_colored(color c, string_view format_str,
-                          const Args & ... args) {
-  vprint_colored(c, format_str, make_format_args(args...));
-}
-
-template <typename... Args>
-inline void print_colored(color c, wstring_view format_str,
-                          const Args & ... args) {
-  vprint_colored(c, format_str, make_format_args<wformat_context>(args...));
-}
-
 format_context::iterator vformat_to(
     internal::buffer &buf, string_view format_str, format_args args);
 wformat_context::iterator vformat_to(

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -499,22 +499,6 @@ FMT_FUNC void vprint(wstring_view format_str, wformat_args args) {
   vprint(stdout, format_str, args);
 }
 
-FMT_FUNC void vprint_colored(color c, string_view format, format_args args) {
-  char escape[] = "\x1b[30m";
-  escape[3] = static_cast<char>('0' + c);
-  std::fputs(escape, stdout);
-  vprint(format, args);
-  std::fputs(RESET_COLOR, stdout);
-}
-
-FMT_FUNC void vprint_colored(color c, wstring_view format, wformat_args args) {
-  wchar_t escape[] = L"\x1b[30m";
-  escape[3] = static_cast<wchar_t>('0' + c);
-  std::fputws(escape, stdout);
-  vprint(format, args);
-  std::fputws(WRESET_COLOR, stdout);
-}
-
 FMT_FUNC locale locale_provider::locale() { return fmt::locale(); }
 
 FMT_END_NAMESPACE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,6 +94,7 @@ add_fmt_test(time-test)
 add_fmt_test(util-test mock-allocator.h)
 add_fmt_test(custom-formatter-test)
 add_fmt_test(ranges-test)
+add_fmt_test(colors_test)
 
 if (HAVE_OPEN)
   add_fmt_executable(posix-mock-test

--- a/test/colors_test.cc
+++ b/test/colors_test.cc
@@ -30,9 +30,9 @@ TEST(ColorsTest, RgbTest) {
 }
 
 TEST(ColorsTest, Colors) {
-  fmt::print(fmt::colors::blue,"blue \n");               // \x1b[38;2;000;000;255mblue \n\x1b[0m
-  fmt::print(fmt::colors::medium_spring_green,"medium_spring_green \n"); // \x1b[38;2;000;250;154mmedium_spring_green \n\x1b[0m
-  fmt::print(fmt::colors::light_golden_rod_yellow,"light_golden_rod_yellow \n"); // \x1b[38;2;250;250;210mlight_golden_rod_yellow \n\x1b[0m
+  fmt::print(fmt::color::blue,"blue \n");               // \x1b[38;2;000;000;255mblue \n\x1b[0m
+  fmt::print(fmt::color::medium_spring_green,"medium_spring_green \n"); // \x1b[38;2;000;250;154mmedium_spring_green \n\x1b[0m
+  fmt::print(fmt::color::light_golden_rod_yellow,"light_golden_rod_yellow \n"); // \x1b[38;2;250;250;210mlight_golden_rod_yellow \n\x1b[0m
 
-  EXPECT_WRITE(stdout, fmt::print(fmt::colors::blue,"blue"), "\x1b[38;2;000;000;255mblue\x1b[0m");
+  EXPECT_WRITE(stdout, fmt::print(fmt::color::blue,"blue"), "\x1b[38;2;000;000;255mblue\x1b[0m");
 }

--- a/test/colors_test.cc
+++ b/test/colors_test.cc
@@ -1,0 +1,38 @@
+// Formatting library for C++ - the core API
+//
+// Copyright (c) 2012 - present, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+//
+// Copyright (c) 2018 - present, Remotion (Igor Schulz)
+// All Rights Reserved
+// {fmt} support for rgb color output.
+
+#include "gtest.h"
+#include "gtest-extra.h"
+
+#include "fmt/colors.h"
+#include "fmt/printf.h"
+
+#include <vector>
+#include <array>
+#include <map>
+#include <string>
+
+TEST(ColorsTest, RgbTest) {
+  fmt::print(fmt::rgb(10,20,30), "rgb(10,20,30) \n");    // \x1b[38;2;010;020;030mrgb(10,20,30) \n\x1b[0m
+  fmt::print(fmt::rgb(255,20,30), "rgb(255,20,30) \n");  // \x1b[38;2;255;020;030mrgb(255,20,30) \n\x1b[0m
+  fmt::print(fmt::rgb(30,255,30), "rgb(30,255,30) \n");  // \x1b[38;2;030;255;030mrgb(30,255,30) \n\x1b[0m
+  fmt::print(fmt::rgb(30,30,255), "rgb(30,30,255) \n");  // \x1b[38;2;030;030;255mrgb(30,30,255) \n\x1b[0m
+
+  EXPECT_WRITE(stdout, fmt::print(fmt::rgb(255,20,30), "rgb(255,20,30)"), "\x1b[38;2;255;020;030mrgb(255,20,30)\x1b[0m");
+}
+
+TEST(ColorsTest, Colors) {
+  fmt::print(fmt::colors::blue,"blue \n");               // \x1b[38;2;000;000;255mblue \n\x1b[0m
+  fmt::print(fmt::colors::medium_spring_green,"medium_spring_green \n"); // \x1b[38;2;000;250;154mmedium_spring_green \n\x1b[0m
+  fmt::print(fmt::colors::light_golden_rod_yellow,"light_golden_rod_yellow \n"); // \x1b[38;2;250;250;210mlight_golden_rod_yellow \n\x1b[0m
+
+  EXPECT_WRITE(stdout, fmt::print(fmt::colors::blue,"blue"), "\x1b[38;2;000;000;255mblue\x1b[0m");
+}

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1266,13 +1266,6 @@ TEST(FormatTest, Print) {
 #endif
 }
 
-#if FMT_USE_FILE_DESCRIPTORS
-TEST(FormatTest, PrintColored) {
-  EXPECT_WRITE(stdout, fmt::print_colored(fmt::red, "Hello, {}!\n", "world"),
-    "\x1b[31mHello, world!\n\x1b[0m");
-}
-#endif
-
 TEST(FormatTest, Variadic) {
   EXPECT_EQ("abc1", format("{}c{}", "ab", 1));
   EXPECT_EQ(L"abc1", format(L"{}c{}", L"ab", 1));


### PR DESCRIPTION
Added enum colors conversion to rgb struct.
Added colors_test.cpp.

Now it looks a bit strange. 
We have `enum color`  from format.h and `enum class colors` from colors.h.
