### PR TITLE
Use full paths for fmt.pc.in

### DIFF
--- a/support/cmake/fmt.pc.in
+++ b/support/cmake/fmt.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: fmt
 Description: A modern formatting library


### PR DESCRIPTION
CMAKE_INSTALL_INCLUDEDIR used in the fmt.pc.in is converted to just "include", not a full path, on OSX. (not tested on other envrionments).

Thus `pkg-config fmt --cflags` results `-Iinclude`.
The same applies to CMAKE_INSTALL_LIBDIR. 

I suppose that they should be CMAKE_INSTALL_FULL_x variables.

Releated information:
* https://gitlab.freedesktop.org/poppler/poppler/commit/c45efa2d7e0db8a4ace0e8c6955b3fa48dc6d070
* https://bugzilla.redhat.com/show_bug.cgi?id=795542