### PR TITLE
Fix incompatibilities with c++2a mode in clang

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -400,8 +400,12 @@ void basic_buffer<T>::append(const U *begin, const U *end) {
 }
 }  // namespace internal
 
+// C++20 feature test, since r346892 Clang considers char8_t a fundamental
+// type in this mode. If this is the case __cpp_char8_t will be defined.
+#if !defined(__cpp_char8_t)
 // A UTF-8 code unit type.
 enum char8_t: unsigned char {};
+#endif
 
 // A UTF-8 string view.
 class u8string_view : public basic_string_view<char8_t> {


### PR DESCRIPTION
This closes https://github.com/fmtlib/fmt/issues/932.