### PR TITLE
DOCS: VS .sln filename changed from FORMAT.sln to FMT.sln

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -45,7 +45,7 @@ You can control generation of the make ``test`` target with the ``FMT_TEST``
 CMake option. This can be useful if you include fmt as a subdirectory in
 your project but don't want to add fmt's tests to your ``test`` target.
 
-If you use Windows and have Visual Studio installed, a :file:`FORMAT.sln`
+If you use Windows and have Visual Studio installed, a :file:`FMT.sln`
 file and several :file:`.vcproj` files will be created. You can then build them
 using Visual Studio or msbuild.
 


### PR DESCRIPTION
after executing `cmake <path-to-fmt>, the output .sln file is FMT.sln not FORMAT.sln.