### PR TITLE
minor documentation corrections

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -40,7 +40,7 @@ The ``fmt::format`` function returns a string "The answer is 42.". You can use
   format_to(out, "For a moment, {} happened.", "nothing");
   out.data(); // returns a pointer to the formatted data
 
-The ``fmt::print`` function performs formatting and writes the result to a file:
+The ``fmt::print`` function performs formatting and writes the result to a stream:
 
 .. code:: c++
 
@@ -94,7 +94,7 @@ Safety
 
 The library is fully type safe, automatic memory management prevents buffer
 overflow, errors in format strings are reported using exceptions or at compile
-tim. For example, the code
+time. For example, the code
 
 .. code:: c++
 


### PR DESCRIPTION
In the Format API section, it says fmt:print writes to a file, but it
writes to a stream as referenced from fopen(3), "stream open
functions". Also in the Safety section a typo; tim should be time.