### PR TITLE
Fix C4127 warning in basic_writer<Range>::write_double

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2923,8 +2923,8 @@ void basic_writer<Range>::write_double(T value, const format_specs &spec) {
     return write_inf_or_nan(handler.upper ? "INF" : "inf");
 
   basic_memory_buffer<char_type> buffer;
-  if (FMT_USE_GRISU && sizeof(T) <= sizeof(double) &&
-      std::numeric_limits<double>::is_iec559) {
+  if (internal::const_check(FMT_USE_GRISU && sizeof(T) <= sizeof(double) &&
+      std::numeric_limits<double>::is_iec559)) {
     internal::fp fp_value(static_cast<double>(value));
     fp_value.normalize();
     // Find a cached power of 10 close to 1 / fp_value.


### PR DESCRIPTION
Hello. 

The situation is similar to #146. 
Got a lot of C4127 warnings (constant expression) on /W4 in VS 2017. This fixes it via the same approach that was previously used.