### PR TITLE
Add support for dynamic arg sets

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1151,7 +1151,7 @@ class basic_format_args {
    \endrst
    */
   basic_format_args(const format_arg *args, size_type count)
-  : types_(-(int64_t)count) {
+  : types_(-static_cast<int64_t>(count)) {
     set_data(args);
   }
 

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1145,6 +1145,16 @@ class basic_format_args {
     set_data(store.data_);
   }
 
+  /**
+   \rst
+   Constructs a `basic_format_args` object from a dynamic set of arguments.
+   \endrst
+   */
+  basic_format_args(const format_arg *args, size_type count)
+  : types_(-(int64_t)count) {
+    set_data(args);
+  }
+
   /** Returns the argument at specified index. */
   format_arg get(size_type index) const {
     format_arg arg = do_get(index);

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1315,7 +1315,11 @@ TEST(FormatTest, Dynamic) {
   args.emplace_back(fmt::internal::make_arg<ctx>("abc1"));
   args.emplace_back(fmt::internal::make_arg<ctx>(1.2f));
 
-  std::string result = fmt::vformat("{} and {} and {}", fmt::basic_format_args<ctx>(args.data(), (unsigned)args.size()));
+  std::string result = fmt::vformat("{} and {} and {}",
+                                    fmt::basic_format_args<ctx>(
+                                        args.data(),
+                                        static_cast<unsigned>(args.size())));
+
   EXPECT_EQ("42 and abc1 and 1.2", result);
 }
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1308,6 +1308,17 @@ TEST(FormatTest, Variadic) {
   EXPECT_EQ(L"abc1", format(L"{}c{}", L"ab", 1));
 }
 
+TEST(FormatTest, Dynamic) {
+  using ctx = fmt::format_context;
+  std::vector<fmt::basic_format_arg<ctx>> args;
+  args.emplace_back(fmt::internal::make_arg<ctx>(42));
+  args.emplace_back(fmt::internal::make_arg<ctx>("abc1"));
+  args.emplace_back(fmt::internal::make_arg<ctx>(1.2f));
+
+  std::string result = fmt::vformat("{} and {} and {}", fmt::basic_format_args<ctx>(args.data(), (unsigned)args.size()));
+  EXPECT_EQ("42 and abc1 and 1.2", result);
+}
+
 TEST(FormatTest, JoinArg) {
   using fmt::join;
   int v1[3] = { 1, 2, 3 };


### PR DESCRIPTION
This allows construction of basic_format_args from a dynamic set of arguments. The syntax is a little clunky and could probably be improved but this at least enables the functionality.