### PR TITLE
Fix compilation with intel compilers (ICC/ICPC) v14.0

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -89,7 +89,8 @@
 # endif
 #endif
 
-#if FMT_HAS_FEATURE(cxx_explicit_conversions) || FMT_MSC_VER >= 1800
+#if FMT_HAS_FEATURE(cxx_explicit_conversions) || \
+  FMT_GCC_VERSION >= 405 || FMT_MSC_VER >= 1800
 # define FMT_EXPLICIT explicit
 #else
 # define FMT_EXPLICIT

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2159,7 +2159,8 @@ FMT_CONSTEXPR void parse_format_string(
     }
     Handler &handler_;
   } write{handler};
-  auto begin = format_str.data(), end = begin + format_str.size();
+  auto begin = format_str.data();
+  auto end = begin + format_str.size();
   while (begin != end) {
     // Doing two passes with memchr (one for '{' and another for '}') is up to
     // 2.5x faster than the naive one-pass implementation on big format strings.

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1577,7 +1577,7 @@ struct explicitly_convertible_to_string_like {
       typename String,
       typename = typename std::enable_if<
         std::is_constructible<String, const char*, std::size_t>::value>::type>
-  explicit operator String() const { return String("foo", 3u); }
+  FMT_EXPLICIT operator String() const { return String("foo", 3u); }
 };
 
 TEST(FormatterTest, FormatExplicitlyConvertibleToStringLike) {


### PR DESCRIPTION
The `auto` change was a warning

```
warning #3373: nonstandard use of "auto" to both deduce the type from an initializer and to announce a trailing return type
    auto begin = format_str.data(), end = begin + format_str.size();
```

The `explicit` change was an error

```
error: "explicit" is not allowed
    explicit operator String() const { return String("foo", 3u); }
``` 