### PR TITLE
Better support for newer CMake's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,15 @@
-message(STATUS "CMake version: ${CMAKE_VERSION}")
+cmake_minimum_required(VERSION 3.1.0...3.11)
 
-cmake_minimum_required(VERSION 3.1.0)
+if(${CMAKE_VERSION} VERSION_LESS 3.12)
+    cmake_policy(VERSION ${CMAKE_VERSION})
+endif()
 
 # Determine if fmt is built as a subproject (using add_subdirectory)
 # or if it is the master project.
 set(MASTER_PROJECT OFF)
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(MASTER_PROJECT ON)
+  message(STATUS "CMake version: ${CMAKE_VERSION}")
 endif ()
 
 # Joins arguments and places the results in ${result_var}.


### PR DESCRIPTION
This fixes the first half of #802 , and is what was recommended in #719: basically, if CMake version is less than 3.12, use the latest features. If cmake is equal or more to 3.12, just take the features from 3.11. (For each new CMake version, once it comes out and is tested, the one number that needs changing is the one in `cmake_minimum_required`, since this syntax is supported in 3.12+).

I've also moved the CMake version printout so that it does not print if this is not the main project (cleaner add as subdirectory).