### PR TITLE
Remove conversion compiler warnings

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -395,7 +395,7 @@ FMT_FUNC void grisu2_gen_digits(
       FMT_ASSERT(false, "invalid number of digits");
     }
     if (digit != 0 || size != 0)
-      buffer[size++] = '0' + static_cast<char>(digit);
+      buffer[size++] = static_cast<char>('0' + static_cast<char>(digit));
     --kappa;
     uint64_t remainder = (static_cast<uint64_t>(hi) << -one.e) + lo;
     if (remainder <= delta) {
@@ -410,7 +410,7 @@ FMT_FUNC void grisu2_gen_digits(
     delta *= 10;
     char digit = static_cast<char>(lo >> -one.e);
     if (digit != 0 || size != 0)
-      buffer[size++] = '0' + digit;
+      buffer[size++] = static_cast<char>('0' + digit);
     lo &= one.f - 1;
     --kappa;
     if (lo < delta) {

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -374,7 +374,7 @@ FMT_FUNC char *write_exponent(char *buffer, int exp) {
     *buffer++ = '+';
   }
   if (exp >= 100) {
-    *buffer++ = '0' + static_cast<char>(exp / 100);
+    *buffer++ = static_cast<char>('0' + static_cast<char>(exp / 100));
     exp %= 100;
     const char *d = data::DIGITS + exp * 2;
     *buffer++ = d[0];
@@ -384,7 +384,7 @@ FMT_FUNC char *write_exponent(char *buffer, int exp) {
     *buffer++ = d[0];
     *buffer++ = d[1];
   } else {
-    *buffer++ = '0' + static_cast<char>(exp);
+    *buffer++ = static_cast<char>('0' + static_cast<char>(exp));
   }
   return buffer;
 }
@@ -529,7 +529,7 @@ FMT_FUNC void grisu2_format(double value, char *buffer, size_t &size, char type,
   size_t unsigned_precision = precision >= 0 ? precision : 6;
   if (size > unsigned_precision) {
     // TODO: round instead of truncating
-    dec_exp += size - unsigned_precision;
+    dec_exp += static_cast<int>(size - unsigned_precision); 
     size = unsigned_precision;
   }
   grisu2_prettify(buffer, size, dec_exp, type, unsigned_precision,

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -374,7 +374,7 @@ FMT_FUNC char *write_exponent(char *buffer, int exp) {
     *buffer++ = '+';
   }
   if (exp >= 100) {
-    *buffer++ = static_cast<char>('0' + static_cast<char>(exp / 100));
+    *buffer++ = static_cast<char>('0' + exp / 100);
     exp %= 100;
     const char *d = data::DIGITS + exp * 2;
     *buffer++ = d[0];
@@ -384,7 +384,7 @@ FMT_FUNC char *write_exponent(char *buffer, int exp) {
     *buffer++ = d[0];
     *buffer++ = d[1];
   } else {
-    *buffer++ = static_cast<char>('0' + static_cast<char>(exp));
+    *buffer++ = static_cast<char>('0' + exp);
   }
   return buffer;
 }
@@ -421,7 +421,7 @@ FMT_FUNC void grisu2_gen_digits(
       FMT_ASSERT(false, "invalid number of digits");
     }
     if (digit != 0 || size != 0)
-      buffer[size++] = static_cast<char>('0' + static_cast<char>(digit));
+      buffer[size++] = static_cast<char>('0' + digit);
     --exp;
     uint64_t remainder = (static_cast<uint64_t>(hi) << -one.e) + lo;
     if (remainder <= delta) {


### PR DESCRIPTION
When compiling with g++8, I get the following two errors:
```
include/fmt/format-inl.h:400:29: error: conversion from ‘int’ to ‘char’ may change value [-Werror=conversion]
       buffer[size++] = zero + static_cast<char>(digit);
                        ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
include/fmt/format-inl.h:416:28: error: conversion from ‘int’ to ‘char’ may change value [-Werror=conversion]
       buffer[size++] = '0' + digit;
                        ~~~~^~~~~~~
```

With this change, the errors are gone.