### PR TITLE
Fixing return unreachable warning on NVCC

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1476,7 +1476,6 @@ void arg_map<Context>::init(const basic_format_args<Context> &args) {
           break; // Do nothing.
       }
     }
-    return;
   }
   for (unsigned i = 0; ; ++i) {
     switch (args.args_[i].type_) {


### PR DESCRIPTION
Fixes the other half of #802.

The return is unreachable since all paths either return or break, which gets them out past the return.

PS: This bug is a showstopper for me for upgrading to fmt 5.1.0, since I get a massive number of copies of warnings in the build process.