### PR TITLE
Add unicode support for print and vprint_rgb

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -535,7 +535,35 @@ FMT_FUNC void vprint_rgb(rgb fd, string_view format, format_args args) {
   std::fputs(internal::data::RESET_COLOR, stdout);
 }
 
+FMT_FUNC void vprint_rgb(rgb fd, wstring_view format, wformat_args args) {
+  char escape_fd[] = "\x1b[38;2;000;000;000m";
+  internal::to_esc(fd.r, escape_fd, 7);
+  internal::to_esc(fd.g, escape_fd, 11);
+  internal::to_esc(fd.b, escape_fd, 15);
+
+  std::fputs(escape_fd, stdout);
+  vprint(format, args);
+  std::fputs(internal::data::RESET_COLOR, stdout);
+}
+
 FMT_FUNC void vprint_rgb(rgb fd, rgb bg, string_view format, format_args args) {
+  char escape_fd[] = "\x1b[38;2;000;000;000m"; // foreground color
+  char escape_bg[] = "\x1b[48;2;000;000;000m"; // background color
+  internal::to_esc(fd.r, escape_fd, 7);
+  internal::to_esc(fd.g, escape_fd, 11);
+  internal::to_esc(fd.b, escape_fd, 15);
+
+  internal::to_esc(bg.r, escape_bg, 7);
+  internal::to_esc(bg.g, escape_bg, 11);
+  internal::to_esc(bg.b, escape_bg, 15);
+
+  std::fputs(escape_fd, stdout);
+  std::fputs(escape_bg, stdout);
+  vprint(format, args);
+  std::fputs(internal::data::RESET_COLOR, stdout);
+}
+
+FMT_FUNC void vprint_rgb(rgb fd, rgb bg, wstring_view format, wformat_args args) {
   char escape_fd[] = "\x1b[38;2;000;000;000m"; // foreground color
   char escape_bg[] = "\x1b[48;2;000;000;000m"; // background color
   internal::to_esc(fd.r, escape_fd, 7);

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -522,6 +522,12 @@ FMT_CONSTEXPR void to_esc(uint8_t c, char out[], int offset) {
   out[offset + 1] = static_cast<char>('0' + c / 10 % 10);
   out[offset + 2] = static_cast<char>('0' + c % 10);
 }
+
+FMT_CONSTEXPR void to_esc(uint8_t c, wchar_t out[], int offset) {
+  out[offset + 0] = static_cast<wchar_t>('0' + c / 100);
+  out[offset + 1] = static_cast<wchar_t>('0' + c / 10 % 10);
+  out[offset + 2] = static_cast<wchar_t>('0' + c % 10);
+}
 } // namespace internal
 
 FMT_FUNC void vprint_rgb(rgb fd, string_view format, format_args args) {
@@ -536,14 +542,14 @@ FMT_FUNC void vprint_rgb(rgb fd, string_view format, format_args args) {
 }
 
 FMT_FUNC void vprint_rgb(rgb fd, wstring_view format, wformat_args args) {
-  char escape_fd[] = "\x1b[38;2;000;000;000m";
+  wchar_t escape_fd[] = L"\x1b[38;2;000;000;000m";
   internal::to_esc(fd.r, escape_fd, 7);
   internal::to_esc(fd.g, escape_fd, 11);
   internal::to_esc(fd.b, escape_fd, 15);
 
-  std::fputs(escape_fd, stdout);
+  std::fputws(escape_fd, stdout);
   vprint(format, args);
-  std::fputs(internal::data::RESET_COLOR, stdout);
+  std::fputws(internal::data::WRESET_COLOR, stdout);
 }
 
 FMT_FUNC void vprint_rgb(rgb fd, rgb bg, string_view format, format_args args) {
@@ -564,8 +570,8 @@ FMT_FUNC void vprint_rgb(rgb fd, rgb bg, string_view format, format_args args) {
 }
 
 FMT_FUNC void vprint_rgb(rgb fd, rgb bg, wstring_view format, wformat_args args) {
-  char escape_fd[] = "\x1b[38;2;000;000;000m"; // foreground color
-  char escape_bg[] = "\x1b[48;2;000;000;000m"; // background color
+  wchar_t escape_fd[] = L"\x1b[38;2;000;000;000m"; // foreground color
+  wchar_t escape_bg[] = L"\x1b[48;2;000;000;000m"; // background color
   internal::to_esc(fd.r, escape_fd, 7);
   internal::to_esc(fd.g, escape_fd, 11);
   internal::to_esc(fd.b, escape_fd, 15);
@@ -574,10 +580,10 @@ FMT_FUNC void vprint_rgb(rgb fd, rgb bg, wstring_view format, wformat_args args)
   internal::to_esc(bg.g, escape_bg, 11);
   internal::to_esc(bg.b, escape_bg, 15);
 
-  std::fputs(escape_fd, stdout);
-  std::fputs(escape_bg, stdout);
+  std::fputws(escape_fd, stdout);
+  std::fputws(escape_bg, stdout);
   vprint(format, args);
-  std::fputs(internal::data::RESET_COLOR, stdout);
+  std::fputws(internal::data::WRESET_COLOR, stdout);
 }
 #endif
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3830,6 +3830,8 @@ struct rgb {
 
 void vprint_rgb(rgb fd, string_view format, format_args args);
 void vprint_rgb(rgb fd, rgb bg, string_view format, format_args args);
+void vprint_rgb(rgb fd, wstring_view format, wformat_args args);
+void vprint_rgb(rgb fd, rgb bg, wstring_view format, wformat_args args);
 
 /**
   Formats a string and prints it to stdout using ANSI escape sequences to
@@ -3844,6 +3846,17 @@ inline void print(rgb fd, string_view format_str, const Args & ... args) {
 
 /**
   Formats a string and prints it to stdout using ANSI escape sequences to
+  specify foreground color 'fd'.
+  Example:
+    fmt::print(fmt::color::red, L"Elapsed time: {0:.2f} seconds", 1.23);
+ */
+template <typename... Args>
+inline void print(rgb fd, wstring_view format_str, const Args & ... args) {
+  vprint_rgb(fd, format_str, make_format_args<wformat_context>(args...));
+}
+
+/**
+  Formats a string and prints it to stdout using ANSI escape sequences to
   specify foreground color 'fd' and background color 'bg'.
   Example:
     fmt::print(fmt::color::red, fmt::color::black, "Elapsed time: {0:.2f} seconds", 1.23);
@@ -3851,6 +3864,17 @@ inline void print(rgb fd, string_view format_str, const Args & ... args) {
 template <typename... Args>
 inline void print(rgb fd, rgb bg, string_view format_str, const Args & ... args) {
   vprint_rgb(fd, bg, format_str, make_format_args(args...));
+}
+
+/**
+  Formats a string and prints it to stdout using ANSI escape sequences to
+  specify foreground color 'fd' and background color 'bg'.
+  Example:
+    fmt::print(fmt::color::red, fmt::color::black, L"Elapsed time: {0:.2f} seconds", 1.23);
+ */
+template <typename... Args>
+inline void print(rgb fd, rgb bg, wstring_view format_str, const Args & ... args) {
+  vprint_rgb(fd, bg, format_str, make_format_args<wformat_context>(args...));
 }
 #endif  // FMT_EXTENDED_COLORS
 


### PR DESCRIPTION
Unicode support was missing for print and vprint_rgb.
Edit: updated because changed char to wchar_t and std::fputs to std::fputws
Edit again: its fucked up because i need to account for wchar_t being two bytes