### PR TITLE
Fix ambiguous complier error C2666 in vs2017.The '+' opeator may cause ambiguity.

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2975,7 +2975,7 @@ class format_int {
 
   // Formats value in reverse and returns a pointer to the beginning.
   char *format_decimal(unsigned long long value) {
-    char *ptr = buffer_ + BUFFER_SIZE - 1;
+    char *ptr = buffer_ + static_cast<unsigned>(BUFFER_SIZE) - 1;
     while (value >= 100) {
       // Integer division is slow so do it for a group of two digits instead
       // of for every digit. The idea comes from the talk by Alexandrescu


### PR DESCRIPTION
vs2017 complier error log:
spdlog\fmt\bundled\format.h(3036): error C2666: “operator +”:
....
...
spdlog\fmt\bundled\format.h(3036): note: or “builtin C++ operator+(char [22], __int64)”
spdlog\fmt\bundled\format.h(3036): note: try to match the parameter list“(char [22], fmt::v5::format_int::<unnamed-enum-BUFFER_SIZE>)”

format.h 3036 line:
char *ptr = buffer_ + BUFFER_SIZE - 1;//The 'BUFFER_SIZE' exist implicit conversion