### PR TITLE
Improve error message when formatting unknown types

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -340,9 +340,22 @@ class basic_format_arg;
 template <typename Context>
 class basic_format_args;
 
+template <typename T>
+struct no_formatter_error : std::false_type {};
+
 // A formatter for objects of type T.
 template <typename T, typename Char = char, typename Enable = void>
-struct formatter;
+struct formatter {
+  static_assert(no_formatter_error<T>::value,
+    "don't know how to format the type, include fmt/ostream.h if it provides "
+    "an operator<< that should be used");
+
+  // The following functions are not defined intentionally.
+  template <typename ParseContext>
+  typename ParseContext::iterator parse(ParseContext &);
+  template <typename FormatContext>
+  auto format(const T &val, FormatContext &ctx) -> decltype(ctx.out());
+};
 
 template <typename T, typename Char, typename Enable = void>
 struct convert_to_int {


### PR DESCRIPTION
This replaces the confusing "use of incomplete type" when formatting an unknown type with a nice static_assert, like this:

```
In file included from /home/foonathan/Programming/fmt/include/fmt/format.h:54,
                 from /home/foonathan/Programming/fmt/test/add-subdirectory-test/main.cc:1:
/home/foonathan/Programming/fmt/include/fmt/core.h: In instantiation of ‘struct fmt::v5::formatter<ostream_only, char, void>’:
/home/foonathan/Programming/fmt/include/fmt/core.h:590:56:   required from ‘static void fmt::v5::internal::value<Context>::format_custom_arg(const void*, Context&) [with T = ostream_only; Context = fmt::v5::basic_format_context<std::back_insert_iterator<fmt::v5::internal::basic_buffer<char> >, char>]’
/home/foonathan/Programming/fmt/include/fmt/core.h:576:19:   required from ‘fmt::v5::internal::value<Context>::value(const T&) [with T = ostream_only; Context = fmt::v5::basic_format_context<std::back_insert_iterator<fmt::v5::internal::basic_buffer<char> >, char>]’
/home/foonathan/Programming/fmt/include/fmt/core.h:604:58:   required from ‘constexpr fmt::v5::internal::init<Context, T, TYPE>::operator fmt::v5::internal::value<Context>() const [with Context = fmt::v5::basic_format_context<std::back_insert_iterator<fmt::v5::internal::basic_buffer<char> >, char>; T = const ostream_only&; fmt::v5::internal::type TYPE = (fmt::v5::internal::type)13]’
/home/foonathan/Programming/fmt/include/fmt/core.h:1008:35:   required from ‘typename std::enable_if<IS_PACKED, fmt::v5::internal::value<Context> >::type fmt::v5::internal::make_arg(const T&) [with bool IS_PACKED = true; Context = fmt::v5::basic_format_context<std::back_insert_iterator<fmt::v5::internal::basic_buffer<char> >, char>; T = ostream_only; typename std::enable_if<IS_PACKED, fmt::v5::internal::value<Context> >::type = fmt::v5::internal::value<fmt::v5::basic_format_context<std::back_insert_iterator<fmt::v5::internal::basic_buffer<char> >, char> >]’
/home/foonathan/Programming/fmt/include/fmt/core.h:1066:51:   required from ‘fmt::v5::format_arg_store<Context, Args>::format_arg_store(const Args& ...) [with Context = fmt::v5::basic_format_context<std::back_insert_iterator<fmt::v5::internal::basic_buffer<char> >, char>; Args = {ostream_only}]’
/home/foonathan/Programming/fmt/include/fmt/core.h:1444:45:   required from ‘void fmt::v5::print(fmt::v5::string_view, const Args& ...) [with Args = {ostream_only}; fmt::v5::string_view = fmt::v5::basic_string_view<char>]’
/home/foonathan/Programming/fmt/test/add-subdirectory-test/main.cc:9:36:   required from here
/home/foonathan/Programming/fmt/include/fmt/core.h:350:19: error: static assertion failed: don't know how to format the type, include fmt/ostream.h if the type provides an operator<< that should be used
     static_assert(no_formatter_error<T>::value,
                   ^~~~~~~~~~~~~~~~~~~~~
```

(well, "nice", you've still got the whole error message stack)

This should hopefully reduce the number of issues like #871.