### PR TITLE
find sphinx-build before calling build.py

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -4,8 +4,11 @@ if (NOT DOXYGEN)
   return ()
 endif ()
 
+find_program(SPHINX_EXECUTABLE
+  NAMES sphinx-build sphinx-build-3)
 add_custom_target(doc
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/build.py ${FMT_VERSION}
+  COMMAND ${CMAKE_COMMAND} -E env SPHINX_EXECUTABLE=${SPHINX_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/build.py ${FMT_VERSION})
   SOURCES api.rst syntax.rst build.py conf.py _templates/layout.html)
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -4,11 +4,13 @@ if (NOT DOXYGEN)
   return ()
 endif ()
 
+find_package(PythonInterp
+  QUIET REQUIRED)
 find_program(SPHINX_EXECUTABLE
   NAMES sphinx-build sphinx-build-3)
 add_custom_target(doc
   COMMAND ${CMAKE_COMMAND} -E env SPHINX_EXECUTABLE=${SPHINX_EXECUTABLE}
-    ${CMAKE_CURRENT_SOURCE_DIR}/build.py ${FMT_VERSION})
+    ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/build.py ${FMT_VERSION}
   SOURCES api.rst syntax.rst build.py conf.py _templates/layout.html)
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/

--- a/doc/build.py
+++ b/doc/build.py
@@ -100,7 +100,8 @@ def build_docs(version='dev', **kwargs):
     raise CalledProcessError(p.returncode, cmd)
   html_dir = os.path.join(work_dir, 'html')
   main_versions = reversed(versions[-3:])
-  check_call(['sphinx-build',
+  sphinx_build = os.environ.get('SPHINX_EXECUTABLE', 'sphinx-build')
+  check_call([sphinx_build,
               '-Dbreathe_projects.format=' + os.path.abspath(doxyxml_dir),
               '-Dversion=' + version, '-Drelease=' + version,
               '-Aversion=' + version, '-Aversions=' + ','.join(main_versions),


### PR DESCRIPTION
this allows us to use sphinx-build-3, as user might already in a python3
world, and distros, like fedora 28, tend to add a "-3" suffix to sphinx-build.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>