### PR TITLE
Get rid of implicit-fallthrough warn. in GCC 7 and 8

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -630,6 +630,8 @@ FMT_FUNC void grisu2_prettify(char *buffer, size_t &size, int exp,
 
 #if FMT_CLANG_VERSION
 # define FMT_FALLTHROUGH [[clang::fallthrough]];
+#elif FMT_GCC_VERSION >= 700
+# define FMT_FALLTHROUGH [[gnu::fallthrough]];
 #else
 # define FMT_FALLTHROUGH
 #endif


### PR DESCRIPTION
This change enables FMT_FALLLTHROUGH also for GCC-Compilers in the versions 7 and 8.