### PR TITLE
Add experimental emphasis support

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -293,15 +293,15 @@ public:
     return static_cast<uint8_t>(ems);
   }
   FMT_CONSTEXPR_DECL rgb get_foreground() const FMT_NOEXCEPT {
-    assert(set_foreground_color);
+    assert(has_foreground() && "no foreground specified for this style");
     return foreground_color;
   }
   FMT_CONSTEXPR_DECL rgb get_background() const FMT_NOEXCEPT {
-    assert(set_background_color);
+    assert(has_background() && "no background specified for this style");
     return background_color;
   }
   FMT_CONSTEXPR emphasis get_emphasis() const FMT_NOEXCEPT {
-    assert(ems);
+    assert(has_emphasis() && "no emphasis specified for this style");
     return ems;
   }
 

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -453,7 +453,7 @@ print(const text_style &tf, const String &format_str, const Args & ... args) {
   typedef typename internal::char_t<String>::type char_t;
   typedef typename buffer_context<char_t>::type context_t;
   format_arg_store<context_t, Args...> as{args...};
-  vprint_text_style(tf, format_str, basic_format_args<context_t>(as));
+  vprint(tf, format_str, basic_format_args<context_t>(as));
 }
 
 #endif

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -290,7 +290,7 @@ public:
     return set_background_color;
   }
   FMT_CONSTEXPR_DECL bool has_emphasis() const FMT_NOEXCEPT {
-    return static_cast<uint8_t>(ems);
+    return static_cast<uint8_t>(ems) != 0;
   }
   FMT_CONSTEXPR_DECL rgb get_foreground() const FMT_NOEXCEPT {
     assert(has_foreground() && "no foreground specified for this style");

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -281,6 +281,24 @@ public:
     return lhs &= rhs;
   }
 
+  FMT_CONSTEXPR_DECL bool has_foreground() const FMT_NOEXCEPT {
+    return set_foreground_color;
+  }
+  FMT_CONSTEXPR_DECL bool has_background() const FMT_NOEXCEPT {
+    return set_background_color;
+  }
+  FMT_CONSTEXPR_DECL rgb get_foreground() const FMT_NOEXCEPT {
+    assert(set_foreground_color);
+    return foreground_color;
+  }
+  FMT_CONSTEXPR_DECL rgb get_background() const FMT_NOEXCEPT {
+    assert(set_background_color);
+    return background_color;
+  }
+  FMT_CONSTEXPR emphasis get_emphasis() const FMT_NOEXCEPT {
+    return ems;
+  }
+
  private:
   FMT_CONSTEXPR_DECL text_format(bool is_foreground,
                                  rgb text_color) FMT_NOEXCEPT
@@ -297,10 +315,6 @@ public:
 
   friend FMT_CONSTEXPR_DECL text_format fg(rgb foreground) FMT_NOEXCEPT;
   friend FMT_CONSTEXPR_DECL text_format bg(rgb background) FMT_NOEXCEPT;
-  template <typename S, typename Char>
-  friend void vprint_text_format(
-      const text_format &tf, const S &format,
-      basic_format_args<typename buffer_context<Char>::type> args);
 
   rgb foreground_color;
   rgb background_color;
@@ -408,14 +422,13 @@ template <
   typename S, typename Char = typename internal::char_t<S>::type>
 void vprint_text_format(const text_format &tf, const S &format,
                 basic_format_args<typename buffer_context<Char>::type> args) {
-  internal::fputs<Char>(internal::make_emphasis<Char>(tf.ems), stdout);
-
-  if (tf.set_foreground_color)
+  internal::fputs<Char>(internal::make_emphasis<Char>(tf.get_emphasis()), stdout);
+  if (tf.has_foreground())
     internal::fputs<Char>(
-        internal::make_foreground_color<Char>(tf.foreground_color), stdout);
-  if (tf.set_background_color)
+        internal::make_foreground_color<Char>(tf.get_foreground()), stdout);
+  if (tf.has_background())
     internal::fputs<Char>(
-        internal::make_background_color<Char>(tf.background_color), stdout);
+        internal::make_background_color<Char>(tf.get_background()), stdout);
   vprint(format, args);
   internal::reset_color<Char>(stdout);
 }

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -289,6 +289,9 @@ public:
   FMT_CONSTEXPR_DECL bool has_background() const FMT_NOEXCEPT {
     return set_background_color;
   }
+  FMT_CONSTEXPR_DECL bool has_emphasis() const FMT_NOEXCEPT {
+    return static_cast<uint8_t>(ems);
+  }
   FMT_CONSTEXPR_DECL rgb get_foreground() const FMT_NOEXCEPT {
     assert(set_foreground_color);
     return foreground_color;
@@ -298,6 +301,7 @@ public:
     return background_color;
   }
   FMT_CONSTEXPR emphasis get_emphasis() const FMT_NOEXCEPT {
+    assert(ems);
     return ems;
   }
 
@@ -352,13 +356,14 @@ struct ansi_color_escape {
   }
   FMT_CONSTEXPR ansi_color_escape(emphasis em) FMT_NOEXCEPT {
     uint8_t em_codes[4] = {};
-    if ((uint32_t)em & (uint32_t)emphasis::bold)
+    uint8_t em_bits = static_cast<uint8_t>(em);
+    if (em_bits & static_cast<uint8_t>(emphasis::bold))
       em_codes[0] = 1;
-    if ((uint32_t)em & (uint32_t)emphasis::italic)
+    if (em_bits & static_cast<uint8_t>(emphasis::italic))
       em_codes[1] = 3;
-    if ((uint32_t)em & (uint32_t)emphasis::underline)
+    if (em_bits & static_cast<uint8_t>(emphasis::underline))
       em_codes[2] = 4;
-    if ((uint32_t)em & (uint32_t)emphasis::strikethrough)
+    if (em_bits & static_cast<uint8_t>(emphasis::strikethrough))
       em_codes[3] = 9;
 
     std::size_t index = 0;
@@ -428,7 +433,8 @@ template <
   typename S, typename Char = typename internal::char_t<S>::type>
 void vprint(const text_style &tf, const S &format,
                 basic_format_args<typename buffer_context<Char>::type> args) {
-  internal::fputs<Char>(internal::make_emphasis<Char>(tf.get_emphasis()), stdout);
+  if (tf.has_emphasis())
+    internal::fputs<Char>(internal::make_emphasis<Char>(tf.get_emphasis()), stdout);
   if (tf.has_foreground())
     internal::fputs<Char>(
         internal::make_foreground_color<Char>(tf.get_foreground()), stdout);

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -218,34 +218,34 @@ struct rgb {
 // Experimental text formatting support.
 class text_format {
 public:
- FMT_CONSTEXPR_DECL text_format(emphasis em) FMT_NOEXCEPT
-     : set_foreground_color(),
-       set_background_color(),
-       ems(em) {}
+  FMT_CONSTEXPR_DECL text_format(emphasis em) FMT_NOEXCEPT
+      : set_foreground_color(),
+        set_background_color(),
+        ems(em) {}
 
- FMT_CONSTEXPR_DECL
- text_format &operator|=(const text_format &rhs) FMT_NOEXCEPT {
-   if (!set_foreground_color) {
-     set_foreground_color = rhs.set_foreground_color;
-     foreground_color = rhs.foreground_color;
-   } else if (rhs.set_foreground_color) {
-     foreground_color.r |= rhs.foreground_color.r;
-     foreground_color.g |= rhs.foreground_color.g;
-     foreground_color.b |= rhs.foreground_color.b;
+  FMT_CONSTEXPR_DECL
+  text_format &operator|=(const text_format &rhs) FMT_NOEXCEPT {
+    if (!set_foreground_color) {
+      set_foreground_color = rhs.set_foreground_color;
+      foreground_color = rhs.foreground_color;
+    } else if (rhs.set_foreground_color) {
+      foreground_color.r |= rhs.foreground_color.r;
+      foreground_color.g |= rhs.foreground_color.g;
+      foreground_color.b |= rhs.foreground_color.b;
+    }
+
+    if (!set_background_color) {
+      set_background_color = rhs.set_background_color;
+      background_color = rhs.background_color;
+    } else if (rhs.set_background_color) {
+      background_color.r |= rhs.background_color.r;
+      background_color.g |= rhs.background_color.g;
+      background_color.b |= rhs.background_color.b;
+    }
+
+    ems = (emphasis)((uint32_t)ems | (uint32_t)rhs.ems);
+    return *this;
   }
-
-   if (!set_background_color) {
-     set_background_color = rhs.set_background_color;
-     background_color = rhs.background_color;
-   } else if (rhs.set_background_color) {
-     background_color.r |= rhs.background_color.r;
-     background_color.g |= rhs.background_color.g;
-     background_color.b |= rhs.background_color.b;
-   }
-
-   ems = (emphasis)((uint32_t)ems | (uint32_t)rhs.ems);
-   return *this;
- }
 
   friend FMT_CONSTEXPR_DECL
   text_format operator|(text_format lhs, const text_format &rhs) FMT_NOEXCEPT {
@@ -299,7 +299,7 @@ public:
     return ems;
   }
 
- private:
+private:
   FMT_CONSTEXPR_DECL text_format(bool is_foreground,
                                  rgb text_color) FMT_NOEXCEPT
     : set_foreground_color(), set_background_color(), ems() {

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -194,7 +194,9 @@ enum class color : uint32_t {
 
 enum class emphasis : uint8_t {
   bold = 1,
-  underline = 4
+  italic = 3,
+  underline = 4,
+  strikethrough = 9
 };  // enum class emphasis
 
 // rgb is a struct for red, green and blue colors.

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -331,6 +331,10 @@ FMT_CONSTEXPR_DECL text_format bg(rgb background) FMT_NOEXCEPT {
   return text_format(/*is_foreground=*/false, background);
 }
 
+FMT_CONSTEXPR_DECL text_format operator|(emphasis lhs, emphasis rhs) FMT_NOEXCEPT {
+  return text_format(lhs) | rhs;
+}
+
 namespace internal {
 
 template <typename Char>
@@ -348,9 +352,9 @@ struct ansi_color_escape {
     uint8_t em_codes[4] = {};
     if ((uint32_t)em & (uint32_t)emphasis::bold)
       em_codes[0] = 1;
-    if ((uint32_t)em & (uint32_t)emphasis::underline)
-      em_codes[1] = 3;
     if ((uint32_t)em & (uint32_t)emphasis::italic)
+      em_codes[1] = 3;
+    if ((uint32_t)em & (uint32_t)emphasis::underline)
       em_codes[2] = 4;
     if ((uint32_t)em & (uint32_t)emphasis::strikethrough)
       em_codes[3] = 9;

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -194,7 +194,7 @@ enum class color : uint32_t {
 
 enum class emphasis : uint8_t {
   bold = 1,
-  underline = 4,
+  underline = 4
 };  // enum class emphasis
 
 // rgb is a struct for red, green and blue colors.
@@ -408,13 +408,13 @@ typename std::enable_if<internal::is_string<String>::value>::type print(
  */
 template <typename String, typename... Args>
 typename std::enable_if<internal::is_string<String>::value>::type print(
-    emphasis em, rgb fg, rgb bg, const String &format_str,
+    emphasis em, rgb fd, rgb bg, const String &format_str,
     const Args &... args) {
   internal::check_format_string<Args...>(format_str);
   typedef typename internal::char_t<String>::type char_t;
   typedef typename buffer_context<char_t>::type context_t;
   format_arg_store<context_t, Args...> as{args...};
-  vprint_emphasis(em, fg, bg, format_str, basic_format_args<context_t>(as));
+  vprint_emphasis(em, fd, bg, format_str, basic_format_args<context_t>(as));
 }
 
 #endif

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -224,5 +224,5 @@ TEST(ColorsTest, Colors) {
   EXPECT_WRITE(
       stdout,
       fmt::print(fg(fmt::color::blue) | fmt::emphasis::bold, "blue/bold"),
-      "\x1b[38;2;000;000;255m\x1b[1mblue/bold\x1b[0m");
+      "\x1b[1m\x1b[38;2;000;000;255mblue/bold\x1b[0m");
 }

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -214,10 +214,10 @@ TEST(ColorsTest, Colors) {
       "\x1b[38;2;000;000;255m\x1b[48;2;255;000;000mtwo color\x1b[0m");
   EXPECT_WRITE(stdout, fmt::print(fmt::emphasis::bold, "bold"),
                "\x1b[1mbold\x1b[0m");
-  EXPECT_WRITE(stdout, fmt::print(fmt::emphasis::underline, "underline"),
-               "\x1b[3munderline\x1b[0m");
   EXPECT_WRITE(stdout, fmt::print(fmt::emphasis::italic, "italic"),
-               "\x1b[4mitalic\x1b[0m");
+               "\x1b[3mitalic\x1b[0m");
+  EXPECT_WRITE(stdout, fmt::print(fmt::emphasis::underline, "underline"),
+               "\x1b[4munderline\x1b[0m");
   EXPECT_WRITE(stdout,
                fmt::print(fmt::emphasis::strikethrough, "strikethrough"),
                "\x1b[9mstrikethrough\x1b[0m");

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -25,9 +25,9 @@
 #undef max
 
 #if FMT_HAS_CPP_ATTRIBUTE(noreturn)
-# define FMT_NORETURN [[noreturn]]
+#define FMT_NORETURN [[noreturn]]
 #else
-# define FMT_NORETURN
+#define FMT_NORETURN
 #endif
 
 using fmt::internal::fp;
@@ -108,10 +108,8 @@ TEST(FPTest, Grisu2FormatCompilesWithNonIEEEDouble) {
 }
 
 template <typename T>
-struct ValueExtractor: fmt::internal::function<T> {
-  T operator()(T value) {
-    return value;
-  }
+struct ValueExtractor : fmt::internal::function<T> {
+  T operator()(T value) { return value; }
 
   template <typename U>
   FMT_NORETURN T operator()(U) {
@@ -178,8 +176,8 @@ TEST(FormatTest, FormatErrorCode) {
   }
   {
     fmt::memory_buffer buffer;
-    std::string prefix(
-        fmt::inline_buffer_size - msg.size() - sep.size() + 1, 'x');
+    std::string prefix(fmt::inline_buffer_size - msg.size() - sep.size() + 1,
+                       'x');
     fmt::format_error_code(buffer, 42, prefix);
     EXPECT_EQ(msg, to_string(buffer));
   }
@@ -188,8 +186,7 @@ TEST(FormatTest, FormatErrorCode) {
     // Test maximum buffer size.
     msg = fmt::format("error {}", codes[i]);
     fmt::memory_buffer buffer;
-    std::string prefix(
-        fmt::inline_buffer_size - msg.size() - sep.size(), 'x');
+    std::string prefix(fmt::inline_buffer_size - msg.size() - sep.size(), 'x');
     fmt::format_error_code(buffer, codes[i], prefix);
     EXPECT_EQ(prefix + sep + msg, to_string(buffer));
     std::size_t size = fmt::inline_buffer_size;
@@ -207,24 +204,25 @@ TEST(FormatTest, CountCodePoints) {
 }
 
 TEST(ColorsTest, Colors) {
-  EXPECT_WRITE(stdout, fmt::print(fg(fmt::rgb(255,20,30)), "rgb(255,20,30)"),
+  EXPECT_WRITE(stdout, fmt::print(fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30)"),
                "\x1b[38;2;255;020;030mrgb(255,20,30)\x1b[0m");
   EXPECT_WRITE(stdout, fmt::print(fg(fmt::color::blue), "blue"),
                "\x1b[38;2;000;000;255mblue\x1b[0m");
-  EXPECT_WRITE(stdout,
-               fmt::print(fg(fmt::color::blue) | bg(fmt::color::red), "two color"),
-               "\x1b[38;2;000;000;255m\x1b[48;2;255;000;000mtwo color\x1b[0m");
-  EXPECTED_WRITE(stdout, fmt::print(fmt::emphasis::bold, "bold"),
-                 "\x1b[1mbold\x1b[0m");
-  EXPECTED_WRITE(stdout, fmt::print(fmt::emphasis::underline, "underline"),
-                 "\x1b[3munderline\x1b[0m");
-  EXPECTED_WRITE(stdout, fmt::print(fmt::emphasis::italic, "italic"),
-                 "\x1b[4mitalic\x1b[0m");
-  EXPECTED_WRITE(stdout,
-                 fmt::print(fmt::emphasis::strikethrough, "strikethrough"),
-                 "\x1b[9mstrikethrough\x1b[0m");
-  EXPECTED_WRITE(
+  EXPECT_WRITE(
       stdout,
-      fmt::prirnt(fg(fmt::color::blue) | fmt::emphasis::bold, "blue/bold"),
+      fmt::print(fg(fmt::color::blue) | bg(fmt::color::red), "two color"),
+      "\x1b[38;2;000;000;255m\x1b[48;2;255;000;000mtwo color\x1b[0m");
+  EXPECT_WRITE(stdout, fmt::print(fmt::emphasis::bold, "bold"),
+               "\x1b[1mbold\x1b[0m");
+  EXPECT_WRITE(stdout, fmt::print(fmt::emphasis::underline, "underline"),
+               "\x1b[3munderline\x1b[0m");
+  EXPECT_WRITE(stdout, fmt::print(fmt::emphasis::italic, "italic"),
+               "\x1b[4mitalic\x1b[0m");
+  EXPECT_WRITE(stdout,
+               fmt::print(fmt::emphasis::strikethrough, "strikethrough"),
+               "\x1b[9mstrikethrough\x1b[0m");
+  EXPECT_WRITE(
+      stdout,
+      fmt::print(fg(fmt::color::blue) | fmt::emphasis::bold, "blue/bold"),
       "\x1b[38;2;000;000;255m\x1b[1mblue/bold\x1b[0m");
 }

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -25,9 +25,9 @@
 #undef max
 
 #if FMT_HAS_CPP_ATTRIBUTE(noreturn)
-#define FMT_NORETURN [[noreturn]]
+# define FMT_NORETURN [[noreturn]]
 #else
-#define FMT_NORETURN
+# define FMT_NORETURN
 #endif
 
 using fmt::internal::fp;
@@ -108,8 +108,10 @@ TEST(FPTest, Grisu2FormatCompilesWithNonIEEEDouble) {
 }
 
 template <typename T>
-struct ValueExtractor : fmt::internal::function<T> {
-  T operator()(T value) { return value; }
+struct ValueExtractor: fmt::internal::function<T> {
+  T operator()(T value) {
+    return value;
+  }
 
   template <typename U>
   FMT_NORETURN T operator()(U) {
@@ -176,8 +178,8 @@ TEST(FormatTest, FormatErrorCode) {
   }
   {
     fmt::memory_buffer buffer;
-    std::string prefix(fmt::inline_buffer_size - msg.size() - sep.size() + 1,
-                       'x');
+    std::string prefix(
+        fmt::inline_buffer_size - msg.size() - sep.size() + 1, 'x');
     fmt::format_error_code(buffer, 42, prefix);
     EXPECT_EQ(msg, to_string(buffer));
   }
@@ -186,7 +188,8 @@ TEST(FormatTest, FormatErrorCode) {
     // Test maximum buffer size.
     msg = fmt::format("error {}", codes[i]);
     fmt::memory_buffer buffer;
-    std::string prefix(fmt::inline_buffer_size - msg.size() - sep.size(), 'x');
+    std::string prefix(
+        fmt::inline_buffer_size - msg.size() - sep.size(), 'x');
     fmt::format_error_code(buffer, codes[i], prefix);
     EXPECT_EQ(prefix + sep + msg, to_string(buffer));
     std::size_t size = fmt::inline_buffer_size;

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -207,11 +207,24 @@ TEST(FormatTest, CountCodePoints) {
 }
 
 TEST(ColorsTest, Colors) {
-  EXPECT_WRITE(stdout, fmt::print(fmt::rgb(255,20,30), "rgb(255,20,30)"),
+  EXPECT_WRITE(stdout, fmt::print(fg(fmt::rgb(255,20,30)), "rgb(255,20,30)"),
                "\x1b[38;2;255;020;030mrgb(255,20,30)\x1b[0m");
-  EXPECT_WRITE(stdout, fmt::print(fmt::color::blue, "blue"),
+  EXPECT_WRITE(stdout, fmt::print(fg(fmt::color::blue), "blue"),
                "\x1b[38;2;000;000;255mblue\x1b[0m");
   EXPECT_WRITE(stdout,
-               fmt::print(fmt::color::blue, fmt::color::red, "two color"),
+               fmt::print(fg(fmt::color::blue) | bg(fmt::color::red), "two color"),
                "\x1b[38;2;000;000;255m\x1b[48;2;255;000;000mtwo color\x1b[0m");
+  EXPECTED_WRITE(stdout, fmt::print(fmt::emphasis::bold, "bold"),
+                 "\x1b[1mbold\x1b[0m");
+  EXPECTED_WRITE(stdout, fmt::print(fmt::emphasis::underline, "underline"),
+                 "\x1b[3munderline\x1b[0m");
+  EXPECTED_WRITE(stdout, fmt::print(fmt::emphasis::italic, "italic"),
+                 "\x1b[4mitalic\x1b[0m");
+  EXPECTED_WRITE(stdout,
+                 fmt::print(fmt::emphasis::strikethrough, "strikethrough"),
+                 "\x1b[9mstrikethrough\x1b[0m");
+  EXPECTED_WRITE(
+      stdout,
+      fmt::prirnt(fg(fmt::color::blue) | fmt::emphasis::bold, "blue/bold"),
+      "\x1b[38;2;000;000;255m\x1b[1mblue/bold\x1b[0m");
 }


### PR DESCRIPTION
This patch adds support for text emphasis: bold and underline.

```c++
#define FMT_HEADER_ONLY
#include "include/fmt/color.h"
#include "include/fmt/format.h"

int main() {
  fmt::print(fmt::emphasis::bold, "bold\n");
  fmt::print(fmt::emphasis::underline, "underline\n");

  fmt::print(fmt::emphasis::bold, fmt::color::red, "bold and red\n");
  fmt::print(fmt::emphasis::underline, fmt::color::red, fmt::color::yellow,
             "underline, red and yellow\n");
}
```