### PR TITLE
Fix vs2017 warning fmt::v5::localtime 'not all control paths return a value'

### DIFF
--- a/include/fmt/time.h
+++ b/include/fmt/time.h
@@ -58,6 +58,7 @@ inline std::tm localtime(std::time_t time) {
     return lt.tm_;
   // Too big time values may be unsupported.
   FMT_THROW(format_error("time_t value out of range"));
+  return {};
 }
 
 // Thread-safe replacement for std::gmtime
@@ -93,6 +94,7 @@ inline std::tm gmtime(std::time_t time) {
     return gt.tm_;
   // Too big time values may be unsupported.
   FMT_THROW(format_error("time_t value out of range"));
+  return {};
 }
 
 namespace internal {


### PR DESCRIPTION
The `fmt::internal::do_throw` workaround for 'bogus MSVC warning about unreachable code' has a unwanted side effect when using time formatting. It is always my goal to have no warning in my code, but when I building my project ([CamStudio fork](https://github.com/stevenhoving/camstudio) ) with warning level 4. I get a nice `warning C4715: 'fmt::v5::localtime': not all control paths return a value` warning. This PR should resolve this issue, although i'm not sure about the fix itself. It feels like adding additional noise.
One thing I also tried was to remove the `fmt::internal::do_throw` workaround completely and fix the warnings about unreachable code by removing the unreachable code. But you would have done that already if that would have fixed it.
