### PR TITLE
Remove basic_fixed_buffer.

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -822,11 +822,6 @@ FMT_FUNC void format_system_error(
   format_error_code(out, error_code, message);
 }
 
-template <typename Char>
-void basic_fixed_buffer<Char>::grow(std::size_t) {
-  FMT_THROW(std::runtime_error("buffer overflow"));
-}
-
 FMT_FUNC void internal::error_handler::on_error(const char *message) {
   FMT_THROW(format_error(message));
 }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -592,43 +592,6 @@ void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
 typedef basic_memory_buffer<char> memory_buffer;
 typedef basic_memory_buffer<wchar_t> wmemory_buffer;
 
-/**
-  \rst
-  A fixed-size memory buffer. For a dynamically growing buffer use
-  :class:`fmt::basic_memory_buffer`.
-
-  Trying to increase the buffer size past the initial capacity will throw
-  ``std::runtime_error``.
-  \endrst
- */
-template <typename Char>
-class basic_fixed_buffer : public internal::basic_buffer<Char> {
- public:
-  /**
-   \rst
-   Constructs a :class:`fmt::basic_fixed_buffer` object for *array* of the
-   given size.
-   \endrst
-   */
-  basic_fixed_buffer(Char *array, std::size_t size) {
-    this->set(array, size);
-  }
-
-  /**
-   \rst
-   Constructs a :class:`fmt::basic_fixed_buffer` object for *array* of the
-   size known at compile time.
-   \endrst
-   */
-  template <std::size_t SIZE>
-  explicit basic_fixed_buffer(Char (&array)[SIZE]) {
-    this->set(array, SIZE);
-  }
-
- protected:
-  FMT_API void grow(std::size_t size) FMT_OVERRIDE;
-};
-
 namespace internal {
 
 template <typename Char>

--- a/src/format.cc
+++ b/src/format.cc
@@ -16,8 +16,6 @@ template FMT_API char internal::thousands_sep(locale_provider *lp);
 
 template void internal::basic_buffer<char>::append(const char *, const char *);
 
-template void basic_fixed_buffer<char>::grow(std::size_t);
-
 template void internal::arg_map<format_context>::init(
     const basic_format_args<format_context> &args);
 
@@ -36,8 +34,6 @@ template FMT_API wchar_t internal::thousands_sep(locale_provider *);
 
 template void internal::basic_buffer<wchar_t>::append(
     const wchar_t *, const wchar_t *);
-
-template void basic_fixed_buffer<wchar_t>::grow(std::size_t);
 
 template void internal::arg_map<wformat_context>::init(
     const basic_format_args<wformat_context> &);

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -351,29 +351,6 @@ TEST(MemoryBufferTest, ExceptionInDeallocate) {
   EXPECT_CALL(alloc, deallocate(&mem2[0], 2 * size));
 }
 
-TEST(FixedBufferTest, Ctor) {
-  char array[10] = "garbage";
-  fmt::basic_fixed_buffer<char> buffer(array, sizeof(array));
-  EXPECT_EQ(static_cast<size_t>(0), buffer.size());
-  EXPECT_EQ(10u, buffer.capacity());
-  EXPECT_EQ(array, buffer.data());
-}
-
-TEST(FixedBufferTest, CompileTimeSizeCtor) {
-  char array[10] = "garbage";
-  fmt::basic_fixed_buffer<char> buffer(array);
-  EXPECT_EQ(static_cast<size_t>(0), buffer.size());
-  EXPECT_EQ(10u, buffer.capacity());
-  EXPECT_EQ(array, buffer.data());
-}
-
-TEST(FixedBufferTest, BufferOverflow) {
-  char array[10];
-  fmt::basic_fixed_buffer<char> buffer(array);
-  buffer.resize(10);
-  EXPECT_THROW_MSG(buffer.resize(11), std::runtime_error, "buffer overflow");
-}
-
 #ifdef _WIN32
 TEST(UtilTest, UTF16ToUTF8) {
   std::string s = "ёжик";


### PR DESCRIPTION
Issue #873 indicates that this class is no longer required,
as it has been superseded by a new API.

Fixes #873