### PR TITLE
Add file stream support for stylized text printing.

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -427,22 +427,40 @@ inline void reset_color<wchar_t>(FILE *stream) FMT_NOEXCEPT {
 
 template <
   typename S, typename Char = typename internal::char_t<S>::type>
-void vprint(const text_style &tf, const S &format,
+void vprint(std::FILE *f, const text_style &ts, const S &format,
             basic_format_args<typename buffer_context<Char>::type> args) {
-  if (tf.has_emphasis()) {
+  if (ts.has_emphasis()) {
     internal::fputs<Char>(
-          internal::make_emphasis<Char>(tf.get_emphasis()), stdout);
+          internal::make_emphasis<Char>(ts.get_emphasis()), f);
   }
-  if (tf.has_foreground()) {
+  if (ts.has_foreground()) {
     internal::fputs<Char>(
-          internal::make_foreground_color<Char>(tf.get_foreground()), stdout);
+          internal::make_foreground_color<Char>(ts.get_foreground()), f);
   }
-  if (tf.has_background()) {
+  if (ts.has_background()) {
     internal::fputs<Char>(
-        internal::make_background_color<Char>(tf.get_background()), stdout);
+        internal::make_background_color<Char>(ts.get_background()), f);
   }
-  vprint(format, args);
-  internal::reset_color<Char>(stdout);
+  vprint(f, format, args);
+  internal::reset_color<Char>(f);
+}
+
+/**
+  Formats a string and prints it to the specified file stream using ANSI
+  escape sequences to specify text formatting.
+  Example:
+    fmt::print(fmt::emphasis::bold | fg(fmt::color::red),
+               "Elapsed time: {0:.2f} seconds", 1.23);
+ */
+template <typename String, typename... Args>
+typename std::enable_if<internal::is_string<String>::value>::type print(
+    std::FILE *f, const text_style &ts, const String &format_str,
+    const Args &... args) {
+  internal::check_format_string<Args...>(format_str);
+  typedef typename internal::char_t<String>::type char_t;
+  typedef typename buffer_context<char_t>::type context_t;
+  format_arg_store<context_t, Args...> as{args...};
+  vprint(f, ts, format_str, basic_format_args<context_t>(as));
 }
 
 /**
@@ -453,13 +471,10 @@ void vprint(const text_style &tf, const S &format,
                "Elapsed time: {0:.2f} seconds", 1.23);
  */
 template <typename String, typename... Args>
-typename std::enable_if<internal::is_string<String>::value>::type
-print(const text_style &tf, const String &format_str, const Args & ... args) {
-  internal::check_format_string<Args...>(format_str);
-  typedef typename internal::char_t<String>::type char_t;
-  typedef typename buffer_context<char_t>::type context_t;
-  format_arg_store<context_t, Args...> as{args...};
-  vprint(tf, format_str, basic_format_args<context_t>(as));
+typename std::enable_if<internal::is_string<String>::value>::type print(
+    const text_style &ts, const String &format_str,
+    const Args &... args) {
+  return print(stdout, ts, format_str, args...);
 }
 
 #endif

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -508,6 +508,7 @@ namespace internal {
 
 struct dummy_string_view { typedef void char_type; };
 dummy_string_view to_string_view(...);
+dummy_string_view to_string_view(const std::FILE *);
 using fmt::v5::to_string_view;
 
 // Specifies whether S is a string type convertible to fmt::basic_string_view.


### PR DESCRIPTION
This PR adds file stream support to color.h:

```c++
fmt::print(stderr, fmt::emphasis::bold, "bold error");
```

Fixes #944 