### PR TITLE
Do not override user provided compile flag

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -112,11 +112,13 @@
 #endif
 
 // Check if exceptions are disabled.
+#ifndef FMT_EXCEPTIONS
 #if (defined(__GNUC__) && !defined(__EXCEPTIONS)) || \
     FMT_MSC_VER && !_HAS_EXCEPTIONS
 # define FMT_EXCEPTIONS 0
 #else
 # define FMT_EXCEPTIONS 1
+#endif
 #endif
 
 // Define FMT_USE_NOEXCEPT to make fmt use noexcept (C++11 feature).


### PR DESCRIPTION
Currently core.h overrides my -DFMT_EXCEPTIONS=0 flag supplied from my CMake project which includes fmtlib as a third-party dependency.

This minor edit allows a parent CMake file to disable exceptions by explicitly setting the FMT_EXCEPTIONS flag to 0.