### PR TITLE
Reduce executable size overhead for embedded targets using newlib nano

### DIFF
--- a/include/fmt/posix.h
+++ b/include/fmt/posix.h
@@ -266,7 +266,7 @@ class file {
 long getpagesize();
 
 #if (defined(LC_NUMERIC_MASK) || defined(_MSC_VER)) && \
-    !defined(__ANDROID__) && !defined(__CYGWIN__) && !defined(__OpenBSD__)
+    !defined(__ANDROID__) && !defined(__CYGWIN__) && !defined(__OpenBSD__) && !defined(__NEWLIB_H__)
 # define FMT_LOCALE
 #endif
 


### PR DESCRIPTION
This pull request makes libfmt usable for small embedded targets.

Detecting newlib is necessary as it doesn't provide the function strtod_l.

The second aspect is the dependency on std::locale which bring loads of code overhead (100kb in my tests) just to get hold of the  separation character for thousands. To work around this, a static separator can be configured through the define FMT_STATIC_THOUSANDS_SEPARATOR.