### PR TITLE
add make_printf_args and make_wprintf_args functions

### DIFF
--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -581,6 +581,33 @@ struct printf_context {
 typedef basic_format_args<printf_context<internal::buffer>::type> printf_args;
 typedef basic_format_args<printf_context<internal::wbuffer>::type> wprintf_args;
 
+typedef printf_context<internal::buffer>::type printf_char_context;
+typedef printf_context<internal::wbuffer>::type printf_wchar_context;
+
+
+/**
+  \rst
+  Constructs an `~fmt::format_arg_store` object that contains references to
+  arguments and can be implicitly converted to `~fmt::printf_args`. `Context`
+  can be omitted in which case it defaults to `~fmt::printf_char_context`.
+  \endrst
+ */
+template<typename Context=printf_char_context, typename... Args>
+inline format_arg_store<Context, Args...>
+  make_printf_args(const Args &... args) { return {args...}; }
+
+/**
+  \rst
+  Constructs an `~fmt::format_arg_store` object that contains references to
+  arguments and can be implicitly converted to `~fmt::wprintf_args`. `Context`
+  can be omitted in which case it defaults to `~fmt::printf_wchar_context`.
+  \endrst
+ */
+template<typename Context = printf_wchar_context, typename... Args>
+inline format_arg_store<Context, Args...>
+  make_wprintf_args(const Args &... args) { return {args...}; }
+
+
 template <typename S, typename Char = FMT_CHAR(S)>
 inline std::basic_string<Char>
 vsprintf(const S &format,

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -578,33 +578,30 @@ struct printf_context {
     std::back_insert_iterator<Buffer>, typename Buffer::value_type> type;
 };
 
-typedef basic_format_args<printf_context<internal::buffer>::type> printf_args;
-typedef basic_format_args<printf_context<internal::wbuffer>::type> wprintf_args;
-
 typedef printf_context<internal::buffer>::type printf_char_context;
 typedef printf_context<internal::wbuffer>::type printf_wchar_context;
 
+typedef basic_format_args<printf_char_context> printf_args;
+typedef basic_format_args<printf_wchar_context> wprintf_args;
 
 /**
   \rst
   Constructs an `~fmt::format_arg_store` object that contains references to
-  arguments and can be implicitly converted to `~fmt::printf_args`. `Context`
-  can be omitted in which case it defaults to `~fmt::printf_char_context`.
+  arguments and can be implicitly converted to `~fmt::printf_args`. 
   \endrst
  */
-template<typename Context=printf_char_context, typename... Args>
-inline format_arg_store<Context, Args...>
+template<typename... Args>
+inline format_arg_store<printf_char_context, Args...>
   make_printf_args(const Args &... args) { return {args...}; }
 
 /**
   \rst
   Constructs an `~fmt::format_arg_store` object that contains references to
-  arguments and can be implicitly converted to `~fmt::wprintf_args`. `Context`
-  can be omitted in which case it defaults to `~fmt::printf_wchar_context`.
+  arguments and can be implicitly converted to `~fmt::wprintf_args`. 
   \endrst
  */
-template<typename Context = printf_wchar_context, typename... Args>
-inline format_arg_store<Context, Args...>
+template<typename... Args>
+inline format_arg_store<printf_wchar_context, Args...>
   make_wprintf_args(const Args &... args) { return {args...}; }
 
 

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -573,16 +573,16 @@ void printf(internal::basic_buffer<Char> &buf, basic_string_view<Char> format,
 }
 
 template <typename Buffer>
-struct printf_context {
+struct basic_printf_context_t {
   typedef basic_printf_context<
     std::back_insert_iterator<Buffer>, typename Buffer::value_type> type;
 };
 
-typedef printf_context<internal::buffer>::type printf_char_context;
-typedef printf_context<internal::wbuffer>::type printf_wchar_context;
+typedef basic_printf_context_t<internal::buffer>::type printf_context;
+typedef basic_printf_context_t<internal::wbuffer>::type wprintf_context;
 
-typedef basic_format_args<printf_char_context> printf_args;
-typedef basic_format_args<printf_wchar_context> wprintf_args;
+typedef basic_format_args<printf_context> printf_args;
+typedef basic_format_args<wprintf_context> wprintf_args;
 
 /**
   \rst
@@ -591,7 +591,7 @@ typedef basic_format_args<printf_wchar_context> wprintf_args;
   \endrst
  */
 template<typename... Args>
-inline format_arg_store<printf_char_context, Args...>
+inline format_arg_store<printf_context, Args...>
   make_printf_args(const Args &... args) { return {args...}; }
 
 /**
@@ -601,14 +601,13 @@ inline format_arg_store<printf_char_context, Args...>
   \endrst
  */
 template<typename... Args>
-inline format_arg_store<printf_wchar_context, Args...>
+inline format_arg_store<wprintf_context, Args...>
   make_wprintf_args(const Args &... args) { return {args...}; }
-
 
 template <typename S, typename Char = FMT_CHAR(S)>
 inline std::basic_string<Char>
 vsprintf(const S &format,
-         basic_format_args<typename printf_context<
+         basic_format_args<typename basic_printf_context_t<
            internal::basic_buffer<Char>>::type> args) {
   basic_memory_buffer<Char> buffer;
   printf(buffer, to_string_view(format), args);
@@ -629,7 +628,7 @@ inline FMT_ENABLE_IF_STRING(S, std::basic_string<FMT_CHAR(S)>)
     sprintf(const S &format, const Args & ... args) {
   internal::check_format_string<Args...>(format);
   typedef internal::basic_buffer<FMT_CHAR(S)> buffer;
-  typedef typename printf_context<buffer>::type context;
+  typedef typename basic_printf_context_t<buffer>::type context;
   format_arg_store<context, Args...> as{ args... };
   return vsprintf(to_string_view(format),
                   basic_format_args<context>(as));
@@ -637,7 +636,7 @@ inline FMT_ENABLE_IF_STRING(S, std::basic_string<FMT_CHAR(S)>)
 
 template <typename S, typename Char = FMT_CHAR(S)>
 inline int vfprintf(std::FILE *f, const S &format,
-                    basic_format_args<typename printf_context<
+                    basic_format_args<typename basic_printf_context_t<
                       internal::basic_buffer<Char>>::type> args) {
   basic_memory_buffer<Char> buffer;
   printf(buffer, to_string_view(format), args);
@@ -660,7 +659,7 @@ inline FMT_ENABLE_IF_STRING(S, int)
     fprintf(std::FILE *f, const S &format, const Args & ... args) {
   internal::check_format_string<Args...>(format);
   typedef internal::basic_buffer<FMT_CHAR(S)> buffer;
-  typedef typename printf_context<buffer>::type context;
+  typedef typename basic_printf_context_t<buffer>::type context;
   format_arg_store<context, Args...> as{ args... };
   return vfprintf(f, to_string_view(format),
                   basic_format_args<context>(as));
@@ -668,7 +667,7 @@ inline FMT_ENABLE_IF_STRING(S, int)
 
 template <typename S, typename Char = FMT_CHAR(S)>
 inline int vprintf(const S &format,
-                   basic_format_args<typename printf_context<
+                   basic_format_args<typename basic_printf_context_t<
                     internal::basic_buffer<Char>>::type> args) {
   return vfprintf(stdout, to_string_view(format), args);
 }
@@ -687,7 +686,7 @@ inline FMT_ENABLE_IF_STRING(S, int)
     printf(const S &format_str, const Args & ... args) {
   internal::check_format_string<Args...>(format_str);
   typedef internal::basic_buffer<FMT_CHAR(S)> buffer;
-  typedef typename printf_context<buffer>::type context;
+  typedef typename basic_printf_context_t<buffer>::type context;
   format_arg_store<context, Args...> as{ args... };
   return vprintf(to_string_view(format_str),
                  basic_format_args<context>(as));
@@ -696,7 +695,7 @@ inline FMT_ENABLE_IF_STRING(S, int)
 template <typename S, typename Char = FMT_CHAR(S)>
 inline int vfprintf(std::basic_ostream<Char> &os,
                     const S &format,
-                    basic_format_args<typename printf_context<
+                    basic_format_args<typename basic_printf_context_t<
                       internal::basic_buffer<Char>>::type> args) {
   basic_memory_buffer<Char> buffer;
   printf(buffer, to_string_view(format), args);
@@ -719,7 +718,7 @@ inline FMT_ENABLE_IF_STRING(S, int)
             const S &format_str, const Args & ... args) {
   internal::check_format_string<Args...>(format_str);
   typedef internal::basic_buffer<FMT_CHAR(S)> buffer;
-  typedef typename printf_context<buffer>::type context;
+  typedef typename basic_printf_context_t<buffer>::type context;
   format_arg_store<context, Args...> as{ args... };
   return vfprintf(os, to_string_view(format_str),
                   basic_format_args<context>(as));

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -518,3 +518,19 @@ void check_format_string_regression(fmt::string_view s, const Args&... args) {
 TEST(PrintfTest, CheckFormatStringRegression) {
   check_format_string_regression("%c%s", 'x', "");
 }
+
+
+TEST(PrintfTest, VSPrintfMessageExample) {
+  EXPECT_EQ(
+      "[42] something happened",
+      fmt::vsprintf(
+          "[%d] %s happened", fmt::make_printf_args( 42, "something" ) ) );
+}
+
+
+TEST(PrintfTest, VSPrintfWMessageExample) {
+  EXPECT_EQ(
+      L"[42] something happened",
+      fmt::vsprintf(
+          L"[%d] %s happened", fmt::make_wprintf_args( 42, L"something" ) ) );
+}

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -521,14 +521,14 @@ TEST(PrintfTest, CheckFormatStringRegression) {
 
 
 TEST(PrintfTest, VSPrintfMakeArgsExample) {
-  fmt::printf_args args = fmt::make_printf_args( 42, "something");
   EXPECT_EQ("[42] something happened",
-      fmt::vsprintf( "[%d] %s happened", args));
+      fmt::vsprintf(
+          "[%d] %s happened", fmt::make_printf_args( 42, "something" ) ) );
 }
 
 
 TEST( PrintfTest, VSPrintfMakeWArgsExample ) {
-  fmt::wprintf_args args = fmt::make_wprintf_args(42, L"something");
   EXPECT_EQ(L"[42] something happened",
-      fmt::vsprintf(L"[%d] %s happened", args));
+      fmt::vsprintf(
+          L"[%d] %s happened", fmt::make_wprintf_args( 42, L"something" ) ) );
 }

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -501,7 +501,7 @@ TEST(PrintfTest, OStream) {
 }
 
 TEST(PrintfTest, VPrintf) {
-  typedef fmt::printf_context<fmt::internal::buffer>::type context;
+  typedef fmt::basic_printf_context_t<fmt::internal::buffer>::type context;
   fmt::format_arg_store<context, int> as{42};
   fmt::basic_format_args<context> args(as);
   EXPECT_EQ(fmt::vsprintf("%d", args), "42");
@@ -521,16 +521,14 @@ TEST(PrintfTest, CheckFormatStringRegression) {
 
 
 TEST(PrintfTest, VSPrintfMakeArgsExample) {
-  EXPECT_EQ(
-      "[42] something happened",
-      fmt::vsprintf(
-          "[%d] %s happened", fmt::make_printf_args( 42, "something" ) ) );
+  fmt::printf_args args = fmt::make_printf_args( 42, "something");
+  EXPECT_EQ("[42] something happened",
+      fmt::vsprintf( "[%d] %s happened", args));
 }
 
 
-TEST(PrintfTest, VSPrintfMakeWArgsExample) {
-  EXPECT_EQ(
-      L"[42] something happened",
-      fmt::vsprintf(
-          L"[%d] %s happened", fmt::make_wprintf_args( 42, L"something" ) ) );
+TEST( PrintfTest, VSPrintfMakeWArgsExample ) {
+  fmt::wprintf_args args = fmt::make_wprintf_args(42, L"something");
+  EXPECT_EQ(L"[42] something happened",
+      fmt::vsprintf(L"[%d] %s happened", args));
 }

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -519,16 +519,42 @@ TEST(PrintfTest, CheckFormatStringRegression) {
   check_format_string_regression("%c%s", 'x', "");
 }
 
-
-TEST(PrintfTest, VSPrintfMakeArgsExample) {
-  EXPECT_EQ("[42] something happened",
+TEST( PrintfTest, VSPrintfMakeArgsExample ) {
+  fmt::format_arg_store<fmt::printf_context, int, const char *> as{42,
+                                                                   "something"};
+  fmt::basic_format_args<fmt::printf_context> args(as);
+  EXPECT_EQ(
+      "[42] something happened", fmt::vsprintf("[%d] %s happened", args));
+  fmt::format_arg_store<fmt::printf_context, int, char[10]> as2 =
+      fmt::make_printf_args(42, "something");
+  fmt::basic_format_args<fmt::printf_context> args2(as2);
+  EXPECT_EQ(
+      "[42] something happened", fmt::vsprintf("[%d] %s happened", args2));
+  //the older gcc versions can"t cast the return value
+#if !defined(__GNUC__) || (__GNUC__ > 4) 
+  EXPECT_EQ(
+      "[42] something happened",
       fmt::vsprintf(
-          "[%d] %s happened", fmt::make_printf_args( 42, "something" ) ) );
+          "[%d] %s happened", fmt::make_printf_args(42, "something")));
+#endif
 }
 
-
 TEST( PrintfTest, VSPrintfMakeWArgsExample ) {
-  EXPECT_EQ(L"[42] something happened",
+  fmt::format_arg_store<fmt::wprintf_context, int, const wchar_t *> as{
+     42,L"something"};
+  fmt::basic_format_args<fmt::wprintf_context> args(as);
+  EXPECT_EQ(
+     L"[42] something happened",
+     fmt::vsprintf(L"[%d] %s happened", args));
+  fmt::format_arg_store<fmt::wprintf_context, int, wchar_t[10]> as2 =
+      fmt::make_wprintf_args(42, L"something");
+  fmt::basic_format_args<fmt::wprintf_context> args2( as2 );
+  EXPECT_EQ(
+      L"[42] something happened", fmt::vsprintf(L"[%d] %s happened", args2));
+#if !defined(__GNUC__) || (__GNUC__ > 4)
+  EXPECT_EQ(
+      L"[42] something happened",
       fmt::vsprintf(
-          L"[%d] %s happened", fmt::make_wprintf_args( 42, L"something" ) ) );
+          L"[%d] %s happened", fmt::make_wprintf_args(42, L"something")));
+#endif
 }

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -502,7 +502,7 @@ TEST(PrintfTest, OStream) {
 
 TEST(PrintfTest, VPrintf) {
   fmt::format_arg_store<fmt::printf_context, int> as{42};
-  fmt::basic_format_args<fmt::printf_context> args( as );
+  fmt::basic_format_args<fmt::printf_context> args(as);
   EXPECT_EQ(fmt::vsprintf("%d", args), "42");
   EXPECT_WRITE(stdout, fmt::vprintf("%d", args), "42");
   EXPECT_WRITE(stdout, fmt::vfprintf(stdout, "%d", args), "42");
@@ -518,18 +518,17 @@ TEST(PrintfTest, CheckFormatStringRegression) {
   check_format_string_regression("%c%s", 'x', "");
 }
 
-TEST( PrintfTest, VSPrintfMakeArgsExample ) {
+TEST(PrintfTest, VSPrintfMakeArgsExample) {
   fmt::format_arg_store<fmt::printf_context, int, const char *> as{42,
                                                                    "something"};
   fmt::basic_format_args<fmt::printf_context> args(as);
   EXPECT_EQ(
       "[42] something happened", fmt::vsprintf("[%d] %s happened", args));
-  fmt::format_arg_store<fmt::printf_context, int, char[10]> as2 =
-      fmt::make_printf_args(42, "something");
+  auto as2 = fmt::make_printf_args(42, "something");
   fmt::basic_format_args<fmt::printf_context> args2(as2);
   EXPECT_EQ(
       "[42] something happened", fmt::vsprintf("[%d] %s happened", args2));
-  //the older gcc versions can"t cast the return value
+  //the older gcc versions can't cast the return value
 #if !defined(__GNUC__) || (__GNUC__ > 4) 
   EXPECT_EQ(
       "[42] something happened",
@@ -538,18 +537,18 @@ TEST( PrintfTest, VSPrintfMakeArgsExample ) {
 #endif
 }
 
-TEST( PrintfTest, VSPrintfMakeWArgsExample ) {
+TEST(PrintfTest, VSPrintfMakeWArgsExample) {
   fmt::format_arg_store<fmt::wprintf_context, int, const wchar_t *> as{
      42,L"something"};
   fmt::basic_format_args<fmt::wprintf_context> args(as);
   EXPECT_EQ(
      L"[42] something happened",
      fmt::vsprintf(L"[%d] %s happened", args));
-  fmt::format_arg_store<fmt::wprintf_context, int, wchar_t[10]> as2 =
-      fmt::make_wprintf_args(42, L"something");
-  fmt::basic_format_args<fmt::wprintf_context> args2( as2 );
+  auto  as2 = fmt::make_wprintf_args(42, L"something");
+  fmt::basic_format_args<fmt::wprintf_context> args2(as2);
   EXPECT_EQ(
       L"[42] something happened", fmt::vsprintf(L"[%d] %s happened", args2));
+  // the older gcc versions can't cast the return value
 #if !defined(__GNUC__) || (__GNUC__ > 4)
   EXPECT_EQ(
       L"[42] something happened",

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -501,9 +501,8 @@ TEST(PrintfTest, OStream) {
 }
 
 TEST(PrintfTest, VPrintf) {
-  typedef fmt::basic_printf_context_t<fmt::internal::buffer>::type context;
-  fmt::format_arg_store<context, int> as{42};
-  fmt::basic_format_args<context> args(as);
+  fmt::format_arg_store<fmt::printf_context, int> as{42};
+  fmt::basic_format_args<fmt::printf_context> args( as );
   EXPECT_EQ(fmt::vsprintf("%d", args), "42");
   EXPECT_WRITE(stdout, fmt::vprintf("%d", args), "42");
   EXPECT_WRITE(stdout, fmt::vfprintf(stdout, "%d", args), "42");

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -519,8 +519,8 @@ TEST(PrintfTest, CheckFormatStringRegression) {
 }
 
 TEST(PrintfTest, VSPrintfMakeArgsExample) {
-  fmt::format_arg_store<fmt::printf_context, int, const char *> as{42,
-                                                                   "something"};
+  fmt::format_arg_store<fmt::printf_context, int, const char *> as{
+      42, "something"};
   fmt::basic_format_args<fmt::printf_context> args(as);
   EXPECT_EQ(
       "[42] something happened", fmt::vsprintf("[%d] %s happened", args));
@@ -539,7 +539,7 @@ TEST(PrintfTest, VSPrintfMakeArgsExample) {
 
 TEST(PrintfTest, VSPrintfMakeWArgsExample) {
   fmt::format_arg_store<fmt::wprintf_context, int, const wchar_t *> as{
-     42,L"something"};
+     42, L"something"};
   fmt::basic_format_args<fmt::wprintf_context> args(as);
   EXPECT_EQ(
      L"[42] something happened",

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -520,7 +520,7 @@ TEST(PrintfTest, CheckFormatStringRegression) {
 }
 
 
-TEST(PrintfTest, VSPrintfMessageExample) {
+TEST(PrintfTest, VSPrintfMakeArgsExample) {
   EXPECT_EQ(
       "[42] something happened",
       fmt::vsprintf(
@@ -528,7 +528,7 @@ TEST(PrintfTest, VSPrintfMessageExample) {
 }
 
 
-TEST(PrintfTest, VSPrintfWMessageExample) {
+TEST(PrintfTest, VSPrintfMakeWArgsExample) {
   EXPECT_EQ(
       L"[42] something happened",
       fmt::vsprintf(


### PR DESCRIPTION
Add utitlity functions to allow the easy creation of `fmt::printf_args` and `fmt::wprintf_args`. 