### PR TITLE
Get rid of conversion warning in gcc-4.8

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -371,7 +371,7 @@ class fp {
   explicit fp(Double d) {
     // Assume double is in the format [sign][exponent][significand].
     typedef std::numeric_limits<Double> limits;
-    const size_t double_size = sizeof(Double) * char_size;
+    const int double_size = static_cast<int>(sizeof(Double) * char_size);
     const int exponent_size =
       double_size - double_significand_size - 1;  // -1 for sign
     const uint64_t significand_mask = implicit_bit - 1;

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -371,7 +371,7 @@ class fp {
   explicit fp(Double d) {
     // Assume double is in the format [sign][exponent][significand].
     typedef std::numeric_limits<Double> limits;
-    const int double_size = sizeof(Double) * char_size;
+    const size_t double_size = sizeof(Double) * char_size;
     const int exponent_size =
       double_size - double_significand_size - 1;  // -1 for sign
     const uint64_t significand_mask = implicit_bit - 1;


### PR DESCRIPTION
Get rid of the following warning:
conversion to ‘int’ from ‘long unsigned int’ may alter its value [-Werror=conversion]