### PR TITLE
Parameterize core functions on the type of the format string.

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1340,23 +1340,14 @@ template <typename Char>
 struct is_contiguous<internal::basic_buffer<Char> >: std::true_type {};
 
 /** Formats a string and writes the output to ``out``. */
-template <typename Container>
+template <typename Container, typename S>
 typename std::enable_if<
   is_contiguous<Container>::value, std::back_insert_iterator<Container>>::type
     vformat_to(std::back_insert_iterator<Container> out,
-               string_view format_str, format_args args) {
+               const S &format_str,
+               basic_format_args<typename buffer_context<FMT_CHAR(S)>::type> args) {
   internal::container_buffer<Container> buf(internal::get_container(out));
-  vformat_to(buf, format_str, args);
-  return out;
-}
-
-template <typename Container>
-typename std::enable_if<
-  is_contiguous<Container>::value, std::back_insert_iterator<Container>>::type
-    vformat_to(std::back_insert_iterator<Container> out,
-               wstring_view format_str, wformat_args args) {
-  internal::container_buffer<Container> buf(internal::get_container(out));
-  vformat_to(buf, format_str, args);
+  vformat_to(buf, internal::to_string_view(format_str), args);
   return out;
 }
 
@@ -1366,8 +1357,8 @@ inline typename std::enable_if<
   std::back_insert_iterator<Container>>::type
     format_to(std::back_insert_iterator<Container> out, const S &format_str,
               const Args &... args) {
-  return vformat_to(out, internal::to_string_view(format_str),
-                    internal::checked_args<S, Args...>(format_str, args...));
+  internal::checked_args<S, Args...> ca(format_str, args...);
+  return vformat_to(out, internal::to_string_view(format_str), *ca);
 }
 
 template <typename S>

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2401,6 +2401,26 @@ TEST(FormatTest, FormatStringErrors) {
                "cannot switch from automatic to manual argument indexing",
                int, int);
 }
+
+TEST(FormatTest, VFormatTo) {
+  typedef fmt::format_context context;
+  fmt::basic_format_arg<context> arg = fmt::internal::make_arg<context>(42);
+  fmt::basic_format_args<context> args(&arg, 1);
+  std::string s;
+  fmt::vformat_to(std::back_inserter(s), "{}", args);
+  EXPECT_EQ("42", s);
+  s.clear();
+  fmt::vformat_to(std::back_inserter(s), FMT_STRING("{}"), args);
+  EXPECT_EQ("42", s);
+
+  typedef fmt::wformat_context wcontext;
+  fmt::basic_format_arg<wcontext> warg = fmt::internal::make_arg<wcontext>(42);
+  fmt::basic_format_args<wcontext> wargs(&warg, 1);
+  std::wstring w;
+  fmt::vformat_to(std::back_inserter(w), L"{}", wargs);
+  EXPECT_EQ(L"42", w);
+}
+
 #endif  // FMT_USE_CONSTEXPR
 
 TEST(FormatTest, ConstructU8StringViewFromCString) {


### PR DESCRIPTION
Take #2 of n

Signed-off-by: Daniela Engert <dani@ngrt.de>