### PR TITLE
Clang Format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+BasedOnStyle: Google
+Language: Cpp
+Standard: Cpp11
+
+ColumnLimit: 80
+
+AlwaysBreakTemplateDeclarations: true
+AllowShortIfStatementsOnASingleLine: false
+
+AlignAfterOpenBracket: AlwaysBreak
+BinPackArguments: false
+BinPackParameters: false

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -18,7 +18,7 @@
 
 FMT_BEGIN_NAMESPACE
 
-namespace internal{
+namespace internal {
 
 enum class numeric_system {
   standard,
@@ -28,152 +28,154 @@ enum class numeric_system {
 
 // Parses a put_time-like format string and invokes handler actions.
 template <typename Char, typename Handler>
-FMT_CONSTEXPR const Char *parse_chrono_format(
-    const Char *begin, const Char *end, Handler &&handler) {
+FMT_CONSTEXPR const Char *parse_chrono_format(const Char *begin,
+                                              const Char *end,
+                                              Handler &&handler) {
   auto ptr = begin;
   while (ptr != end) {
     auto c = *ptr;
-    if (c == '}') break;
+    if (c == '}')
+      break;
     if (c != '%') {
       ++ptr;
       continue;
     }
     if (begin != ptr)
       handler.on_text(begin, ptr);
-    ++ptr; // consume '%'
+    ++ptr;  // consume '%'
     if (ptr == end)
       throw format_error("invalid format");
     c = *ptr++;
     switch (c) {
-    case '%':
-      handler.on_text(ptr - 1, ptr);
-      break;
-    case 'n': {
-      const char newline[] = "\n";
-      handler.on_text(newline, newline + 1);
-      break;
-    }
-    case 't': {
-      const char tab[] = "\t";
-      handler.on_text(tab, tab + 1);
-      break;
-    }
-    // Day of the week:
-    case 'a':
-      handler.on_abbr_weekday();
-      break;
-    case 'A':
-      handler.on_full_weekday();
-      break;
-    case 'w':
-      handler.on_dec0_weekday(numeric_system::standard);
-      break;
-    case 'u':
-      handler.on_dec1_weekday(numeric_system::standard);
-      break;
-    // Month:
-    case 'b':
-      handler.on_abbr_month();
-      break;
-    case 'B':
-      handler.on_full_month();
-      break;
-    // Hour, minute, second:
-    case 'H':
-      handler.on_24_hour(numeric_system::standard);
-      break;
-    case 'I':
-      handler.on_12_hour(numeric_system::standard);
-      break;
-    case 'M':
-      handler.on_minute(numeric_system::standard);
-      break;
-    case 'S':
-      handler.on_second(numeric_system::standard);
-      break;
-    // Other:
-    case 'c':
-      handler.on_datetime(numeric_system::standard);
-      break;
-    case 'x':
-      handler.on_loc_date(numeric_system::standard);
-      break;
-    case 'X':
-      handler.on_loc_time(numeric_system::standard);
-      break;
-    case 'D':
-      handler.on_us_date();
-      break;
-    case 'F':
-      handler.on_iso_date();
-      break;
-    case 'r':
-      handler.on_12_hour_time();
-      break;
-    case 'R':
-      handler.on_24_hour_time();
-      break;
-    case 'T':
-      handler.on_iso_time();
-      break;
-    case 'p':
-      handler.on_am_pm();
-      break;
-    case 'z':
-      handler.on_utc_offset();
-      break;
-    case 'Z':
-      handler.on_tz_name();
-      break;
-    // Alternative representation:
-    case 'E': {
-      if (ptr == end)
-        throw format_error("invalid format");
-      c = *ptr++;
-      switch (c) {
-      case 'c':
-        handler.on_datetime(numeric_system::alternative);
+      case '%':
+        handler.on_text(ptr - 1, ptr);
         break;
-      case 'x':
-        handler.on_loc_date(numeric_system::alternative);
+      case 'n': {
+        const char newline[] = "\n";
+        handler.on_text(newline, newline + 1);
         break;
-      case 'X':
-        handler.on_loc_time(numeric_system::alternative);
-        break;
-      default:
-        throw format_error("invalid format");
       }
-      break;
-    }
-    case 'O':
-      if (ptr == end)
-        throw format_error("invalid format");
-      c = *ptr++;
-      switch (c) {
+      case 't': {
+        const char tab[] = "\t";
+        handler.on_text(tab, tab + 1);
+        break;
+      }
+      // Day of the week:
+      case 'a':
+        handler.on_abbr_weekday();
+        break;
+      case 'A':
+        handler.on_full_weekday();
+        break;
       case 'w':
-        handler.on_dec0_weekday(numeric_system::alternative);
+        handler.on_dec0_weekday(numeric_system::standard);
         break;
       case 'u':
-        handler.on_dec1_weekday(numeric_system::alternative);
+        handler.on_dec1_weekday(numeric_system::standard);
         break;
+      // Month:
+      case 'b':
+        handler.on_abbr_month();
+        break;
+      case 'B':
+        handler.on_full_month();
+        break;
+      // Hour, minute, second:
       case 'H':
-        handler.on_24_hour(numeric_system::alternative);
+        handler.on_24_hour(numeric_system::standard);
         break;
       case 'I':
-        handler.on_12_hour(numeric_system::alternative);
+        handler.on_12_hour(numeric_system::standard);
         break;
       case 'M':
-        handler.on_minute(numeric_system::alternative);
+        handler.on_minute(numeric_system::standard);
         break;
       case 'S':
-        handler.on_second(numeric_system::alternative);
+        handler.on_second(numeric_system::standard);
+        break;
+      // Other:
+      case 'c':
+        handler.on_datetime(numeric_system::standard);
+        break;
+      case 'x':
+        handler.on_loc_date(numeric_system::standard);
+        break;
+      case 'X':
+        handler.on_loc_time(numeric_system::standard);
+        break;
+      case 'D':
+        handler.on_us_date();
+        break;
+      case 'F':
+        handler.on_iso_date();
+        break;
+      case 'r':
+        handler.on_12_hour_time();
+        break;
+      case 'R':
+        handler.on_24_hour_time();
+        break;
+      case 'T':
+        handler.on_iso_time();
+        break;
+      case 'p':
+        handler.on_am_pm();
+        break;
+      case 'z':
+        handler.on_utc_offset();
+        break;
+      case 'Z':
+        handler.on_tz_name();
+        break;
+      // Alternative representation:
+      case 'E': {
+        if (ptr == end)
+          throw format_error("invalid format");
+        c = *ptr++;
+        switch (c) {
+          case 'c':
+            handler.on_datetime(numeric_system::alternative);
+            break;
+          case 'x':
+            handler.on_loc_date(numeric_system::alternative);
+            break;
+          case 'X':
+            handler.on_loc_time(numeric_system::alternative);
+            break;
+          default:
+            throw format_error("invalid format");
+        }
+        break;
+      }
+      case 'O':
+        if (ptr == end)
+          throw format_error("invalid format");
+        c = *ptr++;
+        switch (c) {
+          case 'w':
+            handler.on_dec0_weekday(numeric_system::alternative);
+            break;
+          case 'u':
+            handler.on_dec1_weekday(numeric_system::alternative);
+            break;
+          case 'H':
+            handler.on_24_hour(numeric_system::alternative);
+            break;
+          case 'I':
+            handler.on_12_hour(numeric_system::alternative);
+            break;
+          case 'M':
+            handler.on_minute(numeric_system::alternative);
+            break;
+          case 'S':
+            handler.on_second(numeric_system::alternative);
+            break;
+          default:
+            throw format_error("invalid format");
+        }
         break;
       default:
         throw format_error("invalid format");
-      }
-      break;
-    default:
-      throw format_error("invalid format");
     }
     begin = ptr;
   }
@@ -213,7 +215,8 @@ struct chrono_format_checker {
 template <typename Int>
 inline int to_int(Int value) {
   FMT_ASSERT(value >= (std::numeric_limits<int>::min)() &&
-             value <= (std::numeric_limits<int>::max)(), "invalid value");
+                 value <= (std::numeric_limits<int>::max)(),
+             "invalid value");
   return static_cast<int>(value);
 }
 
@@ -227,7 +230,7 @@ struct chrono_formatter {
   typedef typename FormatContext::char_type char_type;
 
   explicit chrono_formatter(FormatContext &ctx)
-    : context(ctx), out(ctx.out()) {}
+      : context(ctx), out(ctx.out()) {}
 
   int hour() const { return to_int((s.count() / 3600) % 24); }
 
@@ -341,30 +344,84 @@ struct chrono_formatter {
 };
 }  // namespace internal
 
-template <typename Period> FMT_CONSTEXPR const char *get_units() {
+template <typename Period>
+FMT_CONSTEXPR const char *get_units() {
   return FMT_NULL;
 }
-template <> FMT_CONSTEXPR const char *get_units<std::atto>() { return "as"; }
-template <> FMT_CONSTEXPR const char *get_units<std::femto>() { return "fs"; }
-template <> FMT_CONSTEXPR const char *get_units<std::pico>() { return "ps"; }
-template <> FMT_CONSTEXPR const char *get_units<std::nano>() { return "ns"; }
-template <> FMT_CONSTEXPR const char *get_units<std::micro>() { return "µs"; }
-template <> FMT_CONSTEXPR const char *get_units<std::milli>() { return "ms"; }
-template <> FMT_CONSTEXPR const char *get_units<std::centi>() { return "cs"; }
-template <> FMT_CONSTEXPR const char *get_units<std::deci>() { return "ds"; }
-template <> FMT_CONSTEXPR const char *get_units<std::ratio<1>>() { return "s"; }
-template <> FMT_CONSTEXPR const char *get_units<std::deca>() { return "das"; }
-template <> FMT_CONSTEXPR const char *get_units<std::hecto>() { return "hs"; }
-template <> FMT_CONSTEXPR const char *get_units<std::kilo>() { return "ks"; }
-template <> FMT_CONSTEXPR const char *get_units<std::mega>() { return "Ms"; }
-template <> FMT_CONSTEXPR const char *get_units<std::giga>() { return "Gs"; }
-template <> FMT_CONSTEXPR const char *get_units<std::tera>() { return "Ts"; }
-template <> FMT_CONSTEXPR const char *get_units<std::peta>() { return "Ps"; }
-template <> FMT_CONSTEXPR const char *get_units<std::exa>() { return "Es"; }
-template <> FMT_CONSTEXPR const char *get_units<std::ratio<60>>() {
+template <>
+FMT_CONSTEXPR const char *get_units<std::atto>() {
+  return "as";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::femto>() {
+  return "fs";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::pico>() {
+  return "ps";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::nano>() {
+  return "ns";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::micro>() {
+  return "µs";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::milli>() {
+  return "ms";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::centi>() {
+  return "cs";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::deci>() {
+  return "ds";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::ratio<1>>() {
+  return "s";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::deca>() {
+  return "das";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::hecto>() {
+  return "hs";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::kilo>() {
+  return "ks";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::mega>() {
+  return "Ms";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::giga>() {
+  return "Gs";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::tera>() {
+  return "Ts";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::peta>() {
+  return "Ps";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::exa>() {
+  return "Es";
+}
+template <>
+FMT_CONSTEXPR const char *get_units<std::ratio<60>>() {
   return "m";
 }
-template <> FMT_CONSTEXPR const char *get_units<std::ratio<3600>>() {
+template <>
+FMT_CONSTEXPR const char *get_units<std::ratio<3600>>() {
   return "h";
 }
 
@@ -409,10 +466,12 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
   FMT_CONSTEXPR auto parse(basic_parse_context<Char> &ctx)
       -> decltype(ctx.begin()) {
     auto begin = ctx.begin(), end = ctx.end();
-    if (begin == end) return begin;
+    if (begin == end)
+      return begin;
     spec_handler handler{*this, ctx};
     begin = internal::parse_align(begin, end, handler);
-    if (begin == end) return begin;
+    if (begin == end)
+      return begin;
     begin = internal::parse_width(begin, end, handler);
     end = parse_chrono_format(begin, end, internal::chrono_format_checker());
     format_str = basic_string_view<Char>(&*begin, end - begin);
@@ -420,8 +479,7 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
   }
 
   template <typename FormatContext>
-  auto format(const duration &d, FormatContext &ctx)
-      -> decltype(ctx.out()) {
+  auto format(const duration &d, FormatContext &ctx) -> decltype(ctx.out()) {
     auto begin = format_str.begin(), end = format_str.end();
     if (begin == end || *begin == '}') {
       memory_buffer buf;
@@ -433,8 +491,8 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
         format_to(buf, "{}[{}/{}]s", d.count(), Period::num, Period::den);
       typedef output_range<decltype(ctx.out()), Char> range;
       basic_writer<range> w(range(ctx.out()));
-      internal::handle_dynamic_spec<internal::width_checker>(
-        spec.width_, width_ref, ctx);
+      internal::handle_dynamic_spec<internal::width_checker>(spec.width_,
+                                                             width_ref, ctx);
       w.write(buf.data(), buf.size(), spec);
       return w.out();
     }

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -28,9 +28,8 @@ enum class numeric_system {
 
 // Parses a put_time-like format string and invokes handler actions.
 template <typename Char, typename Handler>
-FMT_CONSTEXPR const Char *parse_chrono_format(const Char *begin,
-                                              const Char *end,
-                                              Handler &&handler) {
+FMT_CONSTEXPR const Char *parse_chrono_format(
+    const Char *begin, const Char *end, Handler &&handler) {
   auto ptr = begin;
   while (ptr != end) {
     auto c = *ptr;
@@ -214,9 +213,10 @@ struct chrono_format_checker {
 
 template <typename Int>
 inline int to_int(Int value) {
-  FMT_ASSERT(value >= (std::numeric_limits<int>::min)() &&
-                 value <= (std::numeric_limits<int>::max)(),
-             "invalid value");
+  FMT_ASSERT(
+      value >= (std::numeric_limits<int>::min)() &&
+          value <= (std::numeric_limits<int>::max)(),
+      "invalid value");
   return static_cast<int>(value);
 }
 
@@ -491,8 +491,8 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
         format_to(buf, "{}[{}/{}]s", d.count(), Period::num, Period::den);
       typedef output_range<decltype(ctx.out()), Char> range;
       basic_writer<range> w(range(ctx.out()));
-      internal::handle_dynamic_spec<internal::width_checker>(spec.width_,
-                                                             width_ref, ctx);
+      internal::handle_dynamic_spec<internal::width_checker>(
+          spec.width_, width_ref, ctx);
       w.write(buf.data(), buf.size(), spec);
       return w.out();
     }

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -20,12 +20,12 @@ FMT_API void vprint_colored(color c, string_view format, format_args args);
 FMT_API void vprint_colored(color c, wstring_view format, wformat_args args);
 template <typename... Args>
 inline void print_colored(color c, string_view format_str,
-                          const Args & ... args) {
+                          const Args&... args) {
   vprint_colored(c, format_str, make_format_args(args...));
 }
 template <typename... Args>
 inline void print_colored(color c, wstring_view format_str,
-                          const Args & ... args) {
+                          const Args&... args) {
   vprint_colored(c, format_str, make_format_args<wformat_context>(args...));
 }
 
@@ -46,6 +46,8 @@ inline void vprint_colored(color c, wstring_view format, wformat_args args) {
 }
 
 #else
+
+// clang-format off
 
 enum class color : uint32_t {
   alice_blue              = 0xF0F8FF, // rgb(240,248,255)
@@ -191,6 +193,8 @@ enum class color : uint32_t {
   yellow_green            = 0x9ACD32  // rgb(154,205,50)
 };  // enum class color
 
+// clang-format on
+
 enum class terminal_color : uint8_t {
   black = 30,
   red,
@@ -223,12 +227,13 @@ enum class emphasis : uint8_t {
 struct rgb {
   FMT_CONSTEXPR_DECL rgb() : r(0), g(0), b(0) {}
   FMT_CONSTEXPR_DECL rgb(uint8_t r_, uint8_t g_, uint8_t b_)
-    : r(r_), g(g_), b(b_) {}
+      : r(r_), g(g_), b(b_) {}
   FMT_CONSTEXPR_DECL rgb(uint32_t hex)
-    : r((hex >> 16) & 0xFF), g((hex >> 8) & 0xFF), b((hex) & 0xFF) {}
+      : r((hex >> 16) & 0xFF), g((hex >> 8) & 0xFF), b((hex)&0xFF) {}
   FMT_CONSTEXPR_DECL rgb(color hex)
-    : r((uint32_t(hex) >> 16) & 0xFF), g((uint32_t(hex) >> 8) & 0xFF),
-      b(uint32_t(hex) & 0xFF) {}
+      : r((uint32_t(hex) >> 16) & 0xFF),
+        g((uint32_t(hex) >> 8) & 0xFF),
+        b(uint32_t(hex) & 0xFF) {}
   uint8_t r;
   uint8_t g;
   uint8_t b;
@@ -238,18 +243,16 @@ namespace internal {
 
 // color is a struct of either a rgb color or a terminal color.
 struct color_type {
-  FMT_CONSTEXPR color_type() FMT_NOEXCEPT
-    : is_rgb(), value{} {}
-  FMT_CONSTEXPR color_type(color rgb_color) FMT_NOEXCEPT
-    : is_rgb(true), value{} {
+  FMT_CONSTEXPR color_type() FMT_NOEXCEPT : is_rgb(), value{} {}
+  FMT_CONSTEXPR color_type(color rgb_color) FMT_NOEXCEPT : is_rgb(true),
+                                                           value{} {
     value.rgb_color = static_cast<uint32_t>(rgb_color);
   }
-  FMT_CONSTEXPR color_type(rgb rgb_color) FMT_NOEXCEPT
-    : is_rgb(true), value{} {
+  FMT_CONSTEXPR color_type(rgb rgb_color) FMT_NOEXCEPT : is_rgb(true), value{} {
     value.rgb_color = (rgb_color.r << 16) + (rgb_color.g << 8) + rgb_color.b;
   }
-  FMT_CONSTEXPR color_type(terminal_color term_color) FMT_NOEXCEPT
-    : is_rgb(), value{} {
+  FMT_CONSTEXPR color_type(terminal_color term_color) FMT_NOEXCEPT : is_rgb(),
+                                                                     value{} {
     value.term_color = static_cast<uint8_t>(term_color);
   }
   bool is_rgb;
@@ -258,13 +261,15 @@ struct color_type {
     uint32_t rgb_color;
   } value;
 };
-} // namespace internal
+}  // namespace internal
 
 // Experimental text formatting support.
 class text_style {
  public:
   FMT_CONSTEXPR text_style(emphasis em = emphasis()) FMT_NOEXCEPT
-      : set_foreground_color(), set_background_color(), ems(em) {}
+      : set_foreground_color(),
+        set_background_color(),
+        ems(em) {}
 
   FMT_CONSTEXPR text_style &operator|=(const text_style &rhs) {
     if (!set_foreground_color) {
@@ -290,8 +295,8 @@ class text_style {
     return *this;
   }
 
-  friend FMT_CONSTEXPR
-  text_style operator|(text_style lhs, const text_style &rhs) {
+  friend FMT_CONSTEXPR text_style operator|(text_style lhs,
+                                            const text_style &rhs) {
     return lhs |= rhs;
   }
 
@@ -319,8 +324,8 @@ class text_style {
     return *this;
   }
 
-  friend FMT_CONSTEXPR
-  text_style operator&(text_style lhs, const text_style &rhs) {
+  friend FMT_CONSTEXPR text_style operator&(text_style lhs,
+                                            const text_style &rhs) {
     return lhs &= rhs;
   }
 
@@ -346,20 +351,20 @@ class text_style {
     return ems;
   }
 
-private:
- FMT_CONSTEXPR text_style(bool is_foreground,
-                          internal::color_type text_color) FMT_NOEXCEPT
-     : set_foreground_color(),
-       set_background_color(),
-       ems() {
-   if (is_foreground) {
-     foreground_color = text_color;
-     set_foreground_color = true;
-   } else {
-     background_color = text_color;
-     set_background_color = true;
-   }
- }
+ private:
+  FMT_CONSTEXPR text_style(bool is_foreground,
+                           internal::color_type text_color) FMT_NOEXCEPT
+      : set_foreground_color(),
+        set_background_color(),
+        ems() {
+    if (is_foreground) {
+      foreground_color = text_color;
+      set_foreground_color = true;
+    } else {
+      background_color = text_color;
+      set_background_color = true;
+    }
+  }
 
   friend FMT_CONSTEXPR_DECL text_style fg(internal::color_type foreground)
       FMT_NOEXCEPT;
@@ -390,7 +395,7 @@ namespace internal {
 template <typename Char>
 struct ansi_color_escape {
   FMT_CONSTEXPR ansi_color_escape(internal::color_type text_color,
-                                  const char * esc) FMT_NOEXCEPT {
+                                  const char *esc) FMT_NOEXCEPT {
     // If we have a terminal color, we need to output another escape code
     // sequence.
     if (!text_color.is_rgb) {
@@ -421,7 +426,7 @@ struct ansi_color_escape {
       buffer[i] = static_cast<Char>(esc[i]);
     }
     rgb color(text_color.value.rgb_color);
-    to_esc(color.r, buffer +  7, ';');
+    to_esc(color.r, buffer + 7, ';');
     to_esc(color.g, buffer + 11, ';');
     to_esc(color.b, buffer + 15, 'm');
     buffer[19] = static_cast<Char>(0);
@@ -451,7 +456,7 @@ struct ansi_color_escape {
   }
   FMT_CONSTEXPR operator const Char *() const FMT_NOEXCEPT { return buffer; }
 
-private:
+ private:
   Char buffer[7 + 3 * 4 + 1];
 
   static FMT_CONSTEXPR void to_esc(uint8_t c, Char *out,
@@ -464,20 +469,19 @@ private:
 };
 
 template <typename Char>
-FMT_CONSTEXPR ansi_color_escape<Char>
-make_foreground_color(internal::color_type foreground) FMT_NOEXCEPT {
+FMT_CONSTEXPR ansi_color_escape<Char> make_foreground_color(
+    internal::color_type foreground) FMT_NOEXCEPT {
   return ansi_color_escape<Char>(foreground, internal::data::FOREGROUND_COLOR);
 }
 
 template <typename Char>
-FMT_CONSTEXPR ansi_color_escape<Char>
-make_background_color(internal::color_type background) FMT_NOEXCEPT {
+FMT_CONSTEXPR ansi_color_escape<Char> make_background_color(
+    internal::color_type background) FMT_NOEXCEPT {
   return ansi_color_escape<Char>(background, internal::data::BACKGROUND_COLOR);
 }
 
 template <typename Char>
-FMT_CONSTEXPR ansi_color_escape<Char>
-make_emphasis(emphasis em) FMT_NOEXCEPT {
+FMT_CONSTEXPR ansi_color_escape<Char> make_emphasis(emphasis em) FMT_NOEXCEPT {
   return ansi_color_escape<Char>(em);
 }
 
@@ -509,22 +513,20 @@ template <>
 struct is_string<std::FILE *> : std::false_type {};
 template <>
 struct is_string<const std::FILE *> : std::false_type {};
-} // namespace internal
+}  // namespace internal
 
-template <
-  typename S, typename Char = typename internal::char_t<S>::type>
+template <typename S, typename Char = typename internal::char_t<S>::type>
 void vprint(std::FILE *f, const text_style &ts, const S &format,
             basic_format_args<typename buffer_context<Char>::type> args) {
   bool has_style = false;
   if (ts.has_emphasis()) {
     has_style = true;
-    internal::fputs<Char>(
-          internal::make_emphasis<Char>(ts.get_emphasis()), f);
+    internal::fputs<Char>(internal::make_emphasis<Char>(ts.get_emphasis()), f);
   }
   if (ts.has_foreground()) {
     has_style = true;
     internal::fputs<Char>(
-          internal::make_foreground_color<Char>(ts.get_foreground()), f);
+        internal::make_foreground_color<Char>(ts.get_foreground()), f);
   }
   if (ts.has_background()) {
     has_style = true;
@@ -564,8 +566,7 @@ typename std::enable_if<internal::is_string<String>::value>::type print(
  */
 template <typename String, typename... Args>
 typename std::enable_if<internal::is_string<String>::value>::type print(
-    const text_style &ts, const String &format_str,
-    const Args &... args) {
+    const text_style &ts, const String &format_str, const Args &... args) {
   return print(stdout, ts, format_str, args...);
 }
 

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -19,13 +19,13 @@ enum color { black, red, green, yellow, blue, magenta, cyan, white };
 FMT_API void vprint_colored(color c, string_view format, format_args args);
 FMT_API void vprint_colored(color c, wstring_view format, wformat_args args);
 template <typename... Args>
-inline void print_colored(color c, string_view format_str,
-                          const Args&... args) {
+inline void print_colored(
+    color c, string_view format_str, const Args&... args) {
   vprint_colored(c, format_str, make_format_args(args...));
 }
 template <typename... Args>
-inline void print_colored(color c, wstring_view format_str,
-                          const Args&... args) {
+inline void print_colored(
+    color c, wstring_view format_str, const Args&... args) {
   vprint_colored(c, format_str, make_format_args<wformat_context>(args...));
 }
 
@@ -290,13 +290,13 @@ class text_style {
       background_color.value.rgb_color |= rhs.background_color.value.rgb_color;
     }
 
-    ems = static_cast<emphasis>(static_cast<uint8_t>(ems) |
-                                static_cast<uint8_t>(rhs.ems));
+    ems = static_cast<emphasis>(
+        static_cast<uint8_t>(ems) | static_cast<uint8_t>(rhs.ems));
     return *this;
   }
 
-  friend FMT_CONSTEXPR text_style operator|(text_style lhs,
-                                            const text_style &rhs) {
+  friend FMT_CONSTEXPR text_style
+  operator|(text_style lhs, const text_style &rhs) {
     return lhs |= rhs;
   }
 
@@ -319,13 +319,13 @@ class text_style {
       background_color.value.rgb_color &= rhs.background_color.value.rgb_color;
     }
 
-    ems = static_cast<emphasis>(static_cast<uint8_t>(ems) &
-                                static_cast<uint8_t>(rhs.ems));
+    ems = static_cast<emphasis>(
+        static_cast<uint8_t>(ems) & static_cast<uint8_t>(rhs.ems));
     return *this;
   }
 
-  friend FMT_CONSTEXPR text_style operator&(text_style lhs,
-                                            const text_style &rhs) {
+  friend FMT_CONSTEXPR text_style
+  operator&(text_style lhs, const text_style &rhs) {
     return lhs &= rhs;
   }
 
@@ -352,11 +352,10 @@ class text_style {
   }
 
  private:
-  FMT_CONSTEXPR text_style(bool is_foreground,
-                           internal::color_type text_color) FMT_NOEXCEPT
-      : set_foreground_color(),
-        set_background_color(),
-        ems() {
+  FMT_CONSTEXPR text_style(bool is_foreground, internal::color_type text_color)
+      FMT_NOEXCEPT : set_foreground_color(),
+                     set_background_color(),
+                     ems() {
     if (is_foreground) {
       foreground_color = text_color;
       set_foreground_color = true;
@@ -394,8 +393,8 @@ namespace internal {
 
 template <typename Char>
 struct ansi_color_escape {
-  FMT_CONSTEXPR ansi_color_escape(internal::color_type text_color,
-                                  const char *esc) FMT_NOEXCEPT {
+  FMT_CONSTEXPR ansi_color_escape(
+      internal::color_type text_color, const char *esc) FMT_NOEXCEPT {
     // If we have a terminal color, we need to output another escape code
     // sequence.
     if (!text_color.is_rgb) {
@@ -459,8 +458,8 @@ struct ansi_color_escape {
  private:
   Char buffer[7 + 3 * 4 + 1];
 
-  static FMT_CONSTEXPR void to_esc(uint8_t c, Char *out,
-                                   char delimiter) FMT_NOEXCEPT {
+  static FMT_CONSTEXPR void to_esc(uint8_t c, Char *out, char delimiter)
+      FMT_NOEXCEPT {
     out[0] = static_cast<Char>('0' + c / 100);
     out[1] = static_cast<Char>('0' + c / 10 % 10);
     out[2] = static_cast<Char>('0' + c % 10);
@@ -516,8 +515,11 @@ struct is_string<const std::FILE *> : std::false_type {};
 }  // namespace internal
 
 template <typename S, typename Char = typename internal::char_t<S>::type>
-void vprint(std::FILE *f, const text_style &ts, const S &format,
-            basic_format_args<typename buffer_context<Char>::type> args) {
+void vprint(
+    std::FILE *f,
+    const text_style &ts,
+    const S &format,
+    basic_format_args<typename buffer_context<Char>::type> args) {
   bool has_style = false;
   if (ts.has_emphasis()) {
     has_style = true;
@@ -548,7 +550,9 @@ void vprint(std::FILE *f, const text_style &ts, const S &format,
  */
 template <typename String, typename... Args>
 typename std::enable_if<internal::is_string<String>::value>::type print(
-    std::FILE *f, const text_style &ts, const String &format_str,
+    std::FILE *f,
+    const text_style &ts,
+    const String &format_str,
     const Args &... args) {
   internal::check_format_string<Args...>(format_str);
   typedef typename internal::char_t<String>::type char_t;

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -19,171 +19,178 @@
 #define FMT_VERSION 50202
 
 #ifdef __has_feature
-# define FMT_HAS_FEATURE(x) __has_feature(x)
+#define FMT_HAS_FEATURE(x) __has_feature(x)
 #else
-# define FMT_HAS_FEATURE(x) 0
+#define FMT_HAS_FEATURE(x) 0
 #endif
 
 #if defined(__has_include) && !defined(__INTELLISENSE__) && \
     !(defined(__INTEL_COMPILER) && __INTEL_COMPILER < 1600)
-# define FMT_HAS_INCLUDE(x) __has_include(x)
+#define FMT_HAS_INCLUDE(x) __has_include(x)
 #else
-# define FMT_HAS_INCLUDE(x) 0
+#define FMT_HAS_INCLUDE(x) 0
 #endif
 
 #ifdef __has_cpp_attribute
-# define FMT_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+#define FMT_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
 #else
-# define FMT_HAS_CPP_ATTRIBUTE(x) 0
+#define FMT_HAS_CPP_ATTRIBUTE(x) 0
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__)
-# define FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+#define FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #else
-# define FMT_GCC_VERSION 0
+#define FMT_GCC_VERSION 0
 #endif
 
 #if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
-# define FMT_HAS_GXX_CXX11 FMT_GCC_VERSION
+#define FMT_HAS_GXX_CXX11 FMT_GCC_VERSION
 #else
-# define FMT_HAS_GXX_CXX11 0
+#define FMT_HAS_GXX_CXX11 0
 #endif
 
 #ifdef _MSC_VER
-# define FMT_MSC_VER _MSC_VER
+#define FMT_MSC_VER _MSC_VER
 #else
-# define FMT_MSC_VER 0
+#define FMT_MSC_VER 0
 #endif
 
 // Check if relaxed C++14 constexpr is supported.
 // GCC doesn't allow throw in constexpr until version 6 (bug 67371).
 #ifndef FMT_USE_CONSTEXPR
-# define FMT_USE_CONSTEXPR \
+#define FMT_USE_CONSTEXPR                                           \
   (FMT_HAS_FEATURE(cxx_relaxed_constexpr) || FMT_MSC_VER >= 1910 || \
    (FMT_GCC_VERSION >= 600 && __cplusplus >= 201402L))
 #endif
 #if FMT_USE_CONSTEXPR
-# define FMT_CONSTEXPR constexpr
-# define FMT_CONSTEXPR_DECL constexpr
+#define FMT_CONSTEXPR constexpr
+#define FMT_CONSTEXPR_DECL constexpr
 #else
-# define FMT_CONSTEXPR inline
-# define FMT_CONSTEXPR_DECL
+#define FMT_CONSTEXPR inline
+#define FMT_CONSTEXPR_DECL
 #endif
 
 #ifndef FMT_USE_CONSTEXPR11
-# define FMT_USE_CONSTEXPR11 \
-    (FMT_USE_CONSTEXPR || FMT_GCC_VERSION >= 406 || FMT_MSC_VER >= 1900)
+#define FMT_USE_CONSTEXPR11 \
+  (FMT_USE_CONSTEXPR || FMT_GCC_VERSION >= 406 || FMT_MSC_VER >= 1900)
 #endif
 #if FMT_USE_CONSTEXPR11
-# define FMT_CONSTEXPR11 constexpr
+#define FMT_CONSTEXPR11 constexpr
 #else
-# define FMT_CONSTEXPR11
+#define FMT_CONSTEXPR11
 #endif
 
 #ifndef FMT_OVERRIDE
-# if FMT_HAS_FEATURE(cxx_override) || \
-     (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1900
-#  define FMT_OVERRIDE override
-# else
-#  define FMT_OVERRIDE
-# endif
+#if FMT_HAS_FEATURE(cxx_override) || \
+    (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1900
+#define FMT_OVERRIDE override
+#else
+#define FMT_OVERRIDE
+#endif
 #endif
 
-#if FMT_HAS_FEATURE(cxx_explicit_conversions) || \
-    FMT_GCC_VERSION >= 405 || FMT_MSC_VER >= 1800
-# define FMT_USE_EXPLICIT 1
-# define FMT_EXPLICIT explicit
+#if FMT_HAS_FEATURE(cxx_explicit_conversions) || FMT_GCC_VERSION >= 405 || \
+    FMT_MSC_VER >= 1800
+#define FMT_USE_EXPLICIT 1
+#define FMT_EXPLICIT explicit
 #else
-# define FMT_USE_EXPLICIT 0
-# define FMT_EXPLICIT
+#define FMT_USE_EXPLICIT 0
+#define FMT_EXPLICIT
 #endif
 
 #ifndef FMT_NULL
-# if FMT_HAS_FEATURE(cxx_nullptr) || \
-   (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1600
-#  define FMT_NULL nullptr
-#  define FMT_USE_NULLPTR 1
-# else
-#  define FMT_NULL NULL
-# endif
+#if FMT_HAS_FEATURE(cxx_nullptr) || \
+    (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1600
+#define FMT_NULL nullptr
+#define FMT_USE_NULLPTR 1
+#else
+#define FMT_NULL NULL
+#endif
 #endif
 #ifndef FMT_USE_NULLPTR
-# define FMT_USE_NULLPTR 0
+#define FMT_USE_NULLPTR 0
 #endif
 
 // Check if exceptions are disabled.
 #ifndef FMT_EXCEPTIONS
-# if (defined(__GNUC__) && !defined(__EXCEPTIONS)) || \
-     FMT_MSC_VER && !_HAS_EXCEPTIONS
-#  define FMT_EXCEPTIONS 0
-# else
-#  define FMT_EXCEPTIONS 1
-# endif
+#if (defined(__GNUC__) && !defined(__EXCEPTIONS)) || \
+    FMT_MSC_VER && !_HAS_EXCEPTIONS
+#define FMT_EXCEPTIONS 0
+#else
+#define FMT_EXCEPTIONS 1
+#endif
 #endif
 
 // Define FMT_USE_NOEXCEPT to make fmt use noexcept (C++11 feature).
 #ifndef FMT_USE_NOEXCEPT
-# define FMT_USE_NOEXCEPT 0
+#define FMT_USE_NOEXCEPT 0
 #endif
 
 #if FMT_USE_NOEXCEPT || FMT_HAS_FEATURE(cxx_noexcept) || \
     (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1900
-# define FMT_DETECTED_NOEXCEPT noexcept
-# define FMT_HAS_CXX11_NOEXCEPT 1
+#define FMT_DETECTED_NOEXCEPT noexcept
+#define FMT_HAS_CXX11_NOEXCEPT 1
 #else
-# define FMT_DETECTED_NOEXCEPT throw()
-# define FMT_HAS_CXX11_NOEXCEPT 0
+#define FMT_DETECTED_NOEXCEPT throw()
+#define FMT_HAS_CXX11_NOEXCEPT 0
 #endif
 
 #ifndef FMT_NOEXCEPT
-# if FMT_EXCEPTIONS || FMT_HAS_CXX11_NOEXCEPT
-#  define FMT_NOEXCEPT FMT_DETECTED_NOEXCEPT
-# else
-#  define FMT_NOEXCEPT
-# endif
+#if FMT_EXCEPTIONS || FMT_HAS_CXX11_NOEXCEPT
+#define FMT_NOEXCEPT FMT_DETECTED_NOEXCEPT
+#else
+#define FMT_NOEXCEPT
+#endif
 #endif
 
 #ifndef FMT_BEGIN_NAMESPACE
-# if FMT_HAS_FEATURE(cxx_inline_namespaces) || FMT_GCC_VERSION >= 404 || \
-     FMT_MSC_VER >= 1900
-#  define FMT_INLINE_NAMESPACE inline namespace
-#  define FMT_END_NAMESPACE }}
-# else
-#  define FMT_INLINE_NAMESPACE namespace
-#  define FMT_END_NAMESPACE } using namespace v5; }
-# endif
-# define FMT_BEGIN_NAMESPACE namespace fmt { FMT_INLINE_NAMESPACE v5 {
+#if FMT_HAS_FEATURE(cxx_inline_namespaces) || FMT_GCC_VERSION >= 404 || \
+    FMT_MSC_VER >= 1900
+#define FMT_INLINE_NAMESPACE inline namespace
+#define FMT_END_NAMESPACE \
+  }                       \
+  }
+#else
+#define FMT_INLINE_NAMESPACE namespace
+#define FMT_END_NAMESPACE \
+  }                       \
+  using namespace v5;     \
+  }
+#endif
+#define FMT_BEGIN_NAMESPACE \
+  namespace fmt {           \
+  FMT_INLINE_NAMESPACE v5 {
 #endif
 
 #if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
-# ifdef FMT_EXPORT
-#  define FMT_API __declspec(dllexport)
-# elif defined(FMT_SHARED)
-#  define FMT_API __declspec(dllimport)
-# endif
+#ifdef FMT_EXPORT
+#define FMT_API __declspec(dllexport)
+#elif defined(FMT_SHARED)
+#define FMT_API __declspec(dllimport)
+#endif
 #endif
 #ifndef FMT_API
-# define FMT_API
+#define FMT_API
 #endif
 
 #ifndef FMT_ASSERT
-# define FMT_ASSERT(condition, message) assert((condition) && message)
+#define FMT_ASSERT(condition, message) assert((condition) && message)
 #endif
 
 // libc++ supports string_view in pre-c++17.
-#if (FMT_HAS_INCLUDE(<string_view>) && \
-      (__cplusplus > 201402L || defined(_LIBCPP_VERSION))) || \
+#if (FMT_HAS_INCLUDE(<string_view>) &&                       \
+     (__cplusplus > 201402L || defined(_LIBCPP_VERSION))) || \
     (defined(_MSVC_LANG) && _MSVC_LANG > 201402L && _MSC_VER >= 1910)
-# include <string_view>
-# define FMT_STRING_VIEW std::basic_string_view
-#elif FMT_HAS_INCLUDE(<experimental/string_view>) && __cplusplus >= 201402L
-# include <experimental/string_view>
-# define FMT_STRING_VIEW std::experimental::basic_string_view
+#include <string_view>
+#define FMT_STRING_VIEW std::basic_string_view
+#elif FMT_HAS_INCLUDE(<experimental / string_view>) && __cplusplus >= 201402L
+#include <experimental/string_view>
+#define FMT_STRING_VIEW std::experimental::basic_string_view
 #endif
 
 // std::result_of is defined in <functional> in gcc 4.4.
 #if FMT_GCC_VERSION && FMT_GCC_VERSION <= 404
-# include <functional>
+#include <functional>
 #endif
 
 FMT_BEGIN_NAMESPACE
@@ -199,8 +206,8 @@ struct result_of;
 template <typename F, typename... Args>
 struct result_of<F(Args...)> {
   // A workaround for gcc 4.4 that doesn't allow F to be a reference.
-  typedef typename std::result_of<
-    typename std::remove_reference<F>::type(Args...)>::type type;
+  typedef typename std::result_of<typename std::remove_reference<F>::type(
+      Args...)>::type type;
 };
 
 // Casts nonnegative integer to unsigned.
@@ -223,10 +230,12 @@ class basic_buffer {
 
  protected:
   // Don't initialize ptr_ since it is not accessed to save a few cycles.
-  basic_buffer(std::size_t sz) FMT_NOEXCEPT: size_(sz), capacity_(sz) {}
+  basic_buffer(std::size_t sz) FMT_NOEXCEPT : size_(sz), capacity_(sz) {}
 
-  basic_buffer(T *p = FMT_NULL, std::size_t sz = 0, std::size_t cap = 0)
-    FMT_NOEXCEPT: ptr_(p), size_(sz), capacity_(cap) {}
+  basic_buffer(T *p = FMT_NULL, std::size_t sz = 0,
+               std::size_t cap = 0) FMT_NOEXCEPT : ptr_(p),
+                                                   size_(sz),
+                                                   capacity_(cap) {}
 
   /** Sets the buffer data and capacity. */
   void set(T *buf_data, std::size_t buf_capacity) FMT_NOEXCEPT {
@@ -305,14 +314,14 @@ class container_buffer : public basic_buffer<typename Container::value_type> {
 
  public:
   explicit container_buffer(Container &c)
-    : basic_buffer<typename Container::value_type>(c.size()), container_(c) {}
+      : basic_buffer<typename Container::value_type>(c.size()), container_(c) {}
 };
 
 // Extracts a reference to the container from back_insert_iterator.
 template <typename Container>
 inline Container &get_container(std::back_insert_iterator<Container> it) {
   typedef std::back_insert_iterator<Container> bi_iterator;
-  struct accessor: bi_iterator {
+  struct accessor : bi_iterator {
     accessor(bi_iterator iter) : bi_iterator(iter) {}
     using bi_iterator::container;
   };
@@ -333,7 +342,7 @@ struct no_formatter_error : std::false_type {};
 
 #if FMT_GCC_VERSION && FMT_GCC_VERSION < 405
 template <typename... T>
-struct is_constructible: std::false_type {};
+struct is_constructible : std::false_type {};
 #else
 template <typename... T>
 struct is_constructible : std::is_constructible<T...> {};
@@ -360,7 +369,8 @@ class basic_string_view {
 
   /** Constructs a string reference object from a C string and a size. */
   FMT_CONSTEXPR basic_string_view(const Char *s, size_t count) FMT_NOEXCEPT
-    : data_(s), size_(count) {}
+      : data_(s),
+        size_(count) {}
 
   /**
     \rst
@@ -369,17 +379,18 @@ class basic_string_view {
     \endrst
    */
   basic_string_view(const Char *s)
-    : data_(s), size_(std::char_traits<Char>::length(s)) {}
+      : data_(s), size_(std::char_traits<Char>::length(s)) {}
 
   /** Constructs a string reference from a ``std::basic_string`` object. */
   template <typename Alloc>
-  FMT_CONSTEXPR basic_string_view(
-      const std::basic_string<Char, Alloc> &s) FMT_NOEXCEPT
-  : data_(s.data()), size_(s.size()) {}
+  FMT_CONSTEXPR basic_string_view(const std::basic_string<Char, Alloc> &s)
+      FMT_NOEXCEPT : data_(s.data()),
+                     size_(s.size()) {}
 
 #ifdef FMT_STRING_VIEW
   FMT_CONSTEXPR basic_string_view(FMT_STRING_VIEW<Char> s) FMT_NOEXCEPT
-  : data_(s.data()), size_(s.size()) {}
+      : data_(s.data()),
+        size_(s.size()) {}
 #endif
 
   /** Returns a pointer to the string data. */
@@ -451,20 +462,26 @@ typedef basic_string_view<wchar_t> wstring_view;
   \endrst
  */
 template <typename Char>
-inline basic_string_view<Char>
-  to_string_view(basic_string_view<Char> s) { return s; }
+inline basic_string_view<Char> to_string_view(basic_string_view<Char> s) {
+  return s;
+}
 
 template <typename Char>
-inline basic_string_view<Char>
-  to_string_view(const std::basic_string<Char> &s) { return s; }
+inline basic_string_view<Char> to_string_view(
+    const std::basic_string<Char> &s) {
+  return s;
+}
 
 template <typename Char>
-inline basic_string_view<Char> to_string_view(const Char *s) { return s; }
+inline basic_string_view<Char> to_string_view(const Char *s) {
+  return s;
+}
 
 #ifdef FMT_STRING_VIEW
 template <typename Char>
-inline basic_string_view<Char>
-  to_string_view(FMT_STRING_VIEW<Char> s) { return s; }
+inline basic_string_view<Char> to_string_view(FMT_STRING_VIEW<Char> s) {
+  return s;
+}
 #endif
 
 // A base class for compile-time strings. It is defined in the fmt namespace to
@@ -474,11 +491,12 @@ struct compile_string {};
 template <typename S>
 struct is_compile_string : std::is_base_of<compile_string, S> {};
 
-template <
-  typename S,
-  typename Enable = typename std::enable_if<is_compile_string<S>::value>::type>
-FMT_CONSTEXPR basic_string_view<typename S::char_type>
-  to_string_view(const S &s) { return s; }
+template <typename S, typename Enable = typename std::enable_if<
+                          is_compile_string<S>::value>::type>
+FMT_CONSTEXPR basic_string_view<typename S::char_type> to_string_view(
+    const S &s) {
+  return s;
+}
 
 template <typename Context>
 class basic_format_arg;
@@ -489,9 +507,10 @@ class basic_format_args;
 // A formatter for objects of type T.
 template <typename T, typename Char = char, typename Enable = void>
 struct formatter {
-  static_assert(internal::no_formatter_error<T>::value,
-    "don't know how to format the type, include fmt/ostream.h if it provides "
-    "an operator<< that should be used");
+  static_assert(
+      internal::no_formatter_error<T>::value,
+      "don't know how to format the type, include fmt/ostream.h if it provides "
+      "an operator<< that should be used");
 
   // The following functions are not defined intentionally.
   template <typename ParseContext>
@@ -501,19 +520,25 @@ struct formatter {
 };
 
 template <typename T, typename Char, typename Enable = void>
-struct convert_to_int: std::integral_constant<
-  bool, !std::is_arithmetic<T>::value && std::is_convertible<T, int>::value> {};
+struct convert_to_int
+    : std::integral_constant<bool, !std::is_arithmetic<T>::value &&
+                                       std::is_convertible<T, int>::value> {};
 
 namespace internal {
 
-struct dummy_string_view { typedef void char_type; };
+struct dummy_string_view {
+  typedef void char_type;
+};
 dummy_string_view to_string_view(...);
 using fmt::v5::to_string_view;
 
 // Specifies whether S is a string type convertible to fmt::basic_string_view.
 template <typename S>
-struct is_string : std::integral_constant<bool, !std::is_same<
-    dummy_string_view, decltype(to_string_view(declval<S>()))>::value> {};
+struct is_string
+    : std::integral_constant<
+          bool, !std::is_same<dummy_string_view,
+                              decltype(to_string_view(declval<S>()))>::value> {
+};
 
 template <typename S>
 struct char_t {
@@ -528,13 +553,24 @@ template <typename T, typename Char>
 struct named_arg;
 
 enum type {
-  none_type, named_arg_type,
+  none_type,
+  named_arg_type,
   // Integer types should go first,
-  int_type, uint_type, long_long_type, ulong_long_type, bool_type, char_type,
+  int_type,
+  uint_type,
+  long_long_type,
+  ulong_long_type,
+  bool_type,
+  char_type,
   last_integer_type = char_type,
   // followed by floating-point types.
-  double_type, long_double_type, last_numeric_type = long_double_type,
-  cstring_type, string_type, pointer_type, custom_type
+  double_type,
+  long_double_type,
+  last_numeric_type = long_double_type,
+  cstring_type,
+  string_type,
+  pointer_type,
+  custom_type
 };
 
 FMT_CONSTEXPR bool is_integral(type t) {
@@ -609,7 +645,7 @@ class value {
   }
 
   const named_arg_base<char_type> &as_named_arg() {
-    return *static_cast<const named_arg_base<char_type>*>(pointer);
+    return *static_cast<const named_arg_base<char_type> *>(pointer);
   }
 
  private:
@@ -622,7 +658,7 @@ class value {
     typename Context::template formatter_type<T>::type f;
     auto &&parse_ctx = ctx.parse_context();
     parse_ctx.advance_to(f.parse(parse_ctx));
-    ctx.advance_to(f.format(*static_cast<const T*>(arg), ctx));
+    ctx.advance_to(f.format(*static_cast<const T *>(arg), ctx));
   }
 };
 
@@ -639,15 +675,17 @@ struct init {
 template <typename Context, typename T>
 FMT_CONSTEXPR basic_format_arg<Context> make_arg(const T &value);
 
-#define FMT_MAKE_VALUE(TAG, ArgType, ValueType) \
-  template <typename C> \
+#define FMT_MAKE_VALUE(TAG, ArgType, ValueType)                   \
+  template <typename C>                                           \
   FMT_CONSTEXPR init<C, ValueType, TAG> make_value(ArgType val) { \
-    return static_cast<ValueType>(val); \
+    return static_cast<ValueType>(val);                           \
   }
 
-#define FMT_MAKE_VALUE_SAME(TAG, Type) \
-  template <typename C> \
-  FMT_CONSTEXPR init<C, Type, TAG> make_value(Type val) { return val; }
+#define FMT_MAKE_VALUE_SAME(TAG, Type)                    \
+  template <typename C>                                   \
+  FMT_CONSTEXPR init<C, Type, TAG> make_value(Type val) { \
+    return val;                                           \
+  }
 
 FMT_MAKE_VALUE(bool_type, bool, int)
 FMT_MAKE_VALUE(int_type, short, int)
@@ -658,14 +696,14 @@ FMT_MAKE_VALUE_SAME(uint_type, unsigned)
 // To minimize the number of types we need to deal with, long is translated
 // either to int or to long long depending on its size.
 typedef std::conditional<sizeof(long) == sizeof(int), int, long long>::type
-        long_type;
-FMT_MAKE_VALUE(
-    (sizeof(long) == sizeof(int) ? int_type : long_long_type), long, long_type)
-typedef std::conditional<sizeof(unsigned long) == sizeof(unsigned),
-                         unsigned, unsigned long long>::type ulong_type;
-FMT_MAKE_VALUE(
-    (sizeof(unsigned long) == sizeof(unsigned) ? uint_type : ulong_long_type),
-    unsigned long, ulong_type)
+    long_type;
+FMT_MAKE_VALUE((sizeof(long) == sizeof(int) ? int_type : long_long_type), long,
+               long_type)
+typedef std::conditional<sizeof(unsigned long) == sizeof(unsigned), unsigned,
+                         unsigned long long>::type ulong_type;
+FMT_MAKE_VALUE((sizeof(unsigned long) == sizeof(unsigned) ? uint_type
+                                                          : ulong_long_type),
+               unsigned long, ulong_type)
 
 FMT_MAKE_VALUE_SAME(long_long_type, long long)
 FMT_MAKE_VALUE_SAME(ulong_long_type, unsigned long long)
@@ -674,14 +712,20 @@ FMT_MAKE_VALUE(uint_type, unsigned char, unsigned)
 
 // This doesn't use FMT_MAKE_VALUE because of ambiguity in gcc 4.4.
 template <typename C, typename Char>
-FMT_CONSTEXPR typename std::enable_if<
-  std::is_same<typename C::char_type, Char>::value,
-  init<C, int, char_type>>::type make_value(Char val) { return val; }
+FMT_CONSTEXPR
+    typename std::enable_if<std::is_same<typename C::char_type, Char>::value,
+                            init<C, int, char_type>>::type
+    make_value(Char val) {
+  return val;
+}
 
 template <typename C>
-FMT_CONSTEXPR typename std::enable_if<
-  !std::is_same<typename C::char_type, char>::value,
-  init<C, int, char_type>>::type make_value(char val) { return val; }
+FMT_CONSTEXPR
+    typename std::enable_if<!std::is_same<typename C::char_type, char>::value,
+                            init<C, int, char_type>>::type
+    make_value(char val) {
+  return val;
+}
 
 FMT_MAKE_VALUE(double_type, float, double)
 FMT_MAKE_VALUE_SAME(double_type, double)
@@ -689,26 +733,26 @@ FMT_MAKE_VALUE_SAME(long_double_type, long double)
 
 // Formatting of wide strings into a narrow buffer and multibyte strings
 // into a wide buffer is disallowed (https://github.com/fmtlib/fmt/pull/606).
-FMT_MAKE_VALUE(cstring_type, typename C::char_type*,
-               const typename C::char_type*)
-FMT_MAKE_VALUE(cstring_type, const typename C::char_type*,
-               const typename C::char_type*)
+FMT_MAKE_VALUE(cstring_type, typename C::char_type *,
+               const typename C::char_type *)
+FMT_MAKE_VALUE(cstring_type, const typename C::char_type *,
+               const typename C::char_type *)
 
-FMT_MAKE_VALUE(cstring_type, signed char*, const signed char*)
-FMT_MAKE_VALUE_SAME(cstring_type, const signed char*)
-FMT_MAKE_VALUE(cstring_type, unsigned char*, const unsigned char*)
-FMT_MAKE_VALUE_SAME(cstring_type, const unsigned char*)
+FMT_MAKE_VALUE(cstring_type, signed char *, const signed char *)
+FMT_MAKE_VALUE_SAME(cstring_type, const signed char *)
+FMT_MAKE_VALUE(cstring_type, unsigned char *, const unsigned char *)
+FMT_MAKE_VALUE_SAME(cstring_type, const unsigned char *)
 FMT_MAKE_VALUE_SAME(string_type, basic_string_view<typename C::char_type>)
 FMT_MAKE_VALUE(string_type,
                typename basic_string_view<typename C::char_type>::type,
                basic_string_view<typename C::char_type>)
-FMT_MAKE_VALUE(string_type, const std::basic_string<typename C::char_type>&,
+FMT_MAKE_VALUE(string_type, const std::basic_string<typename C::char_type> &,
                basic_string_view<typename C::char_type>)
-FMT_MAKE_VALUE(pointer_type, void*, const void*)
-FMT_MAKE_VALUE_SAME(pointer_type, const void*)
+FMT_MAKE_VALUE(pointer_type, void *, const void *)
+FMT_MAKE_VALUE_SAME(pointer_type, const void *)
 
 #if FMT_USE_NULLPTR
-FMT_MAKE_VALUE(pointer_type, std::nullptr_t, const void*)
+FMT_MAKE_VALUE(pointer_type, std::nullptr_t, const void *)
 #endif
 
 // Formatting of arbitrary pointers is disallowed. If you want to output a
@@ -717,51 +761,58 @@ FMT_MAKE_VALUE(pointer_type, std::nullptr_t, const void*)
 // iostreams.
 template <typename C, typename T>
 typename std::enable_if<!std::is_same<T, typename C::char_type>::value>::type
-    make_value(const T *) {
+make_value(const T *) {
   static_assert(!sizeof(T), "formatting of non-void pointers is disallowed");
 }
 
 template <typename C, typename T>
-inline typename std::enable_if<
-    std::is_enum<T>::value && convert_to_int<T, typename C::char_type>::value,
-    init<C, int, int_type>>::type
-  make_value(const T &val) { return static_cast<int>(val); }
+inline
+    typename std::enable_if<std::is_enum<T>::value &&
+                                convert_to_int<T, typename C::char_type>::value,
+                            init<C, int, int_type>>::type
+    make_value(const T &val) {
+  return static_cast<int>(val);
+}
 
 template <typename C, typename T, typename Char = typename C::char_type>
 inline typename std::enable_if<
     is_constructible<basic_string_view<Char>, T>::value &&
-    !internal::is_string<T>::value,
+        !internal::is_string<T>::value,
     init<C, basic_string_view<Char>, string_type>>::type
-  make_value(const T &val) { return basic_string_view<Char>(val); }
+make_value(const T &val) {
+  return basic_string_view<Char>(val);
+}
 
 template <typename C, typename T, typename Char = typename C::char_type>
 inline typename std::enable_if<
     !convert_to_int<T, Char>::value && !std::is_same<T, Char>::value &&
-    !std::is_convertible<T, basic_string_view<Char>>::value &&
-    !is_constructible<basic_string_view<Char>, T>::value &&
-    !internal::is_string<T>::value,
+        !std::is_convertible<T, basic_string_view<Char>>::value &&
+        !is_constructible<basic_string_view<Char>, T>::value &&
+        !internal::is_string<T>::value,
     // Implicit conversion to std::string is not handled here because it's
     // unsafe: https://github.com/fmtlib/fmt/issues/729
     init<C, const T &, custom_type>>::type
-  make_value(const T &val) { return val; }
+make_value(const T &val) {
+  return val;
+}
 
 template <typename C, typename T>
-init<C, const void*, named_arg_type>
-    make_value(const named_arg<T, typename C::char_type> &val) {
+init<C, const void *, named_arg_type> make_value(
+    const named_arg<T, typename C::char_type> &val) {
   basic_format_arg<C> arg = make_arg<C>(val.value);
   std::memcpy(val.data, &arg, sizeof(arg));
-  return static_cast<const void*>(&val);
+  return static_cast<const void *>(&val);
 }
 
 template <typename C, typename S>
 FMT_CONSTEXPR11 typename std::enable_if<
-  internal::is_string<S>::value,
-  init<C, basic_string_view<typename C::char_type>, string_type>>::type
-    make_value(const S &val) {
+    internal::is_string<S>::value,
+    init<C, basic_string_view<typename C::char_type>, string_type>>::type
+make_value(const S &val) {
   // Handle adapted strings.
-  static_assert(std::is_same<
-    typename C::char_type, typename internal::char_t<S>::type>::value,
-    "mismatch between char-types of context and argument");
+  static_assert(std::is_same<typename C::char_type,
+                             typename internal::char_t<S>::type>::value,
+                "mismatch between char-types of context and argument");
   return to_string_view(val);
 }
 
@@ -782,12 +833,12 @@ class basic_format_arg {
   internal::type type_;
 
   template <typename ContextType, typename T>
-  friend FMT_CONSTEXPR basic_format_arg<ContextType>
-    internal::make_arg(const T &value);
+  friend FMT_CONSTEXPR basic_format_arg<ContextType> internal::make_arg(
+      const T &value);
 
   template <typename Visitor, typename Ctx>
   friend FMT_CONSTEXPR typename internal::result_of<Visitor(int)>::type
-    visit_format_arg(Visitor &&vis, const basic_format_arg<Ctx> &arg);
+  visit_format_arg(Visitor &&vis, const basic_format_arg<Ctx> &arg);
 
   friend class basic_format_args<Context>;
   friend class internal::arg_map<Context>;
@@ -797,7 +848,7 @@ class basic_format_arg {
  public:
   class handle {
    public:
-    explicit handle(internal::custom_value<Context> custom): custom_(custom) {}
+    explicit handle(internal::custom_value<Context> custom) : custom_(custom) {}
 
     void format(Context &ctx) const { custom_.format(custom_.value, ctx); }
 
@@ -827,47 +878,47 @@ struct monostate {};
   \endrst
  */
 template <typename Visitor, typename Context>
-FMT_CONSTEXPR typename internal::result_of<Visitor(int)>::type
-    visit_format_arg(Visitor &&vis, const basic_format_arg<Context> &arg) {
+FMT_CONSTEXPR typename internal::result_of<Visitor(int)>::type visit_format_arg(
+    Visitor &&vis, const basic_format_arg<Context> &arg) {
   typedef typename Context::char_type char_type;
   switch (arg.type_) {
-  case internal::none_type:
-    break;
-  case internal::named_arg_type:
-    FMT_ASSERT(false, "invalid argument type");
-    break;
-  case internal::int_type:
-    return vis(arg.value_.int_value);
-  case internal::uint_type:
-    return vis(arg.value_.uint_value);
-  case internal::long_long_type:
-    return vis(arg.value_.long_long_value);
-  case internal::ulong_long_type:
-    return vis(arg.value_.ulong_long_value);
-  case internal::bool_type:
-    return vis(arg.value_.int_value != 0);
-  case internal::char_type:
-    return vis(static_cast<char_type>(arg.value_.int_value));
-  case internal::double_type:
-    return vis(arg.value_.double_value);
-  case internal::long_double_type:
-    return vis(arg.value_.long_double_value);
-  case internal::cstring_type:
-    return vis(arg.value_.string.value);
-  case internal::string_type:
-    return vis(basic_string_view<char_type>(
-                 arg.value_.string.value, arg.value_.string.size));
-  case internal::pointer_type:
-    return vis(arg.value_.pointer);
-  case internal::custom_type:
-    return vis(typename basic_format_arg<Context>::handle(arg.value_.custom));
+    case internal::none_type:
+      break;
+    case internal::named_arg_type:
+      FMT_ASSERT(false, "invalid argument type");
+      break;
+    case internal::int_type:
+      return vis(arg.value_.int_value);
+    case internal::uint_type:
+      return vis(arg.value_.uint_value);
+    case internal::long_long_type:
+      return vis(arg.value_.long_long_value);
+    case internal::ulong_long_type:
+      return vis(arg.value_.ulong_long_value);
+    case internal::bool_type:
+      return vis(arg.value_.int_value != 0);
+    case internal::char_type:
+      return vis(static_cast<char_type>(arg.value_.int_value));
+    case internal::double_type:
+      return vis(arg.value_.double_value);
+    case internal::long_double_type:
+      return vis(arg.value_.long_double_value);
+    case internal::cstring_type:
+      return vis(arg.value_.string.value);
+    case internal::string_type:
+      return vis(basic_string_view<char_type>(arg.value_.string.value,
+                                              arg.value_.string.size));
+    case internal::pointer_type:
+      return vis(arg.value_.pointer);
+    case internal::custom_type:
+      return vis(typename basic_format_arg<Context>::handle(arg.value_.custom));
   }
   return vis(monostate());
 }
 
 template <typename Visitor, typename Context>
-FMT_CONSTEXPR typename internal::result_of<Visitor(int)>::type
-    visit(Visitor &&vis, const basic_format_arg<Context> &arg) {
+FMT_CONSTEXPR typename internal::result_of<Visitor(int)>::type visit(
+    Visitor &&vis, const basic_format_arg<Context> &arg) {
   return visit_format_arg(std::forward<Visitor>(vis), arg);
 }
 
@@ -883,9 +934,9 @@ class basic_parse_context : private ErrorHandler {
   typedef Char char_type;
   typedef typename basic_string_view<Char>::iterator iterator;
 
-  explicit FMT_CONSTEXPR basic_parse_context(
-      basic_string_view<Char> format_str, ErrorHandler eh = ErrorHandler())
-    : ErrorHandler(eh), format_str_(format_str), next_arg_id_(0) {}
+  explicit FMT_CONSTEXPR basic_parse_context(basic_string_view<Char> format_str,
+                                             ErrorHandler eh = ErrorHandler())
+      : ErrorHandler(eh), format_str_(format_str), next_arg_id_(0) {}
 
   // Returns an iterator to the beginning of the format string range being
   // parsed.
@@ -955,7 +1006,7 @@ class arg_map {
  public:
   arg_map() : map_(FMT_NULL), size_(0) {}
   void init(const basic_format_args<Context> &args);
-  ~arg_map() { delete [] map_; }
+  ~arg_map() { delete[] map_; }
 
   basic_format_arg<Context> find(basic_string_view<char_type> name) const {
     // The list is unsorted, so just return the first matching name.
@@ -1001,7 +1052,7 @@ class context_base {
   context_base(OutputIt out, basic_string_view<char_type> format_str,
                basic_format_args<Context> ctx_args,
                locale_ref loc = locale_ref())
-  : parse_context_(format_str), out_(out), args_(ctx_args), loc_(loc) {}
+      : parse_context_(format_str), out_(out), args_(ctx_args), loc_(loc) {}
 
   // Returns the argument with specified index.
   format_arg do_get_arg(unsigned arg_id) {
@@ -1014,13 +1065,13 @@ class context_base {
   // Checks if manual indexing is used and returns the argument with
   // specified index.
   format_arg get_arg(unsigned arg_id) {
-    return this->parse_context().check_arg_id(arg_id) ?
-      this->do_get_arg(arg_id) : format_arg();
+    return this->parse_context().check_arg_id(arg_id) ? this->do_get_arg(arg_id)
+                                                      : format_arg();
   }
 
  public:
   basic_parse_context<char_type> &parse_context() { return parse_context_; }
-  basic_format_args<Context> args() const { return args_; } // DEPRECATED!
+  basic_format_args<Context> args() const { return args_; }  // DEPRECATED!
   basic_format_arg<Context> arg(unsigned id) const { return args_.get(id); }
 
   internal::error_handler error_handler() {
@@ -1042,12 +1093,14 @@ class context_base {
 template <typename Context, typename T>
 struct get_type {
   typedef decltype(make_value<Context>(
-        declval<typename std::decay<T>::type&>())) value_type;
+      declval<typename std::decay<T>::type &>())) value_type;
   static const type value = value_type::type_tag;
 };
 
 template <typename Context>
-FMT_CONSTEXPR11 unsigned long long get_types() { return 0; }
+FMT_CONSTEXPR11 unsigned long long get_types() {
+  return 0;
+}
 
 template <typename Context, typename Arg, typename... Args>
 FMT_CONSTEXPR11 unsigned long long get_types() {
@@ -1063,30 +1116,32 @@ FMT_CONSTEXPR basic_format_arg<Context> make_arg(const T &value) {
 }
 
 template <bool IS_PACKED, typename Context, typename T>
-inline typename std::enable_if<IS_PACKED, value<Context>>::type
-    make_arg(const T &value) {
+inline typename std::enable_if<IS_PACKED, value<Context>>::type make_arg(
+    const T &value) {
   return make_value<Context>(value);
 }
 
 template <bool IS_PACKED, typename Context, typename T>
 inline typename std::enable_if<!IS_PACKED, basic_format_arg<Context>>::type
-    make_arg(const T &value) {
+make_arg(const T &value) {
   return make_arg<Context>(value);
 }
 }  // namespace internal
 
 // Formatting context.
 template <typename OutputIt, typename Char>
-class basic_format_context :
-  public internal::context_base<
-    OutputIt, basic_format_context<OutputIt, Char>, Char> {
+class basic_format_context
+    : public internal::context_base<
+          OutputIt, basic_format_context<OutputIt, Char>, Char> {
  public:
   /** The character type for the output. */
   typedef Char char_type;
 
   // using formatter_type = formatter<T, char_type>;
   template <typename T>
-  struct formatter_type { typedef formatter<T, char_type> type; };
+  struct formatter_type {
+    typedef formatter<T, char_type> type;
+  };
 
  private:
   internal::arg_map<basic_format_context> map_;
@@ -1108,7 +1163,7 @@ class basic_format_context :
   basic_format_context(OutputIt out, basic_string_view<char_type> format_str,
                        basic_format_args<basic_format_context> ctx_args,
                        internal::locale_ref loc = internal::locale_ref())
-    : base(out, format_str, ctx_args, loc) {}
+      : base(out, format_str, ctx_args, loc) {}
 
   format_arg next_arg() {
     return this->do_get_arg(this->parse_context().next_arg_id());
@@ -1123,7 +1178,8 @@ class basic_format_context :
 template <typename Char>
 struct buffer_context {
   typedef basic_format_context<
-    std::back_insert_iterator<internal::basic_buffer<Char>>, Char> type;
+      std::back_insert_iterator<internal::basic_buffer<Char>>, Char>
+      type;
 };
 typedef buffer_context<char>::type format_context;
 typedef buffer_context<wchar_t>::type wformat_context;
@@ -1135,7 +1191,7 @@ typedef buffer_context<wchar_t>::type wformat_context;
   such as `~fmt::vformat`.
   \endrst
  */
-template <typename Context, typename ...Args>
+template <typename Context, typename... Args>
 class format_arg_store {
  private:
   static const size_t NUM_ARGS = sizeof...(Args);
@@ -1143,20 +1199,19 @@ class format_arg_store {
   // Packed is a macro on MinGW so use IS_PACKED instead.
   static const bool IS_PACKED = NUM_ARGS < internal::max_packed_args;
 
-  typedef typename std::conditional<IS_PACKED,
-    internal::value<Context>, basic_format_arg<Context>>::type value_type;
+  typedef typename std::conditional<IS_PACKED, internal::value<Context>,
+                                    basic_format_arg<Context>>::type value_type;
 
   // If the arguments are not packed, add one more element to mark the end.
   static const size_t DATA_SIZE =
-          NUM_ARGS + (IS_PACKED && NUM_ARGS != 0 ? 0 : 1);
+      NUM_ARGS + (IS_PACKED && NUM_ARGS != 0 ? 0 : 1);
   value_type data_[DATA_SIZE];
 
   friend class basic_format_args<Context>;
 
   static FMT_CONSTEXPR11 unsigned long long get_types() {
-    return IS_PACKED ?
-      internal::get_types<Context, Args...>() :
-      internal::is_unpacked_bit | NUM_ARGS;
+    return IS_PACKED ? internal::get_types<Context, Args...>()
+                     : internal::is_unpacked_bit | NUM_ARGS;
   }
 
  public:
@@ -1170,18 +1225,18 @@ class format_arg_store {
     (FMT_MSC_VER && FMT_MSC_VER <= 1800)
   // Workaround array initialization issues in gcc <= 4.5 and MSVC <= 2013.
   format_arg_store(const Args &... args) {
-    value_type init[DATA_SIZE] =
-      {internal::make_arg<IS_PACKED, Context>(args)...};
+    value_type init[DATA_SIZE] = {
+        internal::make_arg<IS_PACKED, Context>(args)...};
     std::memcpy(data_, init, sizeof(init));
   }
 #else
   format_arg_store(const Args &... args)
-    : data_{internal::make_arg<IS_PACKED, Context>(args)...} {}
+      : data_{internal::make_arg<IS_PACKED, Context>(args)...} {}
 #endif
 };
 
 #if !FMT_USE_CONSTEXPR11
-template <typename Context, typename ...Args>
+template <typename Context, typename... Args>
 const unsigned long long format_arg_store<Context, Args...>::TYPES =
     get_types();
 #endif
@@ -1193,16 +1248,18 @@ const unsigned long long format_arg_store<Context, Args...>::TYPES =
   can be omitted in which case it defaults to `~fmt::context`.
   \endrst
  */
-template <typename Context = format_context, typename ...Args>
-inline format_arg_store<Context, Args...>
-  make_format_args(const Args &... args) { return {args...}; }
+template <typename Context = format_context, typename... Args>
+inline format_arg_store<Context, Args...> make_format_args(
+    const Args &... args) {
+  return {args...};
+}
 
 /** Formatting arguments. */
 template <typename Context>
 class basic_format_args {
  public:
   typedef unsigned size_type;
-  typedef basic_format_arg<Context>  format_arg;
+  typedef basic_format_arg<Context> format_arg;
 
  private:
   // To reduce compiled code size per formatting function call, types of first
@@ -1222,8 +1279,8 @@ class basic_format_args {
 
   typename internal::type type(unsigned index) const {
     unsigned shift = index * 4;
-    return static_cast<typename internal::type>(
-      (types_ & (0xfull << shift)) >> shift);
+    return static_cast<typename internal::type>((types_ & (0xfull << shift)) >>
+                                                shift);
   }
 
   friend class internal::arg_map<Context>;
@@ -1259,7 +1316,7 @@ class basic_format_args {
    */
   template <typename... Args>
   basic_format_args(const format_arg_store<Context, Args...> &store)
-  : types_(static_cast<unsigned long long>(store.TYPES)) {
+      : types_(static_cast<unsigned long long>(store.TYPES)) {
     set_data(store.data_);
   }
 
@@ -1269,7 +1326,7 @@ class basic_format_args {
    \endrst
    */
   basic_format_args(const format_arg *args, size_type count)
-    : types_(internal::is_unpacked_bit | count) {
+      : types_(internal::is_unpacked_bit | count) {
     set_data(args);
   }
 
@@ -1284,38 +1341,38 @@ class basic_format_args {
   size_type max_size() const {
     unsigned long long max_packed = internal::max_packed_args;
     return static_cast<size_type>(
-      is_packed() ? max_packed : types_ & ~internal::is_unpacked_bit);
+        is_packed() ? max_packed : types_ & ~internal::is_unpacked_bit);
   }
 };
 
 /** An alias to ``basic_format_args<context>``. */
 // It is a separate type rather than a typedef to make symbols readable.
 struct format_args : basic_format_args<format_context> {
-  template <typename ...Args>
+  template <typename... Args>
   format_args(Args &&... arg)
-  : basic_format_args<format_context>(std::forward<Args>(arg)...) {}
+      : basic_format_args<format_context>(std::forward<Args>(arg)...) {}
 };
 struct wformat_args : basic_format_args<wformat_context> {
-  template <typename ...Args>
+  template <typename... Args>
   wformat_args(Args &&... arg)
-  : basic_format_args<wformat_context>(std::forward<Args>(arg)...) {}
+      : basic_format_args<wformat_context>(std::forward<Args>(arg)...) {}
 };
 
 #define FMT_ENABLE_IF_T(B, T) typename std::enable_if<B, T>::type
 
 #ifndef FMT_USE_ALIAS_TEMPLATES
-# define FMT_USE_ALIAS_TEMPLATES FMT_HAS_FEATURE(cxx_alias_templates)
+#define FMT_USE_ALIAS_TEMPLATES FMT_HAS_FEATURE(cxx_alias_templates)
 #endif
 #if FMT_USE_ALIAS_TEMPLATES
 /** String's character type. */
 template <typename S>
-using char_t = FMT_ENABLE_IF_T(
-  internal::is_string<S>::value, typename internal::char_t<S>::type);
+using char_t = FMT_ENABLE_IF_T(internal::is_string<S>::value,
+                               typename internal::char_t<S>::type);
 #define FMT_CHAR(S) fmt::char_t<S>
 #else
 template <typename S>
-struct char_t : std::enable_if<
-    internal::is_string<S>::value, typename internal::char_t<S>::type> {};
+struct char_t : std::enable_if<internal::is_string<S>::value,
+                               typename internal::char_t<S>::type> {};
 #define FMT_CHAR(S) typename char_t<S>::type
 #endif
 
@@ -1325,8 +1382,8 @@ struct named_arg_base {
   basic_string_view<Char> name;
 
   // Serialized value<context>.
-  mutable char data[
-    sizeof(basic_format_arg<typename buffer_context<Char>::type>)];
+  mutable char
+      data[sizeof(basic_format_arg<typename buffer_context<Char>::type>)];
 
   named_arg_base(basic_string_view<Char> nm) : name(nm) {}
 
@@ -1343,23 +1400,23 @@ struct named_arg : named_arg_base<Char> {
   const T &value;
 
   named_arg(basic_string_view<Char> name, const T &val)
-    : named_arg_base<Char>(name), value(val) {}
+      : named_arg_base<Char>(name), value(val) {}
 };
 
 template <typename... Args, typename S>
 inline typename std::enable_if<!is_compile_string<S>::value>::type
-  check_format_string(const S &) {}
+check_format_string(const S &) {}
 template <typename... Args, typename S>
-typename std::enable_if<is_compile_string<S>::value>::type
-  check_format_string(S);
+typename std::enable_if<is_compile_string<S>::value>::type check_format_string(
+    S);
 
 template <typename S, typename... Args>
-struct checked_args : format_arg_store<
-  typename buffer_context<FMT_CHAR(S)>::type, Args...> {
+struct checked_args
+    : format_arg_store<typename buffer_context<FMT_CHAR(S)>::type, Args...> {
   typedef typename buffer_context<FMT_CHAR(S)>::type context;
 
-  checked_args(const S &format_str, const Args &... args):
-    format_arg_store<context, Args...>(args...) {
+  checked_args(const S &format_str, const Args &... args)
+      : format_arg_store<context, Args...>(args...) {
     internal::check_format_string<Args...>(format_str);
   }
 
@@ -1368,14 +1425,14 @@ struct checked_args : format_arg_store<
 
 template <typename Char>
 std::basic_string<Char> vformat(
-  basic_string_view<Char> format_str,
-  basic_format_args<typename buffer_context<Char>::type> args);
+    basic_string_view<Char> format_str,
+    basic_format_args<typename buffer_context<Char>::type> args);
 
 template <typename Char>
 typename buffer_context<Char>::type::iterator vformat_to(
-  internal::basic_buffer<Char> &buf, basic_string_view<Char> format_str,
-  basic_format_args<typename buffer_context<Char>::type> args);
-}
+    internal::basic_buffer<Char> &buf, basic_string_view<Char> format_str,
+    basic_format_args<typename buffer_context<Char>::type> args);
+}  // namespace internal
 
 /**
   \rst
@@ -1401,33 +1458,31 @@ template <typename S, typename T, typename Char>
 void arg(S, internal::named_arg<T, Char>) = delete;
 
 template <typename Container>
-struct is_contiguous: std::false_type {};
+struct is_contiguous : std::false_type {};
 
 template <typename Char>
-struct is_contiguous<std::basic_string<Char> >: std::true_type {};
+struct is_contiguous<std::basic_string<Char>> : std::true_type {};
 
 template <typename Char>
-struct is_contiguous<internal::basic_buffer<Char> >: std::true_type {};
+struct is_contiguous<internal::basic_buffer<Char>> : std::true_type {};
 
 /** Formats a string and writes the output to ``out``. */
 template <typename Container, typename S>
-typename std::enable_if<
-    is_contiguous<Container>::value, std::back_insert_iterator<Container>>::type
-  vformat_to(
-    std::back_insert_iterator<Container> out,
-    const S &format_str,
-    basic_format_args<typename buffer_context<FMT_CHAR(S)>::type> args) {
+typename std::enable_if<is_contiguous<Container>::value,
+                        std::back_insert_iterator<Container>>::type
+vformat_to(std::back_insert_iterator<Container> out, const S &format_str,
+           basic_format_args<typename buffer_context<FMT_CHAR(S)>::type> args) {
   internal::container_buffer<Container> buf(internal::get_container(out));
   internal::vformat_to(buf, to_string_view(format_str), args);
   return out;
 }
 
 template <typename Container, typename S, typename... Args>
-inline typename std::enable_if<
-  is_contiguous<Container>::value && internal::is_string<S>::value,
-  std::back_insert_iterator<Container>>::type
-    format_to(std::back_insert_iterator<Container> out, const S &format_str,
-              const Args &... args) {
+inline typename std::enable_if<is_contiguous<Container>::value &&
+                                   internal::is_string<S>::value,
+                               std::back_insert_iterator<Container>>::type
+format_to(std::back_insert_iterator<Container> out, const S &format_str,
+          const Args &... args) {
   internal::checked_args<S, Args...> ca(format_str, args...);
   return vformat_to(out, to_string_view(format_str), *ca);
 }
@@ -1450,11 +1505,11 @@ inline std::basic_string<Char> vformat(
   \endrst
 */
 template <typename S, typename... Args>
-inline std::basic_string<FMT_CHAR(S)> format(
-    const S &format_str, const Args &... args) {
+inline std::basic_string<FMT_CHAR(S)> format(const S &format_str,
+                                             const Args &... args) {
   return internal::vformat(
-    to_string_view(format_str),
-    *internal::checked_args<S, Args...>(format_str, args...));
+      to_string_view(format_str),
+      *internal::checked_args<S, Args...>(format_str, args...));
 }
 
 FMT_API void vprint(std::FILE *f, string_view format_str, format_args args);

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -95,8 +95,8 @@ typedef void (*FormatFunc)(internal::buffer &, int, string_view);
 //   ERANGE - buffer is not large enough to store the error message
 //   other  - failure
 // Buffer should be at least of size 1.
-int safe_strerror(int error_code, char *&buffer,
-                  std::size_t buffer_size) FMT_NOEXCEPT {
+int safe_strerror(int error_code, char *&buffer, std::size_t buffer_size)
+    FMT_NOEXCEPT {
   FMT_ASSERT(buffer != FMT_NULL && buffer_size != 0, "invalid buffer");
 
   class dispatcher {
@@ -153,8 +153,8 @@ int safe_strerror(int error_code, char *&buffer,
   return dispatcher(error_code, buffer, buffer_size).run();
 }
 
-void format_error_code(internal::buffer &out, int error_code,
-                       string_view message) FMT_NOEXCEPT {
+void format_error_code(
+    internal::buffer &out, int error_code, string_view message) FMT_NOEXCEPT {
   // Report error code making sure that the output fits into
   // inline_buffer_size to avoid dynamic memory allocation and potential
   // bad_alloc.
@@ -180,8 +180,8 @@ void format_error_code(internal::buffer &out, int error_code,
   assert(out.size() <= inline_buffer_size);
 }
 
-void report_error(FormatFunc func, int error_code,
-                  string_view message) FMT_NOEXCEPT {
+void report_error(FormatFunc func, int error_code, string_view message)
+    FMT_NOEXCEPT {
   memory_buffer full_message;
   func(full_message, error_code, message);
   // Use Writer::data instead of Writer::c_str to avoid potential memory
@@ -228,8 +228,8 @@ FMT_FUNC Char internal::thousands_sep_impl(locale_ref) {
 }
 #endif
 
-FMT_FUNC void system_error::init(int err_code, string_view format_str,
-                                 format_args args) {
+FMT_FUNC void system_error::init(
+    int err_code, string_view format_str, format_args args) {
   error_code_ = err_code;
   memory_buffer buffer;
   format_system_error(buffer, err_code, vformat(format_str, args));
@@ -239,17 +239,19 @@ FMT_FUNC void system_error::init(int err_code, string_view format_str,
 
 namespace internal {
 template <typename T>
-int char_traits<char>::format_float(char *buf, std::size_t size,
-                                    const char *format, int precision,
-                                    T value) {
+int char_traits<char>::format_float(
+    char *buf, std::size_t size, const char *format, int precision, T value) {
   return precision < 0 ? FMT_SNPRINTF(buf, size, format, value)
                        : FMT_SNPRINTF(buf, size, format, precision, value);
 }
 
 template <typename T>
-int char_traits<wchar_t>::format_float(wchar_t *buf, std::size_t size,
-                                       const wchar_t *format, int precision,
-                                       T value) {
+int char_traits<wchar_t>::format_float(
+    wchar_t *buf,
+    std::size_t size,
+    const wchar_t *format,
+    int precision,
+    T value) {
   return precision < 0 ? FMT_SWPRINTF(buf, size, format, value)
                        : FMT_SWPRINTF(buf, size, format, precision, value);
 }
@@ -276,7 +278,9 @@ const uint32_t basic_data<T>::ZERO_OR_POWERS_OF_10_32[] = {0,
 
 template <typename T>
 const uint64_t basic_data<T>::ZERO_OR_POWERS_OF_10_64[] = {
-    0, FMT_POWERS_OF_10(1), FMT_POWERS_OF_10(1000000000ull),
+    0,
+    FMT_POWERS_OF_10(1),
+    FMT_POWERS_OF_10(1000000000ull),
     10000000000000000000ull};
 
 // Normalized 64-bit significands of pow(10, k), for k = -348, -340, ..., 340.
@@ -451,9 +455,15 @@ FMT_FUNC fp get_cached_power(int min_exponent, int &pow10_exponent) {
   return fp(data::POW10_SIGNIFICANDS[index], data::POW10_EXPONENTS[index]);
 }
 
-FMT_FUNC bool grisu2_round(char *buf, ptrdiff_t &size, size_t max_digits,
-                           uint64_t delta, uint64_t remainder, uint64_t exp,
-                           uint64_t diff, int &exp10) {
+FMT_FUNC bool grisu2_round(
+    char *buf,
+    ptrdiff_t &size,
+    size_t max_digits,
+    uint64_t delta,
+    uint64_t remainder,
+    uint64_t exp,
+    uint64_t diff,
+    int &exp10) {
   while (
       remainder < diff && delta - remainder >= exp &&
       (remainder + exp < diff || diff - remainder > remainder + exp - diff)) {
@@ -470,10 +480,16 @@ FMT_FUNC bool grisu2_round(char *buf, ptrdiff_t &size, size_t max_digits,
 }
 
 // Generates output using Grisu2 digit-gen algorithm.
-FMT_FUNC bool grisu2_gen_digits(char *buf, ptrdiff_t &size, uint32_t hi,
-                                uint64_t lo, int &exp, uint64_t delta,
-                                const fp &one, const fp &diff,
-                                size_t max_digits) {
+FMT_FUNC bool grisu2_gen_digits(
+    char *buf,
+    ptrdiff_t &size,
+    uint32_t hi,
+    uint64_t lo,
+    int &exp,
+    uint64_t delta,
+    const fp &one,
+    const fp &diff,
+    size_t max_digits) {
   // Generate digits for the most significant part (hi).
   while (exp > 0) {
     uint32_t digit = 0;
@@ -529,8 +545,13 @@ FMT_FUNC bool grisu2_gen_digits(char *buf, ptrdiff_t &size, uint32_t hi,
     uint64_t remainder = (static_cast<uint64_t>(hi) << -one.e) + lo;
     if (remainder <= delta || size > static_cast<ptrdiff_t>(max_digits)) {
       return grisu2_round(
-          buf, size, max_digits, delta, remainder,
-          static_cast<uint64_t>(data::POWERS_OF_10_32[exp]) << -one.e, diff.f,
+          buf,
+          size,
+          max_digits,
+          delta,
+          remainder,
+          static_cast<uint64_t>(data::POWERS_OF_10_32[exp]) << -one.e,
+          diff.f,
           exp);
     }
   }
@@ -544,8 +565,15 @@ FMT_FUNC bool grisu2_gen_digits(char *buf, ptrdiff_t &size, uint32_t hi,
     lo &= one.f - 1;
     --exp;
     if (lo < delta || size > static_cast<ptrdiff_t>(max_digits)) {
-      return grisu2_round(buf, size, max_digits, delta, lo, one.f,
-                          diff.f * data::POWERS_OF_10_32[-exp], exp);
+      return grisu2_round(
+          buf,
+          size,
+          max_digits,
+          delta,
+          lo,
+          one.f,
+          diff.f * data::POWERS_OF_10_32[-exp],
+          exp);
     }
   }
 }
@@ -636,8 +664,8 @@ struct fill {
 
 // The number is given as v = f * pow(10, exp), where f has size digits.
 template <typename Handler>
-FMT_FUNC void grisu2_prettify(const gen_digits_params &params, int size,
-                              int exp, Handler &&handler) {
+FMT_FUNC void grisu2_prettify(
+    const gen_digits_params &params, int size, int exp, Handler &&handler) {
   if (!params.fixed) {
     // Insert a decimal point after the first digit and add an exponent.
     handler.insert(1, '.');
@@ -692,8 +720,8 @@ struct char_counter {
 // Converts format specifiers into parameters for digit generation and computes
 // output buffer size for a number in the range [pow(10, exp - 1), pow(10, exp)
 // or 0 if exp == 1.
-FMT_FUNC gen_digits_params process_specs(const core_format_specs &specs,
-                                         int exp, buffer &buf) {
+FMT_FUNC gen_digits_params
+process_specs(const core_format_specs &specs, int exp, buffer &buf) {
   auto params = gen_digits_params();
   int num_digits = specs.precision >= 0 ? specs.precision : 6;
   switch (specs.type) {
@@ -754,7 +782,8 @@ grisu2_format(Double value, buffer &buf, core_format_specs specs) {
   const int min_exp = -60;             // alpha in Grisu.
   int cached_exp = 0;                  // K in Grisu.
   auto cached_pow = get_cached_power(  // \tilde{c}_{-k} in Grisu.
-      min_exp - (upper.e + fp::significand_size), cached_exp);
+      min_exp - (upper.e + fp::significand_size),
+      cached_exp);
   cached_exp = -cached_exp;
   upper = upper * cached_pow;  // \tilde{M}^+ in Grisu.
   --upper.f;                   // \tilde{M}^+ - 1 ulp -> M^+_{\downarrow}.
@@ -774,8 +803,8 @@ grisu2_format(Double value, buffer &buf, core_format_specs specs) {
   // lo = supper % one.
   uint64_t lo = upper.f & (one.f - 1);
   ptrdiff_t size = 0;
-  if (!grisu2_gen_digits(buf.data(), size, hi, lo, exp, delta, one, diff,
-                         params.num_digits)) {
+  if (!grisu2_gen_digits(
+          buf.data(), size, hi, lo, exp, delta, one, diff, params.num_digits)) {
     buf.clear();
     return false;
   }
@@ -784,8 +813,8 @@ grisu2_format(Double value, buffer &buf, core_format_specs specs) {
 }
 
 template <typename Double>
-void sprintf_format(Double value, internal::buffer &buf,
-                    core_format_specs spec) {
+void sprintf_format(
+    Double value, internal::buffer &buf, core_format_specs spec) {
   // Buffer capacity must be non-zero, otherwise MSVC's vsnprintf_s will fail.
   FMT_ASSERT(buf.capacity() != 0, "empty buffer");
 
@@ -842,13 +871,13 @@ FMT_FUNC internal::utf8_to_utf16::utf8_to_utf16(string_view s) {
     return;
   }
 
-  int length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s.data(),
-                                   s_size, FMT_NULL, 0);
+  int length = MultiByteToWideChar(
+      CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size, FMT_NULL, 0);
   if (length == 0)
     FMT_THROW(windows_error(GetLastError(), ERROR_MSG));
   buffer_.resize(length + 1);
-  length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size,
-                               &buffer_[0], length);
+  length = MultiByteToWideChar(
+      CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size, &buffer_[0], length);
   if (length == 0)
     FMT_THROW(windows_error(GetLastError(), ERROR_MSG));
   buffer_[length] = 0;
@@ -856,8 +885,8 @@ FMT_FUNC internal::utf8_to_utf16::utf8_to_utf16(string_view s) {
 
 FMT_FUNC internal::utf16_to_utf8::utf16_to_utf8(wstring_view s) {
   if (int error_code = convert(s)) {
-    FMT_THROW(windows_error(error_code,
-                            "cannot convert string from UTF-16 to UTF-8"));
+    FMT_THROW(windows_error(
+        error_code, "cannot convert string from UTF-16 to UTF-8"));
   }
 }
 
@@ -872,21 +901,21 @@ FMT_FUNC int internal::utf16_to_utf8::convert(wstring_view s) {
     return 0;
   }
 
-  int length = WideCharToMultiByte(CP_UTF8, 0, s.data(), s_size, FMT_NULL, 0,
-                                   FMT_NULL, FMT_NULL);
+  int length = WideCharToMultiByte(
+      CP_UTF8, 0, s.data(), s_size, FMT_NULL, 0, FMT_NULL, FMT_NULL);
   if (length == 0)
     return GetLastError();
   buffer_.resize(length + 1);
-  length = WideCharToMultiByte(CP_UTF8, 0, s.data(), s_size, &buffer_[0],
-                               length, FMT_NULL, FMT_NULL);
+  length = WideCharToMultiByte(
+      CP_UTF8, 0, s.data(), s_size, &buffer_[0], length, FMT_NULL, FMT_NULL);
   if (length == 0)
     return GetLastError();
   buffer_[length] = 0;
   return 0;
 }
 
-FMT_FUNC void windows_error::init(int err_code, string_view format_str,
-                                  format_args args) {
+FMT_FUNC void windows_error::init(
+    int err_code, string_view format_str, format_args args) {
   error_code_ = err_code;
   memory_buffer buffer;
   internal::format_windows_error(buffer, err_code, vformat(format_str, args));
@@ -894,18 +923,21 @@ FMT_FUNC void windows_error::init(int err_code, string_view format_str,
   base = std::runtime_error(to_string(buffer));
 }
 
-FMT_FUNC void internal::format_windows_error(internal::buffer &out,
-                                             int error_code,
-                                             string_view message) FMT_NOEXCEPT {
+FMT_FUNC void internal::format_windows_error(
+    internal::buffer &out, int error_code, string_view message) FMT_NOEXCEPT {
   FMT_TRY {
     wmemory_buffer buf;
     buf.resize(inline_buffer_size);
     for (;;) {
       wchar_t *system_message = &buf[0];
       int result = FormatMessageW(
-          FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, FMT_NULL,
-          error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), system_message,
-          static_cast<uint32_t>(buf.size()), FMT_NULL);
+          FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+          FMT_NULL,
+          error_code,
+          MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+          system_message,
+          static_cast<uint32_t>(buf.size()),
+          FMT_NULL);
       if (result != 0) {
         utf16_to_utf8 utf8_message;
         if (utf8_message.convert(system_message) == ERROR_SUCCESS) {
@@ -928,8 +960,8 @@ FMT_FUNC void internal::format_windows_error(internal::buffer &out,
 
 #endif  // FMT_USE_WINDOWS_H
 
-FMT_FUNC void format_system_error(internal::buffer &out, int error_code,
-                                  string_view message) FMT_NOEXCEPT {
+FMT_FUNC void format_system_error(
+    internal::buffer &out, int error_code, string_view message) FMT_NOEXCEPT {
   FMT_TRY {
     memory_buffer buf;
     buf.resize(inline_buffer_size);
@@ -956,22 +988,22 @@ FMT_FUNC void internal::error_handler::on_error(const char *message) {
   FMT_THROW(format_error(message));
 }
 
-FMT_FUNC void report_system_error(int error_code,
-                                  fmt::string_view message) FMT_NOEXCEPT {
+FMT_FUNC void report_system_error(int error_code, fmt::string_view message)
+    FMT_NOEXCEPT {
   report_error(format_system_error, error_code, message);
 }
 
 #if FMT_USE_WINDOWS_H
-FMT_FUNC void report_windows_error(int error_code,
-                                   fmt::string_view message) FMT_NOEXCEPT {
+FMT_FUNC void report_windows_error(int error_code, fmt::string_view message)
+    FMT_NOEXCEPT {
   report_error(internal::format_windows_error, error_code, message);
 }
 #endif
 
 FMT_FUNC void vprint(std::FILE *f, string_view format_str, format_args args) {
   memory_buffer buffer;
-  internal::vformat_to(buffer, format_str,
-                       basic_format_args<buffer_context<char>::type>(args));
+  internal::vformat_to(
+      buffer, format_str, basic_format_args<buffer_context<char>::type>(args));
   std::fwrite(buffer.data(), 1, buffer.size(), f);
 }
 

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -10,47 +10,46 @@
 
 #include "format.h"
 
-#include <string.h>
-
 #include <cctype>
 #include <cerrno>
 #include <climits>
 #include <cmath>
 #include <cstdarg>
 #include <cstddef>  // for std::ptrdiff_t
+#include <cstring>
 #include <cstring>  // for std::memmove
 #if !defined(FMT_STATIC_THOUSANDS_SEPARATOR)
-# include <locale>
+#include <locale>
 #endif
 
 #if FMT_USE_WINDOWS_H
-# if !defined(FMT_HEADER_ONLY) && !defined(WIN32_LEAN_AND_MEAN)
-#  define WIN32_LEAN_AND_MEAN
-# endif
-# if defined(NOMINMAX) || defined(FMT_WIN_MINMAX)
-#  include <windows.h>
-# else
-#  define NOMINMAX
-#  include <windows.h>
-#  undef NOMINMAX
-# endif
+#if !defined(FMT_HEADER_ONLY) && !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#if defined(NOMINMAX) || defined(FMT_WIN_MINMAX)
+#include <windows.h>
+#else
+#define NOMINMAX
+#include <windows.h>
+#undef NOMINMAX
+#endif
 #endif
 
 #if FMT_EXCEPTIONS
-# define FMT_TRY try
-# define FMT_CATCH(x) catch (x)
+#define FMT_TRY try
+#define FMT_CATCH(x) catch (x)
 #else
-# define FMT_TRY if (true)
-# define FMT_CATCH(x) if (false)
+#define FMT_TRY if (true)
+#define FMT_CATCH(x) if (false)
 #endif
 
 #ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable: 4127)  // conditional expression is constant
-# pragma warning(disable: 4702)  // unreachable code
+#pragma warning(push)
+#pragma warning(disable : 4127)  // conditional expression is constant
+#pragma warning(disable : 4702)  // unreachable code
 // Disable deprecation warning for strerror. The latter is not called but
 // MSVC fails to detect it.
-# pragma warning(disable: 4996)
+#pragma warning(disable : 4996)
 #endif
 
 // Dummy implementations of strerror_r and strerror_s called if corresponding
@@ -67,7 +66,7 @@ FMT_BEGIN_NAMESPACE
 namespace {
 
 #ifndef _MSC_VER
-# define FMT_SNPRINTF snprintf
+#define FMT_SNPRINTF snprintf
 #else  // _MSC_VER
 inline int fmt_snprintf(char *buffer, size_t size, const char *format, ...) {
   va_list args;
@@ -76,14 +75,14 @@ inline int fmt_snprintf(char *buffer, size_t size, const char *format, ...) {
   va_end(args);
   return result;
 }
-# define FMT_SNPRINTF fmt_snprintf
+#define FMT_SNPRINTF fmt_snprintf
 #endif  // _MSC_VER
 
 #if defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
-# define FMT_SWPRINTF snwprintf
+#define FMT_SWPRINTF snwprintf
 #else
-# define FMT_SWPRINTF swprintf
-#endif // defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
+#define FMT_SWPRINTF swprintf
+#endif  // defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
 
 typedef void (*FormatFunc)(internal::buffer &, int, string_view);
 
@@ -96,8 +95,8 @@ typedef void (*FormatFunc)(internal::buffer &, int, string_view);
 //   ERANGE - buffer is not large enough to store the error message
 //   other  - failure
 // Buffer should be at least of size 1.
-int safe_strerror(
-    int error_code, char *&buffer, std::size_t buffer_size) FMT_NOEXCEPT {
+int safe_strerror(int error_code, char *&buffer,
+                  std::size_t buffer_size) FMT_NOEXCEPT {
   FMT_ASSERT(buffer != FMT_NULL && buffer_size != 0, "invalid buffer");
 
   class dispatcher {
@@ -132,8 +131,8 @@ int safe_strerror(
     // Fallback to strerror_s when strerror_r is not available.
     int fallback(int result) {
       // If the buffer is full then the message is probably truncated.
-      return result == 0 && strlen(buffer_) == buffer_size_ - 1 ?
-            ERANGE : result;
+      return result == 0 && strlen(buffer_) == buffer_size_ - 1 ? ERANGE
+                                                                : result;
     }
 
 #if !FMT_MSC_VER
@@ -147,11 +146,9 @@ int safe_strerror(
 
    public:
     dispatcher(int err_code, char *&buf, std::size_t buf_size)
-      : error_code_(err_code), buffer_(buf), buffer_size_(buf_size) {}
+        : error_code_(err_code), buffer_(buf), buffer_size_(buf_size) {}
 
-    int run() {
-      return handle(strerror_r(error_code_, buffer_, buffer_size_));
-    }
+    int run() { return handle(strerror_r(error_code_, buffer_, buffer_size_)); }
   };
   return dispatcher(error_code, buffer, buffer_size).run();
 }
@@ -215,15 +212,15 @@ locale_ref::locale_ref(const Locale &loc) : locale_(&loc) {
 template <typename Locale>
 Locale locale_ref::get() const {
   static_assert(std::is_same<Locale, std::locale>::value, "");
-  return locale_ ? *static_cast<const std::locale*>(locale_) : std::locale();
+  return locale_ ? *static_cast<const std::locale *>(locale_) : std::locale();
 }
 
 template <typename Char>
 FMT_FUNC Char thousands_sep_impl(locale_ref loc) {
-  return std::use_facet<std::numpunct<Char> >(
-    loc.get<std::locale>()).thousands_sep();
+  return std::use_facet<std::numpunct<Char>>(loc.get<std::locale>())
+      .thousands_sep();
 }
-}
+}  // namespace internal
 #else
 template <typename Char>
 FMT_FUNC Char internal::thousands_sep_impl(locale_ref) {
@@ -231,8 +228,8 @@ FMT_FUNC Char internal::thousands_sep_impl(locale_ref) {
 }
 #endif
 
-FMT_FUNC void system_error::init(
-    int err_code, string_view format_str, format_args args) {
+FMT_FUNC void system_error::init(int err_code, string_view format_str,
+                                 format_args args) {
   error_code_ = err_code;
   memory_buffer buffer;
   format_system_error(buffer, err_code, vformat(format_str, args));
@@ -242,20 +239,19 @@ FMT_FUNC void system_error::init(
 
 namespace internal {
 template <typename T>
-int char_traits<char>::format_float(
-    char *buf, std::size_t size, const char *format, int precision, T value) {
-  return precision < 0 ?
-      FMT_SNPRINTF(buf, size, format, value) :
-      FMT_SNPRINTF(buf, size, format, precision, value);
+int char_traits<char>::format_float(char *buf, std::size_t size,
+                                    const char *format, int precision,
+                                    T value) {
+  return precision < 0 ? FMT_SNPRINTF(buf, size, format, value)
+                       : FMT_SNPRINTF(buf, size, format, precision, value);
 }
 
 template <typename T>
-int char_traits<wchar_t>::format_float(
-    wchar_t *buf, std::size_t size, const wchar_t *format, int precision,
-    T value) {
-  return precision < 0 ?
-      FMT_SWPRINTF(buf, size, format, value) :
-      FMT_SWPRINTF(buf, size, format, precision, value);
+int char_traits<wchar_t>::format_float(wchar_t *buf, std::size_t size,
+                                       const wchar_t *format, int precision,
+                                       T value) {
+  return precision < 0 ? FMT_SWPRINTF(buf, size, format, value)
+                       : FMT_SWPRINTF(buf, size, format, precision, value);
 }
 
 template <typename T>
@@ -266,88 +262,79 @@ const char basic_data<T>::DIGITS[] =
     "6061626364656667686970717273747576777879"
     "8081828384858687888990919293949596979899";
 
-#define FMT_POWERS_OF_10(factor) \
-  factor * 10, \
-  factor * 100, \
-  factor * 1000, \
-  factor * 10000, \
-  factor * 100000, \
-  factor * 1000000, \
-  factor * 10000000, \
-  factor * 100000000, \
-  factor * 1000000000
+#define FMT_POWERS_OF_10(factor)                                             \
+  factor * 10, factor * 100, factor * 1000, factor * 10000, factor * 100000, \
+      factor * 1000000, factor * 10000000, factor * 100000000,               \
+      factor * 1000000000
 
 template <typename T>
-const uint32_t basic_data<T>::POWERS_OF_10_32[] = {
-  1, FMT_POWERS_OF_10(1)
-};
+const uint32_t basic_data<T>::POWERS_OF_10_32[] = {1, FMT_POWERS_OF_10(1)};
 
 template <typename T>
-const uint32_t basic_data<T>::ZERO_OR_POWERS_OF_10_32[] = {
-  0, FMT_POWERS_OF_10(1)
-};
+const uint32_t basic_data<T>::ZERO_OR_POWERS_OF_10_32[] = {0,
+                                                           FMT_POWERS_OF_10(1)};
 
 template <typename T>
 const uint64_t basic_data<T>::ZERO_OR_POWERS_OF_10_64[] = {
-  0,
-  FMT_POWERS_OF_10(1),
-  FMT_POWERS_OF_10(1000000000ull),
-  10000000000000000000ull
-};
+    0, FMT_POWERS_OF_10(1), FMT_POWERS_OF_10(1000000000ull),
+    10000000000000000000ull};
 
 // Normalized 64-bit significands of pow(10, k), for k = -348, -340, ..., 340.
 // These are generated by support/compute-powers.py.
 template <typename T>
 const uint64_t basic_data<T>::POW10_SIGNIFICANDS[] = {
-  0xfa8fd5a0081c0288, 0xbaaee17fa23ebf76, 0x8b16fb203055ac76,
-  0xcf42894a5dce35ea, 0x9a6bb0aa55653b2d, 0xe61acf033d1a45df,
-  0xab70fe17c79ac6ca, 0xff77b1fcbebcdc4f, 0xbe5691ef416bd60c,
-  0x8dd01fad907ffc3c, 0xd3515c2831559a83, 0x9d71ac8fada6c9b5,
-  0xea9c227723ee8bcb, 0xaecc49914078536d, 0x823c12795db6ce57,
-  0xc21094364dfb5637, 0x9096ea6f3848984f, 0xd77485cb25823ac7,
-  0xa086cfcd97bf97f4, 0xef340a98172aace5, 0xb23867fb2a35b28e,
-  0x84c8d4dfd2c63f3b, 0xc5dd44271ad3cdba, 0x936b9fcebb25c996,
-  0xdbac6c247d62a584, 0xa3ab66580d5fdaf6, 0xf3e2f893dec3f126,
-  0xb5b5ada8aaff80b8, 0x87625f056c7c4a8b, 0xc9bcff6034c13053,
-  0x964e858c91ba2655, 0xdff9772470297ebd, 0xa6dfbd9fb8e5b88f,
-  0xf8a95fcf88747d94, 0xb94470938fa89bcf, 0x8a08f0f8bf0f156b,
-  0xcdb02555653131b6, 0x993fe2c6d07b7fac, 0xe45c10c42a2b3b06,
-  0xaa242499697392d3, 0xfd87b5f28300ca0e, 0xbce5086492111aeb,
-  0x8cbccc096f5088cc, 0xd1b71758e219652c, 0x9c40000000000000,
-  0xe8d4a51000000000, 0xad78ebc5ac620000, 0x813f3978f8940984,
-  0xc097ce7bc90715b3, 0x8f7e32ce7bea5c70, 0xd5d238a4abe98068,
-  0x9f4f2726179a2245, 0xed63a231d4c4fb27, 0xb0de65388cc8ada8,
-  0x83c7088e1aab65db, 0xc45d1df942711d9a, 0x924d692ca61be758,
-  0xda01ee641a708dea, 0xa26da3999aef774a, 0xf209787bb47d6b85,
-  0xb454e4a179dd1877, 0x865b86925b9bc5c2, 0xc83553c5c8965d3d,
-  0x952ab45cfa97a0b3, 0xde469fbd99a05fe3, 0xa59bc234db398c25,
-  0xf6c69a72a3989f5c, 0xb7dcbf5354e9bece, 0x88fcf317f22241e2,
-  0xcc20ce9bd35c78a5, 0x98165af37b2153df, 0xe2a0b5dc971f303a,
-  0xa8d9d1535ce3b396, 0xfb9b7cd9a4a7443c, 0xbb764c4ca7a44410,
-  0x8bab8eefb6409c1a, 0xd01fef10a657842c, 0x9b10a4e5e9913129,
-  0xe7109bfba19c0c9d, 0xac2820d9623bf429, 0x80444b5e7aa7cf85,
-  0xbf21e44003acdd2d, 0x8e679c2f5e44ff8f, 0xd433179d9c8cb841,
-  0x9e19db92b4e31ba9, 0xeb96bf6ebadf77d9, 0xaf87023b9bf0ee6b,
+    0xfa8fd5a0081c0288, 0xbaaee17fa23ebf76, 0x8b16fb203055ac76,
+    0xcf42894a5dce35ea, 0x9a6bb0aa55653b2d, 0xe61acf033d1a45df,
+    0xab70fe17c79ac6ca, 0xff77b1fcbebcdc4f, 0xbe5691ef416bd60c,
+    0x8dd01fad907ffc3c, 0xd3515c2831559a83, 0x9d71ac8fada6c9b5,
+    0xea9c227723ee8bcb, 0xaecc49914078536d, 0x823c12795db6ce57,
+    0xc21094364dfb5637, 0x9096ea6f3848984f, 0xd77485cb25823ac7,
+    0xa086cfcd97bf97f4, 0xef340a98172aace5, 0xb23867fb2a35b28e,
+    0x84c8d4dfd2c63f3b, 0xc5dd44271ad3cdba, 0x936b9fcebb25c996,
+    0xdbac6c247d62a584, 0xa3ab66580d5fdaf6, 0xf3e2f893dec3f126,
+    0xb5b5ada8aaff80b8, 0x87625f056c7c4a8b, 0xc9bcff6034c13053,
+    0x964e858c91ba2655, 0xdff9772470297ebd, 0xa6dfbd9fb8e5b88f,
+    0xf8a95fcf88747d94, 0xb94470938fa89bcf, 0x8a08f0f8bf0f156b,
+    0xcdb02555653131b6, 0x993fe2c6d07b7fac, 0xe45c10c42a2b3b06,
+    0xaa242499697392d3, 0xfd87b5f28300ca0e, 0xbce5086492111aeb,
+    0x8cbccc096f5088cc, 0xd1b71758e219652c, 0x9c40000000000000,
+    0xe8d4a51000000000, 0xad78ebc5ac620000, 0x813f3978f8940984,
+    0xc097ce7bc90715b3, 0x8f7e32ce7bea5c70, 0xd5d238a4abe98068,
+    0x9f4f2726179a2245, 0xed63a231d4c4fb27, 0xb0de65388cc8ada8,
+    0x83c7088e1aab65db, 0xc45d1df942711d9a, 0x924d692ca61be758,
+    0xda01ee641a708dea, 0xa26da3999aef774a, 0xf209787bb47d6b85,
+    0xb454e4a179dd1877, 0x865b86925b9bc5c2, 0xc83553c5c8965d3d,
+    0x952ab45cfa97a0b3, 0xde469fbd99a05fe3, 0xa59bc234db398c25,
+    0xf6c69a72a3989f5c, 0xb7dcbf5354e9bece, 0x88fcf317f22241e2,
+    0xcc20ce9bd35c78a5, 0x98165af37b2153df, 0xe2a0b5dc971f303a,
+    0xa8d9d1535ce3b396, 0xfb9b7cd9a4a7443c, 0xbb764c4ca7a44410,
+    0x8bab8eefb6409c1a, 0xd01fef10a657842c, 0x9b10a4e5e9913129,
+    0xe7109bfba19c0c9d, 0xac2820d9623bf429, 0x80444b5e7aa7cf85,
+    0xbf21e44003acdd2d, 0x8e679c2f5e44ff8f, 0xd433179d9c8cb841,
+    0x9e19db92b4e31ba9, 0xeb96bf6ebadf77d9, 0xaf87023b9bf0ee6b,
 };
 
 // Binary exponents of pow(10, k), for k = -348, -340, ..., 340, corresponding
 // to significands above.
 template <typename T>
 const int16_t basic_data<T>::POW10_EXPONENTS[] = {
-  -1220, -1193, -1166, -1140, -1113, -1087, -1060, -1034, -1007,  -980,  -954,
-   -927,  -901,  -874,  -847,  -821,  -794,  -768,  -741,  -715,  -688,  -661,
-   -635,  -608,  -582,  -555,  -529,  -502,  -475,  -449,  -422,  -396,  -369,
-   -343,  -316,  -289,  -263,  -236,  -210,  -183,  -157,  -130,  -103,   -77,
-    -50,   -24,     3,    30,    56,    83,   109,   136,   162,   189,   216,
-    242,   269,   295,   322,   348,   375,   402,   428,   455,   481,   508,
-    534,   561,   588,   614,   641,   667,   694,   720,   747,   774,   800,
-    827,   853,   880,   907,   933,   960,   986,  1013,  1039,  1066
-};
+    -1220, -1193, -1166, -1140, -1113, -1087, -1060, -1034, -1007, -980, -954,
+    -927,  -901,  -874,  -847,  -821,  -794,  -768,  -741,  -715,  -688, -661,
+    -635,  -608,  -582,  -555,  -529,  -502,  -475,  -449,  -422,  -396, -369,
+    -343,  -316,  -289,  -263,  -236,  -210,  -183,  -157,  -130,  -103, -77,
+    -50,   -24,   3,     30,    56,    83,    109,   136,   162,   189,  216,
+    242,   269,   295,   322,   348,   375,   402,   428,   455,   481,  508,
+    534,   561,   588,   614,   641,   667,   694,   720,   747,   774,  800,
+    827,   853,   880,   907,   933,   960,   986,   1013,  1039,  1066};
 
-template <typename T> const char basic_data<T>::FOREGROUND_COLOR[] = "\x1b[38;2;";
-template <typename T> const char basic_data<T>::BACKGROUND_COLOR[] = "\x1b[48;2;";
-template <typename T> const char basic_data<T>::RESET_COLOR[] = "\x1b[0m";
-template <typename T> const wchar_t basic_data<T>::WRESET_COLOR[] = L"\x1b[0m";
+template <typename T>
+const char basic_data<T>::FOREGROUND_COLOR[] = "\x1b[38;2;";
+template <typename T>
+const char basic_data<T>::BACKGROUND_COLOR[] = "\x1b[48;2;";
+template <typename T>
+const char basic_data<T>::RESET_COLOR[] = "\x1b[0m";
+template <typename T>
+const wchar_t basic_data<T>::WRESET_COLOR[] = L"\x1b[0m";
 
 // A handmade floating-point number f * pow(2, e).
 class fp {
@@ -356,23 +343,23 @@ class fp {
 
   // All sizes are in bits.
   static FMT_CONSTEXPR_DECL const int char_size =
-    std::numeric_limits<unsigned char>::digits;
+      std::numeric_limits<unsigned char>::digits;
   // Subtract 1 to account for an implicit most significant bit in the
   // normalized form.
   static FMT_CONSTEXPR_DECL const int double_significand_size =
-    std::numeric_limits<double>::digits - 1;
+      std::numeric_limits<double>::digits - 1;
   static FMT_CONSTEXPR_DECL const uint64_t implicit_bit =
-    1ull << double_significand_size;
+      1ull << double_significand_size;
 
  public:
   significand_type f;
   int e;
 
   static FMT_CONSTEXPR_DECL const int significand_size =
-    sizeof(significand_type) * char_size;
+      sizeof(significand_type) * char_size;
 
-  fp(): f(0), e(0) {}
-  fp(uint64_t f_val, int e_val): f(f_val), e(e_val) {}
+  fp() : f(0), e(0) {}
+  fp(uint64_t f_val, int e_val) : f(f_val), e(e_val) {}
 
   // Constructs fp from an IEEE754 double. It is a template to prevent compile
   // errors on platforms where double is not IEEE754.
@@ -382,7 +369,7 @@ class fp {
     typedef std::numeric_limits<Double> limits;
     const int double_size = static_cast<int>(sizeof(Double) * char_size);
     const int exponent_size =
-      double_size - double_significand_size - 1;  // -1 for sign
+        double_size - double_significand_size - 1;  // -1 for sign
     const uint64_t significand_mask = implicit_bit - 1;
     const uint64_t exponent_mask = (~0ull >> 1) & ~significand_mask;
     const int exponent_bias = (1 << exponent_size) - limits::max_exponent - 1;
@@ -416,8 +403,8 @@ class fp {
   // (lower) or successor (upper). The upper boundary is normalized and lower
   // has the same exponent but may be not normalized.
   void compute_boundaries(fp &lower, fp &upper) const {
-    lower = f == implicit_bit ?
-          fp((f << 2) - 1, e - 2) : fp((f << 1) - 1, e - 1);
+    lower =
+        f == implicit_bit ? fp((f << 2) - 1, e - 2) : fp((f << 1) - 1, e - 1);
     upper = fp((f << 1) + 1, e - 1);
     upper.normalize<1>();  // 1 is to account for the exponent shift above.
     lower.f <<= lower.e - upper.e;
@@ -432,7 +419,8 @@ inline fp operator-(fp x, fp y) {
 }
 
 // Computes an fp number r with r.f = x.f * y.f / pow(2, 64) rounded to nearest
-// with half-up tie breaking, r.e = x.e + y.e + 64. Result may not be normalized.
+// with half-up tie breaking, r.e = x.e + y.e + 64. Result may not be
+// normalized.
 FMT_API fp operator*(fp x, fp y);
 
 // Returns cached power (of 10) c_k = c_k.f * pow(2, c_k.e) such that its
@@ -452,8 +440,8 @@ FMT_FUNC fp operator*(fp x, fp y) {
 
 FMT_FUNC fp get_cached_power(int min_exponent, int &pow10_exponent) {
   const double one_over_log2_10 = 0.30102999566398114;  // 1 / log2(10)
-  int index = static_cast<int>(std::ceil(
-        (min_exponent + fp::significand_size - 1) * one_over_log2_10));
+  int index = static_cast<int>(
+      std::ceil((min_exponent + fp::significand_size - 1) * one_over_log2_10));
   // Decimal exponent of the first (smallest) cached power of 10.
   const int first_dec_exp = -348;
   // Difference between 2 consecutive decimal exponents in cached powers of 10.
@@ -463,11 +451,12 @@ FMT_FUNC fp get_cached_power(int min_exponent, int &pow10_exponent) {
   return fp(data::POW10_SIGNIFICANDS[index], data::POW10_EXPONENTS[index]);
 }
 
-FMT_FUNC bool grisu2_round(
-    char *buf, ptrdiff_t &size, size_t max_digits, uint64_t delta,
-    uint64_t remainder, uint64_t exp, uint64_t diff, int &exp10) {
-  while (remainder < diff && delta - remainder >= exp &&
-        (remainder + exp < diff || diff - remainder > remainder + exp - diff)) {
+FMT_FUNC bool grisu2_round(char *buf, ptrdiff_t &size, size_t max_digits,
+                           uint64_t delta, uint64_t remainder, uint64_t exp,
+                           uint64_t diff, int &exp10) {
+  while (
+      remainder < diff && delta - remainder >= exp &&
+      (remainder + exp < diff || diff - remainder > remainder + exp - diff)) {
     --buf[size - 1];
     remainder += exp;
   }
@@ -481,27 +470,58 @@ FMT_FUNC bool grisu2_round(
 }
 
 // Generates output using Grisu2 digit-gen algorithm.
-FMT_FUNC bool grisu2_gen_digits(
-    char *buf, ptrdiff_t &size, uint32_t hi, uint64_t lo, int &exp,
-    uint64_t delta, const fp &one, const fp &diff, size_t max_digits) {
+FMT_FUNC bool grisu2_gen_digits(char *buf, ptrdiff_t &size, uint32_t hi,
+                                uint64_t lo, int &exp, uint64_t delta,
+                                const fp &one, const fp &diff,
+                                size_t max_digits) {
   // Generate digits for the most significant part (hi).
   while (exp > 0) {
     uint32_t digit = 0;
     // This optimization by miloyip reduces the number of integer divisions by
     // one per iteration.
     switch (exp) {
-    case 10: digit = hi / 1000000000; hi %= 1000000000; break;
-    case  9: digit = hi /  100000000; hi %=  100000000; break;
-    case  8: digit = hi /   10000000; hi %=   10000000; break;
-    case  7: digit = hi /    1000000; hi %=    1000000; break;
-    case  6: digit = hi /     100000; hi %=     100000; break;
-    case  5: digit = hi /      10000; hi %=      10000; break;
-    case  4: digit = hi /       1000; hi %=       1000; break;
-    case  3: digit = hi /        100; hi %=        100; break;
-    case  2: digit = hi /         10; hi %=         10; break;
-    case  1: digit = hi;              hi =           0; break;
-    default:
-      FMT_ASSERT(false, "invalid number of digits");
+      case 10:
+        digit = hi / 1000000000;
+        hi %= 1000000000;
+        break;
+      case 9:
+        digit = hi / 100000000;
+        hi %= 100000000;
+        break;
+      case 8:
+        digit = hi / 10000000;
+        hi %= 10000000;
+        break;
+      case 7:
+        digit = hi / 1000000;
+        hi %= 1000000;
+        break;
+      case 6:
+        digit = hi / 100000;
+        hi %= 100000;
+        break;
+      case 5:
+        digit = hi / 10000;
+        hi %= 10000;
+        break;
+      case 4:
+        digit = hi / 1000;
+        hi %= 1000;
+        break;
+      case 3:
+        digit = hi / 100;
+        hi %= 100;
+        break;
+      case 2:
+        digit = hi / 10;
+        hi %= 10;
+        break;
+      case 1:
+        digit = hi;
+        hi = 0;
+        break;
+      default:
+        FMT_ASSERT(false, "invalid number of digits");
     }
     if (digit != 0 || size != 0)
       buf[size++] = static_cast<char>('0' + digit);
@@ -509,9 +529,9 @@ FMT_FUNC bool grisu2_gen_digits(
     uint64_t remainder = (static_cast<uint64_t>(hi) << -one.e) + lo;
     if (remainder <= delta || size > static_cast<ptrdiff_t>(max_digits)) {
       return grisu2_round(
-            buf, size, max_digits, delta, remainder,
-            static_cast<uint64_t>(data::POWERS_OF_10_32[exp]) << -one.e,
-            diff.f, exp);
+          buf, size, max_digits, delta, remainder,
+          static_cast<uint64_t>(data::POWERS_OF_10_32[exp]) << -one.e, diff.f,
+          exp);
     }
   }
   // Generate digits for the least significant part (lo).
@@ -531,11 +551,11 @@ FMT_FUNC bool grisu2_gen_digits(
 }
 
 #if FMT_CLANG_VERSION
-# define FMT_FALLTHROUGH [[clang::fallthrough]];
+#define FMT_FALLTHROUGH [[clang::fallthrough]];
 #elif FMT_GCC_VERSION >= 700
-# define FMT_FALLTHROUGH [[gnu::fallthrough]];
+#define FMT_FALLTHROUGH [[gnu::fallthrough]];
 #else
-# define FMT_FALLTHROUGH
+#define FMT_FALLTHROUGH
 #endif
 
 struct gen_digits_params {
@@ -551,7 +571,7 @@ struct prettify_handler {
   buffer &buf;
 
   explicit prettify_handler(buffer &b, ptrdiff_t n)
-    : data(b.data()), size(n), buf(b) {}
+      : data(b.data()), size(n), buf(b) {}
   ~prettify_handler() {
     assert(buf.size() >= to_unsigned(size));
     buf.resize(to_unsigned(size));
@@ -616,8 +636,8 @@ struct fill {
 
 // The number is given as v = f * pow(10, exp), where f has size digits.
 template <typename Handler>
-FMT_FUNC void grisu2_prettify(const gen_digits_params &params,
-                              int size, int exp, Handler &&handler) {
+FMT_FUNC void grisu2_prettify(const gen_digits_params &params, int size,
+                              int exp, Handler &&handler) {
   if (!params.fixed) {
     // Insert a decimal point after the first digit and add an exponent.
     handler.insert(1, '.');
@@ -660,7 +680,9 @@ struct char_counter {
   ptrdiff_t size;
 
   template <typename F>
-  void insert(ptrdiff_t, ptrdiff_t n, F) { size += n; }
+  void insert(ptrdiff_t, ptrdiff_t n, F) {
+    size += n;
+  }
   void insert(ptrdiff_t, char) { ++size; }
   void append(ptrdiff_t n, char) { size += n; }
   void append(char) { ++size; }
@@ -675,34 +697,35 @@ FMT_FUNC gen_digits_params process_specs(const core_format_specs &specs,
   auto params = gen_digits_params();
   int num_digits = specs.precision >= 0 ? specs.precision : 6;
   switch (specs.type) {
-  case 'G':
-    params.upper = true;
-    FMT_FALLTHROUGH
-  case '\0': case 'g':
-    params.trailing_zeros = (specs.flags & HASH_FLAG) != 0;
-    if (-4 <= exp && exp < num_digits + 1) {
+    case 'G':
+      params.upper = true;
+      FMT_FALLTHROUGH
+    case '\0':
+    case 'g':
+      params.trailing_zeros = (specs.flags & HASH_FLAG) != 0;
+      if (-4 <= exp && exp < num_digits + 1) {
+        params.fixed = true;
+        if (!specs.type && params.trailing_zeros && exp >= 0)
+          num_digits = exp + 1;
+      }
+      break;
+    case 'F':
+      params.upper = true;
+      FMT_FALLTHROUGH
+    case 'f': {
       params.fixed = true;
-      if (!specs.type && params.trailing_zeros && exp >= 0)
-        num_digits = exp + 1;
+      params.trailing_zeros = true;
+      int adjusted_min_digits = num_digits + exp;
+      if (adjusted_min_digits > 0)
+        num_digits = adjusted_min_digits;
+      break;
     }
-    break;
-  case 'F':
-    params.upper = true;
-    FMT_FALLTHROUGH
-  case 'f': {
-    params.fixed = true;
-    params.trailing_zeros = true;
-    int adjusted_min_digits = num_digits + exp;
-    if (adjusted_min_digits > 0)
-      num_digits = adjusted_min_digits;
-    break;
-  }
-  case 'E':
-    params.upper = true;
-    FMT_FALLTHROUGH
-  case 'e':
-    ++num_digits;
-    break;
+    case 'E':
+      params.upper = true;
+      FMT_FALLTHROUGH
+    case 'e':
+      ++num_digits;
+      break;
   }
   params.num_digits = to_unsigned(num_digits);
   char_counter counter{num_digits};
@@ -713,7 +736,7 @@ FMT_FUNC gen_digits_params process_specs(const core_format_specs &specs,
 
 template <typename Double>
 FMT_FUNC typename std::enable_if<sizeof(Double) == sizeof(uint64_t), bool>::type
-    grisu2_format(Double value, buffer &buf, core_format_specs specs) {
+grisu2_format(Double value, buffer &buf, core_format_specs specs) {
   FMT_ASSERT(value >= 0, "value is negative");
   if (value == 0) {
     gen_digits_params params = process_specs(specs, 1, buf);
@@ -728,13 +751,13 @@ FMT_FUNC typename std::enable_if<sizeof(Double) == sizeof(uint64_t), bool>::type
   fp_value.compute_boundaries(lower, upper);
 
   // Find a cached power of 10 close to 1 / upper and use it to scale upper.
-  const int min_exp = -60;  // alpha in Grisu.
-  int cached_exp = 0;  // K in Grisu.
+  const int min_exp = -60;             // alpha in Grisu.
+  int cached_exp = 0;                  // K in Grisu.
   auto cached_pow = get_cached_power(  // \tilde{c}_{-k} in Grisu.
       min_exp - (upper.e + fp::significand_size), cached_exp);
   cached_exp = -cached_exp;
   upper = upper * cached_pow;  // \tilde{M}^+ in Grisu.
-  --upper.f;  // \tilde{M}^+ - 1 ulp -> M^+_{\downarrow}.
+  --upper.f;                   // \tilde{M}^+ - 1 ulp -> M^+_{\downarrow}.
   fp one(1ull << -upper.e, upper.e);
   // hi (p1 in Grisu) contains the most significant digits of scaled_upper.
   // hi = floor(upper / one).
@@ -744,9 +767,9 @@ FMT_FUNC typename std::enable_if<sizeof(Double) == sizeof(uint64_t), bool>::type
   fp_value.normalize();
   fp scaled_value = fp_value * cached_pow;
   lower = lower * cached_pow;  // \tilde{M}^- in Grisu.
-  ++lower.f;  // \tilde{M}^- + 1 ulp -> M^-_{\uparrow}.
+  ++lower.f;                   // \tilde{M}^- + 1 ulp -> M^-_{\uparrow}.
   uint64_t delta = upper.f - lower.f;
-  fp diff = upper - scaled_value; // wp_w in Grisu.
+  fp diff = upper - scaled_value;  // wp_w in Grisu.
   // lo (p2 in Grisu) contains the least significants digits of scaled_upper.
   // lo = supper % one.
   uint64_t lo = upper.f & (one.f - 1);
@@ -767,7 +790,7 @@ void sprintf_format(Double value, internal::buffer &buf,
   FMT_ASSERT(buf.capacity() != 0, "empty buffer");
 
   // Build format string.
-  enum { MAX_FORMAT_SIZE = 10}; // longest format: %#-*.*Lg
+  enum { MAX_FORMAT_SIZE = 10 };  // longest format: %#-*.*Lg
   char format[MAX_FORMAT_SIZE];
   char *format_ptr = format;
   *format_ptr++ = '%';
@@ -819,13 +842,13 @@ FMT_FUNC internal::utf8_to_utf16::utf8_to_utf16(string_view s) {
     return;
   }
 
-  int length = MultiByteToWideChar(
-      CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size, FMT_NULL, 0);
+  int length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s.data(),
+                                   s_size, FMT_NULL, 0);
   if (length == 0)
     FMT_THROW(windows_error(GetLastError(), ERROR_MSG));
   buffer_.resize(length + 1);
-  length = MultiByteToWideChar(
-    CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size, &buffer_[0], length);
+  length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size,
+                               &buffer_[0], length);
   if (length == 0)
     FMT_THROW(windows_error(GetLastError(), ERROR_MSG));
   buffer_[length] = 0;
@@ -834,7 +857,7 @@ FMT_FUNC internal::utf8_to_utf16::utf8_to_utf16(string_view s) {
 FMT_FUNC internal::utf16_to_utf8::utf16_to_utf8(wstring_view s) {
   if (int error_code = convert(s)) {
     FMT_THROW(windows_error(error_code,
-        "cannot convert string from UTF-16 to UTF-8"));
+                            "cannot convert string from UTF-16 to UTF-8"));
   }
 }
 
@@ -849,21 +872,21 @@ FMT_FUNC int internal::utf16_to_utf8::convert(wstring_view s) {
     return 0;
   }
 
-  int length = WideCharToMultiByte(
-        CP_UTF8, 0, s.data(), s_size, FMT_NULL, 0, FMT_NULL, FMT_NULL);
+  int length = WideCharToMultiByte(CP_UTF8, 0, s.data(), s_size, FMT_NULL, 0,
+                                   FMT_NULL, FMT_NULL);
   if (length == 0)
     return GetLastError();
   buffer_.resize(length + 1);
-  length = WideCharToMultiByte(
-    CP_UTF8, 0, s.data(), s_size, &buffer_[0], length, FMT_NULL, FMT_NULL);
+  length = WideCharToMultiByte(CP_UTF8, 0, s.data(), s_size, &buffer_[0],
+                               length, FMT_NULL, FMT_NULL);
   if (length == 0)
     return GetLastError();
   buffer_[length] = 0;
   return 0;
 }
 
-FMT_FUNC void windows_error::init(
-    int err_code, string_view format_str, format_args args) {
+FMT_FUNC void windows_error::init(int err_code, string_view format_str,
+                                  format_args args) {
   error_code_ = err_code;
   memory_buffer buffer;
   internal::format_windows_error(buffer, err_code, vformat(format_str, args));
@@ -871,17 +894,18 @@ FMT_FUNC void windows_error::init(
   base = std::runtime_error(to_string(buffer));
 }
 
-FMT_FUNC void internal::format_windows_error(
-    internal::buffer &out, int error_code, string_view message) FMT_NOEXCEPT {
+FMT_FUNC void internal::format_windows_error(internal::buffer &out,
+                                             int error_code,
+                                             string_view message) FMT_NOEXCEPT {
   FMT_TRY {
     wmemory_buffer buf;
     buf.resize(inline_buffer_size);
     for (;;) {
       wchar_t *system_message = &buf[0];
       int result = FormatMessageW(
-          FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-          FMT_NULL, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-          system_message, static_cast<uint32_t>(buf.size()), FMT_NULL);
+          FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, FMT_NULL,
+          error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), system_message,
+          static_cast<uint32_t>(buf.size()), FMT_NULL);
       if (result != 0) {
         utf16_to_utf8 utf8_message;
         if (utf8_message.convert(system_message) == ERROR_SUCCESS) {
@@ -897,14 +921,15 @@ FMT_FUNC void internal::format_windows_error(
         break;  // Can't get error message, report error code instead.
       buf.resize(buf.size() * 2);
     }
-  } FMT_CATCH(...) {}
+  }
+  FMT_CATCH(...) {}
   format_error_code(out, error_code, message);
 }
 
 #endif  // FMT_USE_WINDOWS_H
 
-FMT_FUNC void format_system_error(
-    internal::buffer &out, int error_code, string_view message) FMT_NOEXCEPT {
+FMT_FUNC void format_system_error(internal::buffer &out, int error_code,
+                                  string_view message) FMT_NOEXCEPT {
   FMT_TRY {
     memory_buffer buf;
     buf.resize(inline_buffer_size);
@@ -922,7 +947,8 @@ FMT_FUNC void format_system_error(
         break;  // Can't get error message, report error code instead.
       buf.resize(buf.size() * 2);
     }
-  } FMT_CATCH(...) {}
+  }
+  FMT_CATCH(...) {}
   format_error_code(out, error_code, message);
 }
 
@@ -930,14 +956,14 @@ FMT_FUNC void internal::error_handler::on_error(const char *message) {
   FMT_THROW(format_error(message));
 }
 
-FMT_FUNC void report_system_error(
-    int error_code, fmt::string_view message) FMT_NOEXCEPT {
+FMT_FUNC void report_system_error(int error_code,
+                                  fmt::string_view message) FMT_NOEXCEPT {
   report_error(format_system_error, error_code, message);
 }
 
 #if FMT_USE_WINDOWS_H
-FMT_FUNC void report_windows_error(
-    int error_code, fmt::string_view message) FMT_NOEXCEPT {
+FMT_FUNC void report_windows_error(int error_code,
+                                   fmt::string_view message) FMT_NOEXCEPT {
   report_error(internal::format_windows_error, error_code, message);
 }
 #endif
@@ -966,7 +992,7 @@ FMT_FUNC void vprint(wstring_view format_str, wformat_args args) {
 FMT_END_NAMESPACE
 
 #ifdef _MSC_VER
-# pragma warning(pop)
+#pragma warning(pop)
 #endif
 
 #endif  // FMT_FORMAT_INL_H_

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -130,8 +130,9 @@ FMT_END_NAMESPACE
 #ifndef FMT_USE_USER_DEFINED_LITERALS
 // For Intel's compiler and NVIDIA's compiler both it and the system gcc/msc
 // must support UDLs.
-#if (FMT_HAS_FEATURE(cxx_user_literals) || FMT_GCC_VERSION >= 407 ||      \
-     FMT_MSC_VER >= 1900) &&                                              \
+#if (                                                                     \
+    FMT_HAS_FEATURE(cxx_user_literals) || FMT_GCC_VERSION >= 407 ||       \
+    FMT_MSC_VER >= 1900) &&                                               \
     (!(FMT_ICC_VERSION || FMT_CUDA_VERSION) || FMT_ICC_VERSION >= 1500 || \
      FMT_CUDA_VERSION >= 700)
 #define FMT_USE_USER_DEFINED_LITERALS 1
@@ -398,8 +399,8 @@ struct checked {
 
 // Make a checked iterator to avoid warnings on MSVC.
 template <typename T>
-inline stdext::checked_array_iterator<T *> make_checked(T *p,
-                                                        std::size_t size) {
+inline stdext::checked_array_iterator<T *> make_checked(
+    T *p, std::size_t size) {
   return {p, size};
 }
 #else
@@ -418,8 +419,8 @@ template <typename U>
 void basic_buffer<T>::append(const U *begin, const U *end) {
   std::size_t new_size = size_ + internal::to_unsigned(end - begin);
   reserve(new_size);
-  std::uninitialized_copy(begin, end,
-                          internal::make_checked(ptr_, capacity_) + size_);
+  std::uninitialized_copy(
+      begin, end, internal::make_checked(ptr_, capacity_) + size_);
   size_ = new_size;
 }
 }  // namespace internal
@@ -439,8 +440,8 @@ class u8string_view : public basic_string_view<char8_t> {
   u8string_view(const char *s)
       : basic_string_view<char8_t>(reinterpret_cast<const char8_t *>(s)) {}
   u8string_view(const char *s, size_t count) FMT_NOEXCEPT
-      : basic_string_view<char8_t>(reinterpret_cast<const char8_t *>(s),
-                                   count) {}
+      : basic_string_view<char8_t>(
+            reinterpret_cast<const char8_t *>(s), count) {}
 };
 
 #if FMT_USE_USER_DEFINED_LITERALS
@@ -484,8 +485,10 @@ enum { inline_buffer_size = 500 };
   The output can be converted to an ``std::string`` with ``to_string(out)``.
   \endrst
  */
-template <typename T, std::size_t SIZE = inline_buffer_size,
-          typename Allocator = std::allocator<T>>
+template <
+    typename T,
+    std::size_t SIZE = inline_buffer_size,
+    typename Allocator = std::allocator<T>>
 class basic_memory_buffer : private Allocator,
                             public internal::basic_buffer<T> {
  private:
@@ -517,8 +520,10 @@ class basic_memory_buffer : private Allocator,
     std::size_t size = other.size(), capacity = other.capacity();
     if (data == other.store_) {
       this->set(store_, capacity);
-      std::uninitialized_copy(other.store_, other.store_ + size,
-                              internal::make_checked(store_, capacity));
+      std::uninitialized_copy(
+          other.store_,
+          other.store_ + size,
+          internal::make_checked(store_, capacity));
     } else {
       this->set(data, capacity);
       // Set pointer to the inline array so that delete is not called
@@ -562,8 +567,10 @@ void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
   T *old_data = this->data();
   T *new_data = internal::allocate<Allocator>(*this, new_capacity);
   // The following code doesn't throw, so the raw pointer above doesn't leak.
-  std::uninitialized_copy(old_data, old_data + this->size(),
-                          internal::make_checked(new_data, new_capacity));
+  std::uninitialized_copy(
+      old_data,
+      old_data + this->size(),
+      internal::make_checked(new_data, new_capacity));
   this->set(new_data, new_capacity);
   // deallocate must not throw according to the standard, but even if it does,
   // the buffer already uses the new storage and will deallocate it in
@@ -584,33 +591,50 @@ template <>
 struct char_traits<char> {
   // Formats a floating-point number.
   template <typename T>
-  FMT_API static int format_float(char *buffer, std::size_t size,
-                                  const char *format, int precision, T value);
+  FMT_API static int format_float(
+      char *buffer,
+      std::size_t size,
+      const char *format,
+      int precision,
+      T value);
 };
 
 template <>
 struct char_traits<wchar_t> {
   template <typename T>
-  FMT_API static int format_float(wchar_t *buffer, std::size_t size,
-                                  const wchar_t *format, int precision,
-                                  T value);
+  FMT_API static int format_float(
+      wchar_t *buffer,
+      std::size_t size,
+      const wchar_t *format,
+      int precision,
+      T value);
 };
 
 #if FMT_USE_EXTERN_TEMPLATES
-extern template int char_traits<char>::format_float<double>(char *buffer,
-                                                            std::size_t size,
-                                                            const char *format,
-                                                            int precision,
-                                                            double value);
+extern template int char_traits<char>::format_float<double>(
+    char *buffer,
+    std::size_t size,
+    const char *format,
+    int precision,
+    double value);
 extern template int char_traits<char>::format_float<long double>(
-    char *buffer, std::size_t size, const char *format, int precision,
+    char *buffer,
+    std::size_t size,
+    const char *format,
+    int precision,
     long double value);
 
 extern template int char_traits<wchar_t>::format_float<double>(
-    wchar_t *buffer, std::size_t size, const wchar_t *format, int precision,
+    wchar_t *buffer,
+    std::size_t size,
+    const wchar_t *format,
+    int precision,
     double value);
 extern template int char_traits<wchar_t>::format_float<long double>(
-    wchar_t *buffer, std::size_t size, const wchar_t *format, int precision,
+    wchar_t *buffer,
+    std::size_t size,
+    const wchar_t *format,
+    int precision,
     long double value);
 #endif
 
@@ -694,9 +718,10 @@ class truncating_iterator_base {
 
 // An output iterator that truncates the output and counts the number of objects
 // written to it.
-template <typename OutputIt,
-          typename Enable = typename std::is_void<
-              typename std::iterator_traits<OutputIt>::value_type>::type>
+template <
+    typename OutputIt,
+    typename Enable = typename std::is_void<
+        typename std::iterator_traits<OutputIt>::value_type>::type>
 class truncating_iterator;
 
 template <typename OutputIt>
@@ -768,8 +793,10 @@ template <typename T>
 struct int_traits {
   // Smallest of uint32_t and uint64_t that is large enough to represent
   // all values of T.
-  typedef typename std::conditional<std::numeric_limits<T>::digits <= 32,
-                                    uint32_t, uint64_t>::type main_type;
+  typedef typename std::conditional<
+      std::numeric_limits<T>::digits <= 32,
+      uint32_t,
+      uint64_t>::type main_type;
 };
 
 // Static data is placed in this class template to allow header-only
@@ -838,21 +865,23 @@ inline char8_t to_char8_t(char c) { return static_cast<char8_t>(c); }
 template <typename InputIt, typename OutChar>
 struct needs_conversion
     : std::integral_constant<
-          bool, std::is_same<typename std::iterator_traits<InputIt>::value_type,
-                             char>::value &&
-                    std::is_same<OutChar, char8_t>::value> {};
+          bool,
+          std::is_same<
+              typename std::iterator_traits<InputIt>::value_type,
+              char>::value &&
+              std::is_same<OutChar, char8_t>::value> {};
 
 template <typename OutChar, typename InputIt, typename OutputIt>
-typename std::enable_if<!needs_conversion<InputIt, OutChar>::value,
-                        OutputIt>::type
-copy_str(InputIt begin, InputIt end, OutputIt it) {
+typename std::enable_if<!needs_conversion<InputIt, OutChar>::value, OutputIt>::
+    type
+    copy_str(InputIt begin, InputIt end, OutputIt it) {
   return std::copy(begin, end, it);
 }
 
 template <typename OutChar, typename InputIt, typename OutputIt>
-typename std::enable_if<needs_conversion<InputIt, OutChar>::value,
-                        OutputIt>::type
-copy_str(InputIt begin, InputIt end, OutputIt it) {
+typename std::enable_if<needs_conversion<InputIt, OutChar>::value, OutputIt>::
+    type
+    copy_str(InputIt begin, InputIt end, OutputIt it) {
   return std::transform(begin, end, it, to_char8_t);
 }
 
@@ -971,8 +1000,10 @@ class add_thousands_sep {
     if (++digit_index_ % 3 != 0)
       return;
     buffer -= sep_.size();
-    std::uninitialized_copy(sep_.data(), sep_.data() + sep_.size(),
-                            internal::make_checked(buffer, sep_.size()));
+    std::uninitialized_copy(
+        sep_.data(),
+        sep_.data() + sep_.size(),
+        internal::make_checked(buffer, sep_.size()));
   }
 
   enum { size = 1 };
@@ -995,8 +1026,8 @@ inline wchar_t thousands_sep(locale_ref loc) {
 // thousands_sep is a functor that is called after writing each char to
 // add a thousands separator if necessary.
 template <typename UInt, typename Char, typename ThousandsSep>
-inline Char *format_decimal(Char *buffer, UInt value, unsigned num_digits,
-                            ThousandsSep thousands_sep) {
+inline Char *format_decimal(
+    Char *buffer, UInt value, unsigned num_digits, ThousandsSep thousands_sep) {
   buffer += num_digits;
   Char *end = buffer;
   while (value >= 100) {
@@ -1021,10 +1052,13 @@ inline Char *format_decimal(Char *buffer, UInt value, unsigned num_digits,
   return end;
 }
 
-template <typename OutChar, typename UInt, typename Iterator,
-          typename ThousandsSep>
-inline Iterator format_decimal(Iterator out, UInt value, unsigned num_digits,
-                               ThousandsSep sep) {
+template <
+    typename OutChar,
+    typename UInt,
+    typename Iterator,
+    typename ThousandsSep>
+inline Iterator format_decimal(
+    Iterator out, UInt value, unsigned num_digits, ThousandsSep sep) {
   typedef typename ThousandsSep::char_type char_type;
   // Buffer should be large enough to hold all digits (<= digits10 + 1).
   enum { max_size = std::numeric_limits<UInt>::digits10 + 1 };
@@ -1040,8 +1074,8 @@ inline It format_decimal(It out, UInt value, unsigned num_digits) {
 }
 
 template <unsigned BASE_BITS, typename Char, typename UInt>
-inline Char *format_uint(Char *buffer, UInt value, unsigned num_digits,
-                         bool upper = false) {
+inline Char *format_uint(
+    Char *buffer, UInt value, unsigned num_digits, bool upper = false) {
   buffer += num_digits;
   Char *end = buffer;
   do {
@@ -1053,8 +1087,8 @@ inline Char *format_uint(Char *buffer, UInt value, unsigned num_digits,
 }
 
 template <unsigned BASE_BITS, typename Char, typename It, typename UInt>
-inline It format_uint(It out, UInt value, unsigned num_digits,
-                      bool upper = false) {
+inline It format_uint(
+    It out, UInt value, unsigned num_digits, bool upper = false) {
   // Buffer should be large enough to hold all digits (digits / BASE_BITS + 1)
   // and null.
   char buffer[std::numeric_limits<UInt>::digits / BASE_BITS + 2];
@@ -1105,8 +1139,10 @@ class utf16_to_utf8 {
   FMT_API int convert(wstring_view s);
 };
 
-FMT_API void format_windows_error(fmt::internal::buffer &out, int error_code,
-                                  fmt::string_view message) FMT_NOEXCEPT;
+FMT_API void format_windows_error(
+    fmt::internal::buffer &out,
+    int error_code,
+    fmt::string_view message) FMT_NOEXCEPT;
 #endif
 
 template <typename T = void>
@@ -1232,8 +1268,8 @@ FMT_CONSTEXPR void handle_float_type_spec(char spec, Handler &&handler) {
 }
 
 template <typename Char, typename Handler>
-FMT_CONSTEXPR void handle_char_specs(const basic_format_specs<Char> *specs,
-                                     Handler &&handler) {
+FMT_CONSTEXPR void handle_char_specs(
+    const basic_format_specs<Char> *specs, Handler &&handler) {
   if (!specs)
     return handler.on_char();
   if (specs->type && specs->type != 'c')
@@ -1420,9 +1456,9 @@ class arg_formatter_base {
   }
 
   template <typename T>
-  typename std::enable_if<std::is_integral<T>::value ||
-                              std::is_same<T, char_type>::value,
-                          iterator>::type
+  typename std::enable_if<
+      std::is_integral<T>::value || std::is_same<T, char_type>::value,
+      iterator>::type
   operator()(T value) {
     // MSVC2013 fails to compile separate overloads for bool and char_type so
     // use std::is_same instead.
@@ -1476,8 +1512,8 @@ class arg_formatter_base {
   iterator operator()(const char_type *value) {
     if (!specs_)
       return write(value), out();
-    internal::handle_cstring_type_spec(specs_->type,
-                                       cstring_spec_handler(*this, value));
+    internal::handle_cstring_type_spec(
+        specs_->type, cstring_spec_handler(*this, value));
     return out();
   }
 
@@ -1507,9 +1543,8 @@ FMT_CONSTEXPR bool is_name_start(Char c) {
 // Parses the range [begin, end) as an unsigned integer. This function assumes
 // that the range is non-empty and the first character is a digit.
 template <typename Char, typename ErrorHandler>
-FMT_CONSTEXPR unsigned parse_nonnegative_int(const Char *&begin,
-                                             const Char *end,
-                                             ErrorHandler &&eh) {
+FMT_CONSTEXPR unsigned parse_nonnegative_int(
+    const Char *&begin, const Char *end, ErrorHandler &&eh) {
   assert(begin != end && '0' <= *begin && *begin <= '9');
   if (*begin == '0') {
     ++begin;
@@ -1712,10 +1747,13 @@ class specs_checker : public Handler {
   internal::type arg_type_;
 };
 
-template <template <typename> class Handler, typename T, typename Context,
-          typename ErrorHandler>
-FMT_CONSTEXPR void set_dynamic_spec(T &value, basic_format_arg<Context> arg,
-                                    ErrorHandler eh) {
+template <
+    template <typename> class Handler,
+    typename T,
+    typename Context,
+    typename ErrorHandler>
+FMT_CONSTEXPR void set_dynamic_spec(
+    T &value, basic_format_arg<Context> arg, ErrorHandler eh) {
   unsigned long long big_value =
       visit_format_arg(Handler<ErrorHandler>(eh), arg);
   if (big_value > to_unsigned((std::numeric_limits<int>::max)()))
@@ -1731,20 +1769,20 @@ class specs_handler : public specs_setter<typename Context::char_type> {
  public:
   typedef typename Context::char_type char_type;
 
-  FMT_CONSTEXPR specs_handler(basic_format_specs<char_type> &specs,
-                              Context &ctx)
+  FMT_CONSTEXPR specs_handler(
+      basic_format_specs<char_type> &specs, Context &ctx)
       : specs_setter<char_type>(specs), context_(ctx) {}
 
   template <typename Id>
   FMT_CONSTEXPR void on_dynamic_width(Id arg_id) {
-    set_dynamic_spec<width_checker>(this->specs_.width_, get_arg(arg_id),
-                                    context_.error_handler());
+    set_dynamic_spec<width_checker>(
+        this->specs_.width_, get_arg(arg_id), context_.error_handler());
   }
 
   template <typename Id>
   FMT_CONSTEXPR void on_dynamic_precision(Id arg_id) {
-    set_dynamic_spec<precision_checker>(this->specs_.precision, get_arg(arg_id),
-                                        context_.error_handler());
+    set_dynamic_spec<precision_checker>(
+        this->specs_.precision, get_arg(arg_id), context_.error_handler());
   }
 
   void on_error(const char *message) { context_.on_error(message); }
@@ -1804,8 +1842,8 @@ class dynamic_specs_handler
  public:
   typedef typename ParseContext::char_type char_type;
 
-  FMT_CONSTEXPR dynamic_specs_handler(dynamic_format_specs<char_type> &specs,
-                                      ParseContext &ctx)
+  FMT_CONSTEXPR dynamic_specs_handler(
+      dynamic_format_specs<char_type> &specs, ParseContext &ctx)
       : specs_setter<char_type>(specs), specs_(specs), context_(ctx) {}
 
   FMT_CONSTEXPR dynamic_specs_handler(const dynamic_specs_handler &other)
@@ -1845,8 +1883,8 @@ class dynamic_specs_handler
 };
 
 template <typename Char, typename IDHandler>
-FMT_CONSTEXPR const Char *parse_arg_id(const Char *begin, const Char *end,
-                                       IDHandler &&handler) {
+FMT_CONSTEXPR const Char *parse_arg_id(
+    const Char *begin, const Char *end, IDHandler &&handler) {
   assert(begin != end);
   Char c = *begin;
   if (c == '}' || c == ':')
@@ -1908,8 +1946,8 @@ struct precision_adapter {
 
 // Parses fill and alignment.
 template <typename Char, typename Handler>
-FMT_CONSTEXPR const Char *parse_align(const Char *begin, const Char *end,
-                                      Handler &&handler) {
+FMT_CONSTEXPR const Char *parse_align(
+    const Char *begin, const Char *end, Handler &&handler) {
   FMT_ASSERT(begin != end, "");
   alignment align = ALIGN_DEFAULT;
   int i = 0;
@@ -1947,8 +1985,8 @@ FMT_CONSTEXPR const Char *parse_align(const Char *begin, const Char *end,
 }
 
 template <typename Char, typename Handler>
-FMT_CONSTEXPR const Char *parse_width(const Char *begin, const Char *end,
-                                      Handler &&handler) {
+FMT_CONSTEXPR const Char *parse_width(
+    const Char *begin, const Char *end, Handler &&handler) {
   FMT_ASSERT(begin != end, "");
   if ('0' <= *begin && *begin <= '9') {
     handler.on_width(parse_nonnegative_int(begin, end, handler));
@@ -1966,8 +2004,8 @@ FMT_CONSTEXPR const Char *parse_width(const Char *begin, const Char *end,
 // Parses standard format specifiers and sends notifications about parsed
 // components to handler.
 template <typename Char, typename SpecHandler>
-FMT_CONSTEXPR const Char *parse_format_specs(const Char *begin, const Char *end,
-                                             SpecHandler &&handler) {
+FMT_CONSTEXPR const Char *parse_format_specs(
+    const Char *begin, const Char *end, SpecHandler &&handler) {
   if (begin == end || *begin == '}')
     return begin;
 
@@ -2019,8 +2057,8 @@ FMT_CONSTEXPR const Char *parse_format_specs(const Char *begin, const Char *end,
     } else if (c == '{') {
       ++begin;
       if (begin != end) {
-        begin = parse_arg_id(begin, end,
-                             precision_adapter<SpecHandler, Char>(handler));
+        begin = parse_arg_id(
+            begin, end, precision_adapter<SpecHandler, Char>(handler));
       }
       if (begin == end || *begin++ != '}')
         return handler.on_error("invalid format string"), begin;
@@ -2047,8 +2085,8 @@ FMT_CONSTEXPR bool find(Ptr first, Ptr last, T value, Ptr &out) {
 }
 
 template <>
-inline bool find<false, char>(const char *first, const char *last, char value,
-                              const char *&out) {
+inline bool find<false, char>(
+    const char *first, const char *last, char value, const char *&out) {
   out = static_cast<const char *>(std::memchr(first, value, last - first));
   return out != FMT_NULL;
 }
@@ -2067,8 +2105,8 @@ struct id_adapter {
 };
 
 template <bool IS_CONSTEXPR, typename Char, typename Handler>
-FMT_CONSTEXPR void parse_format_string(basic_string_view<Char> format_str,
-                                       Handler &&handler) {
+FMT_CONSTEXPR void parse_format_string(
+    basic_string_view<Char> format_str, Handler &&handler) {
   struct writer {
     FMT_CONSTEXPR void operator()(const Char *begin, const Char *end) {
       if (begin == end)
@@ -2180,8 +2218,8 @@ class format_string_checker {
 };
 
 template <typename Char, typename ErrorHandler, typename... Args>
-FMT_CONSTEXPR bool do_check_format_string(basic_string_view<Char> s,
-                                          ErrorHandler eh = ErrorHandler()) {
+FMT_CONSTEXPR bool do_check_format_string(
+    basic_string_view<Char> s, ErrorHandler eh = ErrorHandler()) {
   format_string_checker<Char, ErrorHandler, Args...> checker(s, eh);
   parse_format_string<true>(s, checker);
   return true;
@@ -2191,9 +2229,9 @@ template <typename... Args, typename S>
 typename std::enable_if<is_compile_string<S>::value>::type check_format_string(
     S format_str) {
   typedef typename S::char_type char_t;
-  FMT_CONSTEXPR_DECL bool invalid_format =
-      internal::do_check_format_string<char_t, internal::error_handler,
-                                       Args...>(to_string_view(format_str));
+  FMT_CONSTEXPR_DECL bool invalid_format = internal::
+      do_check_format_string<char_t, internal::error_handler, Args...>(
+          to_string_view(format_str));
   (void)invalid_format;
 }
 
@@ -2206,19 +2244,20 @@ struct format_type
 };
 
 template <template <typename> class Handler, typename Spec, typename Context>
-void handle_dynamic_spec(Spec &value, arg_ref<typename Context::char_type> ref,
-                         Context &ctx) {
+void handle_dynamic_spec(
+    Spec &value, arg_ref<typename Context::char_type> ref, Context &ctx) {
   typedef typename Context::char_type char_type;
   switch (ref.kind) {
     case arg_ref<char_type>::NONE:
       break;
     case arg_ref<char_type>::INDEX:
-      internal::set_dynamic_spec<Handler>(value, ctx.get_arg(ref.index),
-                                          ctx.error_handler());
+      internal::set_dynamic_spec<Handler>(
+          value, ctx.get_arg(ref.index), ctx.error_handler());
       break;
     case arg_ref<char_type>::NAME:
       internal::set_dynamic_spec<Handler>(
-          value, ctx.get_arg({ref.name.value, ref.name.size}),
+          value,
+          ctx.get_arg({ref.name.value, ref.name.size}),
           ctx.error_handler());
       break;
   }
@@ -2323,8 +2362,10 @@ class system_error : public std::runtime_error {
   may look like "Unknown error -1" and is platform-dependent.
   \endrst
  */
-FMT_API void format_system_error(internal::buffer &out, int error_code,
-                                 fmt::string_view message) FMT_NOEXCEPT;
+FMT_API void format_system_error(
+    internal::buffer &out,
+    int error_code,
+    fmt::string_view message) FMT_NOEXCEPT;
 
 /**
   This template provides operations for formatting and writing data into a
@@ -2398,8 +2439,8 @@ class basic_writer {
   //   <left-padding><prefix><numeric-padding><digits><right-padding>
   // where <digits> are written by f(it).
   template <typename Spec, typename F>
-  void write_int(unsigned num_digits, string_view prefix, const Spec &spec,
-                 F f) {
+  void write_int(
+      unsigned num_digits, string_view prefix, const Spec &spec, F f) {
     std::size_t size = prefix.size() + num_digits;
     char_type fill = static_cast<char_type>(spec.fill());
     std::size_t padding = 0;
@@ -2485,8 +2526,8 @@ class basic_writer {
 
     void on_dec() {
       unsigned num_digits = internal::count_digits(abs_value);
-      writer.write_int(num_digits, get_prefix(), spec,
-                       dec_writer{abs_value, num_digits});
+      writer.write_int(
+          num_digits, get_prefix(), spec, dec_writer{abs_value, num_digits});
     }
 
     struct hex_writer {
@@ -2495,8 +2536,8 @@ class basic_writer {
 
       template <typename It>
       void operator()(It &&it) const {
-        it = internal::format_uint<4, char_type>(it, self.abs_value, num_digits,
-                                                 self.spec.type != 'x');
+        it = internal::format_uint<4, char_type>(
+            it, self.abs_value, num_digits, self.spec.type != 'x');
       }
     };
 
@@ -2506,8 +2547,8 @@ class basic_writer {
         prefix[prefix_size++] = static_cast<char>(spec.type);
       }
       unsigned num_digits = count_digits<4>();
-      writer.write_int(num_digits, get_prefix(), spec,
-                       hex_writer{*this, num_digits});
+      writer.write_int(
+          num_digits, get_prefix(), spec, hex_writer{*this, num_digits});
     }
 
     template <int BITS>
@@ -2527,8 +2568,8 @@ class basic_writer {
         prefix[prefix_size++] = static_cast<char>(spec.type);
       }
       unsigned num_digits = count_digits<1>();
-      writer.write_int(num_digits, get_prefix(), spec,
-                       bin_writer<1>{abs_value, num_digits});
+      writer.write_int(
+          num_digits, get_prefix(), spec, bin_writer<1>{abs_value, num_digits});
     }
 
     void on_oct() {
@@ -2539,8 +2580,8 @@ class basic_writer {
         // is not greater than the number of digits.
         prefix[prefix_size++] = '0';
       }
-      writer.write_int(num_digits, get_prefix(), spec,
-                       bin_writer<3>{abs_value, num_digits});
+      writer.write_int(
+          num_digits, get_prefix(), spec, bin_writer<3>{abs_value, num_digits});
     }
 
     enum { SEP_SIZE = 1 };
@@ -2562,8 +2603,8 @@ class basic_writer {
       unsigned num_digits = internal::count_digits(abs_value);
       char_type sep = internal::thousands_sep<char_type>(writer.locale_);
       unsigned size = num_digits + SEP_SIZE * ((num_digits - 1) / 3);
-      writer.write_int(size, get_prefix(), spec,
-                       num_writer{abs_value, size, sep});
+      writer.write_int(
+          size, get_prefix(), spec, num_writer{abs_value, size, sep});
     }
 
     void on_error() { FMT_THROW(format_error("invalid type specifier")); }
@@ -2572,8 +2613,8 @@ class basic_writer {
   // Writes a formatted integer.
   template <typename T, typename Spec>
   void write_int(T value, const Spec &spec) {
-    internal::handle_int_type_spec(spec.type,
-                                   int_writer<T, Spec>(*this, value, spec));
+    internal::handle_int_type_spec(
+        spec.type, int_writer<T, Spec>(*this, value, spec));
   }
 
   enum { INF_SIZE = 3 };  // This is an enum to workaround a bug in MSVC.
@@ -2639,8 +2680,8 @@ class basic_writer {
 
  public:
   /** Constructs a ``basic_writer`` object. */
-  explicit basic_writer(Range out,
-                        internal::locale_ref loc = internal::locale_ref())
+  explicit basic_writer(
+      Range out, internal::locale_ref loc = internal::locale_ref())
       : out_(out.begin()), locale_(loc) {}
 
   iterator out() const { return out_; }
@@ -2705,8 +2746,8 @@ class basic_writer {
   }
 
   template <typename Char>
-  void write(basic_string_view<Char> s,
-             const format_specs &spec = format_specs()) {
+  void write(
+      basic_string_view<Char> s, const format_specs &spec = format_specs()) {
     const Char *data = s.data();
     std::size_t size = s.size();
     if (spec.precision >= 0 && internal::to_unsigned(spec.precision) < size)
@@ -2825,8 +2866,8 @@ void basic_writer<Range>::write_double(T value, const format_specs &spec) {
 
 // Reports a system error without throwing an exception.
 // Can be used to report errors from destructors.
-FMT_API void report_system_error(int error_code,
-                                 string_view message) FMT_NOEXCEPT;
+FMT_API void report_system_error(int error_code, string_view message)
+    FMT_NOEXCEPT;
 
 #if FMT_USE_WINDOWS_H
 
@@ -2872,8 +2913,8 @@ class windows_error : public system_error {
 
 // Reports a Windows error without throwing an exception.
 // Can be used to report errors from destructors.
-FMT_API void report_windows_error(int error_code,
-                                  string_view message) FMT_NOEXCEPT;
+FMT_API void report_windows_error(int error_code, string_view message)
+    FMT_NOEXCEPT;
 
 #endif
 
@@ -2977,16 +3018,19 @@ inline void format_decimal(char *&buffer, T value) {
     return;
   }
   unsigned num_digits = internal::count_digits(abs_value);
-  internal::format_decimal<char>(internal::make_checked(buffer, num_digits),
-                                 abs_value, num_digits);
+  internal::format_decimal<char>(
+      internal::make_checked(buffer, num_digits), abs_value, num_digits);
   buffer += num_digits;
 }
 
 // Formatter of objects of type T.
 template <typename T, typename Char>
-struct formatter<T, Char,
-                 typename std::enable_if<internal::format_type<
-                     typename buffer_context<Char>::type, T>::value>::type> {
+struct formatter<
+    T,
+    Char,
+    typename std::enable_if<
+        internal::format_type<typename buffer_context<Char>::type, T>::value>::
+        type> {
   // Parses format specifiers stopping either at the end of the range or at the
   // terminating '}'.
   template <typename ParseContext>
@@ -2994,8 +3038,8 @@ struct formatter<T, Char,
     typedef internal::dynamic_specs_handler<ParseContext> handler_type;
     auto type =
         internal::get_type<typename buffer_context<Char>::type, T>::value;
-    internal::specs_checker<handler_type> handler(handler_type(specs_, ctx),
-                                                  type);
+    internal::specs_checker<handler_type> handler(
+        handler_type(specs_, ctx), type);
     auto it = parse_format_specs(ctx.begin(), ctx.end(), handler);
     auto type_spec = specs_.type;
     auto eh = ctx.error_handler();
@@ -3009,8 +3053,8 @@ struct formatter<T, Char,
       case internal::long_long_type:
       case internal::ulong_long_type:
       case internal::bool_type:
-        handle_int_type_spec(type_spec,
-                             internal::int_type_checker<decltype(eh)>(eh));
+        handle_int_type_spec(
+            type_spec, internal::int_type_checker<decltype(eh)>(eh));
         break;
       case internal::char_type:
         handle_char_specs(
@@ -3018,8 +3062,8 @@ struct formatter<T, Char,
         break;
       case internal::double_type:
       case internal::long_double_type:
-        handle_float_type_spec(type_spec,
-                               internal::float_type_checker<decltype(eh)>(eh));
+        handle_float_type_spec(
+            type_spec, internal::float_type_checker<decltype(eh)>(eh));
         break;
       case internal::cstring_type:
         internal::handle_cstring_type_spec(
@@ -3045,11 +3089,13 @@ struct formatter<T, Char,
         specs_.width_, specs_.width_ref, ctx);
     internal::handle_dynamic_spec<internal::precision_checker>(
         specs_.precision, specs_.precision_ref, ctx);
-    typedef output_range<typename FormatContext::iterator,
-                         typename FormatContext::char_type>
+    typedef output_range<
+        typename FormatContext::iterator,
+        typename FormatContext::char_type>
         range_type;
-    return visit_format_arg(arg_formatter<range_type>(ctx, &specs_),
-                            internal::make_arg<FormatContext>(val));
+    return visit_format_arg(
+        arg_formatter<range_type>(ctx, &specs_),
+        internal::make_arg<FormatContext>(val));
   }
 
  private:
@@ -3101,11 +3147,13 @@ class dynamic_formatter {
       checker.on_hash();
     if (specs_.precision != -1)
       checker.end_precision();
-    typedef output_range<typename FormatContext::iterator,
-                         typename FormatContext::char_type>
+    typedef output_range<
+        typename FormatContext::iterator,
+        typename FormatContext::char_type>
         range;
-    visit_format_arg(arg_formatter<range>(ctx, &specs_),
-                     internal::make_arg<FormatContext>(val));
+    visit_format_arg(
+        arg_formatter<range>(ctx, &specs_),
+        internal::make_arg<FormatContext>(val));
     return ctx.out();
   }
 
@@ -3135,9 +3183,11 @@ template <typename ArgFormatter, typename Char, typename Context>
 struct format_handler : internal::error_handler {
   typedef typename ArgFormatter::range range;
 
-  format_handler(range r, basic_string_view<Char> str,
-                 basic_format_args<Context> format_args,
-                 internal::locale_ref loc)
+  format_handler(
+      range r,
+      basic_string_view<Char> str,
+      basic_format_args<Context> format_args,
+      internal::locale_ref loc)
       : context(r.begin(), str, format_args, loc) {}
 
   void on_text(const Char *begin, const Char *end) {
@@ -3187,7 +3237,8 @@ struct format_handler : internal::error_handler {
 /** Formats arguments and writes the output to the range. */
 template <typename ArgFormatter, typename Char, typename Context>
 typename Context::iterator vformat_to(
-    typename ArgFormatter::range out, basic_string_view<Char> format_str,
+    typename ArgFormatter::range out,
+    basic_string_view<Char> format_str,
     basic_format_args<Context> args,
     internal::locale_ref loc = internal::locale_ref()) {
   format_handler<ArgFormatter, Char, Context> h(out, format_str, args, loc);
@@ -3297,30 +3348,36 @@ std::basic_string<Char> to_string(const basic_memory_buffer<Char, SIZE> &buf) {
 
 template <typename Char>
 typename buffer_context<Char>::type::iterator internal::vformat_to(
-    internal::basic_buffer<Char> &buf, basic_string_view<Char> format_str,
+    internal::basic_buffer<Char> &buf,
+    basic_string_view<Char> format_str,
     basic_format_args<typename buffer_context<Char>::type> args) {
   typedef back_insert_range<internal::basic_buffer<Char>> range;
-  return vformat_to<arg_formatter<range>>(buf, to_string_view(format_str),
-                                          args);
+  return vformat_to<arg_formatter<range>>(
+      buf, to_string_view(format_str), args);
 }
 
 template <typename S, typename Char = FMT_CHAR(S)>
 inline typename buffer_context<Char>::type::iterator vformat_to(
-    internal::basic_buffer<Char> &buf, const S &format_str,
+    internal::basic_buffer<Char> &buf,
+    const S &format_str,
     basic_format_args<typename buffer_context<Char>::type> args) {
   return internal::vformat_to(buf, to_string_view(format_str), args);
 }
 
-template <typename S, typename... Args, std::size_t SIZE = inline_buffer_size,
-          typename Char = typename internal::char_t<S>::type>
+template <
+    typename S,
+    typename... Args,
+    std::size_t SIZE = inline_buffer_size,
+    typename Char = typename internal::char_t<S>::type>
 inline typename buffer_context<Char>::type::iterator format_to(
-    basic_memory_buffer<Char, SIZE> &buf, const S &format_str,
+    basic_memory_buffer<Char, SIZE> &buf,
+    const S &format_str,
     const Args &... args) {
   internal::check_format_string<Args...>(format_str);
   typedef typename buffer_context<Char>::type context;
   format_arg_store<context, Args...> as{args...};
-  return internal::vformat_to(buf, to_string_view(format_str),
-                              basic_format_args<context>(as));
+  return internal::vformat_to(
+      buf, to_string_view(format_str), basic_format_args<context>(as));
 }
 
 namespace internal {
@@ -3386,13 +3443,15 @@ struct format_args_t {
 };
 
 template <typename String, typename OutputIt, typename... Args>
-inline typename std::enable_if<internal::is_output_iterator<OutputIt>::value,
-                               OutputIt>::type
-vformat_to(OutputIt out, const String &format_str,
-           typename format_args_t<OutputIt, FMT_CHAR(String)>::type args) {
+inline typename std::
+    enable_if<internal::is_output_iterator<OutputIt>::value, OutputIt>::type
+    vformat_to(
+        OutputIt out,
+        const String &format_str,
+        typename format_args_t<OutputIt, FMT_CHAR(String)>::type args) {
   typedef output_range<OutputIt, FMT_CHAR(String)> range;
-  return vformat_to<arg_formatter<range>>(range(out),
-                                          to_string_view(format_str), args);
+  return vformat_to<arg_formatter<range>>(
+      range(out), to_string_view(format_str), args);
 }
 
 /**
@@ -3407,15 +3466,16 @@ vformat_to(OutputIt out, const String &format_str,
  \endrst
  */
 template <typename OutputIt, typename S, typename... Args>
-inline FMT_ENABLE_IF_T(internal::is_string<S>::value
-                           &&internal::is_output_iterator<OutputIt>::value,
-                       OutputIt)
+inline FMT_ENABLE_IF_T(
+    internal::is_string<S>::value
+        &&internal::is_output_iterator<OutputIt>::value,
+    OutputIt)
     format_to(OutputIt out, const S &format_str, const Args &... args) {
   internal::check_format_string<Args...>(format_str);
   typedef typename format_context_t<OutputIt, FMT_CHAR(S)>::type context;
   format_arg_store<context, Args...> as{args...};
-  return vformat_to(out, to_string_view(format_str),
-                    basic_format_args<context>(as));
+  return vformat_to(
+      out, to_string_view(format_str), basic_format_args<context>(as));
 }
 
 template <typename OutputIt>
@@ -3437,18 +3497,24 @@ struct format_to_n_args {
 };
 
 template <typename OutputIt, typename Char, typename... Args>
-inline format_arg_store<typename format_to_n_context<OutputIt, Char>::type,
-                        Args...>
+inline format_arg_store<
+    typename format_to_n_context<OutputIt, Char>::type,
+    Args...>
 make_format_to_n_args(const Args &... args) {
-  return format_arg_store<typename format_to_n_context<OutputIt, Char>::type,
-                          Args...>(args...);
+  return format_arg_store<
+      typename format_to_n_context<OutputIt, Char>::type,
+      Args...>(args...);
 }
 
 template <typename OutputIt, typename Char, typename... Args>
-inline typename std::enable_if<internal::is_output_iterator<OutputIt>::value,
-                               format_to_n_result<OutputIt>>::type
-vformat_to_n(OutputIt out, std::size_t n, basic_string_view<Char> format_str,
-             typename format_to_n_args<OutputIt, Char>::type args) {
+inline typename std::enable_if<
+    internal::is_output_iterator<OutputIt>::value,
+    format_to_n_result<OutputIt>>::type
+vformat_to_n(
+    OutputIt out,
+    std::size_t n,
+    basic_string_view<Char> format_str,
+    typename format_to_n_args<OutputIt, Char>::type args) {
   typedef internal::truncating_iterator<OutputIt> It;
   auto it = vformat_to(It(out, n), format_str, args);
   return {it.base(), it.count()};
@@ -3462,17 +3528,24 @@ vformat_to_n(OutputIt out, std::size_t n, basic_string_view<Char> format_str,
  \endrst
  */
 template <typename OutputIt, typename S, typename... Args>
-inline FMT_ENABLE_IF_T(internal::is_string<S>::value
-                           &&internal::is_output_iterator<OutputIt>::value,
-                       format_to_n_result<OutputIt>)
-    format_to_n(OutputIt out, std::size_t n, const S &format_str,
-                const Args &... args) {
+inline FMT_ENABLE_IF_T(
+    internal::is_string<S>::value
+        &&internal::is_output_iterator<OutputIt>::value,
+    format_to_n_result<OutputIt>)
+    format_to_n(
+        OutputIt out,
+        std::size_t n,
+        const S &format_str,
+        const Args &... args) {
   internal::check_format_string<Args...>(format_str);
   typedef FMT_CHAR(S) Char;
   format_arg_store<typename format_to_n_context<OutputIt, Char>::type, Args...>
   as(args...);
-  return vformat_to_n(out, n, to_string_view(format_str),
-                      typename format_to_n_args<OutputIt, Char>::type(as));
+  return vformat_to_n(
+      out,
+      n,
+      to_string_view(format_str),
+      typename format_to_n_args<OutputIt, Char>::type(as));
 }
 
 template <typename Char>
@@ -3489,8 +3562,8 @@ inline std::basic_string<Char> internal::vformat(
   ``format(format_str, args...)``.
  */
 template <typename... Args>
-inline std::size_t formatted_size(string_view format_str,
-                                  const Args &... args) {
+inline std::size_t formatted_size(
+    string_view format_str, const Args &... args) {
   auto it = format_to(internal::counting_iterator<char>(), format_str, args...);
   return it.count();
 }
@@ -3554,12 +3627,12 @@ FMT_CONSTEXPR internal::udl_formatter<Char, CHARS...> operator""_format() {
     std::string message = "The answer is {}"_format(42);
   \endrst
  */
-inline internal::udl_formatter<char> operator"" _format(const char *s,
-                                                        std::size_t) {
+inline internal::udl_formatter<char> operator"" _format(
+    const char *s, std::size_t) {
   return {s};
 }
-inline internal::udl_formatter<wchar_t> operator"" _format(const wchar_t *s,
-                                                           std::size_t) {
+inline internal::udl_formatter<wchar_t> operator"" _format(
+    const wchar_t *s, std::size_t) {
   return {s};
 }
 #endif  // FMT_UDL_TEMPLATE

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -31,77 +31,77 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <memory>
 #include <stdexcept>
-#include <stdint.h>
 
 #ifdef __clang__
-# define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
+#define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
 #else
-# define FMT_CLANG_VERSION 0
+#define FMT_CLANG_VERSION 0
 #endif
 
 #ifdef __INTEL_COMPILER
-# define FMT_ICC_VERSION __INTEL_COMPILER
+#define FMT_ICC_VERSION __INTEL_COMPILER
 #elif defined(__ICL)
-# define FMT_ICC_VERSION __ICL
+#define FMT_ICC_VERSION __ICL
 #else
-# define FMT_ICC_VERSION 0
+#define FMT_ICC_VERSION 0
 #endif
 
 #ifdef __NVCC__
-# define FMT_CUDA_VERSION (__CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__)
+#define FMT_CUDA_VERSION (__CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__)
 #else
-# define FMT_CUDA_VERSION 0
+#define FMT_CUDA_VERSION 0
 #endif
 
 #include "core.h"
 
 #if FMT_GCC_VERSION >= 406 || FMT_CLANG_VERSION
-# pragma GCC diagnostic push
+#pragma GCC diagnostic push
 
 // Disable the warning about declaration shadowing because it affects too
 // many valid cases.
-# pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wshadow"
 
 // Disable the warning about implicit conversions that may change the sign of
 // an integer; silencing it otherwise would require many explicit casts.
-# pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 
 // Disable the warning about nonliteral format strings because we construct
 // them dynamically when falling back to snprintf for FP formatting.
-# pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #endif
 
-# if FMT_CLANG_VERSION
-#  pragma GCC diagnostic ignored "-Wgnu-string-literal-operator-template"
-# endif
+#if FMT_CLANG_VERSION
+#pragma GCC diagnostic ignored "-Wgnu-string-literal-operator-template"
+#endif
 
 #ifdef _SECURE_SCL
-# define FMT_SECURE_SCL _SECURE_SCL
+#define FMT_SECURE_SCL _SECURE_SCL
 #else
-# define FMT_SECURE_SCL 0
+#define FMT_SECURE_SCL 0
 #endif
 
 #if FMT_SECURE_SCL
-# include <iterator>
+#include <iterator>
 #endif
 
 #ifdef __has_builtin
-# define FMT_HAS_BUILTIN(x) __has_builtin(x)
+#define FMT_HAS_BUILTIN(x) __has_builtin(x)
 #else
-# define FMT_HAS_BUILTIN(x) 0
+#define FMT_HAS_BUILTIN(x) 0
 #endif
 
 #ifdef __GNUC_LIBSTD__
-# define FMT_GNUC_LIBSTD_VERSION (__GNUC_LIBSTD__ * 100 + __GNUC_LIBSTD_MINOR__)
+#define FMT_GNUC_LIBSTD_VERSION (__GNUC_LIBSTD__ * 100 + __GNUC_LIBSTD_MINOR__)
 #endif
 
 #ifndef FMT_THROW
-# if FMT_EXCEPTIONS
-#  if FMT_MSC_VER
+#if FMT_EXCEPTIONS
+#if FMT_MSC_VER
 FMT_BEGIN_NAMESPACE
 namespace internal {
 template <typename Exception>
@@ -112,88 +112,91 @@ inline void do_throw(const Exception &x) {
   if (b)
     throw x;
 }
-}
+}  // namespace internal
 FMT_END_NAMESPACE
-#   define FMT_THROW(x) fmt::internal::do_throw(x)
-#  else
-#   define FMT_THROW(x) throw x
-#  endif
-# else
-#  define FMT_THROW(x) do { static_cast<void>(sizeof(x)); assert(false); } while(false);
-# endif
+#define FMT_THROW(x) fmt::internal::do_throw(x)
+#else
+#define FMT_THROW(x) throw x
+#endif
+#else
+#define FMT_THROW(x)              \
+  do {                            \
+    static_cast<void>(sizeof(x)); \
+    assert(false);                \
+  } while (false);
+#endif
 #endif
 
 #ifndef FMT_USE_USER_DEFINED_LITERALS
 // For Intel's compiler and NVIDIA's compiler both it and the system gcc/msc
 // must support UDLs.
-# if (FMT_HAS_FEATURE(cxx_user_literals) || \
-      FMT_GCC_VERSION >= 407 || FMT_MSC_VER >= 1900) && \
-      (!(FMT_ICC_VERSION || FMT_CUDA_VERSION) || \
-       FMT_ICC_VERSION >= 1500 || FMT_CUDA_VERSION >= 700)
-#  define FMT_USE_USER_DEFINED_LITERALS 1
-# else
-#  define FMT_USE_USER_DEFINED_LITERALS 0
-# endif
+#if (FMT_HAS_FEATURE(cxx_user_literals) || FMT_GCC_VERSION >= 407 ||      \
+     FMT_MSC_VER >= 1900) &&                                              \
+    (!(FMT_ICC_VERSION || FMT_CUDA_VERSION) || FMT_ICC_VERSION >= 1500 || \
+     FMT_CUDA_VERSION >= 700)
+#define FMT_USE_USER_DEFINED_LITERALS 1
+#else
+#define FMT_USE_USER_DEFINED_LITERALS 0
+#endif
 #endif
 
 // EDG C++ Front End based compilers (icc, nvcc) do not currently support UDL
 // templates.
-#if FMT_USE_USER_DEFINED_LITERALS && \
-    FMT_ICC_VERSION == 0 && \
-    FMT_CUDA_VERSION == 0 && \
-    ((FMT_GCC_VERSION >= 600 && __cplusplus >= 201402L) || \
-    (defined(FMT_CLANG_VERSION) && FMT_CLANG_VERSION >= 304))
-# define FMT_UDL_TEMPLATE 1
+#if FMT_USE_USER_DEFINED_LITERALS && FMT_ICC_VERSION == 0 && \
+    FMT_CUDA_VERSION == 0 &&                                 \
+    ((FMT_GCC_VERSION >= 600 && __cplusplus >= 201402L) ||   \
+     (defined(FMT_CLANG_VERSION) && FMT_CLANG_VERSION >= 304))
+#define FMT_UDL_TEMPLATE 1
 #else
-# define FMT_UDL_TEMPLATE 0
+#define FMT_UDL_TEMPLATE 0
 #endif
 
 #ifndef FMT_USE_EXTERN_TEMPLATES
-# ifndef FMT_HEADER_ONLY
-#  define FMT_USE_EXTERN_TEMPLATES \
-     ((FMT_CLANG_VERSION >= 209 && __cplusplus >= 201103L) || \
-      (FMT_GCC_VERSION >= 303 && FMT_HAS_GXX_CXX11))
-# else
-#  define FMT_USE_EXTERN_TEMPLATES 0
-# endif
+#ifndef FMT_HEADER_ONLY
+#define FMT_USE_EXTERN_TEMPLATES                           \
+  ((FMT_CLANG_VERSION >= 209 && __cplusplus >= 201103L) || \
+   (FMT_GCC_VERSION >= 303 && FMT_HAS_GXX_CXX11))
+#else
+#define FMT_USE_EXTERN_TEMPLATES 0
+#endif
 #endif
 
 #if FMT_HAS_GXX_CXX11 || FMT_HAS_FEATURE(cxx_trailing_return) || \
     FMT_MSC_VER >= 1600
-# define FMT_USE_TRAILING_RETURN 1
+#define FMT_USE_TRAILING_RETURN 1
 #else
-# define FMT_USE_TRAILING_RETURN 0
+#define FMT_USE_TRAILING_RETURN 0
 #endif
 
 #ifndef FMT_USE_GRISU
-# define FMT_USE_GRISU 0
+#define FMT_USE_GRISU 0
 //# define FMT_USE_GRISU std::numeric_limits<double>::is_iec559
 #endif
 
 // __builtin_clz is broken in clang with Microsoft CodeGen:
 // https://github.com/fmtlib/fmt/issues/519
 #ifndef _MSC_VER
-# if FMT_GCC_VERSION >= 400 || FMT_HAS_BUILTIN(__builtin_clz)
-#  define FMT_BUILTIN_CLZ(n) __builtin_clz(n)
-# endif
+#if FMT_GCC_VERSION >= 400 || FMT_HAS_BUILTIN(__builtin_clz)
+#define FMT_BUILTIN_CLZ(n) __builtin_clz(n)
+#endif
 
-# if FMT_GCC_VERSION >= 400 || FMT_HAS_BUILTIN(__builtin_clzll)
-#  define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
-# endif
+#if FMT_GCC_VERSION >= 400 || FMT_HAS_BUILTIN(__builtin_clzll)
+#define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
+#endif
 #endif
 
 // Some compilers masquerade as both MSVC and GCC-likes or otherwise support
 // __builtin_clz and __builtin_clzll, so only define FMT_BUILTIN_CLZ using the
 // MSVC intrinsics if the clz and clzll builtins are not available.
 #if FMT_MSC_VER && !defined(FMT_BUILTIN_CLZLL) && !defined(_MANAGED)
-# include <intrin.h>  // _BitScanReverse, _BitScanReverse64
+#include <intrin.h>  // _BitScanReverse, _BitScanReverse64
 
 FMT_BEGIN_NAMESPACE
 namespace internal {
 // Avoid Clang with Microsoft CodeGen's -Wunknown-pragmas warning.
-# ifndef __clang__
-#  pragma intrinsic(_BitScanReverse)
-# endif
+#ifndef __clang__
+#pragma intrinsic(_BitScanReverse)
+#endif
 inline uint32_t clz(uint32_t x) {
   unsigned long r = 0;
   _BitScanReverse(&r, x);
@@ -202,37 +205,37 @@ inline uint32_t clz(uint32_t x) {
   // Static analysis complains about using uninitialized data
   // "r", but the only way that can happen is if "x" is 0,
   // which the callers guarantee to not happen.
-# pragma warning(suppress: 6102)
+#pragma warning(suppress : 6102)
   return 31 - r;
 }
-# define FMT_BUILTIN_CLZ(n) fmt::internal::clz(n)
+#define FMT_BUILTIN_CLZ(n) fmt::internal::clz(n)
 
-# if defined(_WIN64) && !defined(__clang__)
-#  pragma intrinsic(_BitScanReverse64)
-# endif
+#if defined(_WIN64) && !defined(__clang__)
+#pragma intrinsic(_BitScanReverse64)
+#endif
 
 inline uint32_t clzll(uint64_t x) {
   unsigned long r = 0;
-# ifdef _WIN64
+#ifdef _WIN64
   _BitScanReverse64(&r, x);
-# else
+#else
   // Scan the high 32 bits.
   if (_BitScanReverse(&r, static_cast<uint32_t>(x >> 32)))
     return 63 - (r + 32);
 
   // Scan the low 32 bits.
   _BitScanReverse(&r, static_cast<uint32_t>(x));
-# endif
+#endif
 
   assert(x != 0);
   // Static analysis complains about using uninitialized data
   // "r", but the only way that can happen is if "x" is 0,
   // which the callers guarantee to not happen.
-# pragma warning(suppress: 6102)
+#pragma warning(suppress : 6102)
   return 63 - r;
 }
-# define FMT_BUILTIN_CLZLL(n) fmt::internal::clzll(n)
-}
+#define FMT_BUILTIN_CLZLL(n) fmt::internal::clzll(n)
+}  // namespace internal
 FMT_END_NAMESPACE
 #endif
 
@@ -243,7 +246,7 @@ namespace internal {
 // undefined behavior (e.g. due to type aliasing).
 // Example: uint64_t d = bit_cast<uint64_t>(2.718);
 template <typename Dest, typename Source>
-inline Dest bit_cast(const Source& source) {
+inline Dest bit_cast(const Source &source) {
   static_assert(sizeof(Dest) == sizeof(Source), "size mismatch");
   Dest dest;
   std::memcpy(&dest, &source, sizeof(dest));
@@ -256,17 +259,25 @@ FMT_CONSTEXPR auto begin(const C &c) -> decltype(c.begin()) {
   return c.begin();
 }
 template <typename T, std::size_t N>
-FMT_CONSTEXPR T *begin(T (&array)[N]) FMT_NOEXCEPT { return array; }
+FMT_CONSTEXPR T *begin(T (&array)[N]) FMT_NOEXCEPT {
+  return array;
+}
 template <typename C>
-FMT_CONSTEXPR auto end(const C &c) -> decltype(c.end()) { return c.end(); }
+FMT_CONSTEXPR auto end(const C &c) -> decltype(c.end()) {
+  return c.end();
+}
 template <typename T, std::size_t N>
-FMT_CONSTEXPR T *end(T (&array)[N]) FMT_NOEXCEPT { return array + N; }
+FMT_CONSTEXPR T *end(T (&array)[N]) FMT_NOEXCEPT {
+  return array + N;
+}
 
 // For std::result_of in gcc 4.4.
 template <typename Result>
 struct function {
   template <typename T>
-  struct result { typedef Result type; };
+  struct result {
+    typedef Result type;
+  };
 };
 
 struct dummy_int {
@@ -283,7 +294,7 @@ inline dummy_int isnan(...) { return dummy_int(); }
 inline dummy_int _isnan(...) { return dummy_int(); }
 
 template <typename Allocator>
-typename Allocator::value_type *allocate(Allocator& alloc, std::size_t n) {
+typename Allocator::value_type *allocate(Allocator &alloc, std::size_t n) {
 #if __cplusplus >= 201103L || FMT_MSC_VER >= 1700
   return std::allocator_traits<Allocator>::allocate(alloc, n);
 #else
@@ -294,7 +305,9 @@ typename Allocator::value_type *allocate(Allocator& alloc, std::size_t n) {
 // A helper function to suppress bogus "conditional expression is constant"
 // warnings.
 template <typename T>
-inline T const_check(T value) { return value; }
+inline T const_check(T value) {
+  return value;
+}
 }  // namespace internal
 FMT_END_NAMESPACE
 
@@ -304,8 +317,8 @@ namespace std {
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48891
 // and the same for isnan.
 template <>
-class numeric_limits<fmt::internal::dummy_int> :
-    public std::numeric_limits<int> {
+class numeric_limits<fmt::internal::dummy_int>
+    : public std::numeric_limits<int> {
  public:
   // Portable version of isinf.
   template <typename T>
@@ -346,20 +359,21 @@ class output_range {
   typedef OutputIt iterator;
   typedef T value_type;
 
-  explicit output_range(OutputIt it): it_(it) {}
+  explicit output_range(OutputIt it) : it_(it) {}
   OutputIt begin() const { return it_; }
 };
 
 // A range where begin() returns back_insert_iterator.
 template <typename Container>
-class back_insert_range:
-    public output_range<std::back_insert_iterator<Container>> {
+class back_insert_range
+    : public output_range<std::back_insert_iterator<Container>> {
   typedef output_range<std::back_insert_iterator<Container>> base;
+
  public:
   typedef typename Container::value_type value_type;
 
-  back_insert_range(Container &c): base(std::back_inserter(c)) {}
-  back_insert_range(typename base::iterator it): base(it) {}
+  back_insert_range(Container &c) : base(std::back_inserter(c)) {}
+  back_insert_range(typename base::iterator it) : base(it) {}
 };
 
 typedef basic_writer<back_insert_range<internal::buffer>> writer;
@@ -368,29 +382,35 @@ typedef basic_writer<back_insert_range<internal::wbuffer>> wwriter;
 /** A formatting error such as invalid format string. */
 class format_error : public std::runtime_error {
  public:
-  explicit format_error(const char *message)
-  : std::runtime_error(message) {}
+  explicit format_error(const char *message) : std::runtime_error(message) {}
 
   explicit format_error(const std::string &message)
-  : std::runtime_error(message) {}
+      : std::runtime_error(message) {}
 };
 
 namespace internal {
 
 #if FMT_SECURE_SCL
 template <typename T>
-struct checked { typedef stdext::checked_array_iterator<T*> type; };
+struct checked {
+  typedef stdext::checked_array_iterator<T *> type;
+};
 
 // Make a checked iterator to avoid warnings on MSVC.
 template <typename T>
-inline stdext::checked_array_iterator<T*> make_checked(T *p, std::size_t size) {
+inline stdext::checked_array_iterator<T *> make_checked(T *p,
+                                                        std::size_t size) {
   return {p, size};
 }
 #else
 template <typename T>
-struct checked { typedef T *type; };
+struct checked {
+  typedef T *type;
+};
 template <typename T>
-inline T *make_checked(T *p, std::size_t) { return p; }
+inline T *make_checked(T *p, std::size_t) {
+  return p;
+}
 #endif
 
 template <typename T>
@@ -408,7 +428,7 @@ void basic_buffer<T>::append(const U *begin, const U *end) {
 // type in this mode. If this is the case __cpp_char8_t will be defined.
 #if !defined(__cpp_char8_t)
 // A UTF-8 code unit type.
-enum char8_t: unsigned char {};
+enum char8_t : unsigned char {};
 #endif
 
 // A UTF-8 string view.
@@ -416,10 +436,11 @@ class u8string_view : public basic_string_view<char8_t> {
  public:
   typedef char8_t char_type;
 
-  u8string_view(const char *s):
-    basic_string_view<char8_t>(reinterpret_cast<const char8_t*>(s)) {}
-  u8string_view(const char *s, size_t count) FMT_NOEXCEPT:
-    basic_string_view<char8_t>(reinterpret_cast<const char8_t*>(s), count) {}
+  u8string_view(const char *s)
+      : basic_string_view<char8_t>(reinterpret_cast<const char8_t *>(s)) {}
+  u8string_view(const char *s, size_t count) FMT_NOEXCEPT
+      : basic_string_view<char8_t>(reinterpret_cast<const char8_t *>(s),
+                                   count) {}
 };
 
 #if FMT_USE_USER_DEFINED_LITERALS
@@ -427,7 +448,7 @@ inline namespace literals {
 inline u8string_view operator"" _u(const char *s, std::size_t n) {
   return {s, n};
 }
-}
+}  // namespace literals
 #endif
 
 // The number of characters to store in the basic_memory_buffer object itself
@@ -464,15 +485,17 @@ enum { inline_buffer_size = 500 };
   \endrst
  */
 template <typename T, std::size_t SIZE = inline_buffer_size,
-          typename Allocator = std::allocator<T> >
-class basic_memory_buffer: private Allocator, public internal::basic_buffer<T> {
+          typename Allocator = std::allocator<T>>
+class basic_memory_buffer : private Allocator,
+                            public internal::basic_buffer<T> {
  private:
   T store_[SIZE];
 
   // Deallocate memory allocated by the buffer.
   void deallocate() {
-    T* data = this->data();
-    if (data != store_) Allocator::deallocate(data, this->capacity());
+    T *data = this->data();
+    if (data != store_)
+      Allocator::deallocate(data, this->capacity());
   }
 
  protected:
@@ -490,7 +513,7 @@ class basic_memory_buffer: private Allocator, public internal::basic_buffer<T> {
   void move(basic_memory_buffer &other) {
     Allocator &this_alloc = *this, &other_alloc = other;
     this_alloc = std::move(other_alloc);
-    T* data = other.data();
+    T *data = other.data();
     std::size_t size = other.size(), capacity = other.capacity();
     if (data == other.store_) {
       this->set(store_, capacity);
@@ -512,9 +535,7 @@ class basic_memory_buffer: private Allocator, public internal::basic_buffer<T> {
     of the other object to it.
     \endrst
    */
-  basic_memory_buffer(basic_memory_buffer &&other) {
-    move(other);
-  }
+  basic_memory_buffer(basic_memory_buffer &&other) { move(other); }
 
   /**
     \rst
@@ -537,7 +558,7 @@ void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
   std::size_t old_capacity = this->capacity();
   std::size_t new_capacity = old_capacity + old_capacity / 2;
   if (size > new_capacity)
-      new_capacity = size;
+    new_capacity = size;
   T *old_data = this->data();
   T *new_data = internal::allocate<Allocator>(*this, new_capacity);
   // The following code doesn't throw, so the raw pointer above doesn't leak.
@@ -564,37 +585,40 @@ struct char_traits<char> {
   // Formats a floating-point number.
   template <typename T>
   FMT_API static int format_float(char *buffer, std::size_t size,
-      const char *format, int precision, T value);
+                                  const char *format, int precision, T value);
 };
 
 template <>
 struct char_traits<wchar_t> {
   template <typename T>
   FMT_API static int format_float(wchar_t *buffer, std::size_t size,
-      const wchar_t *format, int precision, T value);
+                                  const wchar_t *format, int precision,
+                                  T value);
 };
 
 #if FMT_USE_EXTERN_TEMPLATES
-extern template int char_traits<char>::format_float<double>(
-    char *buffer, std::size_t size, const char* format, int precision,
-    double value);
+extern template int char_traits<char>::format_float<double>(char *buffer,
+                                                            std::size_t size,
+                                                            const char *format,
+                                                            int precision,
+                                                            double value);
 extern template int char_traits<char>::format_float<long double>(
-    char *buffer, std::size_t size, const char* format, int precision,
+    char *buffer, std::size_t size, const char *format, int precision,
     long double value);
 
 extern template int char_traits<wchar_t>::format_float<double>(
-    wchar_t *buffer, std::size_t size, const wchar_t* format, int precision,
+    wchar_t *buffer, std::size_t size, const wchar_t *format, int precision,
     double value);
 extern template int char_traits<wchar_t>::format_float<long double>(
-    wchar_t *buffer, std::size_t size, const wchar_t* format, int precision,
+    wchar_t *buffer, std::size_t size, const wchar_t *format, int precision,
     long double value);
 #endif
 
 template <typename Container>
 inline typename std::enable_if<
-  is_contiguous<Container>::value,
-  typename checked<typename Container::value_type>::type>::type
-    reserve(std::back_insert_iterator<Container> &it, std::size_t n) {
+    is_contiguous<Container>::value,
+    typename checked<typename Container::value_type>::type>::type
+reserve(std::back_insert_iterator<Container> &it, std::size_t n) {
   Container &c = internal::get_container(it);
   std::size_t size = c.size();
   c.resize(size + n);
@@ -602,7 +626,9 @@ inline typename std::enable_if<
 }
 
 template <typename Iterator>
-inline Iterator &reserve(Iterator &it, std::size_t) { return it; }
+inline Iterator &reserve(Iterator &it, std::size_t) {
+  return it;
+}
 
 template <typename Char>
 class null_terminating_iterator;
@@ -622,15 +648,15 @@ class counting_iterator {
   typedef std::output_iterator_tag iterator_category;
   typedef T value_type;
   typedef std::ptrdiff_t difference_type;
-  typedef T* pointer;
-  typedef T& reference;
+  typedef T *pointer;
+  typedef T &reference;
   typedef counting_iterator _Unchecked_type;  // Mark iterator as checked.
 
-  counting_iterator(): count_(0) {}
+  counting_iterator() : count_(0) {}
 
   std::size_t count() const { return count_; }
 
-  counting_iterator& operator++() {
+  counting_iterator &operator++() {
     ++count_;
     return *this;
   }
@@ -652,14 +678,15 @@ class truncating_iterator_base {
   std::size_t count_;
 
   truncating_iterator_base(OutputIt out, std::size_t limit)
-    : out_(out), limit_(limit), count_(0) {}
+      : out_(out), limit_(limit), count_(0) {}
 
  public:
   typedef std::output_iterator_tag iterator_category;
   typedef void difference_type;
   typedef void pointer;
   typedef void reference;
-  typedef truncating_iterator_base _Unchecked_type; // Mark iterator as checked.
+  typedef truncating_iterator_base
+      _Unchecked_type;  // Mark iterator as checked.
 
   OutputIt base() const { return out_; }
   std::size_t count() const { return count_; }
@@ -667,13 +694,14 @@ class truncating_iterator_base {
 
 // An output iterator that truncates the output and counts the number of objects
 // written to it.
-template <typename OutputIt, typename Enable = typename std::is_void<
-    typename std::iterator_traits<OutputIt>::value_type>::type>
+template <typename OutputIt,
+          typename Enable = typename std::is_void<
+              typename std::iterator_traits<OutputIt>::value_type>::type>
 class truncating_iterator;
 
 template <typename OutputIt>
-class truncating_iterator<OutputIt, std::false_type>:
-  public truncating_iterator_base<OutputIt> {
+class truncating_iterator<OutputIt, std::false_type>
+    : public truncating_iterator_base<OutputIt> {
   typedef std::iterator_traits<OutputIt> traits;
 
   mutable typename traits::value_type blackhole_;
@@ -682,9 +710,9 @@ class truncating_iterator<OutputIt, std::false_type>:
   typedef typename traits::value_type value_type;
 
   truncating_iterator(OutputIt out, std::size_t limit)
-    : truncating_iterator_base<OutputIt>(out, limit) {}
+      : truncating_iterator_base<OutputIt>(out, limit) {}
 
-  truncating_iterator& operator++() {
+  truncating_iterator &operator++() {
     if (this->count_++ < this->limit_)
       ++this->out_;
     return *this;
@@ -696,41 +724,43 @@ class truncating_iterator<OutputIt, std::false_type>:
     return it;
   }
 
-  value_type& operator*() const {
+  value_type &operator*() const {
     return this->count_ < this->limit_ ? *this->out_ : blackhole_;
   }
 };
 
 template <typename OutputIt>
-class truncating_iterator<OutputIt, std::true_type>:
-  public truncating_iterator_base<OutputIt> {
+class truncating_iterator<OutputIt, std::true_type>
+    : public truncating_iterator_base<OutputIt> {
  public:
   typedef typename OutputIt::container_type::value_type value_type;
 
   truncating_iterator(OutputIt out, std::size_t limit)
-    : truncating_iterator_base<OutputIt>(out, limit) {}
+      : truncating_iterator_base<OutputIt>(out, limit) {}
 
-  truncating_iterator& operator=(value_type val) {
+  truncating_iterator &operator=(value_type val) {
     if (this->count_++ < this->limit_)
       this->out_ = val;
     return *this;
   }
 
-  truncating_iterator& operator++() { return *this; }
-  truncating_iterator& operator++(int) { return *this; }
-  truncating_iterator& operator*() { return *this; }
+  truncating_iterator &operator++() { return *this; }
+  truncating_iterator &operator++(int) { return *this; }
+  truncating_iterator &operator*() { return *this; }
 };
 
 // Returns true if value is negative, false otherwise.
 // Same as (value < 0) but doesn't produce warnings if T is an unsigned type.
 template <typename T>
-FMT_CONSTEXPR typename std::enable_if<
-    std::numeric_limits<T>::is_signed, bool>::type is_negative(T value) {
+FMT_CONSTEXPR
+    typename std::enable_if<std::numeric_limits<T>::is_signed, bool>::type
+    is_negative(T value) {
   return value < 0;
 }
 template <typename T>
-FMT_CONSTEXPR typename std::enable_if<
-    !std::numeric_limits<T>::is_signed, bool>::type is_negative(T) {
+FMT_CONSTEXPR
+    typename std::enable_if<!std::numeric_limits<T>::is_signed, bool>::type
+    is_negative(T) {
   return false;
 }
 
@@ -738,8 +768,8 @@ template <typename T>
 struct int_traits {
   // Smallest of uint32_t and uint64_t that is large enough to represent
   // all values of T.
-  typedef typename std::conditional<
-    std::numeric_limits<T>::digits <= 32, uint32_t, uint64_t>::type main_type;
+  typedef typename std::conditional<std::numeric_limits<T>::digits <= 32,
+                                    uint32_t, uint64_t>::type main_type;
 };
 
 // Static data is placed in this class template to allow header-only
@@ -781,10 +811,14 @@ inline unsigned count_digits(uint64_t n) {
     // Integer division is slow so do it for a group of four digits instead
     // of for every digit. The idea comes from the talk by Alexandrescu
     // "Three Optimization Tips for C++". See speed-test for a comparison.
-    if (n < 10) return count;
-    if (n < 100) return count + 1;
-    if (n < 1000) return count + 2;
-    if (n < 10000) return count + 3;
+    if (n < 10)
+      return count;
+    if (n < 100)
+      return count + 1;
+    if (n < 1000)
+      return count + 2;
+    if (n < 10000)
+      return count + 3;
     n /= 10000u;
     count += 4;
   }
@@ -792,7 +826,9 @@ inline unsigned count_digits(uint64_t n) {
 #endif
 
 template <typename Char>
-inline size_t count_code_points(basic_string_view<Char> s) { return s.size(); }
+inline size_t count_code_points(basic_string_view<Char> s) {
+  return s.size();
+}
 
 // Counts the number of code points in a UTF-8 string.
 FMT_API size_t count_code_points(basic_string_view<char8_t> s);
@@ -800,29 +836,30 @@ FMT_API size_t count_code_points(basic_string_view<char8_t> s);
 inline char8_t to_char8_t(char c) { return static_cast<char8_t>(c); }
 
 template <typename InputIt, typename OutChar>
-struct needs_conversion: std::integral_constant<bool,
-  std::is_same<
-    typename std::iterator_traits<InputIt>::value_type, char>::value &&
-  std::is_same<OutChar, char8_t>::value> {};
+struct needs_conversion
+    : std::integral_constant<
+          bool, std::is_same<typename std::iterator_traits<InputIt>::value_type,
+                             char>::value &&
+                    std::is_same<OutChar, char8_t>::value> {};
 
 template <typename OutChar, typename InputIt, typename OutputIt>
-typename std::enable_if<
-  !needs_conversion<InputIt, OutChar>::value, OutputIt>::type
-    copy_str(InputIt begin, InputIt end, OutputIt it) {
+typename std::enable_if<!needs_conversion<InputIt, OutChar>::value,
+                        OutputIt>::type
+copy_str(InputIt begin, InputIt end, OutputIt it) {
   return std::copy(begin, end, it);
 }
 
 template <typename OutChar, typename InputIt, typename OutputIt>
-typename std::enable_if<
-  needs_conversion<InputIt, OutChar>::value, OutputIt>::type
-    copy_str(InputIt begin, InputIt end, OutputIt it) {
+typename std::enable_if<needs_conversion<InputIt, OutChar>::value,
+                        OutputIt>::type
+copy_str(InputIt begin, InputIt end, OutputIt it) {
   return std::transform(begin, end, it, to_char8_t);
 }
 
 #if FMT_HAS_CPP_ATTRIBUTE(always_inline)
-# define FMT_ALWAYS_INLINE __attribute__((always_inline))
+#define FMT_ALWAYS_INLINE __attribute__((always_inline))
 #else
-# define FMT_ALWAYS_INLINE
+#define FMT_ALWAYS_INLINE
 #endif
 
 template <typename Handler>
@@ -856,7 +893,8 @@ class decimal_formatter {
  public:
   explicit decimal_formatter(char *buf) : buffer_(buf) {}
 
-  template <unsigned N> char *on(uint32_t u) {
+  template <unsigned N>
+  char *on(uint32_t u) {
     if (N == 0) {
       *buffer_ = static_cast<char>(u) + '0';
     } else if (N == 1) {
@@ -866,8 +904,8 @@ class decimal_formatter {
       // https://github.com/jeaiii/itoa
       unsigned n = N - 1;
       unsigned a = n / 5 * n * 53 / 16;
-      uint64_t t = ((1ULL << (32 + a)) /
-                   data::ZERO_OR_POWERS_OF_10_32[n] + 1 - n / 9);
+      uint64_t t =
+          ((1ULL << (32 + a)) / data::ZERO_OR_POWERS_OF_10_32[n] + 1 - n / 9);
       t = ((t * u) >> a) + n / 5 * 4;
       write_pair(0, t >> 32);
       for (unsigned i = 2; i < N; i += 2) {
@@ -875,8 +913,8 @@ class decimal_formatter {
         write_pair(i, t >> 32);
       }
       if (N % 2 == 0) {
-        buffer_[N] = static_cast<char>(
-          (10ULL * static_cast<uint32_t>(t)) >> 32) + '0';
+        buffer_[N] =
+            static_cast<char>((10ULL * static_cast<uint32_t>(t)) >> 32) + '0';
       }
     }
     return buffer_ += N + 1;
@@ -888,7 +926,8 @@ class decimal_formatter_null : public decimal_formatter {
  public:
   explicit decimal_formatter_null(char *buf) : decimal_formatter(buf) {}
 
-  template <unsigned N> char *on(uint32_t u) {
+  template <unsigned N>
+  char *on(uint32_t u) {
     char *buf = decimal_formatter::on<N>(u);
     *buf = '\0';
     return buf;
@@ -926,7 +965,7 @@ class add_thousands_sep {
   typedef Char char_type;
 
   explicit add_thousands_sep(basic_string_view<Char> sep)
-    : sep_(sep), digit_index_(0) {}
+      : sep_(sep), digit_index_(0) {}
 
   void operator()(Char *&buffer) {
     if (++digit_index_ % 3 != 0)
@@ -984,8 +1023,8 @@ inline Char *format_decimal(Char *buffer, UInt value, unsigned num_digits,
 
 template <typename OutChar, typename UInt, typename Iterator,
           typename ThousandsSep>
-inline Iterator format_decimal(
-    Iterator out, UInt value, unsigned num_digits, ThousandsSep sep) {
+inline Iterator format_decimal(Iterator out, UInt value, unsigned num_digits,
+                               ThousandsSep sep) {
   typedef typename ThousandsSep::char_type char_type;
   // Buffer should be large enough to hold all digits (<= digits10 + 1).
   enum { max_size = std::numeric_limits<UInt>::digits10 + 1 };
@@ -1024,9 +1063,9 @@ inline It format_uint(It out, UInt value, unsigned num_digits,
 }
 
 #ifndef _WIN32
-# define FMT_USE_WINDOWS_H 0
+#define FMT_USE_WINDOWS_H 0
 #elif !defined(FMT_USE_WINDOWS_H)
-# define FMT_USE_WINDOWS_H 1
+#define FMT_USE_WINDOWS_H 1
 #endif
 
 // Define FMT_USE_WINDOWS_H to 0 to disable use of windows.h.
@@ -1075,7 +1114,11 @@ struct null {};
 }  // namespace internal
 
 enum alignment {
-  ALIGN_DEFAULT, ALIGN_LEFT, ALIGN_RIGHT, ALIGN_CENTER, ALIGN_NUMERIC
+  ALIGN_DEFAULT,
+  ALIGN_LEFT,
+  ALIGN_RIGHT,
+  ALIGN_CENTER,
+  ALIGN_NUMERIC
 };
 
 // Flags.
@@ -1126,10 +1169,12 @@ namespace internal {
 // https://www.cs.tufts.edu/~nr/cs257/archive/florian-loitsch/printf.pdf
 template <typename Double>
 FMT_API typename std::enable_if<sizeof(Double) == sizeof(uint64_t), bool>::type
-  grisu2_format(Double value, buffer &buf, core_format_specs);
+grisu2_format(Double value, buffer &buf, core_format_specs);
 template <typename Double>
 inline typename std::enable_if<sizeof(Double) != sizeof(uint64_t), bool>::type
-  grisu2_format(Double, buffer &, core_format_specs) { return false; }
+grisu2_format(Double, buffer &, core_format_specs) {
+  return false;
+}
 
 template <typename Double>
 void sprintf_format(Double, internal::buffer &, core_format_specs);
@@ -1137,52 +1182,62 @@ void sprintf_format(Double, internal::buffer &, core_format_specs);
 template <typename Handler>
 FMT_CONSTEXPR void handle_int_type_spec(char spec, Handler &&handler) {
   switch (spec) {
-  case 0: case 'd':
-    handler.on_dec();
-    break;
-  case 'x': case 'X':
-    handler.on_hex();
-    break;
-  case 'b': case 'B':
-    handler.on_bin();
-    break;
-  case 'o':
-    handler.on_oct();
-    break;
-  case 'n':
-    handler.on_num();
-    break;
-  default:
-    handler.on_error();
+    case 0:
+    case 'd':
+      handler.on_dec();
+      break;
+    case 'x':
+    case 'X':
+      handler.on_hex();
+      break;
+    case 'b':
+    case 'B':
+      handler.on_bin();
+      break;
+    case 'o':
+      handler.on_oct();
+      break;
+    case 'n':
+      handler.on_num();
+      break;
+    default:
+      handler.on_error();
   }
 }
 
 template <typename Handler>
 FMT_CONSTEXPR void handle_float_type_spec(char spec, Handler &&handler) {
   switch (spec) {
-  case 0: case 'g': case 'G':
-    handler.on_general();
-    break;
-  case 'e': case 'E':
-    handler.on_exp();
-    break;
-  case 'f': case 'F':
-    handler.on_fixed();
-    break;
-   case 'a': case 'A':
-    handler.on_hex();
-    break;
-  default:
-    handler.on_error();
-    break;
+    case 0:
+    case 'g':
+    case 'G':
+      handler.on_general();
+      break;
+    case 'e':
+    case 'E':
+      handler.on_exp();
+      break;
+    case 'f':
+    case 'F':
+      handler.on_fixed();
+      break;
+    case 'a':
+    case 'A':
+      handler.on_hex();
+      break;
+    default:
+      handler.on_error();
+      break;
   }
 }
 
 template <typename Char, typename Handler>
-FMT_CONSTEXPR void handle_char_specs(
-    const basic_format_specs<Char> *specs, Handler &&handler) {
-  if (!specs) return handler.on_char();
-  if (specs->type && specs->type != 'c') return handler.on_int();
+FMT_CONSTEXPR void handle_char_specs(const basic_format_specs<Char> *specs,
+                                     Handler &&handler) {
+  if (!specs)
+    return handler.on_char();
+  if (specs->type && specs->type != 'c')
+    return handler.on_int();
   if (specs->align() == ALIGN_NUMERIC || specs->flags != 0)
     handler.on_error("invalid format specifier for char");
   handler.on_char();
@@ -1230,7 +1285,7 @@ template <typename ErrorHandler>
 class float_type_checker : private ErrorHandler {
  public:
   FMT_CONSTEXPR explicit float_type_checker(ErrorHandler eh)
-    : ErrorHandler(eh) {}
+      : ErrorHandler(eh) {}
 
   FMT_CONSTEXPR void on_general() {}
   FMT_CONSTEXPR void on_exp() {}
@@ -1249,7 +1304,7 @@ class char_specs_checker : public ErrorHandler {
 
  public:
   FMT_CONSTEXPR char_specs_checker(char type, ErrorHandler eh)
-    : ErrorHandler(eh), type_(type) {}
+      : ErrorHandler(eh), type_(type) {}
 
   FMT_CONSTEXPR void on_int() {
     handle_int_type_spec(type_, int_type_checker<ErrorHandler>(*this));
@@ -1261,7 +1316,7 @@ template <typename ErrorHandler>
 class cstring_type_checker : public ErrorHandler {
  public:
   FMT_CONSTEXPR explicit cstring_type_checker(ErrorHandler eh)
-    : ErrorHandler(eh) {}
+      : ErrorHandler(eh) {}
 
   FMT_CONSTEXPR void on_string() {}
   FMT_CONSTEXPR void on_pointer() {}
@@ -1273,7 +1328,7 @@ void arg_map<Context>::init(const basic_format_args<Context> &args) {
     return;
   map_ = new entry[args.max_size()];
   if (args.is_packed()) {
-    for (unsigned i = 0;/*nothing*/; ++i) {
+    for (unsigned i = 0; /*nothing*/; ++i) {
       internal::type arg_type = args.type(i);
       switch (arg_type) {
         case internal::none_type:
@@ -1282,11 +1337,11 @@ void arg_map<Context>::init(const basic_format_args<Context> &args) {
           push_back(args.values_[i]);
           break;
         default:
-          break; // Do nothing.
+          break;  // Do nothing.
       }
     }
   }
-  for (unsigned i = 0; ; ++i) {
+  for (unsigned i = 0;; ++i) {
     switch (args.args_[i].type_) {
       case internal::none_type:
         return;
@@ -1294,7 +1349,7 @@ void arg_map<Context>::init(const basic_format_args<Context> &args) {
         push_back(args.args_[i].value_);
         break;
       default:
-        break; // Do nothing.
+        break;  // Do nothing.
     }
   }
 }
@@ -1318,7 +1373,9 @@ class arg_formatter_base {
     size_t width() const { return 1; }
 
     template <typename It>
-    void operator()(It &&it) const { *it++ = value; }
+    void operator()(It &&it) const {
+      *it++ = value;
+    }
   };
 
   void write_char(char_type value) {
@@ -1355,7 +1412,7 @@ class arg_formatter_base {
 
  public:
   arg_formatter_base(Range r, format_specs *s, locale_ref loc)
-    : writer_(r, loc), specs_(s) {}
+      : writer_(r, loc), specs_(s) {}
 
   iterator operator()(monostate) {
     FMT_ASSERT(false, "invalid argument type");
@@ -1363,9 +1420,10 @@ class arg_formatter_base {
   }
 
   template <typename T>
-  typename std::enable_if<
-    std::is_integral<T>::value || std::is_same<T, char_type>::value,
-    iterator>::type operator()(T value) {
+  typename std::enable_if<std::is_integral<T>::value ||
+                              std::is_same<T, char_type>::value,
+                          iterator>::type
+  operator()(T value) {
     // MSVC2013 fails to compile separate overloads for bool and char_type so
     // use std::is_same instead.
     if (std::is_same<T, bool>::value) {
@@ -1374,7 +1432,7 @@ class arg_formatter_base {
       write(value != 0);
     } else if (std::is_same<T, char_type>::value) {
       internal::handle_char_specs(
-        specs_, char_spec_handler(*this, static_cast<char_type>(value)));
+          specs_, char_spec_handler(*this, static_cast<char_type>(value)));
     } else {
       specs_ ? writer_.write_int(value, *specs_) : writer_.write(value);
     }
@@ -1383,7 +1441,7 @@ class arg_formatter_base {
 
   template <typename T>
   typename std::enable_if<std::is_floating_point<T>::value, iterator>::type
-      operator()(T value) {
+  operator()(T value) {
     writer_.write_double(value, specs_ ? *specs_ : format_specs());
     return out();
   }
@@ -1392,8 +1450,8 @@ class arg_formatter_base {
     arg_formatter_base &formatter;
     char_type value;
 
-    char_spec_handler(arg_formatter_base& f, char_type val)
-      : formatter(f), value(val) {}
+    char_spec_handler(arg_formatter_base &f, char_type val)
+        : formatter(f), value(val) {}
 
     void on_int() {
       if (formatter.specs_)
@@ -1409,23 +1467,23 @@ class arg_formatter_base {
     const char_type *value;
 
     cstring_spec_handler(arg_formatter_base &f, const char_type *val)
-      : formatter(f), value(val) {}
+        : formatter(f), value(val) {}
 
     void on_string() { formatter.write(value); }
     void on_pointer() { formatter.write_pointer(value); }
   };
 
   iterator operator()(const char_type *value) {
-    if (!specs_) return write(value), out();
-    internal::handle_cstring_type_spec(
-          specs_->type, cstring_spec_handler(*this, value));
+    if (!specs_)
+      return write(value), out();
+    internal::handle_cstring_type_spec(specs_->type,
+                                       cstring_spec_handler(*this, value));
     return out();
   }
 
   iterator operator()(basic_string_view<char_type> value) {
     if (specs_) {
-      internal::check_string_type_spec(
-            specs_->type, internal::error_handler());
+      internal::check_string_type_spec(specs_->type, internal::error_handler());
       writer_.write(value, *specs_);
     } else {
       writer_.write(value);
@@ -1449,8 +1507,9 @@ FMT_CONSTEXPR bool is_name_start(Char c) {
 // Parses the range [begin, end) as an unsigned integer. This function assumes
 // that the range is non-empty and the first character is a digit.
 template <typename Char, typename ErrorHandler>
-FMT_CONSTEXPR unsigned parse_nonnegative_int(
-    const Char *&begin, const Char *end, ErrorHandler &&eh) {
+FMT_CONSTEXPR unsigned parse_nonnegative_int(const Char *&begin,
+                                             const Char *end,
+                                             ErrorHandler &&eh) {
   assert(begin != end && '0' <= *begin && *begin <= '9');
   if (*begin == '0') {
     ++begin;
@@ -1475,12 +1534,12 @@ FMT_CONSTEXPR unsigned parse_nonnegative_int(
 }
 
 template <typename Char, typename Context>
-class custom_formatter: public function<bool> {
+class custom_formatter : public function<bool> {
  private:
   Context &ctx_;
 
  public:
-  explicit custom_formatter(Context &ctx): ctx_(ctx) {}
+  explicit custom_formatter(Context &ctx) : ctx_(ctx) {}
 
   bool operator()(typename basic_format_arg<Context>::handle h) const {
     h.format(ctx_);
@@ -1488,7 +1547,9 @@ class custom_formatter: public function<bool> {
   }
 
   template <typename T>
-  bool operator()(T) const { return false; }
+  bool operator()(T) const {
+    return false;
+  }
 };
 
 template <typename T>
@@ -1500,22 +1561,23 @@ struct is_integer {
 };
 
 template <typename ErrorHandler>
-class width_checker: public function<unsigned long long> {
+class width_checker : public function<unsigned long long> {
  public:
   explicit FMT_CONSTEXPR width_checker(ErrorHandler &eh) : handler_(eh) {}
 
   template <typename T>
   FMT_CONSTEXPR
-  typename std::enable_if<
-      is_integer<T>::value, unsigned long long>::type operator()(T value) {
+      typename std::enable_if<is_integer<T>::value, unsigned long long>::type
+      operator()(T value) {
     if (is_negative(value))
       handler_.on_error("negative width");
     return static_cast<unsigned long long>(value);
   }
 
   template <typename T>
-  FMT_CONSTEXPR typename std::enable_if<
-      !is_integer<T>::value, unsigned long long>::type operator()(T) {
+  FMT_CONSTEXPR
+      typename std::enable_if<!is_integer<T>::value, unsigned long long>::type
+      operator()(T) {
     handler_.on_error("width is not integer");
     return 0;
   }
@@ -1525,21 +1587,23 @@ class width_checker: public function<unsigned long long> {
 };
 
 template <typename ErrorHandler>
-class precision_checker: public function<unsigned long long> {
+class precision_checker : public function<unsigned long long> {
  public:
   explicit FMT_CONSTEXPR precision_checker(ErrorHandler &eh) : handler_(eh) {}
 
   template <typename T>
-  FMT_CONSTEXPR typename std::enable_if<
-      is_integer<T>::value, unsigned long long>::type operator()(T value) {
+  FMT_CONSTEXPR
+      typename std::enable_if<is_integer<T>::value, unsigned long long>::type
+      operator()(T value) {
     if (is_negative(value))
       handler_.on_error("negative precision");
     return static_cast<unsigned long long>(value);
   }
 
   template <typename T>
-  FMT_CONSTEXPR typename std::enable_if<
-      !is_integer<T>::value, unsigned long long>::type operator()(T) {
+  FMT_CONSTEXPR
+      typename std::enable_if<!is_integer<T>::value, unsigned long long>::type
+      operator()(T) {
     handler_.on_error("precision is not integer");
     return 0;
   }
@@ -1552,10 +1616,11 @@ class precision_checker: public function<unsigned long long> {
 template <typename Char>
 class specs_setter {
  public:
-  explicit FMT_CONSTEXPR specs_setter(basic_format_specs<Char> &specs):
-    specs_(specs) {}
+  explicit FMT_CONSTEXPR specs_setter(basic_format_specs<Char> &specs)
+      : specs_(specs) {}
 
-  FMT_CONSTEXPR specs_setter(const specs_setter &other): specs_(other.specs_) {}
+  FMT_CONSTEXPR specs_setter(const specs_setter &other)
+      : specs_(other.specs_) {}
 
   FMT_CONSTEXPR void on_align(alignment align) { specs_.align_ = align; }
   FMT_CONSTEXPR void on_fill(Char fill) { specs_.fill_ = fill; }
@@ -1588,11 +1653,11 @@ class specs_setter {
 template <typename Handler>
 class specs_checker : public Handler {
  public:
-  FMT_CONSTEXPR specs_checker(const Handler& handler, internal::type arg_type)
-    : Handler(handler), arg_type_(arg_type) {}
+  FMT_CONSTEXPR specs_checker(const Handler &handler, internal::type arg_type)
+      : Handler(handler), arg_type_(arg_type) {}
 
   FMT_CONSTEXPR specs_checker(const specs_checker &other)
-    : Handler(other), arg_type_(other.arg_type_) {}
+      : Handler(other), arg_type_(other.arg_type_) {}
 
   FMT_CONSTEXPR void on_align(alignment align) {
     if (align == ALIGN_NUMERIC)
@@ -1647,10 +1712,10 @@ class specs_checker : public Handler {
   internal::type arg_type_;
 };
 
-template <template <typename> class Handler, typename T,
-          typename Context, typename ErrorHandler>
-FMT_CONSTEXPR void set_dynamic_spec(
-    T &value, basic_format_arg<Context> arg, ErrorHandler eh) {
+template <template <typename> class Handler, typename T, typename Context,
+          typename ErrorHandler>
+FMT_CONSTEXPR void set_dynamic_spec(T &value, basic_format_arg<Context> arg,
+                                    ErrorHandler eh) {
   unsigned long long big_value =
       visit_format_arg(Handler<ErrorHandler>(eh), arg);
   if (big_value > to_unsigned((std::numeric_limits<int>::max)()))
@@ -1662,29 +1727,27 @@ struct auto_id {};
 
 // The standard format specifier handler with checking.
 template <typename Context>
-class specs_handler: public specs_setter<typename Context::char_type> {
+class specs_handler : public specs_setter<typename Context::char_type> {
  public:
   typedef typename Context::char_type char_type;
 
-  FMT_CONSTEXPR specs_handler(
-      basic_format_specs<char_type> &specs, Context &ctx)
-    : specs_setter<char_type>(specs), context_(ctx) {}
+  FMT_CONSTEXPR specs_handler(basic_format_specs<char_type> &specs,
+                              Context &ctx)
+      : specs_setter<char_type>(specs), context_(ctx) {}
 
   template <typename Id>
   FMT_CONSTEXPR void on_dynamic_width(Id arg_id) {
-    set_dynamic_spec<width_checker>(
-          this->specs_.width_, get_arg(arg_id), context_.error_handler());
+    set_dynamic_spec<width_checker>(this->specs_.width_, get_arg(arg_id),
+                                    context_.error_handler());
   }
 
   template <typename Id>
   FMT_CONSTEXPR void on_dynamic_precision(Id arg_id) {
-    set_dynamic_spec<precision_checker>(
-          this->specs_.precision, get_arg(arg_id), context_.error_handler());
+    set_dynamic_spec<precision_checker>(this->specs_.precision, get_arg(arg_id),
+                                        context_.error_handler());
   }
 
-  void on_error(const char *message) {
-    context_.on_error(message);
-  }
+  void on_error(const char *message) { context_.on_error(message); }
 
  private:
   FMT_CONSTEXPR basic_format_arg<Context> get_arg(auto_id) {
@@ -1736,18 +1799,19 @@ struct dynamic_format_specs : basic_format_specs<Char> {
 // Format spec handler that saves references to arguments representing dynamic
 // width and precision to be resolved at formatting time.
 template <typename ParseContext>
-class dynamic_specs_handler :
-    public specs_setter<typename ParseContext::char_type> {
+class dynamic_specs_handler
+    : public specs_setter<typename ParseContext::char_type> {
  public:
   typedef typename ParseContext::char_type char_type;
 
-  FMT_CONSTEXPR dynamic_specs_handler(
-      dynamic_format_specs<char_type> &specs, ParseContext &ctx)
-    : specs_setter<char_type>(specs), specs_(specs), context_(ctx) {}
+  FMT_CONSTEXPR dynamic_specs_handler(dynamic_format_specs<char_type> &specs,
+                                      ParseContext &ctx)
+      : specs_setter<char_type>(specs), specs_(specs), context_(ctx) {}
 
   FMT_CONSTEXPR dynamic_specs_handler(const dynamic_specs_handler &other)
-    : specs_setter<char_type>(other),
-      specs_(other.specs_), context_(other.context_) {}
+      : specs_setter<char_type>(other),
+        specs_(other.specs_),
+        context_(other.context_) {}
 
   template <typename Id>
   FMT_CONSTEXPR void on_dynamic_width(Id arg_id) {
@@ -1781,8 +1845,8 @@ class dynamic_specs_handler :
 };
 
 template <typename Char, typename IDHandler>
-FMT_CONSTEXPR const Char *parse_arg_id(
-    const Char *begin, const Char *end, IDHandler &&handler) {
+FMT_CONSTEXPR const Char *parse_arg_id(const Char *begin, const Char *end,
+                                       IDHandler &&handler) {
   assert(begin != end);
   Char c = *begin;
   if (c == '}' || c == ':')
@@ -1835,33 +1899,36 @@ struct precision_adapter {
     handler.on_dynamic_precision(id);
   }
 
-  FMT_CONSTEXPR void on_error(const char *message) { handler.on_error(message); }
+  FMT_CONSTEXPR void on_error(const char *message) {
+    handler.on_error(message);
+  }
 
   SpecHandler &handler;
 };
 
 // Parses fill and alignment.
 template <typename Char, typename Handler>
-FMT_CONSTEXPR const Char *parse_align(
-    const Char *begin, const Char *end, Handler &&handler) {
+FMT_CONSTEXPR const Char *parse_align(const Char *begin, const Char *end,
+                                      Handler &&handler) {
   FMT_ASSERT(begin != end, "");
   alignment align = ALIGN_DEFAULT;
   int i = 0;
-  if (begin + 1 != end) ++i;
+  if (begin + 1 != end)
+    ++i;
   do {
     switch (static_cast<char>(begin[i])) {
-    case '<':
-      align = ALIGN_LEFT;
-      break;
-    case '>':
-      align = ALIGN_RIGHT;
-      break;
-    case '=':
-      align = ALIGN_NUMERIC;
-      break;
-    case '^':
-      align = ALIGN_CENTER;
-      break;
+      case '<':
+        align = ALIGN_LEFT;
+        break;
+      case '>':
+        align = ALIGN_RIGHT;
+        break;
+      case '=':
+        align = ALIGN_NUMERIC;
+        break;
+      case '^':
+        align = ALIGN_CENTER;
+        break;
     }
     if (align != ALIGN_DEFAULT) {
       if (i > 0) {
@@ -1870,7 +1937,8 @@ FMT_CONSTEXPR const Char *parse_align(
           return handler.on_error("invalid fill character '{'"), begin;
         begin += 2;
         handler.on_fill(c);
-      } else ++begin;
+      } else
+        ++begin;
       handler.on_align(align);
       break;
     }
@@ -1879,8 +1947,8 @@ FMT_CONSTEXPR const Char *parse_align(
 }
 
 template <typename Char, typename Handler>
-FMT_CONSTEXPR const Char *parse_width(
-    const Char *begin, const Char *end, Handler &&handler) {
+FMT_CONSTEXPR const Char *parse_width(const Char *begin, const Char *end,
+                                      Handler &&handler) {
   FMT_ASSERT(begin != end, "");
   if ('0' <= *begin && *begin <= '9') {
     handler.on_width(parse_nonnegative_int(begin, end, handler));
@@ -1898,44 +1966,49 @@ FMT_CONSTEXPR const Char *parse_width(
 // Parses standard format specifiers and sends notifications about parsed
 // components to handler.
 template <typename Char, typename SpecHandler>
-FMT_CONSTEXPR const Char *parse_format_specs(
-    const Char *begin, const Char *end, SpecHandler &&handler) {
+FMT_CONSTEXPR const Char *parse_format_specs(const Char *begin, const Char *end,
+                                             SpecHandler &&handler) {
   if (begin == end || *begin == '}')
     return begin;
 
   begin = parse_align(begin, end, handler);
-  if (begin == end) return begin;
+  if (begin == end)
+    return begin;
 
   // Parse sign.
   switch (static_cast<char>(*begin)) {
-  case '+':
-    handler.on_plus();
-    ++begin;
-    break;
-  case '-':
-    handler.on_minus();
-    ++begin;
-    break;
-  case ' ':
-    handler.on_space();
-    ++begin;
-    break;
+    case '+':
+      handler.on_plus();
+      ++begin;
+      break;
+    case '-':
+      handler.on_minus();
+      ++begin;
+      break;
+    case ' ':
+      handler.on_space();
+      ++begin;
+      break;
   }
-  if (begin == end) return begin;
+  if (begin == end)
+    return begin;
 
   if (*begin == '#') {
     handler.on_hash();
-    if (++begin == end) return begin;
+    if (++begin == end)
+      return begin;
   }
 
   // Parse zero flag.
   if (*begin == '0') {
     handler.on_zero();
-    if (++begin == end) return begin;
+    if (++begin == end)
+      return begin;
   }
 
   begin = parse_width(begin, end, handler);
-  if (begin == end) return begin;
+  if (begin == end)
+    return begin;
 
   // Parse precision.
   if (*begin == '.') {
@@ -1946,8 +2019,8 @@ FMT_CONSTEXPR const Char *parse_format_specs(
     } else if (c == '{') {
       ++begin;
       if (begin != end) {
-        begin = parse_arg_id(
-              begin, end, precision_adapter<SpecHandler, Char>(handler));
+        begin = parse_arg_id(begin, end,
+                             precision_adapter<SpecHandler, Char>(handler));
       }
       if (begin == end || *begin++ != '}')
         return handler.on_error("invalid format string"), begin;
@@ -1964,7 +2037,7 @@ FMT_CONSTEXPR const Char *parse_format_specs(
 }
 
 // Return the result via the out param to workaround gcc bug 77539.
-template <bool IS_CONSTEXPR, typename T, typename Ptr = const T*>
+template <bool IS_CONSTEXPR, typename T, typename Ptr = const T *>
 FMT_CONSTEXPR bool find(Ptr first, Ptr last, T value, Ptr &out) {
   for (out = first; out != last; ++out) {
     if (*out == value)
@@ -1974,9 +2047,9 @@ FMT_CONSTEXPR bool find(Ptr first, Ptr last, T value, Ptr &out) {
 }
 
 template <>
-inline bool find<false, char>(
-    const char *first, const char *last, char value, const char *&out) {
-  out = static_cast<const char*>(std::memchr(first, value, last - first));
+inline bool find<false, char>(const char *first, const char *last, char value,
+                              const char *&out) {
+  out = static_cast<const char *>(std::memchr(first, value, last - first));
   return out != FMT_NULL;
 }
 
@@ -1994,11 +2067,12 @@ struct id_adapter {
 };
 
 template <bool IS_CONSTEXPR, typename Char, typename Handler>
-FMT_CONSTEXPR void parse_format_string(
-        basic_string_view<Char> format_str, Handler &&handler) {
+FMT_CONSTEXPR void parse_format_string(basic_string_view<Char> format_str,
+                                       Handler &&handler) {
   struct writer {
     FMT_CONSTEXPR void operator()(const Char *begin, const Char *end) {
-      if (begin == end) return;
+      if (begin == end)
+        return;
       for (;;) {
         const Char *p = FMT_NULL;
         if (!find<IS_CONSTEXPR>(begin, end, '}', p))
@@ -2047,8 +2121,8 @@ FMT_CONSTEXPR void parse_format_string(
 }
 
 template <typename T, typename ParseContext>
-FMT_CONSTEXPR const typename ParseContext::char_type *
-    parse_format_specs(ParseContext &ctx) {
+FMT_CONSTEXPR const typename ParseContext::char_type *parse_format_specs(
+    ParseContext &ctx) {
   // GCC 7.2 requires initializer.
   formatter<T, typename ParseContext::char_type> f{};
   return f.parse(ctx);
@@ -2059,8 +2133,9 @@ class format_string_checker {
  public:
   explicit FMT_CONSTEXPR format_string_checker(
       basic_string_view<Char> format_str, ErrorHandler eh)
-    : arg_id_(-1), context_(format_str, eh),
-      parse_funcs_{&parse_format_specs<Args, parse_context_type>...} {}
+      : arg_id_(-1),
+        context_(format_str, eh),
+        parse_funcs_{&parse_format_specs<Args, parse_context_type>...} {}
 
   FMT_CONSTEXPR void on_text(const Char *, const Char *) {}
 
@@ -2079,8 +2154,8 @@ class format_string_checker {
 
   FMT_CONSTEXPR const Char *on_format_specs(const Char *begin, const Char *) {
     context_.advance_to(begin);
-    return to_unsigned(arg_id_) < NUM_ARGS ?
-          parse_funcs_[arg_id_](context_) : begin;
+    return to_unsigned(arg_id_) < NUM_ARGS ? parse_funcs_[arg_id_](context_)
+                                           : begin;
   }
 
   FMT_CONSTEXPR void on_error(const char *message) {
@@ -2105,19 +2180,20 @@ class format_string_checker {
 };
 
 template <typename Char, typename ErrorHandler, typename... Args>
-FMT_CONSTEXPR bool do_check_format_string(
-    basic_string_view<Char> s, ErrorHandler eh = ErrorHandler()) {
+FMT_CONSTEXPR bool do_check_format_string(basic_string_view<Char> s,
+                                          ErrorHandler eh = ErrorHandler()) {
   format_string_checker<Char, ErrorHandler, Args...> checker(s, eh);
   parse_format_string<true>(s, checker);
   return true;
 }
 
 template <typename... Args, typename S>
-typename std::enable_if<is_compile_string<S>::value>::type
-    check_format_string(S format_str) {
+typename std::enable_if<is_compile_string<S>::value>::type check_format_string(
+    S format_str) {
   typedef typename S::char_type char_t;
-  FMT_CONSTEXPR_DECL bool invalid_format = internal::do_check_format_string<
-      char_t, internal::error_handler, Args...>(to_string_view(format_str));
+  FMT_CONSTEXPR_DECL bool invalid_format =
+      internal::do_check_format_string<char_t, internal::error_handler,
+                                       Args...>(to_string_view(format_str));
   (void)invalid_format;
 }
 
@@ -2125,35 +2201,36 @@ typename std::enable_if<is_compile_string<S>::value>::type
 // It is not possible to use get_type in formatter specialization directly
 // because of a bug in MSVC.
 template <typename Context, typename T>
-struct format_type :
-  std::integral_constant<bool, get_type<Context, T>::value != custom_type> {};
+struct format_type
+    : std::integral_constant<bool, get_type<Context, T>::value != custom_type> {
+};
 
 template <template <typename> class Handler, typename Spec, typename Context>
-void handle_dynamic_spec(
-    Spec &value, arg_ref<typename Context::char_type> ref, Context &ctx) {
+void handle_dynamic_spec(Spec &value, arg_ref<typename Context::char_type> ref,
+                         Context &ctx) {
   typedef typename Context::char_type char_type;
   switch (ref.kind) {
-  case arg_ref<char_type>::NONE:
-    break;
-  case arg_ref<char_type>::INDEX:
-    internal::set_dynamic_spec<Handler>(
-          value, ctx.get_arg(ref.index), ctx.error_handler());
-    break;
-  case arg_ref<char_type>::NAME:
-    internal::set_dynamic_spec<Handler>(
+    case arg_ref<char_type>::NONE:
+      break;
+    case arg_ref<char_type>::INDEX:
+      internal::set_dynamic_spec<Handler>(value, ctx.get_arg(ref.index),
+                                          ctx.error_handler());
+      break;
+    case arg_ref<char_type>::NAME:
+      internal::set_dynamic_spec<Handler>(
           value, ctx.get_arg({ref.name.value, ref.name.size}),
           ctx.error_handler());
-    break;
+      break;
   }
 }
 }  // namespace internal
 
 /** The default argument formatter. */
 template <typename Range>
-class arg_formatter:
-  public internal::function<
-    typename internal::arg_formatter_base<Range>::iterator>,
-  public internal::arg_formatter_base<Range> {
+class arg_formatter
+    : public internal::function<
+          typename internal::arg_formatter_base<Range>::iterator>,
+      public internal::arg_formatter_base<Range> {
  private:
   typedef typename Range::value_type char_type;
   typedef internal::arg_formatter_base<Range> base;
@@ -2174,11 +2251,11 @@ class arg_formatter:
     \endrst
    */
   explicit arg_formatter(context_type &ctx, format_specs *spec = FMT_NULL)
-  : base(Range(ctx.out()), spec, ctx.locale()), ctx_(ctx) {}
+      : base(Range(ctx.out()), spec, ctx.locale()), ctx_(ctx) {}
 
   // Deprecated.
   arg_formatter(context_type &ctx, format_specs &spec)
-  : base(Range(ctx.out()), &spec), ctx_(ctx) {}
+      : base(Range(ctx.out()), &spec), ctx_(ctx) {}
 
   using base::operator();
 
@@ -2223,7 +2300,7 @@ class system_error : public std::runtime_error {
   */
   template <typename... Args>
   system_error(int error_code, string_view message, const Args &... args)
-    : std::runtime_error("") {
+      : std::runtime_error("") {
     init(error_code, message, make_format_args(args...));
   }
 
@@ -2275,8 +2352,8 @@ class basic_writer {
   // where <value> is written by f(it).
   template <typename F>
   void write_padded(const align_spec &spec, F &&f) {
-    unsigned width = spec.width(); // User-perceived width (in code points).
-    size_t size = f.size(); // The number of code units.
+    unsigned width = spec.width();  // User-perceived width (in code points).
+    size_t size = f.size();         // The number of code units.
     size_t num_code_points = width != 0 ? f.width() : size;
     if (width <= num_code_points)
       return f(reserve(size));
@@ -2321,8 +2398,8 @@ class basic_writer {
   //   <left-padding><prefix><numeric-padding><digits><right-padding>
   // where <digits> are written by f(it).
   template <typename Spec, typename F>
-  void write_int(unsigned num_digits, string_view prefix,
-                 const Spec &spec, F f) {
+  void write_int(unsigned num_digits, string_view prefix, const Spec &spec,
+                 F f) {
     std::size_t size = prefix.size() + num_digits;
     char_type fill = static_cast<char_type>(spec.fill());
     std::size_t padding = 0;
@@ -2382,8 +2459,10 @@ class basic_writer {
     }
 
     int_writer(basic_writer<Range> &w, Int value, const Spec &s)
-      : writer(w), spec(s), abs_value(static_cast<unsigned_type>(value)),
-        prefix_size(0) {
+        : writer(w),
+          spec(s),
+          abs_value(static_cast<unsigned_type>(value)),
+          prefix_size(0) {
       if (internal::is_negative(value)) {
         prefix[0] = '-';
         ++prefix_size;
@@ -2416,8 +2495,8 @@ class basic_writer {
 
       template <typename It>
       void operator()(It &&it) const {
-        it = internal::format_uint<4, char_type>(
-              it, self.abs_value, num_digits, self.spec.type != 'x');
+        it = internal::format_uint<4, char_type>(it, self.abs_value, num_digits,
+                                                 self.spec.type != 'x');
       }
     };
 
@@ -2475,7 +2554,7 @@ class basic_writer {
       void operator()(It &&it) const {
         basic_string_view<char_type> s(&sep, SEP_SIZE);
         it = internal::format_decimal<char_type>(
-              it, abs_value, size, internal::add_thousands_sep<char_type>(s));
+            it, abs_value, size, internal::add_thousands_sep<char_type>(s));
       }
     };
 
@@ -2487,9 +2566,7 @@ class basic_writer {
                        num_writer{abs_value, size, sep});
     }
 
-    void on_error() {
-      FMT_THROW(format_error("invalid type specifier"));
-    }
+    void on_error() { FMT_THROW(format_error("invalid type specifier")); }
   };
 
   // Writes a formatted integer.
@@ -2499,7 +2576,7 @@ class basic_writer {
                                    int_writer<T, Spec>(*this, value, spec));
   }
 
-  enum {INF_SIZE = 3}; // This is an enum to workaround a bug in MSVC.
+  enum { INF_SIZE = 3 };  // This is an enum to workaround a bug in MSVC.
 
   struct inf_or_nan_writer {
     char sign;
@@ -2515,7 +2592,7 @@ class basic_writer {
       if (sign)
         *it++ = static_cast<char_type>(sign);
       it = internal::copy_str<char_type>(
-            str, str + static_cast<std::size_t>(INF_SIZE), it);
+          str, str + static_cast<std::size_t>(INF_SIZE), it);
     }
   };
 
@@ -2562,9 +2639,9 @@ class basic_writer {
 
  public:
   /** Constructs a ``basic_writer`` object. */
-  explicit basic_writer(
-      Range out, internal::locale_ref loc = internal::locale_ref())
-    : out_(out.begin()), locale_(loc) {}
+  explicit basic_writer(Range out,
+                        internal::locale_ref loc = internal::locale_ref())
+      : out_(out.begin()), locale_(loc) {}
 
   iterator out() const { return out_; }
 
@@ -2582,16 +2659,14 @@ class basic_writer {
     \endrst
    */
   template <typename T, typename FormatSpec, typename... FormatSpecs>
-  typename std::enable_if<std::is_integral<T>::value, void>::type
-      write(T value, FormatSpec spec, FormatSpecs... specs) {
+  typename std::enable_if<std::is_integral<T>::value, void>::type write(
+      T value, FormatSpec spec, FormatSpecs... specs) {
     format_specs s(spec, specs...);
     s.align_ = ALIGN_RIGHT;
     write_int(value, s);
   }
 
-  void write(double value) {
-    write_double(value, format_specs());
-  }
+  void write(double value) { write_double(value, format_specs()); }
 
   /**
     \rst
@@ -2599,14 +2674,10 @@ class basic_writer {
     (``'g'``) and writes it to the buffer.
     \endrst
    */
-  void write(long double value) {
-    write_double(value, format_specs());
-  }
+  void write(long double value) { write_double(value, format_specs()); }
 
   /** Writes a character to the buffer. */
-  void write(char value) {
-    *reserve(1) = value;
-  }
+  void write(char value) { *reserve(1) = value; }
   void write(wchar_t value) {
     static_assert(std::is_same<char_type, wchar_t>::value, "");
     *reserve(1) = value;
@@ -2644,8 +2715,8 @@ class basic_writer {
   }
 
   template <typename T>
-  typename std::enable_if<std::is_same<T, void>::value>::type
-      write(const T *p) {
+  typename std::enable_if<std::is_same<T, void>::value>::type write(
+      const T *p) {
     format_specs specs;
     specs.flags = HASH_FLAG;
     specs.type = 'x';
@@ -2686,9 +2757,7 @@ struct float_spec_handler {
       upper = true;
   }
 
-  void on_error() {
-    FMT_THROW(format_error("invalid type specifier"));
-  }
+  void on_error() { FMT_THROW(format_error("invalid type specifier")); }
 };
 
 template <typename Range>
@@ -2725,8 +2794,9 @@ void basic_writer<Range>::write_double(T value, const format_specs &spec) {
     return write_inf_or_nan(handler.upper ? "INF" : "inf");
 
   memory_buffer buffer;
-  bool use_grisu = FMT_USE_GRISU && sizeof(T) <= sizeof(double) &&
-      spec.type != 'a' && spec.type != 'A' &&
+  bool use_grisu =
+      FMT_USE_GRISU && sizeof(T) <= sizeof(double) && spec.type != 'a' &&
+      spec.type != 'A' &&
       internal::grisu2_format(static_cast<double>(value), buffer, spec);
   if (!use_grisu) {
     format_specs normalized_spec(spec);
@@ -2812,7 +2882,7 @@ class format_int {
  private:
   // Buffer should be large enough to hold all digits (digits10 + 1),
   // a sign and a null character.
-  enum {BUFFER_SIZE = std::numeric_limits<unsigned long long>::digits10 + 3};
+  enum { BUFFER_SIZE = std::numeric_limits<unsigned long long>::digits10 + 3 };
   mutable char buffer_[BUFFER_SIZE];
   char *str_;
 
@@ -2907,67 +2977,64 @@ inline void format_decimal(char *&buffer, T value) {
     return;
   }
   unsigned num_digits = internal::count_digits(abs_value);
-  internal::format_decimal<char>(
-        internal::make_checked(buffer, num_digits), abs_value, num_digits);
+  internal::format_decimal<char>(internal::make_checked(buffer, num_digits),
+                                 abs_value, num_digits);
   buffer += num_digits;
 }
 
 // Formatter of objects of type T.
 template <typename T, typename Char>
-struct formatter<
-    T, Char,
-    typename std::enable_if<internal::format_type<
-        typename buffer_context<Char>::type, T>::value>::type> {
-
+struct formatter<T, Char,
+                 typename std::enable_if<internal::format_type<
+                     typename buffer_context<Char>::type, T>::value>::type> {
   // Parses format specifiers stopping either at the end of the range or at the
   // terminating '}'.
   template <typename ParseContext>
   FMT_CONSTEXPR typename ParseContext::iterator parse(ParseContext &ctx) {
     typedef internal::dynamic_specs_handler<ParseContext> handler_type;
-    auto type = internal::get_type<
-      typename buffer_context<Char>::type, T>::value;
-    internal::specs_checker<handler_type>
-        handler(handler_type(specs_, ctx), type);
+    auto type =
+        internal::get_type<typename buffer_context<Char>::type, T>::value;
+    internal::specs_checker<handler_type> handler(handler_type(specs_, ctx),
+                                                  type);
     auto it = parse_format_specs(ctx.begin(), ctx.end(), handler);
     auto type_spec = specs_.type;
     auto eh = ctx.error_handler();
     switch (type) {
-    case internal::none_type:
-    case internal::named_arg_type:
-      FMT_ASSERT(false, "invalid argument type");
-      break;
-    case internal::int_type:
-    case internal::uint_type:
-    case internal::long_long_type:
-    case internal::ulong_long_type:
-    case internal::bool_type:
-      handle_int_type_spec(
-            type_spec, internal::int_type_checker<decltype(eh)>(eh));
-      break;
-    case internal::char_type:
-      handle_char_specs(
-          &specs_,
-          internal::char_specs_checker<decltype(eh)>(type_spec, eh));
-      break;
-    case internal::double_type:
-    case internal::long_double_type:
-      handle_float_type_spec(
-            type_spec, internal::float_type_checker<decltype(eh)>(eh));
-      break;
-    case internal::cstring_type:
-      internal::handle_cstring_type_spec(
+      case internal::none_type:
+      case internal::named_arg_type:
+        FMT_ASSERT(false, "invalid argument type");
+        break;
+      case internal::int_type:
+      case internal::uint_type:
+      case internal::long_long_type:
+      case internal::ulong_long_type:
+      case internal::bool_type:
+        handle_int_type_spec(type_spec,
+                             internal::int_type_checker<decltype(eh)>(eh));
+        break;
+      case internal::char_type:
+        handle_char_specs(
+            &specs_, internal::char_specs_checker<decltype(eh)>(type_spec, eh));
+        break;
+      case internal::double_type:
+      case internal::long_double_type:
+        handle_float_type_spec(type_spec,
+                               internal::float_type_checker<decltype(eh)>(eh));
+        break;
+      case internal::cstring_type:
+        internal::handle_cstring_type_spec(
             type_spec, internal::cstring_type_checker<decltype(eh)>(eh));
-      break;
-    case internal::string_type:
-      internal::check_string_type_spec(type_spec, eh);
-      break;
-    case internal::pointer_type:
-      internal::check_pointer_type_spec(type_spec, eh);
-      break;
-    case internal::custom_type:
-      // Custom format specifiers should be checked in parse functions of
-      // formatter specializations.
-      break;
+        break;
+      case internal::string_type:
+        internal::check_string_type_spec(type_spec, eh);
+        break;
+      case internal::pointer_type:
+        internal::check_pointer_type_spec(type_spec, eh);
+        break;
+      case internal::custom_type:
+        // Custom format specifiers should be checked in parse functions of
+        // formatter specializations.
+        break;
     }
     return it;
   }
@@ -2975,13 +3042,14 @@ struct formatter<
   template <typename FormatContext>
   auto format(const T &val, FormatContext &ctx) -> decltype(ctx.out()) {
     internal::handle_dynamic_spec<internal::width_checker>(
-      specs_.width_, specs_.width_ref, ctx);
+        specs_.width_, specs_.width_ref, ctx);
     internal::handle_dynamic_spec<internal::precision_checker>(
-      specs_.precision, specs_.precision_ref, ctx);
+        specs_.precision, specs_.precision_ref, ctx);
     typedef output_range<typename FormatContext::iterator,
-                         typename FormatContext::char_type> range_type;
+                         typename FormatContext::char_type>
+        range_type;
     return visit_format_arg(arg_formatter<range_type>(ctx, &specs_),
-                      internal::make_arg<FormatContext>(val));
+                            internal::make_arg<FormatContext>(val));
   }
 
  private:
@@ -3001,7 +3069,7 @@ struct formatter<
 template <typename Char = char>
 class dynamic_formatter {
  private:
-  struct null_handler: internal::error_handler {
+  struct null_handler : internal::error_handler {
     void on_align(alignment) {}
     void on_plus() {}
     void on_minus() {}
@@ -3020,10 +3088,11 @@ class dynamic_formatter {
   template <typename T, typename FormatContext>
   auto format(const T &val, FormatContext &ctx) -> decltype(ctx.out()) {
     handle_specs(ctx);
-    internal::specs_checker<null_handler>
-        checker(null_handler(), internal::get_type<FormatContext, T>::value);
+    internal::specs_checker<null_handler> checker(
+        null_handler(), internal::get_type<FormatContext, T>::value);
     checker.on_align(specs_.align());
-    if (specs_.flags == 0);  // Do nothing.
+    if (specs_.flags == 0)
+      ;  // Do nothing.
     else if (specs_.has(SIGN_FLAG))
       specs_.has(PLUS_FLAG) ? checker.on_plus() : checker.on_space();
     else if (specs_.has(MINUS_FLAG))
@@ -3033,9 +3102,10 @@ class dynamic_formatter {
     if (specs_.precision != -1)
       checker.end_precision();
     typedef output_range<typename FormatContext::iterator,
-                         typename FormatContext::char_type> range;
+                         typename FormatContext::char_type>
+        range;
     visit_format_arg(arg_formatter<range>(ctx, &specs_),
-               internal::make_arg<FormatContext>(val));
+                     internal::make_arg<FormatContext>(val));
     return ctx.out();
   }
 
@@ -3043,9 +3113,9 @@ class dynamic_formatter {
   template <typename Context>
   void handle_specs(Context &ctx) {
     internal::handle_dynamic_spec<internal::width_checker>(
-      specs_.width_, specs_.width_ref, ctx);
+        specs_.width_, specs_.width_ref, ctx);
     internal::handle_dynamic_spec<internal::precision_checker>(
-      specs_.precision, specs_.precision_ref, ctx);
+        specs_.precision, specs_.precision_ref, ctx);
   }
 
   internal::dynamic_format_specs<Char> specs_;
@@ -3053,8 +3123,7 @@ class dynamic_formatter {
 
 template <typename Range, typename Char>
 typename basic_format_context<Range, Char>::format_arg
-  basic_format_context<Range, Char>::get_arg(
-    basic_string_view<char_type> name) {
+basic_format_context<Range, Char>::get_arg(basic_string_view<char_type> name) {
   map_.init(this->args());
   format_arg arg = map_.find(name);
   if (arg.type() == internal::none_type)
@@ -3069,7 +3138,7 @@ struct format_handler : internal::error_handler {
   format_handler(range r, basic_string_view<Char> str,
                  basic_format_args<Context> format_args,
                  internal::locale_ref loc)
-    : context(r.begin(), str, format_args, loc) {}
+      : context(r.begin(), str, format_args, loc) {}
 
   void on_text(const Char *begin, const Char *end) {
     auto size = internal::to_unsigned(end - begin);
@@ -3084,9 +3153,7 @@ struct format_handler : internal::error_handler {
     context.parse_context().check_arg_id(id);
     arg = context.get_arg(id);
   }
-  void on_arg_id(basic_string_view<Char> id) {
-    arg = context.get_arg(id);
-  }
+  void on_arg_id(basic_string_view<Char> id) { arg = context.get_arg(id); }
 
   void on_replacement_field(const Char *p) {
     context.parse_context().advance_to(p);
@@ -3103,8 +3170,8 @@ struct format_handler : internal::error_handler {
       return parse_ctx.begin();
     basic_format_specs<Char> specs;
     using internal::specs_handler;
-    internal::specs_checker<specs_handler<Context>>
-        handler(specs_handler<Context>(specs, context), arg.type());
+    internal::specs_checker<specs_handler<Context>> handler(
+        specs_handler<Context>(specs, context), arg.type());
     begin = parse_format_specs(begin, end, handler);
     if (begin == end || *begin != '}')
       on_error("missing '}' in format string");
@@ -3120,8 +3187,7 @@ struct format_handler : internal::error_handler {
 /** Formats arguments and writes the output to the range. */
 template <typename ArgFormatter, typename Char, typename Context>
 typename Context::iterator vformat_to(
-    typename ArgFormatter::range out,
-    basic_string_view<Char> format_str,
+    typename ArgFormatter::range out, basic_string_view<Char> format_str,
     basic_format_args<Context> args,
     internal::locale_ref loc = internal::locale_ref()) {
   format_handler<ArgFormatter, Char, Context> h(out, format_str, args, loc);
@@ -3133,7 +3199,9 @@ typename Context::iterator vformat_to(
 // Example:
 //   auto s = format("{}", ptr(p));
 template <typename T>
-inline const void *ptr(const T *p) { return p; }
+inline const void *ptr(const T *p) {
+  return p;
+}
 
 template <typename It, typename Char>
 struct arg_join {
@@ -3142,12 +3210,12 @@ struct arg_join {
   basic_string_view<Char> sep;
 
   arg_join(It begin, It end, basic_string_view<Char> sep)
-    : begin(begin), end(end), sep(sep) {}
+      : begin(begin), end(end), sep(sep) {}
 };
 
 template <typename It, typename Char>
-struct formatter<arg_join<It, Char>, Char>:
-    formatter<typename std::iterator_traits<It>::value_type, Char> {
+struct formatter<arg_join<It, Char>, Char>
+    : formatter<typename std::iterator_traits<It>::value_type, Char> {
   template <typename FormatContext>
   auto format(const arg_join<It, Char> &value, FormatContext &ctx)
       -> decltype(ctx.out()) {
@@ -3231,9 +3299,9 @@ template <typename Char>
 typename buffer_context<Char>::type::iterator internal::vformat_to(
     internal::basic_buffer<Char> &buf, basic_string_view<Char> format_str,
     basic_format_args<typename buffer_context<Char>::type> args) {
-  typedef back_insert_range<internal::basic_buffer<Char> > range;
-  return vformat_to<arg_formatter<range>>(
-    buf, to_string_view(format_str), args);
+  typedef back_insert_range<internal::basic_buffer<Char>> range;
+  return vformat_to<arg_formatter<range>>(buf, to_string_view(format_str),
+                                          args);
 }
 
 template <typename S, typename Char = FMT_CHAR(S)>
@@ -3243,10 +3311,8 @@ inline typename buffer_context<Char>::type::iterator vformat_to(
   return internal::vformat_to(buf, to_string_view(format_str), args);
 }
 
-template <
-    typename S, typename... Args,
-    std::size_t SIZE = inline_buffer_size,
-    typename Char = typename internal::char_t<S>::type>
+template <typename S, typename... Args, std::size_t SIZE = inline_buffer_size,
+          typename Char = typename internal::char_t<S>::type>
 inline typename buffer_context<Char>::type::iterator format_to(
     basic_memory_buffer<Char, SIZE> &buf, const S &format_str,
     const Args &... args) {
@@ -3264,14 +3330,18 @@ namespace internal {
 // for use in a SFINAE-context.
 
 // the gist of C++17's void_t magic
-template<typename... Ts>
-struct void_ { typedef void type; };
+template <typename... Ts>
+struct void_ {
+  typedef void type;
+};
 
 template <typename T, typename Enable = void>
 struct it_category : std::false_type {};
 
 template <typename T>
-struct it_category<T*> { typedef std::random_access_iterator_tag type; };
+struct it_category<T *> {
+  typedef std::random_access_iterator_tag type;
+};
 
 template <typename T>
 struct it_category<T, typename void_<typename T::iterator_category>::type> {
@@ -3290,33 +3360,36 @@ class is_output_iterator {
   template <typename U>
   static decltype(*(internal::declval<U>())) test(std::input_iterator_tag);
   template <typename U>
-  static char& test(std::output_iterator_tag);
+  static char &test(std::output_iterator_tag);
   template <typename U>
-  static const char& test(...);
+  static const char &test(...);
 
   typedef decltype(test<It>(typename it_category<It>::type{})) type;
   typedef typename std::remove_reference<type>::type result;
+
  public:
   static const bool value = !std::is_const<result>::value;
 };
-} // internal
+}  // namespace internal
 
 template <typename OutputIt, typename Char = char>
-//using format_context_t = basic_format_context<OutputIt, Char>;
-struct format_context_t { typedef basic_format_context<OutputIt, Char> type; };
+// using format_context_t = basic_format_context<OutputIt, Char>;
+struct format_context_t {
+  typedef basic_format_context<OutputIt, Char> type;
+};
 
 template <typename OutputIt, typename Char = char>
-//using format_args_t = basic_format_args<format_context_t<OutputIt, Char>>;
+// using format_args_t = basic_format_args<format_context_t<OutputIt, Char>>;
 struct format_args_t {
-  typedef basic_format_args<
-    typename format_context_t<OutputIt, Char>::type> type;
+  typedef basic_format_args<typename format_context_t<OutputIt, Char>::type>
+      type;
 };
 
 template <typename String, typename OutputIt, typename... Args>
 inline typename std::enable_if<internal::is_output_iterator<OutputIt>::value,
                                OutputIt>::type
-    vformat_to(OutputIt out, const String &format_str,
-               typename format_args_t<OutputIt, FMT_CHAR(String)>::type args) {
+vformat_to(OutputIt out, const String &format_str,
+           typename format_args_t<OutputIt, FMT_CHAR(String)>::type args) {
   typedef output_range<OutputIt, FMT_CHAR(String)> range;
   return vformat_to<arg_formatter<range>>(range(out),
                                           to_string_view(format_str), args);
@@ -3334,9 +3407,9 @@ inline typename std::enable_if<internal::is_output_iterator<OutputIt>::value,
  \endrst
  */
 template <typename OutputIt, typename S, typename... Args>
-inline FMT_ENABLE_IF_T(
-    internal::is_string<S>::value &&
-    internal::is_output_iterator<OutputIt>::value, OutputIt)
+inline FMT_ENABLE_IF_T(internal::is_string<S>::value
+                           &&internal::is_output_iterator<OutputIt>::value,
+                       OutputIt)
     format_to(OutputIt out, const S &format_str, const Args &... args) {
   internal::check_format_string<Args...>(format_str);
   typedef typename format_context_t<OutputIt, FMT_CHAR(S)>::type context;
@@ -3354,29 +3427,28 @@ struct format_to_n_result {
 };
 
 template <typename OutputIt, typename Char = typename OutputIt::value_type>
-struct format_to_n_context :
-  format_context_t<fmt::internal::truncating_iterator<OutputIt>, Char> {};
+struct format_to_n_context
+    : format_context_t<fmt::internal::truncating_iterator<OutputIt>, Char> {};
 
 template <typename OutputIt, typename Char = typename OutputIt::value_type>
 struct format_to_n_args {
-  typedef basic_format_args<
-    typename format_to_n_context<OutputIt, Char>::type> type;
+  typedef basic_format_args<typename format_to_n_context<OutputIt, Char>::type>
+      type;
 };
 
-template <typename OutputIt, typename Char, typename ...Args>
-inline format_arg_store<
-  typename format_to_n_context<OutputIt, Char>::type, Args...>
-    make_format_to_n_args(const Args &... args) {
-  return format_arg_store<
-    typename format_to_n_context<OutputIt, Char>::type, Args...>(args...);
+template <typename OutputIt, typename Char, typename... Args>
+inline format_arg_store<typename format_to_n_context<OutputIt, Char>::type,
+                        Args...>
+make_format_to_n_args(const Args &... args) {
+  return format_arg_store<typename format_to_n_context<OutputIt, Char>::type,
+                          Args...>(args...);
 }
 
 template <typename OutputIt, typename Char, typename... Args>
-inline typename std::enable_if<
-    internal::is_output_iterator<OutputIt>::value,
-    format_to_n_result<OutputIt>>::type vformat_to_n(
-    OutputIt out, std::size_t n, basic_string_view<Char> format_str,
-    typename format_to_n_args<OutputIt, Char>::type args) {
+inline typename std::enable_if<internal::is_output_iterator<OutputIt>::value,
+                               format_to_n_result<OutputIt>>::type
+vformat_to_n(OutputIt out, std::size_t n, basic_string_view<Char> format_str,
+             typename format_to_n_args<OutputIt, Char>::type args) {
   typedef internal::truncating_iterator<OutputIt> It;
   auto it = vformat_to(It(out, n), format_str, args);
   return {it.base(), it.count()};
@@ -3390,16 +3462,15 @@ inline typename std::enable_if<
  \endrst
  */
 template <typename OutputIt, typename S, typename... Args>
-inline FMT_ENABLE_IF_T(
-    internal::is_string<S>::value &&
-    internal::is_output_iterator<OutputIt>::value,
-    format_to_n_result<OutputIt>)
+inline FMT_ENABLE_IF_T(internal::is_string<S>::value
+                           &&internal::is_output_iterator<OutputIt>::value,
+                       format_to_n_result<OutputIt>)
     format_to_n(OutputIt out, std::size_t n, const S &format_str,
                 const Args &... args) {
   internal::check_format_string<Args...>(format_str);
   typedef FMT_CHAR(S) Char;
-  format_arg_store<
-      typename format_to_n_context<OutputIt, Char>::type, Args...> as(args...);
+  format_arg_store<typename format_to_n_context<OutputIt, Char>::type, Args...>
+  as(args...);
   return vformat_to_n(out, n, to_string_view(format_str),
                       typename format_to_n_args<OutputIt, Char>::type(as));
 }
@@ -3427,7 +3498,7 @@ inline std::size_t formatted_size(string_view format_str,
 #if FMT_USE_USER_DEFINED_LITERALS
 namespace internal {
 
-# if FMT_UDL_TEMPLATE
+#if FMT_UDL_TEMPLATE
 template <typename Char, Char... CHARS>
 class udl_formatter {
  public:
@@ -3436,23 +3507,23 @@ class udl_formatter {
     FMT_CONSTEXPR_DECL Char s[] = {CHARS..., '\0'};
     FMT_CONSTEXPR_DECL bool invalid_format =
         do_check_format_string<Char, error_handler, Args...>(
-          basic_string_view<Char>(s, sizeof...(CHARS)));
+            basic_string_view<Char>(s, sizeof...(CHARS)));
     (void)invalid_format;
     return format(s, args...);
   }
 };
-# else
+#else
 template <typename Char>
 struct udl_formatter {
   const Char *str;
 
   template <typename... Args>
   auto operator()(Args &&... args) const
-                  -> decltype(format(str, std::forward<Args>(args)...)) {
+      -> decltype(format(str, std::forward<Args>(args)...)) {
     return format(str, std::forward<Args>(args)...);
   }
 };
-# endif // FMT_UDL_TEMPLATE
+#endif  // FMT_UDL_TEMPLATE
 
 template <typename Char>
 struct udl_arg {
@@ -3464,16 +3535,15 @@ struct udl_arg {
   }
 };
 
-} // namespace internal
+}  // namespace internal
 
 inline namespace literals {
-
-# if FMT_UDL_TEMPLATE
+#if FMT_UDL_TEMPLATE
 template <typename Char, Char... CHARS>
 FMT_CONSTEXPR internal::udl_formatter<Char, CHARS...> operator""_format() {
   return {};
 }
-# else
+#else
 /**
   \rst
   User-defined literal equivalent of :func:`fmt::format`.
@@ -3484,11 +3554,15 @@ FMT_CONSTEXPR internal::udl_formatter<Char, CHARS...> operator""_format() {
     std::string message = "The answer is {}"_format(42);
   \endrst
  */
-inline internal::udl_formatter<char>
-operator"" _format(const char *s, std::size_t) { return {s}; }
-inline internal::udl_formatter<wchar_t>
-operator"" _format(const wchar_t *s, std::size_t) { return {s}; }
-# endif // FMT_UDL_TEMPLATE
+inline internal::udl_formatter<char> operator"" _format(const char *s,
+                                                        std::size_t) {
+  return {s};
+}
+inline internal::udl_formatter<wchar_t> operator"" _format(const wchar_t *s,
+                                                           std::size_t) {
+  return {s};
+}
+#endif  // FMT_UDL_TEMPLATE
 
 /**
   \rst
@@ -3500,24 +3574,27 @@ operator"" _format(const wchar_t *s, std::size_t) { return {s}; }
     fmt::print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
   \endrst
  */
-inline internal::udl_arg<char>
-operator"" _a(const char *s, std::size_t) { return {s}; }
-inline internal::udl_arg<wchar_t>
-operator"" _a(const wchar_t *s, std::size_t) { return {s}; }
-} // inline namespace literals
-#endif // FMT_USE_USER_DEFINED_LITERALS
+inline internal::udl_arg<char> operator"" _a(const char *s, std::size_t) {
+  return {s};
+}
+inline internal::udl_arg<wchar_t> operator"" _a(const wchar_t *s, std::size_t) {
+  return {s};
+}
+}  // namespace literals
+#endif  // FMT_USE_USER_DEFINED_LITERALS
 FMT_END_NAMESPACE
 
-#define FMT_STRING(s) [] { \
-    typedef typename std::remove_cv<std::remove_pointer< \
-      typename std::decay<decltype(s)>::type>::type>::type ct; \
-    struct str : fmt::compile_string { \
-      typedef ct char_type; \
+#define FMT_STRING(s)                                             \
+  [] {                                                            \
+    typedef typename std::remove_cv<std::remove_pointer<          \
+        typename std::decay<decltype(s)>::type>::type>::type ct;  \
+    struct str : fmt::compile_string {                            \
+      typedef ct char_type;                                       \
       FMT_CONSTEXPR operator fmt::basic_string_view<ct>() const { \
-        return {s, sizeof(s) / sizeof(ct) - 1}; \
-      } \
-    }; \
-    return str{}; \
+        return {s, sizeof(s) / sizeof(ct) - 1};                   \
+      }                                                           \
+    };                                                            \
+    return str{};                                                 \
   }()
 
 #if defined(FMT_STRING_ALIAS) && FMT_STRING_ALIAS
@@ -3535,19 +3612,19 @@ FMT_END_NAMESPACE
     std::string s = format(fmt("{:d}"), "foo");
   \endrst
  */
-# define fmt(s) FMT_STRING(s)
+#define fmt(s) FMT_STRING(s)
 #endif
 
 #ifdef FMT_HEADER_ONLY
-# define FMT_FUNC inline
-# include "format-inl.h"
+#define FMT_FUNC inline
+#include "format-inl.h"
 #else
-# define FMT_FUNC
+#define FMT_FUNC
 #endif
 
 // Restore warnings.
 #if FMT_GCC_VERSION >= 406 || FMT_CLANG_VERSION
-# pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 
 #endif  // FMT_FORMAT_H_

--- a/include/fmt/locale.h
+++ b/include/fmt/locale.h
@@ -9,6 +9,7 @@
 #define FMT_LOCALE_H_
 
 #include "format.h"
+
 #include <locale>
 
 FMT_BEGIN_NAMESPACE
@@ -19,9 +20,9 @@ typename buffer_context<Char>::type::iterator vformat_to(
     const std::locale &loc, basic_buffer<Char> &buf,
     basic_string_view<Char> format_str,
     basic_format_args<typename buffer_context<Char>::type> args) {
-  typedef back_insert_range<basic_buffer<Char> > range;
-  return vformat_to<arg_formatter<range>>(
-    buf, to_string_view(format_str), args, internal::locale_ref(loc));
+  typedef back_insert_range<basic_buffer<Char>> range;
+  return vformat_to<arg_formatter<range>>(buf, to_string_view(format_str), args,
+                                          internal::locale_ref(loc));
 }
 
 template <typename Char>
@@ -32,7 +33,7 @@ std::basic_string<Char> vformat(
   internal::vformat_to(loc, buffer, format_str, args);
   return fmt::to_string(buffer);
 }
-}
+}  // namespace internal
 
 template <typename S, typename Char = FMT_CHAR(S)>
 inline std::basic_string<Char> vformat(
@@ -42,27 +43,29 @@ inline std::basic_string<Char> vformat(
 }
 
 template <typename S, typename... Args>
-inline std::basic_string<FMT_CHAR(S)> format(
-    const std::locale &loc, const S &format_str, const Args &... args) {
+inline std::basic_string<FMT_CHAR(S)> format(const std::locale &loc,
+                                             const S &format_str,
+                                             const Args &... args) {
   return internal::vformat(
-    loc, to_string_view(format_str),
-    *internal::checked_args<S, Args...>(format_str, args...));
+      loc, to_string_view(format_str),
+      *internal::checked_args<S, Args...>(format_str, args...));
 }
 
 template <typename String, typename OutputIt, typename... Args>
 inline typename std::enable_if<internal::is_output_iterator<OutputIt>::value,
                                OutputIt>::type
-    vformat_to(OutputIt out, const std::locale &loc, const String &format_str,
-               typename format_args_t<OutputIt, FMT_CHAR(String)>::type args) {
+vformat_to(OutputIt out, const std::locale &loc, const String &format_str,
+           typename format_args_t<OutputIt, FMT_CHAR(String)>::type args) {
   typedef output_range<OutputIt, FMT_CHAR(String)> range;
   return vformat_to<arg_formatter<range>>(
-    range(out), to_string_view(format_str), args, internal::locale_ref(loc));
+      range(out), to_string_view(format_str), args, internal::locale_ref(loc));
 }
 
 template <typename OutputIt, typename S, typename... Args>
-inline typename std::enable_if<
-    internal::is_string<S>::value &&
-    internal::is_output_iterator<OutputIt>::value, OutputIt>::type
+inline
+    typename std::enable_if<internal::is_string<S>::value &&
+                                internal::is_output_iterator<OutputIt>::value,
+                            OutputIt>::type
     format_to(OutputIt out, const std::locale &loc, const S &format_str,
               const Args &... args) {
   internal::check_format_string<Args...>(format_str);

--- a/include/fmt/locale.h
+++ b/include/fmt/locale.h
@@ -17,17 +17,19 @@ FMT_BEGIN_NAMESPACE
 namespace internal {
 template <typename Char>
 typename buffer_context<Char>::type::iterator vformat_to(
-    const std::locale &loc, basic_buffer<Char> &buf,
+    const std::locale &loc,
+    basic_buffer<Char> &buf,
     basic_string_view<Char> format_str,
     basic_format_args<typename buffer_context<Char>::type> args) {
   typedef back_insert_range<basic_buffer<Char>> range;
-  return vformat_to<arg_formatter<range>>(buf, to_string_view(format_str), args,
-                                          internal::locale_ref(loc));
+  return vformat_to<arg_formatter<range>>(
+      buf, to_string_view(format_str), args, internal::locale_ref(loc));
 }
 
 template <typename Char>
 std::basic_string<Char> vformat(
-    const std::locale &loc, basic_string_view<Char> format_str,
+    const std::locale &loc,
+    basic_string_view<Char> format_str,
     basic_format_args<typename buffer_context<Char>::type> args) {
   basic_memory_buffer<Char> buffer;
   internal::vformat_to(loc, buffer, format_str, args);
@@ -37,42 +39,49 @@ std::basic_string<Char> vformat(
 
 template <typename S, typename Char = FMT_CHAR(S)>
 inline std::basic_string<Char> vformat(
-    const std::locale &loc, const S &format_str,
+    const std::locale &loc,
+    const S &format_str,
     basic_format_args<typename buffer_context<Char>::type> args) {
   return internal::vformat(loc, to_string_view(format_str), args);
 }
 
 template <typename S, typename... Args>
-inline std::basic_string<FMT_CHAR(S)> format(const std::locale &loc,
-                                             const S &format_str,
-                                             const Args &... args) {
+inline std::basic_string<FMT_CHAR(S)> format(
+    const std::locale &loc, const S &format_str, const Args &... args) {
   return internal::vformat(
-      loc, to_string_view(format_str),
+      loc,
+      to_string_view(format_str),
       *internal::checked_args<S, Args...>(format_str, args...));
 }
 
 template <typename String, typename OutputIt, typename... Args>
-inline typename std::enable_if<internal::is_output_iterator<OutputIt>::value,
-                               OutputIt>::type
-vformat_to(OutputIt out, const std::locale &loc, const String &format_str,
-           typename format_args_t<OutputIt, FMT_CHAR(String)>::type args) {
+inline typename std::
+    enable_if<internal::is_output_iterator<OutputIt>::value, OutputIt>::type
+    vformat_to(
+        OutputIt out,
+        const std::locale &loc,
+        const String &format_str,
+        typename format_args_t<OutputIt, FMT_CHAR(String)>::type args) {
   typedef output_range<OutputIt, FMT_CHAR(String)> range;
   return vformat_to<arg_formatter<range>>(
       range(out), to_string_view(format_str), args, internal::locale_ref(loc));
 }
 
 template <typename OutputIt, typename S, typename... Args>
-inline
-    typename std::enable_if<internal::is_string<S>::value &&
-                                internal::is_output_iterator<OutputIt>::value,
-                            OutputIt>::type
-    format_to(OutputIt out, const std::locale &loc, const S &format_str,
-              const Args &... args) {
+inline typename std::enable_if<
+    internal::is_string<S>::value &&
+        internal::is_output_iterator<OutputIt>::value,
+    OutputIt>::type
+format_to(
+    OutputIt out,
+    const std::locale &loc,
+    const S &format_str,
+    const Args &... args) {
   internal::check_format_string<Args...>(format_str);
   typedef typename format_context_t<OutputIt, FMT_CHAR(S)>::type context;
   format_arg_store<context, Args...> as{args...};
-  return vformat_to(out, loc, to_string_view(format_str),
-                    basic_format_args<context>(as));
+  return vformat_to(
+      out, loc, to_string_view(format_str), basic_format_args<context>(as));
 }
 
 FMT_END_NAMESPACE

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -9,6 +9,7 @@
 #define FMT_OSTREAM_H_
 
 #include "format.h"
+
 #include <ostream>
 
 FMT_BEGIN_NAMESPACE
@@ -53,14 +54,16 @@ struct test_stream : std::basic_ostream<Char> {
   void operator<<(null);
 };
 
-// Checks if T has a user-defined operator<< (e.g. not a member of std::ostream).
+// Checks if T has a user-defined operator<< (e.g. not a member of
+// std::ostream).
 template <typename T, typename Char>
 class is_streamable {
  private:
   template <typename U>
   static decltype(
-    internal::declval<test_stream<Char>&>()
-      << internal::declval<U>(), std::true_type()) test(int);
+      internal::declval<test_stream<Char> &>() << internal::declval<U>(),
+      std::true_type())
+  test(int);
 
   template <typename>
   static std::false_type test(...);
@@ -101,20 +104,19 @@ void format_value(basic_buffer<Char> &buffer, const T &value) {
 // function (not a member of std::ostream).
 template <typename T, typename Char>
 struct convert_to_int<T, Char, void> {
-  static const bool value =
-    convert_to_int<T, Char, int>::value &&
-    !internal::is_streamable<T, Char>::value;
+  static const bool value = convert_to_int<T, Char, int>::value &&
+                            !internal::is_streamable<T, Char>::value;
 };
 
 // Formats an object of type T that has an overloaded ostream operator<<.
 template <typename T, typename Char>
-struct formatter<T, Char,
+struct formatter<
+    T,
+    Char,
     typename std::enable_if<
-      internal::is_streamable<T, Char>::value &&
-      !internal::format_type<
-        typename buffer_context<Char>::type, T>::value>::type>
-    : formatter<basic_string_view<Char>, Char> {
-
+        internal::is_streamable<T, Char>::value &&
+        !internal::format_type<typename buffer_context<Char>::type, T>::value>::
+        type> : formatter<basic_string_view<Char>, Char> {
   template <typename Context>
   auto format(const T &value, Context &ctx) -> decltype(ctx.out()) {
     basic_memory_buffer<Char> buffer;
@@ -125,9 +127,10 @@ struct formatter<T, Char,
 };
 
 template <typename Char>
-inline void vprint(std::basic_ostream<Char> &os,
-                   basic_string_view<Char> format_str,
-                   basic_format_args<typename buffer_context<Char>::type> args) {
+inline void vprint(
+    std::basic_ostream<Char> &os,
+    basic_string_view<Char> format_str,
+    basic_format_args<typename buffer_context<Char>::type> args) {
   basic_memory_buffer<Char> buffer;
   internal::vformat_to(buffer, format_str, args);
   internal::write(os, buffer);
@@ -142,9 +145,10 @@ inline void vprint(std::basic_ostream<Char> &os,
   \endrst
  */
 template <typename S, typename... Args>
-inline typename std::enable_if<internal::is_string<S>::value>::type
-print(std::basic_ostream<FMT_CHAR(S)> &os, const S &format_str,
-      const Args & ... args) {
+inline typename std::enable_if<internal::is_string<S>::value>::type print(
+    std::basic_ostream<FMT_CHAR(S)> &os,
+    const S &format_str,
+    const Args &... args) {
   internal::checked_args<S, Args...> ca(format_str, args...);
   vprint(os, to_string_view(format_str), *ca);
 }

--- a/include/fmt/posix.h
+++ b/include/fmt/posix.h
@@ -10,7 +10,7 @@
 
 #if defined(__MINGW32__) || defined(__CYGWIN__)
 // Workaround MinGW bug https://sourceforge.net/p/mingw/bugs/2024/.
-# undef __STRICT_ANSI__
+#undef __STRICT_ANSI__
 #endif
 
 #include <errno.h>
@@ -22,42 +22,42 @@
 #include <cstddef>
 
 #if defined __APPLE__ || defined(__FreeBSD__)
-# include <xlocale.h>  // for LC_NUMERIC_MASK on OS X
+#include <xlocale.h>  // for LC_NUMERIC_MASK on OS X
 #endif
 
 #include "format.h"
 
 #ifndef FMT_POSIX
-# if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(_WIN32) && !defined(__MINGW32__)
 // Fix warnings about deprecated symbols.
-#  define FMT_POSIX(call) _##call
-# else
-#  define FMT_POSIX(call) call
-# endif
+#define FMT_POSIX(call) _##call
+#else
+#define FMT_POSIX(call) call
+#endif
 #endif
 
 // Calls to system functions are wrapped in FMT_SYSTEM for testability.
 #ifdef FMT_SYSTEM
-# define FMT_POSIX_CALL(call) FMT_SYSTEM(call)
+#define FMT_POSIX_CALL(call) FMT_SYSTEM(call)
 #else
-# define FMT_SYSTEM(call) call
-# ifdef _WIN32
+#define FMT_SYSTEM(call) call
+#ifdef _WIN32
 // Fix warnings about deprecated symbols.
-#  define FMT_POSIX_CALL(call) ::_##call
-# else
-#  define FMT_POSIX_CALL(call) ::call
-# endif
+#define FMT_POSIX_CALL(call) ::_##call
+#else
+#define FMT_POSIX_CALL(call) ::call
+#endif
 #endif
 
 // Retries the expression while it evaluates to error_result and errno
 // equals to EINTR.
 #ifndef _WIN32
-# define FMT_RETRY_VAL(result, expression, error_result) \
-  do { \
-    result = (expression); \
+#define FMT_RETRY_VAL(result, expression, error_result) \
+  do {                                                  \
+    result = (expression);                              \
   } while (result == error_result && errno == EINTR)
 #else
-# define FMT_RETRY_VAL(result, expression, error_result) result = (expression)
+#define FMT_RETRY_VAL(result, expression, error_result) result = (expression)
 #endif
 
 #define FMT_RETRY(result, expression) FMT_RETRY_VAL(result, expression, -1)
@@ -143,13 +143,12 @@ class buffered_file {
   buffered_file(const buffered_file &) = delete;
   void operator=(const buffered_file &) = delete;
 
-
  public:
   buffered_file(buffered_file &&other) FMT_NOEXCEPT : file_(other.file_) {
     other.file_ = FMT_NULL;
   }
 
-  buffered_file& operator=(buffered_file &&other) {
+  buffered_file &operator=(buffered_file &&other) {
     close();
     file_ = other.file_;
     other.file_ = FMT_NULL;
@@ -167,14 +166,14 @@ class buffered_file {
 
   // We place parentheses around fileno to workaround a bug in some versions
   // of MinGW that define fileno as a macro.
-  FMT_API int (fileno)() const;
+  FMT_API int(fileno)() const;
 
   void vprint(string_view format_str, format_args args) {
     fmt::vprint(file_, format_str, args);
   }
 
   template <typename... Args>
-  inline void print(string_view format_str, const Args & ... args) {
+  inline void print(string_view format_str, const Args &... args) {
     vprint(format_str, make_format_args(args...));
   }
 };
@@ -195,9 +194,9 @@ class file {
  public:
   // Possible values for the oflag argument to the constructor.
   enum {
-    RDONLY = FMT_POSIX(O_RDONLY), // Open for reading only.
-    WRONLY = FMT_POSIX(O_WRONLY), // Open for writing only.
-    RDWR   = FMT_POSIX(O_RDWR)    // Open for reading and writing.
+    RDONLY = FMT_POSIX(O_RDONLY),  // Open for reading only.
+    WRONLY = FMT_POSIX(O_WRONLY),  // Open for writing only.
+    RDWR = FMT_POSIX(O_RDWR)       // Open for reading and writing.
   };
 
   // Constructs a file object which doesn't represent any file.
@@ -211,11 +210,9 @@ class file {
   void operator=(const file &) = delete;
 
  public:
-  file(file &&other) FMT_NOEXCEPT : fd_(other.fd_) {
-    other.fd_ = -1;
-  }
+  file(file &&other) FMT_NOEXCEPT : fd_(other.fd_) { other.fd_ = -1; }
 
-  file& operator=(file &&other) {
+  file &operator=(file &&other) {
     close();
     fd_ = other.fd_;
     other.fd_ = -1;
@@ -265,17 +262,17 @@ class file {
 // Returns the memory page size.
 long getpagesize();
 
-#if (defined(LC_NUMERIC_MASK) || defined(_MSC_VER)) && \
+#if (defined(LC_NUMERIC_MASK) || defined(_MSC_VER)) &&                        \
     !defined(__ANDROID__) && !defined(__CYGWIN__) && !defined(__OpenBSD__) && \
     !defined(__NEWLIB_H__)
-# define FMT_LOCALE
+#define FMT_LOCALE
 #endif
 
 #ifdef FMT_LOCALE
 // A "C" numeric locale.
 class Locale {
  private:
-# ifdef _MSC_VER
+#ifdef _MSC_VER
   typedef _locale_t locale_t;
 
   enum { LC_NUMERIC_MASK = LC_NUMERIC };
@@ -284,14 +281,12 @@ class Locale {
     return _create_locale(category_mask, locale);
   }
 
-  static void freelocale(locale_t locale) {
-    _free_locale(locale);
-  }
+  static void freelocale(locale_t locale) { _free_locale(locale); }
 
   static double strtod_l(const char *nptr, char **endptr, _locale_t locale) {
     return _strtod_l(nptr, endptr, locale);
   }
-# endif
+#endif
 
   locale_t locale_;
 

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -8,10 +8,10 @@
 #ifndef FMT_PRINTF_H_
 #define FMT_PRINTF_H_
 
+#include "ostream.h"
+
 #include <algorithm>  // std::fill_n
 #include <limits>     // std::numeric_limits
-
-#include "ostream.h"
 
 FMT_BEGIN_NAMESPACE
 namespace internal {
@@ -24,18 +24,18 @@ class null_terminating_iterator {
  public:
   typedef std::ptrdiff_t difference_type;
   typedef Char value_type;
-  typedef const Char* pointer;
-  typedef const Char& reference;
+  typedef const Char *pointer;
+  typedef const Char &reference;
   typedef std::random_access_iterator_tag iterator_category;
 
   null_terminating_iterator() : ptr_(0), end_(0) {}
 
   FMT_CONSTEXPR null_terminating_iterator(const Char *ptr, const Char *end)
-    : ptr_(ptr), end_(end) {}
+      : ptr_(ptr), end_(end) {}
 
   template <typename Range>
   FMT_CONSTEXPR explicit null_terminating_iterator(const Range &r)
-    : ptr_(r.begin()), end_(r.end()) {}
+      : ptr_(r.begin()), end_(r.end()) {}
 
   FMT_CONSTEXPR null_terminating_iterator &operator=(const Char *ptr) {
     assert(ptr <= end_);
@@ -43,9 +43,7 @@ class null_terminating_iterator {
     return *this;
   }
 
-  FMT_CONSTEXPR Char operator*() const {
-    return ptr_ != end_ ? *ptr_ : Char();
-  }
+  FMT_CONSTEXPR Char operator*() const { return ptr_ != end_ ? *ptr_ : Char(); }
 
   FMT_CONSTEXPR null_terminating_iterator operator++() {
     ++ptr_;
@@ -76,8 +74,8 @@ class null_terminating_iterator {
     return *this;
   }
 
-  FMT_CONSTEXPR difference_type operator-(
-      null_terminating_iterator other) const {
+  FMT_CONSTEXPR difference_type
+  operator-(null_terminating_iterator other) const {
     return ptr_ - other.ptr_;
   }
 
@@ -101,7 +99,9 @@ class null_terminating_iterator {
 };
 
 template <typename T>
-FMT_CONSTEXPR const T *pointer_from(const T *p) { return p; }
+FMT_CONSTEXPR const T *pointer_from(const T *p) {
+  return p;
+}
 
 template <typename Char>
 FMT_CONSTEXPR const Char *pointer_from(null_terminating_iterator<Char> it) {
@@ -162,33 +162,38 @@ struct int_checker<true> {
   static bool fits_in_int(int) { return true; }
 };
 
-class printf_precision_handler: public function<int> {
+class printf_precision_handler : public function<int> {
  public:
   template <typename T>
-  typename std::enable_if<std::is_integral<T>::value, int>::type
-      operator()(T value) {
+  typename std::enable_if<std::is_integral<T>::value, int>::type operator()(
+      T value) {
     if (!int_checker<std::numeric_limits<T>::is_signed>::fits_in_int(value))
       FMT_THROW(format_error("number is too big"));
     return static_cast<int>(value);
   }
 
   template <typename T>
-  typename std::enable_if<!std::is_integral<T>::value, int>::type operator()(T) {
+  typename std::enable_if<!std::is_integral<T>::value, int>::type operator()(
+      T) {
     FMT_THROW(format_error("precision is not integer"));
     return 0;
   }
 };
 
 // An argument visitor that returns true iff arg is a zero integer.
-class is_zero_int: public function<bool> {
+class is_zero_int : public function<bool> {
  public:
   template <typename T>
-  typename std::enable_if<std::is_integral<T>::value, bool>::type
-      operator()(T value) { return value == 0; }
+  typename std::enable_if<std::is_integral<T>::value, bool>::type operator()(
+      T value) {
+    return value == 0;
+  }
 
   template <typename T>
-  typename std::enable_if<!std::is_integral<T>::value, bool>::type
-      operator()(T) { return false; }
+  typename std::enable_if<!std::is_integral<T>::value, bool>::type operator()(
+      T) {
+    return false;
+  }
 };
 
 template <typename T>
@@ -200,7 +205,7 @@ struct make_unsigned_or_bool<bool> {
 };
 
 template <typename T, typename Context>
-class arg_converter: public function<void> {
+class arg_converter : public function<void> {
  private:
   typedef typename Context::char_type Char;
 
@@ -209,7 +214,7 @@ class arg_converter: public function<void> {
 
  public:
   arg_converter(basic_format_arg<Context> &arg, Char type)
-    : arg_(arg), type_(type) {}
+      : arg_(arg), type_(type) {}
 
   void operator()(bool value) {
     if (type_ != 's')
@@ -217,20 +222,20 @@ class arg_converter: public function<void> {
   }
 
   template <typename U>
-  typename std::enable_if<std::is_integral<U>::value>::type
-      operator()(U value) {
+  typename std::enable_if<std::is_integral<U>::value>::type operator()(
+      U value) {
     bool is_signed = type_ == 'd' || type_ == 'i';
-    typedef typename std::conditional<
-        std::is_same<T, void>::value, U, T>::type TargetType;
+    typedef typename std::conditional<std::is_same<T, void>::value, U, T>::type
+        TargetType;
     if (const_check(sizeof(TargetType) <= sizeof(int))) {
       // Extra casts are used to silence warnings.
       if (is_signed) {
         arg_ = internal::make_arg<Context>(
-          static_cast<int>(static_cast<TargetType>(value)));
+            static_cast<int>(static_cast<TargetType>(value)));
       } else {
         typedef typename make_unsigned_or_bool<TargetType>::type Unsigned;
         arg_ = internal::make_arg<Context>(
-          static_cast<unsigned>(static_cast<Unsigned>(value)));
+            static_cast<unsigned>(static_cast<Unsigned>(value)));
       }
     } else {
       if (is_signed) {
@@ -240,7 +245,7 @@ class arg_converter: public function<void> {
         arg_ = internal::make_arg<Context>(static_cast<long long>(value));
       } else {
         arg_ = internal::make_arg<Context>(
-          static_cast<typename make_unsigned_or_bool<U>::type>(value));
+            static_cast<typename make_unsigned_or_bool<U>::type>(value));
       }
     }
   }
@@ -262,7 +267,7 @@ void convert_arg(basic_format_arg<Context> &arg, Char type) {
 
 // Converts an integer argument to char for printf.
 template <typename Context>
-class char_converter: public function<void> {
+class char_converter : public function<void> {
  private:
   basic_format_arg<Context> &arg_;
 
@@ -270,8 +275,8 @@ class char_converter: public function<void> {
   explicit char_converter(basic_format_arg<Context> &arg) : arg_(arg) {}
 
   template <typename T>
-  typename std::enable_if<std::is_integral<T>::value>::type
-      operator()(T value) {
+  typename std::enable_if<std::is_integral<T>::value>::type operator()(
+      T value) {
     typedef typename Context::char_type Char;
     arg_ = internal::make_arg<Context>(static_cast<Char>(value));
   }
@@ -285,7 +290,7 @@ class char_converter: public function<void> {
 // Checks if an argument is a valid printf width specifier and sets
 // left alignment if it is negative.
 template <typename Char>
-class printf_width_handler: public function<unsigned> {
+class printf_width_handler : public function<unsigned> {
  private:
   typedef basic_format_specs<Char> format_specs;
 
@@ -296,7 +301,7 @@ class printf_width_handler: public function<unsigned> {
 
   template <typename T>
   typename std::enable_if<std::is_integral<T>::value, unsigned>::type
-      operator()(T value) {
+  operator()(T value) {
     typedef typename internal::int_traits<T>::main_type UnsignedType;
     UnsignedType width = static_cast<UnsignedType>(value);
     if (internal::is_negative(value)) {
@@ -311,15 +316,17 @@ class printf_width_handler: public function<unsigned> {
 
   template <typename T>
   typename std::enable_if<!std::is_integral<T>::value, unsigned>::type
-      operator()(T) {
+  operator()(T) {
     FMT_THROW(format_error("width is not integer"));
     return 0;
   }
 };
 
 template <typename Char, typename Context>
-void printf(basic_buffer<Char> &buf, basic_string_view<Char> format,
-            basic_format_args<Context> args) {
+void printf(
+    basic_buffer<Char> &buf,
+    basic_string_view<Char> format,
+    basic_format_args<Context> args) {
   Context(std::back_inserter(buf), format, args).format();
 }
 }  // namespace internal
@@ -330,9 +337,10 @@ template <typename Range>
 class printf_arg_formatter;
 
 template <
-    typename OutputIt, typename Char,
+    typename OutputIt,
+    typename Char,
     typename ArgFormatter =
-      printf_arg_formatter<back_insert_range<internal::basic_buffer<Char>>>>
+        printf_arg_formatter<back_insert_range<internal::basic_buffer<Char>>>>
 class basic_printf_context;
 
 /**
@@ -341,10 +349,10 @@ class basic_printf_context;
   \endrst
  */
 template <typename Range>
-class printf_arg_formatter:
-  public internal::function<
-    typename internal::arg_formatter_base<Range>::iterator>,
-  public internal::arg_formatter_base<Range> {
+class printf_arg_formatter
+    : public internal::function<
+          typename internal::arg_formatter_base<Range>::iterator>,
+      public internal::arg_formatter_base<Range> {
  private:
   typedef typename Range::value_type char_type;
   typedef decltype(internal::declval<Range>().begin()) iterator;
@@ -373,15 +381,19 @@ class printf_arg_formatter:
     specifier information for standard argument types.
     \endrst
    */
-  printf_arg_formatter(internal::basic_buffer<char_type> &buffer,
-                       format_specs &spec, context_type &ctx)
-    : base(back_insert_range<internal::basic_buffer<char_type>>(buffer), &spec,
-           ctx.locale()),
-      context_(ctx) {}
+  printf_arg_formatter(
+      internal::basic_buffer<char_type> &buffer,
+      format_specs &spec,
+      context_type &ctx)
+      : base(
+            back_insert_range<internal::basic_buffer<char_type>>(buffer),
+            &spec,
+            ctx.locale()),
+        context_(ctx) {}
 
   template <typename T>
   typename std::enable_if<std::is_integral<T>::value, iterator>::type
-      operator()(T value) {
+  operator()(T value) {
     // MSVC2013 fails to compile separate overloads for bool and char_type so
     // use std::is_same instead.
     if (std::is_same<T, bool>::value) {
@@ -405,7 +417,7 @@ class printf_arg_formatter:
 
   template <typename T>
   typename std::enable_if<std::is_floating_point<T>::value, iterator>::type
-      operator()(T value) {
+  operator()(T value) {
     return base::operator()(value);
   }
 
@@ -435,9 +447,7 @@ class printf_arg_formatter:
     return base::operator()(value);
   }
 
-  iterator operator()(monostate value) {
-    return base::operator()(value);
-  }
+  iterator operator()(monostate value) { return base::operator()(value); }
 
   /** Formats a pointer. */
   iterator operator()(const void *value) {
@@ -458,7 +468,9 @@ class printf_arg_formatter:
 template <typename T>
 struct printf_formatter {
   template <typename ParseContext>
-  auto parse(ParseContext &ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+  auto parse(ParseContext &ctx) -> decltype(ctx.begin()) {
+    return ctx.begin();
+  }
 
   template <typename FormatContext>
   auto format(const T &value, FormatContext &ctx) -> decltype(ctx.out()) {
@@ -470,16 +482,20 @@ struct printf_formatter {
 /** This template formats data and writes the output to a writer. */
 template <typename OutputIt, typename Char, typename ArgFormatter>
 class basic_printf_context :
-  // Inherit publicly as a workaround for the icc bug
-  // https://software.intel.com/en-us/forums/intel-c-compiler/topic/783476.
-  public internal::context_base<
-    OutputIt, basic_printf_context<OutputIt, Char, ArgFormatter>, Char> {
+    // Inherit publicly as a workaround for the icc bug
+    // https://software.intel.com/en-us/forums/intel-c-compiler/topic/783476.
+    public internal::context_base<
+        OutputIt,
+        basic_printf_context<OutputIt, Char, ArgFormatter>,
+        Char> {
  public:
   /** The character type for the output. */
   typedef Char char_type;
 
   template <typename T>
-  struct formatter_type { typedef printf_formatter<T> type; };
+  struct formatter_type {
+    typedef printf_formatter<T> type;
+  };
 
  private:
   typedef internal::context_base<OutputIt, basic_printf_context, Char> base;
@@ -492,8 +508,7 @@ class basic_printf_context :
   // Returns the argument with specified index or, if arg_index is equal
   // to the maximum unsigned value, the next argument.
   format_arg get_arg(
-      iterator it,
-      unsigned arg_index = (std::numeric_limits<unsigned>::max)());
+      iterator it, unsigned arg_index = (std::numeric_limits<unsigned>::max)());
 
   // Parses argument index, flags and width and returns the argument index.
   unsigned parse_header(iterator &it, format_specs &spec);
@@ -506,13 +521,15 @@ class basic_printf_context :
    appropriate lifetimes.
    \endrst
    */
-  basic_printf_context(OutputIt out, basic_string_view<char_type> format_str,
-                       basic_format_args<basic_printf_context> args)
-    : base(out, format_str, args) {}
+  basic_printf_context(
+      OutputIt out,
+      basic_string_view<char_type> format_str,
+      basic_format_args<basic_printf_context> args)
+      : base(out, format_str, args) {}
 
-  using base::parse_context;
-  using base::out;
   using base::advance_to;
+  using base::out;
+  using base::parse_context;
 
   /** Formats stored arguments and writes the output to the range. */
   void format();
@@ -547,7 +564,7 @@ void basic_printf_context<OutputIt, Char, AF>::parse_flags(
 
 template <typename OutputIt, typename Char, typename AF>
 typename basic_printf_context<OutputIt, Char, AF>::format_arg
-  basic_printf_context<OutputIt, Char, AF>::get_arg(
+basic_printf_context<OutputIt, Char, AF>::get_arg(
     iterator it, unsigned arg_index) {
   (void)it;
   if (arg_index == std::numeric_limits<unsigned>::max())
@@ -557,7 +574,7 @@ typename basic_printf_context<OutputIt, Char, AF>::format_arg
 
 template <typename OutputIt, typename Char, typename AF>
 unsigned basic_printf_context<OutputIt, Char, AF>::parse_header(
-  iterator &it, format_specs &spec) {
+    iterator &it, format_specs &spec) {
   unsigned arg_index = std::numeric_limits<unsigned>::max();
   char_type c = *it;
   if (c >= '0' && c <= '9') {
@@ -587,7 +604,7 @@ unsigned basic_printf_context<OutputIt, Char, AF>::parse_header(
   } else if (*it == '*') {
     ++it;
     spec.width_ = visit_format_arg(
-          internal::printf_width_handler<char_type>(spec), get_arg(it));
+        internal::printf_width_handler<char_type>(spec), get_arg(it));
   }
   return arg_index;
 }
@@ -600,7 +617,8 @@ void basic_printf_context<OutputIt, Char, AF>::format() {
   using internal::pointer_from;
   while (*it) {
     char_type c = *it++;
-    if (c != '%') continue;
+    if (c != '%')
+      continue;
     if (*it == c) {
       buffer.append(pointer_from(start), pointer_from(it));
       start = ++it;
@@ -642,34 +660,34 @@ void basic_printf_context<OutputIt, Char, AF>::format() {
     // Parse length and convert the argument to the required type.
     using internal::convert_arg;
     switch (*it++) {
-    case 'h':
-      if (*it == 'h')
-        convert_arg<signed char>(arg, *++it);
-      else
-        convert_arg<short>(arg, *it);
-      break;
-    case 'l':
-      if (*it == 'l')
-        convert_arg<long long>(arg, *++it);
-      else
-        convert_arg<long>(arg, *it);
-      break;
-    case 'j':
-      convert_arg<intmax_t>(arg, *it);
-      break;
-    case 'z':
-      convert_arg<std::size_t>(arg, *it);
-      break;
-    case 't':
-      convert_arg<std::ptrdiff_t>(arg, *it);
-      break;
-    case 'L':
-      // printf produces garbage when 'L' is omitted for long double, no
-      // need to do the same.
-      break;
-    default:
-      --it;
-      convert_arg<void>(arg, *it);
+      case 'h':
+        if (*it == 'h')
+          convert_arg<signed char>(arg, *++it);
+        else
+          convert_arg<short>(arg, *it);
+        break;
+      case 'l':
+        if (*it == 'l')
+          convert_arg<long long>(arg, *++it);
+        else
+          convert_arg<long>(arg, *it);
+        break;
+      case 'j':
+        convert_arg<intmax_t>(arg, *it);
+        break;
+      case 'z':
+        convert_arg<std::size_t>(arg, *it);
+        break;
+      case 't':
+        convert_arg<std::ptrdiff_t>(arg, *it);
+        break;
+      case 'L':
+        // printf produces garbage when 'L' is omitted for long double, no
+        // need to do the same.
+        break;
+      default:
+        --it;
+        convert_arg<void>(arg, *it);
     }
 
     // Parse type.
@@ -679,14 +697,15 @@ void basic_printf_context<OutputIt, Char, AF>::format() {
     if (arg.is_integral()) {
       // Normalize type.
       switch (spec.type) {
-      case 'i': case 'u':
-        spec.type = 'd';
-        break;
-      case 'c':
-        // TODO: handle wchar_t better?
-        visit_format_arg(
+        case 'i':
+        case 'u':
+          spec.type = 'd';
+          break;
+        case 'c':
+          // TODO: handle wchar_t better?
+          visit_format_arg(
               internal::char_converter<basic_printf_context>(arg), arg);
-        break;
+          break;
       }
     }
 
@@ -701,7 +720,9 @@ void basic_printf_context<OutputIt, Char, AF>::format() {
 template <typename Buffer>
 struct basic_printf_context_t {
   typedef basic_printf_context<
-    std::back_insert_iterator<Buffer>, typename Buffer::value_type> type;
+      std::back_insert_iterator<Buffer>,
+      typename Buffer::value_type>
+      type;
 };
 
 typedef basic_printf_context_t<internal::buffer>::type printf_context;
@@ -713,28 +734,33 @@ typedef basic_format_args<wprintf_context> wprintf_args;
 /**
   \rst
   Constructs an `~fmt::format_arg_store` object that contains references to
-  arguments and can be implicitly converted to `~fmt::printf_args`. 
+  arguments and can be implicitly converted to `~fmt::printf_args`.
   \endrst
  */
-template<typename... Args>
-inline format_arg_store<printf_context, Args...>
-  make_printf_args(const Args &... args) { return {args...}; }
+template <typename... Args>
+inline format_arg_store<printf_context, Args...> make_printf_args(
+    const Args &... args) {
+  return {args...};
+}
 
 /**
   \rst
   Constructs an `~fmt::format_arg_store` object that contains references to
-  arguments and can be implicitly converted to `~fmt::wprintf_args`. 
+  arguments and can be implicitly converted to `~fmt::wprintf_args`.
   \endrst
  */
-template<typename... Args>
-inline format_arg_store<wprintf_context, Args...>
-  make_wprintf_args(const Args &... args) { return {args...}; }
+template <typename... Args>
+inline format_arg_store<wprintf_context, Args...> make_wprintf_args(
+    const Args &... args) {
+  return {args...};
+}
 
 template <typename S, typename Char = FMT_CHAR(S)>
-inline std::basic_string<Char>
-vsprintf(const S &format,
-         basic_format_args<typename basic_printf_context_t<
-           internal::basic_buffer<Char>>::type> args) {
+inline std::basic_string<Char> vsprintf(
+    const S &format,
+    basic_format_args<
+        typename basic_printf_context_t<internal::basic_buffer<Char>>::type>
+        args) {
   basic_memory_buffer<Char> buffer;
   printf(buffer, to_string_view(format), args);
   return to_string(buffer);
@@ -752,24 +778,27 @@ vsprintf(const S &format,
 template <typename S, typename... Args>
 inline FMT_ENABLE_IF_T(
     internal::is_string<S>::value, std::basic_string<FMT_CHAR(S)>)
-    sprintf(const S &format, const Args & ... args) {
+    sprintf(const S &format, const Args &... args) {
   internal::check_format_string<Args...>(format);
   typedef internal::basic_buffer<FMT_CHAR(S)> buffer;
   typedef typename basic_printf_context_t<buffer>::type context;
-  format_arg_store<context, Args...> as{ args... };
-  return vsprintf(to_string_view(format),
-                  basic_format_args<context>(as));
+  format_arg_store<context, Args...> as{args...};
+  return vsprintf(to_string_view(format), basic_format_args<context>(as));
 }
 
 template <typename S, typename Char = FMT_CHAR(S)>
-inline int vfprintf(std::FILE *f, const S &format,
-                    basic_format_args<typename basic_printf_context_t<
-                      internal::basic_buffer<Char>>::type> args) {
+inline int vfprintf(
+    std::FILE *f,
+    const S &format,
+    basic_format_args<
+        typename basic_printf_context_t<internal::basic_buffer<Char>>::type>
+        args) {
   basic_memory_buffer<Char> buffer;
   printf(buffer, to_string_view(format), args);
   std::size_t size = buffer.size();
-  return std::fwrite(
-    buffer.data(), sizeof(Char), size, f) < size ? -1 : static_cast<int>(size);
+  return std::fwrite(buffer.data(), sizeof(Char), size, f) < size
+             ? -1
+             : static_cast<int>(size);
 }
 
 /**
@@ -783,19 +812,20 @@ inline int vfprintf(std::FILE *f, const S &format,
  */
 template <typename S, typename... Args>
 inline FMT_ENABLE_IF_T(internal::is_string<S>::value, int)
-    fprintf(std::FILE *f, const S &format, const Args & ... args) {
+    fprintf(std::FILE *f, const S &format, const Args &... args) {
   internal::check_format_string<Args...>(format);
   typedef internal::basic_buffer<FMT_CHAR(S)> buffer;
   typedef typename basic_printf_context_t<buffer>::type context;
-  format_arg_store<context, Args...> as{ args... };
-  return vfprintf(f, to_string_view(format),
-                  basic_format_args<context>(as));
+  format_arg_store<context, Args...> as{args...};
+  return vfprintf(f, to_string_view(format), basic_format_args<context>(as));
 }
 
 template <typename S, typename Char = FMT_CHAR(S)>
-inline int vprintf(const S &format,
-                   basic_format_args<typename basic_printf_context_t<
-                    internal::basic_buffer<Char>>::type> args) {
+inline int vprintf(
+    const S &format,
+    basic_format_args<
+        typename basic_printf_context_t<internal::basic_buffer<Char>>::type>
+        args) {
   return vfprintf(stdout, to_string_view(format), args);
 }
 
@@ -810,20 +840,21 @@ inline int vprintf(const S &format,
  */
 template <typename S, typename... Args>
 inline FMT_ENABLE_IF_T(internal::is_string<S>::value, int)
-    printf(const S &format_str, const Args & ... args) {
+    printf(const S &format_str, const Args &... args) {
   internal::check_format_string<Args...>(format_str);
   typedef internal::basic_buffer<FMT_CHAR(S)> buffer;
   typedef typename basic_printf_context_t<buffer>::type context;
-  format_arg_store<context, Args...> as{ args... };
-  return vprintf(to_string_view(format_str),
-                 basic_format_args<context>(as));
+  format_arg_store<context, Args...> as{args...};
+  return vprintf(to_string_view(format_str), basic_format_args<context>(as));
 }
 
 template <typename S, typename Char = FMT_CHAR(S)>
-inline int vfprintf(std::basic_ostream<Char> &os,
-                    const S &format,
-                    basic_format_args<typename basic_printf_context_t<
-                      internal::basic_buffer<Char>>::type> args) {
+inline int vfprintf(
+    std::basic_ostream<Char> &os,
+    const S &format,
+    basic_format_args<
+        typename basic_printf_context_t<internal::basic_buffer<Char>>::type>
+        args) {
   basic_memory_buffer<Char> buffer;
   printf(buffer, to_string_view(format), args);
   internal::write(os, buffer);
@@ -840,15 +871,16 @@ inline int vfprintf(std::basic_ostream<Char> &os,
   \endrst
  */
 template <typename S, typename... Args>
-inline FMT_ENABLE_IF_T(internal::is_string<S>::value, int)
-    fprintf(std::basic_ostream<FMT_CHAR(S)> &os,
-            const S &format_str, const Args & ... args) {
+inline FMT_ENABLE_IF_T(internal::is_string<S>::value, int) fprintf(
+    std::basic_ostream<FMT_CHAR(S)> &os,
+    const S &format_str,
+    const Args &... args) {
   internal::check_format_string<Args...>(format_str);
   typedef internal::basic_buffer<FMT_CHAR(S)> buffer;
   typedef typename basic_printf_context_t<buffer>::type context;
-  format_arg_store<context, Args...> as{ args... };
-  return vfprintf(os, to_string_view(format_str),
-                  basic_format_args<context>(as));
+  format_arg_store<context, Args...> as{args...};
+  return vfprintf(
+      os, to_string_view(format_str), basic_format_args<context>(as));
 }
 FMT_END_NAMESPACE
 

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -13,11 +13,12 @@
 #define FMT_RANGES_H_
 
 #include "format.h"
+
 #include <type_traits>
 
 // output only up to N items from the range.
 #ifndef FMT_RANGE_OUTPUT_LENGTH_LIMIT
-# define FMT_RANGE_OUTPUT_LENGTH_LIMIT 256
+#define FMT_RANGE_OUTPUT_LENGTH_LIMIT 256
 #endif
 
 FMT_BEGIN_NAMESPACE
@@ -33,7 +34,8 @@ struct formatting_base {
 template <typename Char, typename Enable = void>
 struct formatting_range : formatting_base<Char> {
   static FMT_CONSTEXPR_DECL const std::size_t range_length_limit =
-      FMT_RANGE_OUTPUT_LENGTH_LIMIT; // output only up to N items from the range.
+      FMT_RANGE_OUTPUT_LENGTH_LIMIT;  // output only up to N items from the
+                                      // range.
   Char prefix;
   Char delimiter;
   Char postfix;
@@ -77,14 +79,14 @@ void copy(char ch, OutputIterator out) {
 template <typename T>
 class is_like_std_string {
   template <typename U>
-  static auto check(U *p) ->
-    decltype(p->find('a'), p->length(), p->data(), int());
+  static auto check(U *p)
+      -> decltype(p->find('a'), p->length(), p->data(), int());
   template <typename>
   static void check(...);
 
  public:
   static FMT_CONSTEXPR_DECL const bool value =
-    !std::is_void<decltype(check<T>(FMT_NULL))>::value;
+      !std::is_void<decltype(check<T>(FMT_NULL))>::value;
 };
 
 template <typename Char>
@@ -98,26 +100,30 @@ struct is_range_ : std::false_type {};
 
 #if !FMT_MSC_VER || FMT_MSC_VER > 1800
 template <typename T>
-struct is_range_<T, typename std::conditional<
-                    false,
-                    conditional_helper<decltype(internal::declval<T>().begin()),
-                                       decltype(internal::declval<T>().end())>,
-                    void>::type> : std::true_type {};
+struct is_range_<
+    T,
+    typename std::conditional<
+        false,
+        conditional_helper<
+            decltype(internal::declval<T>().begin()),
+            decltype(internal::declval<T>().end())>,
+        void>::type> : std::true_type {};
 #endif
 
 /// tuple_size and tuple_element check.
 template <typename T>
 class is_tuple_like_ {
   template <typename U>
-  static auto check(U *p) ->
-    decltype(std::tuple_size<U>::value,
-      internal::declval<typename std::tuple_element<0, U>::type>(), int());
+  static auto check(U *p) -> decltype(
+      std::tuple_size<U>::value,
+      internal::declval<typename std::tuple_element<0, U>::type>(),
+      int());
   template <typename>
   static void check(...);
 
  public:
   static FMT_CONSTEXPR_DECL const bool value =
-    !std::is_void<decltype(check<T>(FMT_NULL))>::value;
+      !std::is_void<decltype(check<T>(FMT_NULL))>::value;
 };
 
 // Check for integer_sequence
@@ -133,9 +139,7 @@ template <typename T, T... N>
 struct integer_sequence {
   typedef T value_type;
 
-  static FMT_CONSTEXPR std::size_t size() {
-    return sizeof...(N);
-  }
+  static FMT_CONSTEXPR std::size_t size() { return sizeof...(N); }
 };
 
 template <std::size_t... N>
@@ -159,8 +163,10 @@ void for_each(index_sequence<Is...>, Tuple &&tup, F &&f) FMT_NOEXCEPT {
 }
 
 template <class T>
-FMT_CONSTEXPR make_index_sequence<std::tuple_size<T>::value> 
-get_indexes(T const &) { return {}; }
+FMT_CONSTEXPR make_index_sequence<std::tuple_size<T>::value> get_indexes(
+    T const &) {
+  return {};
+}
 
 template <class Tuple, class F>
 void for_each(Tuple &&tup, F &&f) {
@@ -168,32 +174,39 @@ void for_each(Tuple &&tup, F &&f) {
   for_each(indexes, std::forward<Tuple>(tup), std::forward<F>(f));
 }
 
-template<typename Arg>
-FMT_CONSTEXPR const char* format_str_quoted(bool add_space, const Arg&, 
-  typename std::enable_if<
-    !is_like_std_string<typename std::decay<Arg>::type>::value>::type* = nullptr) {
+template <typename Arg>
+FMT_CONSTEXPR const char *format_str_quoted(
+    bool add_space,
+    const Arg &,
+    typename std::enable_if<
+        !is_like_std_string<typename std::decay<Arg>::type>::value>::type * =
+        nullptr) {
   return add_space ? " {}" : "{}";
 }
 
-template<typename Arg>
-FMT_CONSTEXPR const char* format_str_quoted(bool add_space, const Arg&, 
-  typename std::enable_if<
-    is_like_std_string<typename std::decay<Arg>::type>::value>::type* = nullptr) {
+template <typename Arg>
+FMT_CONSTEXPR const char *format_str_quoted(
+    bool add_space,
+    const Arg &,
+    typename std::enable_if<
+        is_like_std_string<typename std::decay<Arg>::type>::value>::type * =
+        nullptr) {
   return add_space ? " \"{}\"" : "\"{}\"";
 }
 
-FMT_CONSTEXPR const char* format_str_quoted(bool add_space, const char*) {
+FMT_CONSTEXPR const char *format_str_quoted(bool add_space, const char *) {
   return add_space ? " \"{}\"" : "\"{}\"";
 }
-FMT_CONSTEXPR const wchar_t* format_str_quoted(bool add_space, const wchar_t*) {
-    return add_space ? L" \"{}\"" : L"\"{}\"";
+FMT_CONSTEXPR const wchar_t *format_str_quoted(
+    bool add_space, const wchar_t *) {
+  return add_space ? L" \"{}\"" : L"\"{}\"";
 }
 
-FMT_CONSTEXPR const char* format_str_quoted(bool add_space, const char) {
-    return add_space ? " '{}'" : "'{}'";
+FMT_CONSTEXPR const char *format_str_quoted(bool add_space, const char) {
+  return add_space ? " '{}'" : "'{}'";
 }
-FMT_CONSTEXPR const wchar_t* format_str_quoted(bool add_space, const wchar_t) {
-    return add_space ? L" '{}'" : L"'{}'";
+FMT_CONSTEXPR const wchar_t *format_str_quoted(bool add_space, const wchar_t) {
+  return add_space ? L" '{}'" : L"'{}'";
 }
 
 }  // namespace internal
@@ -201,37 +214,41 @@ FMT_CONSTEXPR const wchar_t* format_str_quoted(bool add_space, const wchar_t) {
 template <typename T>
 struct is_tuple_like {
   static FMT_CONSTEXPR_DECL const bool value =
-    internal::is_tuple_like_<T>::value && !internal::is_range_<T>::value;
+      internal::is_tuple_like_<T>::value && !internal::is_range_<T>::value;
 };
 
 template <typename TupleT, typename Char>
-struct formatter<TupleT, Char, 
+struct formatter<
+    TupleT,
+    Char,
     typename std::enable_if<fmt::is_tuple_like<TupleT>::value>::type> {
-private:
+ private:
   // C++11 generic lambda for format()
   template <typename FormatContext>
   struct format_each {
     template <typename T>
-    void operator()(const T& v) {
+    void operator()(const T &v) {
       if (i > 0) {
         if (formatting.add_prepostfix_space) {
           *out++ = ' ';
         }
         internal::copy(formatting.delimiter, out);
       }
-      format_to(out,
-                internal::format_str_quoted(
-                    (formatting.add_delimiter_spaces && i > 0), v),
-                v);
+      format_to(
+          out,
+          internal::format_str_quoted(
+              (formatting.add_delimiter_spaces && i > 0), v),
+          v);
       ++i;
     }
 
-    formatting_tuple<Char>& formatting;
-    std::size_t& i;
-    typename std::add_lvalue_reference<decltype(std::declval<FormatContext>().out())>::type out;
+    formatting_tuple<Char> &formatting;
+    std::size_t &i;
+    typename std::add_lvalue_reference<decltype(
+        std::declval<FormatContext>().out())>::type out;
   };
 
-public:
+ public:
   formatting_tuple<Char> formatting;
 
   template <typename ParseContext>
@@ -258,13 +275,14 @@ public:
 template <typename T>
 struct is_range {
   static FMT_CONSTEXPR_DECL const bool value =
-    internal::is_range_<T>::value && !internal::is_like_std_string<T>::value;
+      internal::is_range_<T>::value && !internal::is_like_std_string<T>::value;
 };
 
 template <typename RangeT, typename Char>
-struct formatter<RangeT, Char,
+struct formatter<
+    RangeT,
+    Char,
     typename std::enable_if<fmt::is_range<RangeT>::value>::type> {
-
   formatting_range<Char> formatting;
 
   template <typename ParseContext>
@@ -285,10 +303,11 @@ struct formatter<RangeT, Char,
         }
         internal::copy(formatting.delimiter, out);
       }
-      format_to(out,
-                internal::format_str_quoted(
-                    (formatting.add_delimiter_spaces && i > 0), *it),
-                *it);
+      format_to(
+          out,
+          internal::format_str_quoted(
+              (formatting.add_delimiter_spaces && i > 0), *it),
+          *it);
       if (++i > formatting.range_length_limit) {
         format_to(out, " ... <other elements>");
         break;
@@ -304,5 +323,4 @@ struct formatter<RangeT, Char,
 
 FMT_END_NAMESPACE
 
-#endif // FMT_RANGES_H_
-
+#endif  // FMT_RANGES_H_

--- a/include/fmt/time.h
+++ b/include/fmt/time.h
@@ -9,6 +9,7 @@
 #define FMT_TIME_H_
 
 #include "format.h"
+
 #include <ctime>
 #include <locale>
 
@@ -18,7 +19,7 @@ FMT_BEGIN_NAMESPACE
 // Usage: f FMT_NOMACRO()
 #define FMT_NOMACRO
 
-namespace internal{
+namespace internal {
 inline null<> localtime_r FMT_NOMACRO(...) { return null<>(); }
 inline null<> localtime_s(...) { return null<>(); }
 inline null<> gmtime_r(...) { return null<>(); }
@@ -31,7 +32,7 @@ inline std::tm localtime(std::time_t time) {
     std::time_t time_;
     std::tm tm_;
 
-    dispatcher(std::time_t t): time_(t) {}
+    dispatcher(std::time_t t) : time_(t) {}
 
     bool run() {
       using namespace fmt::internal;
@@ -51,7 +52,8 @@ inline std::tm localtime(std::time_t time) {
     bool fallback(internal::null<>) {
       using namespace fmt::internal;
       std::tm *tm = std::localtime(&time_);
-      if (tm) tm_ = *tm;
+      if (tm)
+        tm_ = *tm;
       return tm != FMT_NULL;
     }
 #endif
@@ -69,7 +71,7 @@ inline std::tm gmtime(std::time_t time) {
     std::time_t time_;
     std::tm tm_;
 
-    dispatcher(std::time_t t): time_(t) {}
+    dispatcher(std::time_t t) : time_(t) {}
 
     bool run() {
       using namespace fmt::internal;
@@ -88,7 +90,8 @@ inline std::tm gmtime(std::time_t time) {
 #if !FMT_MSC_VER
     bool fallback(internal::null<>) {
       std::tm *tm = std::gmtime(&time_);
-      if (tm) tm_ = *tm;
+      if (tm)
+        tm_ = *tm;
       return tm != FMT_NULL;
     }
 #endif
@@ -101,16 +104,19 @@ inline std::tm gmtime(std::time_t time) {
 }
 
 namespace internal {
-inline std::size_t strftime(char *str, std::size_t count, const char *format,
-                            const std::tm *time) {
+inline std::size_t strftime(
+    char *str, std::size_t count, const char *format, const std::tm *time) {
   return std::strftime(str, count, format, time);
 }
 
-inline std::size_t strftime(wchar_t *str, std::size_t count,
-                            const wchar_t *format, const std::tm *time) {
+inline std::size_t strftime(
+    wchar_t *str,
+    std::size_t count,
+    const wchar_t *format,
+    const std::tm *time) {
   return std::wcsftime(str, count, format, time);
 }
-}
+}  // namespace internal
 
 template <typename Char>
 struct formatter<std::tm, Char> {
@@ -120,8 +126,7 @@ struct formatter<std::tm, Char> {
     if (it != ctx.end() && *it == ':')
       ++it;
     auto end = it;
-    while (end != ctx.end() && *end != '}')
-      ++end;
+    while (end != ctx.end() && *end != '}') ++end;
     tm_format.reserve(end - it + 1);
     tm_format.append(it, end);
     tm_format.push_back('\0');
@@ -135,7 +140,7 @@ struct formatter<std::tm, Char> {
     for (;;) {
       std::size_t size = buf.capacity() - start;
       std::size_t count =
-        internal::strftime(&buf[start], size, &tm_format[0], &tm);
+          internal::strftime(&buf[start], size, &tm_format[0], &tm);
       if (count != 0) {
         buf.resize(start + count);
         break;

--- a/src/format.cc
+++ b/src/format.cc
@@ -16,7 +16,8 @@ template FMT_API std::locale internal::locale_ref::get<std::locale>() const;
 
 template FMT_API char internal::thousands_sep_impl(locale_ref);
 
-template FMT_API void internal::basic_buffer<char>::append(const char *, const char *);
+template FMT_API void internal::basic_buffer<char>::append(
+    const char *, const char *);
 
 template FMT_API void internal::arg_map<format_context>::init(
     const basic_format_args<format_context> &args);

--- a/src/posix.cc
+++ b/src/posix.cc
@@ -7,43 +7,43 @@
 
 // Disable bogus MSVC warnings.
 #if !defined(_CRT_SECURE_NO_WARNINGS) && defined(_MSC_VER)
-# define _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
 #endif
 
 #include "fmt/posix.h"
 
 #include <limits.h>
-#include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 
 #ifndef _WIN32
-# include <unistd.h>
+#include <unistd.h>
 #else
-# ifndef WIN32_LEAN_AND_MEAN
-#  define WIN32_LEAN_AND_MEAN
-# endif
-# include <windows.h>
-# include <io.h>
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <io.h>
+#include <windows.h>
 
-# define O_CREAT _O_CREAT
-# define O_TRUNC _O_TRUNC
+#define O_CREAT _O_CREAT
+#define O_TRUNC _O_TRUNC
 
-# ifndef S_IRUSR
-#  define S_IRUSR _S_IREAD
-# endif
+#ifndef S_IRUSR
+#define S_IRUSR _S_IREAD
+#endif
 
-# ifndef S_IWUSR
-#  define S_IWUSR _S_IWRITE
-# endif
+#ifndef S_IWUSR
+#define S_IWUSR _S_IWRITE
+#endif
 
-# ifdef __MINGW32__
-#  define _SH_DENYNO 0x40
-# endif
+#ifdef __MINGW32__
+#define _SH_DENYNO 0x40
+#endif
 
 #endif  // _WIN32
 
 #ifdef fileno
-# undef fileno
+#undef fileno
 #endif
 
 namespace {
@@ -62,7 +62,7 @@ typedef ssize_t RWResult;
 
 inline std::size_t convert_rwcount(std::size_t count) { return count; }
 #endif
-}
+}  // namespace
 
 FMT_BEGIN_NAMESPACE
 
@@ -72,8 +72,8 @@ buffered_file::~buffered_file() FMT_NOEXCEPT {
 }
 
 buffered_file::buffered_file(cstring_view filename, cstring_view mode) {
-  FMT_RETRY_VAL(file_,
-                FMT_SYSTEM(fopen(filename.c_str(), mode.c_str())), FMT_NULL);
+  FMT_RETRY_VAL(
+      file_, FMT_SYSTEM(fopen(filename.c_str(), mode.c_str())), FMT_NULL);
   if (!file_)
     FMT_THROW(system_error(errno, "cannot open file {}", filename.c_str()));
 }
@@ -147,7 +147,8 @@ long long file::size() const {
   Stat file_stat = Stat();
   if (FMT_POSIX_CALL(fstat(fd_, &file_stat)) == -1)
     FMT_THROW(system_error(errno, "cannot get file attributes"));
-  static_assert(sizeof(long long) >= sizeof(file_stat.st_size),
+  static_assert(
+      sizeof(long long) >= sizeof(file_stat.st_size),
       "return type of file::size is not large enough");
   return file_stat.st_size;
 #endif
@@ -182,8 +183,8 @@ void file::dup2(int fd) {
   int result = 0;
   FMT_RETRY(result, FMT_POSIX_CALL(dup2(fd_, fd)));
   if (result == -1) {
-    FMT_THROW(system_error(errno,
-      "cannot duplicate file descriptor {} to {}", fd_, fd));
+    FMT_THROW(system_error(
+        errno, "cannot duplicate file descriptor {} to {}", fd_, fd));
   }
 }
 
@@ -221,8 +222,8 @@ buffered_file file::fdopen(const char *mode) {
   // Don't retry as fdopen doesn't return EINTR.
   FILE *f = FMT_POSIX_CALL(fdopen(fd_, mode));
   if (!f)
-    FMT_THROW(system_error(errno,
-                           "cannot associate stream with file descriptor"));
+    FMT_THROW(
+        system_error(errno, "cannot associate stream with file descriptor"));
   buffered_file bf(f);
   fd_ = -1;
   return bf;
@@ -241,4 +242,3 @@ long getpagesize() {
 #endif
 }
 FMT_END_NAMESPACE
-

--- a/test/add-subdirectory-test/main.cc
+++ b/test/add-subdirectory-test/main.cc
@@ -1,6 +1,5 @@
 #include "fmt/format.h"
 
 int main(int argc, char** argv) {
-  for(int i = 0; i < argc; ++i)
-    fmt::print("{}: {}\n", i, argv[i]);
+  for (int i = 0; i < argc; ++i) fmt::print("{}: {}\n", i, argv[i]);
 }

--- a/test/assert-test.cc
+++ b/test/assert-test.cc
@@ -9,11 +9,11 @@
 #include "gtest.h"
 
 #if GTEST_HAS_DEATH_TEST
-# define EXPECT_DEBUG_DEATH_IF_SUPPORTED(statement, regex) \
-    EXPECT_DEBUG_DEATH(statement, regex)
+#define EXPECT_DEBUG_DEATH_IF_SUPPORTED(statement, regex) \
+  EXPECT_DEBUG_DEATH(statement, regex)
 #else
-# define EXPECT_DEBUG_DEATH_IF_SUPPORTED(statement, regex) \
-    GTEST_UNSUPPORTED_DEATH_TEST_(statement, regex, )
+#define EXPECT_DEBUG_DEATH_IF_SUPPORTED(statement, regex) \
+  GTEST_UNSUPPORTED_DEATH_TEST_(statement, regex, )
 #endif
 
 TEST(AssertTest, Fail) {

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -34,8 +34,8 @@ std::tm make_second(int s) {
   return time;
 }
 
-std::string format_tm(const std::tm &time, const char *spec,
-                      const std::locale &loc) {
+std::string format_tm(
+    const std::tm &time, const char *spec, const std::locale &loc) {
   auto &facet = std::use_facet<std::time_put<char>>(loc);
   std::ostringstream os;
   os.imbue(loc);
@@ -43,52 +43,54 @@ std::string format_tm(const std::tm &time, const char *spec,
   return os.str();
 }
 
-#define EXPECT_TIME(spec, time, duration) { \
-    std::locale loc("ja_JP.utf8"); \
-    EXPECT_EQ(format_tm(time, spec, loc), \
-              fmt::format(loc, "{:" spec "}", duration)); \
+#define EXPECT_TIME(spec, time, duration)           \
+  {                                                 \
+    std::locale loc("ja_JP.utf8");                  \
+    EXPECT_EQ(                                      \
+        format_tm(time, spec, loc),                 \
+        fmt::format(loc, "{:" spec "}", duration)); \
   }
 
 TEST(ChronoTest, FormatDefault) {
   EXPECT_EQ("42s", fmt::format("{}", std::chrono::seconds(42)));
-  EXPECT_EQ("42as",
-            fmt::format("{}", std::chrono::duration<int, std::atto>(42)));
-  EXPECT_EQ("42fs",
-            fmt::format("{}", std::chrono::duration<int, std::femto>(42)));
-  EXPECT_EQ("42ps",
-            fmt::format("{}", std::chrono::duration<int, std::pico>(42)));
+  EXPECT_EQ(
+      "42as", fmt::format("{}", std::chrono::duration<int, std::atto>(42)));
+  EXPECT_EQ(
+      "42fs", fmt::format("{}", std::chrono::duration<int, std::femto>(42)));
+  EXPECT_EQ(
+      "42ps", fmt::format("{}", std::chrono::duration<int, std::pico>(42)));
   EXPECT_EQ("42ns", fmt::format("{}", std::chrono::nanoseconds(42)));
   EXPECT_EQ("42µs", fmt::format("{}", std::chrono::microseconds(42)));
   EXPECT_EQ("42ms", fmt::format("{}", std::chrono::milliseconds(42)));
-  EXPECT_EQ("42cs",
-            fmt::format("{}", std::chrono::duration<int, std::centi>(42)));
-  EXPECT_EQ("42ds",
-            fmt::format("{}", std::chrono::duration<int, std::deci>(42)));
+  EXPECT_EQ(
+      "42cs", fmt::format("{}", std::chrono::duration<int, std::centi>(42)));
+  EXPECT_EQ(
+      "42ds", fmt::format("{}", std::chrono::duration<int, std::deci>(42)));
   EXPECT_EQ("42s", fmt::format("{}", std::chrono::seconds(42)));
-  EXPECT_EQ("42das",
-            fmt::format("{}", std::chrono::duration<int, std::deca>(42)));
-  EXPECT_EQ("42hs",
-            fmt::format("{}", std::chrono::duration<int, std::hecto>(42)));
-  EXPECT_EQ("42ks",
-            fmt::format("{}", std::chrono::duration<int, std::kilo>(42)));
-  EXPECT_EQ("42Ms",
-            fmt::format("{}", std::chrono::duration<int, std::mega>(42)));
-  EXPECT_EQ("42Gs",
-            fmt::format("{}", std::chrono::duration<int, std::giga>(42)));
-  EXPECT_EQ("42Ts",
-            fmt::format("{}", std::chrono::duration<int, std::tera>(42)));
-  EXPECT_EQ("42Ps",
-            fmt::format("{}", std::chrono::duration<int, std::peta>(42)));
-  EXPECT_EQ("42Es",
-            fmt::format("{}", std::chrono::duration<int, std::exa>(42)));
+  EXPECT_EQ(
+      "42das", fmt::format("{}", std::chrono::duration<int, std::deca>(42)));
+  EXPECT_EQ(
+      "42hs", fmt::format("{}", std::chrono::duration<int, std::hecto>(42)));
+  EXPECT_EQ(
+      "42ks", fmt::format("{}", std::chrono::duration<int, std::kilo>(42)));
+  EXPECT_EQ(
+      "42Ms", fmt::format("{}", std::chrono::duration<int, std::mega>(42)));
+  EXPECT_EQ(
+      "42Gs", fmt::format("{}", std::chrono::duration<int, std::giga>(42)));
+  EXPECT_EQ(
+      "42Ts", fmt::format("{}", std::chrono::duration<int, std::tera>(42)));
+  EXPECT_EQ(
+      "42Ps", fmt::format("{}", std::chrono::duration<int, std::peta>(42)));
+  EXPECT_EQ(
+      "42Es", fmt::format("{}", std::chrono::duration<int, std::exa>(42)));
   EXPECT_EQ("42m", fmt::format("{}", std::chrono::minutes(42)));
   EXPECT_EQ("42h", fmt::format("{}", std::chrono::hours(42)));
-  EXPECT_EQ("42[15]s",
-            fmt::format("{}",
-                        std::chrono::duration<int, std::ratio<15, 1>>(42)));
-  EXPECT_EQ("42[15/4]s",
-            fmt::format("{}",
-                        std::chrono::duration<int, std::ratio<15, 4>>(42)));
+  EXPECT_EQ(
+      "42[15]s",
+      fmt::format("{}", std::chrono::duration<int, std::ratio<15, 1>>(42)));
+  EXPECT_EQ(
+      "42[15/4]s",
+      fmt::format("{}", std::chrono::duration<int, std::ratio<15, 4>>(42)));
 }
 
 TEST(ChronoTest, Align) {
@@ -120,8 +122,8 @@ TEST(ChronoTest, FormatSpecs) {
   EXPECT_EQ("12", fmt::format("{:%I}", std::chrono::hours(24)));
   EXPECT_EQ("04", fmt::format("{:%I}", std::chrono::hours(4)));
   EXPECT_EQ("02", fmt::format("{:%I}", std::chrono::hours(14)));
-  EXPECT_EQ("03:25:45",
-            fmt::format("{:%H:%M:%S}", std::chrono::seconds(12345)));
+  EXPECT_EQ(
+      "03:25:45", fmt::format("{:%H:%M:%S}", std::chrono::seconds(12345)));
   EXPECT_EQ("03:25", fmt::format("{:%R}", std::chrono::seconds(12345)));
   EXPECT_EQ("03:25:45", fmt::format("{:%T}", std::chrono::seconds(12345)));
 }
@@ -144,12 +146,12 @@ TEST(ChronoTest, InvalidSpecs) {
   EXPECT_THROW_MSG(fmt::format("{:%B}", sec), fmt::format_error, "no date");
   EXPECT_THROW_MSG(fmt::format("{:%z}", sec), fmt::format_error, "no date");
   EXPECT_THROW_MSG(fmt::format("{:%Z}", sec), fmt::format_error, "no date");
-  EXPECT_THROW_MSG(fmt::format("{:%q}", sec), fmt::format_error,
-                   "invalid format");
-  EXPECT_THROW_MSG(fmt::format("{:%Eq}", sec), fmt::format_error,
-                   "invalid format");
-  EXPECT_THROW_MSG(fmt::format("{:%Oq}", sec), fmt::format_error,
-                   "invalid format");
+  EXPECT_THROW_MSG(
+      fmt::format("{:%q}", sec), fmt::format_error, "invalid format");
+  EXPECT_THROW_MSG(
+      fmt::format("{:%Eq}", sec), fmt::format_error, "invalid format");
+  EXPECT_THROW_MSG(
+      fmt::format("{:%Oq}", sec), fmt::format_error, "invalid format");
 }
 
 TEST(ChronoTest, Locale) {
@@ -159,7 +161,8 @@ TEST(ChronoTest, Locale) {
   try {
     loc = std::locale(loc_name);
     has_locale = true;
-  } catch (const std::runtime_error &) {}
+  } catch (const std::runtime_error &) {
+  }
   if (!has_locale) {
     fmt::print("{} locale is missing.\n", loc_name);
     return;

--- a/test/custom-formatter-test.cc
+++ b/test/custom-formatter-test.cc
@@ -13,15 +13,15 @@
 
 // A custom argument formatter that doesn't print `-` for floating-point values
 // rounded to 0.
-class custom_arg_formatter :
-    public fmt::arg_formatter<fmt::back_insert_range<fmt::internal::buffer>> {
+class custom_arg_formatter
+    : public fmt::arg_formatter<fmt::back_insert_range<fmt::internal::buffer>> {
  public:
   typedef fmt::back_insert_range<fmt::internal::buffer> range;
   typedef fmt::arg_formatter<range> base;
 
   custom_arg_formatter(
       fmt::format_context &ctx, fmt::format_specs *s = FMT_NULL)
-  : base(ctx, s) {}
+      : base(ctx, s) {}
 
   using base::operator();
 
@@ -41,7 +41,7 @@ std::string custom_vformat(fmt::string_view format_str, fmt::format_args args) {
 }
 
 template <typename... Args>
-std::string custom_format(const char *format_str, const Args & ... args) {
+std::string custom_format(const char *format_str, const Args &... args) {
   auto va = fmt::make_format_args(args...);
   return custom_vformat(format_str, va);
 }

--- a/test/find-package-test/main.cc
+++ b/test/find-package-test/main.cc
@@ -1,6 +1,5 @@
 #include "fmt/format.h"
 
 int main(int argc, char** argv) {
-  for(int i = 0; i < argc; ++i)
-    fmt::print("{}: {}\n", i, argv[i]);
+  for (int i = 0; i < argc; ++i) fmt::print("{}: {}\n", i, argv[i]);
 }

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -25,9 +25,9 @@
 #undef max
 
 #if FMT_HAS_CPP_ATTRIBUTE(noreturn)
-# define FMT_NORETURN [[noreturn]]
+#define FMT_NORETURN [[noreturn]]
 #else
-# define FMT_NORETURN
+#define FMT_NORETURN
 #endif
 
 using fmt::internal::fp;
@@ -108,10 +108,8 @@ TEST(FPTest, Grisu2FormatCompilesWithNonIEEEDouble) {
 }
 
 template <typename T>
-struct ValueExtractor: fmt::internal::function<T> {
-  T operator()(T value) {
-    return value;
-  }
+struct ValueExtractor : fmt::internal::function<T> {
+  T operator()(T value) { return value; }
 
   template <typename U>
   FMT_NORETURN T operator()(U) {
@@ -122,8 +120,9 @@ struct ValueExtractor: fmt::internal::function<T> {
 TEST(FormatTest, ArgConverter) {
   long long value = std::numeric_limits<long long>::max();
   auto arg = fmt::internal::make_arg<fmt::format_context>(value);
-  visit(fmt::internal::arg_converter<long long, fmt::format_context>(arg, 'd'),
-        arg);
+  visit(
+      fmt::internal::arg_converter<long long, fmt::format_context>(arg, 'd'),
+      arg);
   EXPECT_EQ(value, visit(ValueExtractor<long long>(), arg));
 }
 
@@ -138,10 +137,10 @@ TEST(FormatTest, FormatNegativeNaN) {
 TEST(FormatTest, StrError) {
   char *message = FMT_NULL;
   char buffer[BUFFER_SIZE];
-  EXPECT_ASSERT(fmt::safe_strerror(EDOM, message = FMT_NULL, 0),
-                "invalid buffer");
-  EXPECT_ASSERT(fmt::safe_strerror(EDOM, message = buffer, 0),
-                "invalid buffer");
+  EXPECT_ASSERT(
+      fmt::safe_strerror(EDOM, message = FMT_NULL, 0), "invalid buffer");
+  EXPECT_ASSERT(
+      fmt::safe_strerror(EDOM, message = buffer, 0), "invalid buffer");
   buffer[0] = 'x';
 #if defined(_GNU_SOURCE) && !defined(__COVERITY__)
   // Use invalid error code to make sure that safe_strerror returns an error
@@ -188,8 +187,7 @@ TEST(FormatTest, FormatErrorCode) {
     // Test maximum buffer size.
     msg = fmt::format("error {}", codes[i]);
     fmt::memory_buffer buffer;
-    std::string prefix(
-        fmt::inline_buffer_size - msg.size() - sep.size(), 'x');
+    std::string prefix(fmt::inline_buffer_size - msg.size() - sep.size(), 'x');
     fmt::format_error_code(buffer, codes[i], prefix);
     EXPECT_EQ(prefix + sep + msg, to_string(buffer));
     std::size_t size = fmt::inline_buffer_size;
@@ -207,40 +205,59 @@ TEST(FormatTest, CountCodePoints) {
 }
 
 TEST(ColorsTest, Colors) {
-  EXPECT_WRITE(stdout, fmt::print(fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30)"),
-               "\x1b[38;2;255;020;030mrgb(255,20,30)\x1b[0m");
-  EXPECT_WRITE(stdout, fmt::print(fg(fmt::color::blue), "blue"),
-               "\x1b[38;2;000;000;255mblue\x1b[0m");
+  EXPECT_WRITE(
+      stdout,
+      fmt::print(fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30)"),
+      "\x1b[38;2;255;020;030mrgb(255,20,30)\x1b[0m");
+  EXPECT_WRITE(
+      stdout,
+      fmt::print(fg(fmt::color::blue), "blue"),
+      "\x1b[38;2;000;000;255mblue\x1b[0m");
   EXPECT_WRITE(
       stdout,
       fmt::print(fg(fmt::color::blue) | bg(fmt::color::red), "two color"),
       "\x1b[38;2;000;000;255m\x1b[48;2;255;000;000mtwo color\x1b[0m");
-  EXPECT_WRITE(stdout, fmt::print(fmt::emphasis::bold, "bold"),
-               "\x1b[1mbold\x1b[0m");
-  EXPECT_WRITE(stdout, fmt::print(fmt::emphasis::italic, "italic"),
-               "\x1b[3mitalic\x1b[0m");
-  EXPECT_WRITE(stdout, fmt::print(fmt::emphasis::underline, "underline"),
-               "\x1b[4munderline\x1b[0m");
-  EXPECT_WRITE(stdout,
-               fmt::print(fmt::emphasis::strikethrough, "strikethrough"),
-               "\x1b[9mstrikethrough\x1b[0m");
+  EXPECT_WRITE(
+      stdout, fmt::print(fmt::emphasis::bold, "bold"), "\x1b[1mbold\x1b[0m");
+  EXPECT_WRITE(
+      stdout,
+      fmt::print(fmt::emphasis::italic, "italic"),
+      "\x1b[3mitalic\x1b[0m");
+  EXPECT_WRITE(
+      stdout,
+      fmt::print(fmt::emphasis::underline, "underline"),
+      "\x1b[4munderline\x1b[0m");
+  EXPECT_WRITE(
+      stdout,
+      fmt::print(fmt::emphasis::strikethrough, "strikethrough"),
+      "\x1b[9mstrikethrough\x1b[0m");
   EXPECT_WRITE(
       stdout,
       fmt::print(fg(fmt::color::blue) | fmt::emphasis::bold, "blue/bold"),
       "\x1b[1m\x1b[38;2;000;000;255mblue/bold\x1b[0m");
-  EXPECT_WRITE(stderr, fmt::print(stderr, fmt::emphasis::bold, "bold error"),
-               "\x1b[1mbold error\x1b[0m");
-  EXPECT_WRITE(stderr, fmt::print(stderr, fg(fmt::color::blue), "blue log"),
-                 "\x1b[38;2;000;000;255mblue log\x1b[0m");
+  EXPECT_WRITE(
+      stderr,
+      fmt::print(stderr, fmt::emphasis::bold, "bold error"),
+      "\x1b[1mbold error\x1b[0m");
+  EXPECT_WRITE(
+      stderr,
+      fmt::print(stderr, fg(fmt::color::blue), "blue log"),
+      "\x1b[38;2;000;000;255mblue log\x1b[0m");
   EXPECT_WRITE(stdout, fmt::print(fmt::text_style(), "hi"), "hi");
-  EXPECT_WRITE(stdout, fmt::print(fg(fmt::terminal_color::red), "tred"),
-               "\x1b[31mtred\x1b[0m");
-  EXPECT_WRITE(stdout, fmt::print(bg(fmt::terminal_color::cyan), "tcyan"),
-               "\x1b[46mtcyan\x1b[0m");
-  EXPECT_WRITE(stdout,
-               fmt::print(fg(fmt::terminal_color::bright_green), "tbgreen"),
-               "\x1b[92mtbgreen\x1b[0m");
-  EXPECT_WRITE(stdout,
-               fmt::print(bg(fmt::terminal_color::bright_magenta), "tbmagenta"),
-               "\x1b[105mtbmagenta\x1b[0m");
+  EXPECT_WRITE(
+      stdout,
+      fmt::print(fg(fmt::terminal_color::red), "tred"),
+      "\x1b[31mtred\x1b[0m");
+  EXPECT_WRITE(
+      stdout,
+      fmt::print(bg(fmt::terminal_color::cyan), "tcyan"),
+      "\x1b[46mtcyan\x1b[0m");
+  EXPECT_WRITE(
+      stdout,
+      fmt::print(fg(fmt::terminal_color::bright_green), "tbgreen"),
+      "\x1b[92mtbgreen\x1b[0m");
+  EXPECT_WRITE(
+      stdout,
+      fmt::print(bg(fmt::terminal_color::bright_magenta), "tbmagenta"),
+      "\x1b[105mtbmagenta\x1b[0m");
 }

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -5,6 +5,7 @@
 //
 // For the license information refer to format.h.
 
+#include <stdint.h>
 #include <cctype>
 #include <cfloat>
 #include <climits>
@@ -13,11 +14,10 @@
 #include <list>
 #include <memory>
 #include <string>
-#include <stdint.h>
 
 // Check if fmt/format.h compiles with windows.h included before it.
 #ifdef _WIN32
-# include <windows.h>
+#include <windows.h>
 #endif
 
 #include "fmt/format.h"
@@ -36,8 +36,8 @@ using fmt::basic_memory_buffer;
 using fmt::basic_writer;
 using fmt::format;
 using fmt::format_error;
-using fmt::string_view;
 using fmt::memory_buffer;
+using fmt::string_view;
 using fmt::wmemory_buffer;
 
 using testing::Return;
@@ -49,7 +49,7 @@ namespace {
 template <typename Char, typename T>
 bool check_enabled_formatter() {
   static_assert(
-        std::is_default_constructible<fmt::formatter<T, Char>>::value, "");
+      std::is_default_constructible<fmt::formatter<T, Char>>::value, "");
   return true;
 }
 
@@ -60,16 +60,50 @@ void check_enabled_formatters() {
 }
 
 TEST(FormatterTest, TestFormattersEnabled) {
-  check_enabled_formatters<char,
-      bool, char, signed char, unsigned char, short, unsigned short,
-      int, unsigned, long, unsigned long, long long, unsigned long long,
-      float, double, long double, void*, const void*,
-      char*, const char*, std::string>();
-  check_enabled_formatters<wchar_t,
-      bool, wchar_t, signed char, unsigned char, short, unsigned short,
-      int, unsigned, long, unsigned long, long long, unsigned long long,
-      float, double, long double, void*, const void*,
-      wchar_t*, const wchar_t*, std::wstring>();
+  check_enabled_formatters<
+      char,
+      bool,
+      char,
+      signed char,
+      unsigned char,
+      short,
+      unsigned short,
+      int,
+      unsigned,
+      long,
+      unsigned long,
+      long long,
+      unsigned long long,
+      float,
+      double,
+      long double,
+      void *,
+      const void *,
+      char *,
+      const char *,
+      std::string>();
+  check_enabled_formatters<
+      wchar_t,
+      bool,
+      wchar_t,
+      signed char,
+      unsigned char,
+      short,
+      unsigned short,
+      int,
+      unsigned,
+      long,
+      unsigned long,
+      long long,
+      unsigned long long,
+      float,
+      double,
+      long double,
+      void *,
+      const void *,
+      wchar_t *,
+      const wchar_t *,
+      std::wstring>();
 #if FMT_USE_NULLPTR
   check_enabled_formatters<char, std::nullptr_t>();
   check_enabled_formatters<wchar_t, std::nullptr_t>();
@@ -113,9 +147,9 @@ template <typename Char, typename T>
   if (expected == actual)
     return ::testing::AssertionSuccess();
   return ::testing::AssertionFailure()
-      << "Value of: (Writer<" << type << ">() << value).str()\n"
-      << "  Actual: " << actual << "\n"
-      << "Expected: " << expected << "\n";
+         << "Value of: (Writer<" << type << ">() << value).str()\n"
+         << "  Actual: " << actual << "\n"
+         << "Expected: " << expected << "\n";
 }
 
 struct AnyWriteChecker {
@@ -138,8 +172,7 @@ struct WriteChecker {
 // as writing it to std::ostringstream both for char and wchar_t.
 #define CHECK_WRITE(value) EXPECT_PRED_FORMAT1(AnyWriteChecker(), value)
 
-#define CHECK_WRITE_CHAR(value) \
-  EXPECT_PRED_FORMAT1(WriteChecker<char>(), value)
+#define CHECK_WRITE_CHAR(value) EXPECT_PRED_FORMAT1(WriteChecker<char>(), value)
 #define CHECK_WRITE_WCHAR(value) \
   EXPECT_PRED_FORMAT1(WriteChecker<wchar_t>(), value)
 }  // namespace
@@ -147,10 +180,9 @@ struct WriteChecker {
 // Tests fmt::internal::count_digits for integer type Int.
 template <typename Int>
 void test_count_digits() {
-  for (Int i = 0; i < 10; ++i)
-    EXPECT_EQ(1u, fmt::internal::count_digits(i));
-  for (Int i = 1, n = 1,
-      end = std::numeric_limits<Int>::max() / 10; n <= end; ++i) {
+  for (Int i = 0; i < 10; ++i) EXPECT_EQ(1u, fmt::internal::count_digits(i));
+  for (Int i = 1, n = 1, end = std::numeric_limits<Int>::max() / 10; n <= end;
+       ++i) {
     n *= 10;
     EXPECT_EQ(i, fmt::internal::count_digits(n - 1));
     EXPECT_EQ(i + 1, fmt::internal::count_digits(n));
@@ -196,14 +228,16 @@ TEST(UtilTest, ParseNonnegativeInt) {
   fmt::string_view s = "10000000000";
   auto begin = s.begin(), end = s.end();
   EXPECT_THROW_MSG(
-        parse_nonnegative_int(begin, end, fmt::internal::error_handler()),
-        fmt::format_error, "number is too big");
+      parse_nonnegative_int(begin, end, fmt::internal::error_handler()),
+      fmt::format_error,
+      "number is too big");
   s = "2147483649";
   begin = s.begin();
   end = s.end();
   EXPECT_THROW_MSG(
-        parse_nonnegative_int(begin, end, fmt::internal::error_handler()),
-        fmt::format_error, "number is too big");
+      parse_nonnegative_int(begin, end, fmt::internal::error_handler()),
+      fmt::format_error,
+      "number is too big");
 }
 
 TEST(IteratorTest, CountingIterator) {
@@ -215,7 +249,7 @@ TEST(IteratorTest, CountingIterator) {
 
 TEST(IteratorTest, TruncatingIterator) {
   char *p = FMT_NULL;
-  fmt::internal::truncating_iterator<char*> it(p, 3);
+  fmt::internal::truncating_iterator<char *> it(p, 3);
   auto prev = it++;
   EXPECT_EQ(prev.base(), p);
   EXPECT_EQ(it.base(), p + 1);
@@ -233,18 +267,17 @@ TEST(IteratorTest, TruncatingBackInserter) {
 }
 
 TEST(IteratorTest, IsOutputIterator) {
-  EXPECT_TRUE(fmt::internal::is_output_iterator<char*>::value);
-  EXPECT_FALSE(fmt::internal::is_output_iterator<const char*>::value);
+  EXPECT_TRUE(fmt::internal::is_output_iterator<char *>::value);
+  EXPECT_FALSE(fmt::internal::is_output_iterator<const char *>::value);
   EXPECT_FALSE(fmt::internal::is_output_iterator<std::string>::value);
   EXPECT_TRUE(fmt::internal::is_output_iterator<
               std::back_insert_iterator<std::string>>::value);
-  EXPECT_TRUE(fmt::internal::is_output_iterator<
-              std::string::iterator>::value);
-  EXPECT_FALSE(fmt::internal::is_output_iterator<
-               std::string::const_iterator>::value);
+  EXPECT_TRUE(fmt::internal::is_output_iterator<std::string::iterator>::value);
+  EXPECT_FALSE(
+      fmt::internal::is_output_iterator<std::string::const_iterator>::value);
   EXPECT_FALSE(fmt::internal::is_output_iterator<std::list<char>>::value);
-  EXPECT_TRUE(fmt::internal::is_output_iterator<
-              std::list<char>::iterator>::value);
+  EXPECT_TRUE(
+      fmt::internal::is_output_iterator<std::list<char>::iterator>::value);
   EXPECT_FALSE(fmt::internal::is_output_iterator<
                std::list<char>::const_iterator>::value);
   EXPECT_FALSE(fmt::internal::is_output_iterator<uint32_pair>::value);
@@ -260,7 +293,7 @@ static void check_forwarding(
     mock_allocator<int> &alloc, allocator_ref<mock_allocator<int>> &ref) {
   int mem;
   // Check if value_type is properly defined.
-  allocator_ref< mock_allocator<int> >::value_type *ptr = &mem;
+  allocator_ref<mock_allocator<int>>::value_type *ptr = &mem;
   // Check forwarding.
   EXPECT_CALL(alloc, allocate(42)).WillOnce(testing::Return(ptr));
   ref.allocate(42);
@@ -269,8 +302,8 @@ static void check_forwarding(
 }
 
 TEST(AllocatorTest, allocator_ref) {
-  StrictMock< mock_allocator<int> > alloc;
-  typedef allocator_ref< mock_allocator<int> > test_allocator_ref;
+  StrictMock<mock_allocator<int>> alloc;
+  typedef allocator_ref<mock_allocator<int>> test_allocator_ref;
   test_allocator_ref ref(&alloc);
   // Check if allocator_ref forwards to the underlying allocator.
   check_forwarding(alloc, ref);
@@ -282,10 +315,10 @@ TEST(AllocatorTest, allocator_ref) {
   check_forwarding(alloc, ref3);
 }
 
-typedef allocator_ref< std::allocator<char> > TestAllocator;
+typedef allocator_ref<std::allocator<char>> TestAllocator;
 
-static void check_move_buffer(const char *str,
-                       basic_memory_buffer<char, 5, TestAllocator> &buffer) {
+static void check_move_buffer(
+    const char *str, basic_memory_buffer<char, 5, TestAllocator> &buffer) {
   std::allocator<char> *alloc = buffer.get_allocator().get();
   basic_memory_buffer<char, 5, TestAllocator> buffer2(std::move(buffer));
   // Move shouldn't destroy the inline content of the first buffer.
@@ -350,7 +383,7 @@ TEST(MemoryBufferTest, MoveAssignment) {
 }
 
 TEST(MemoryBufferTest, Grow) {
-  typedef allocator_ref< mock_allocator<int> > Allocator;
+  typedef allocator_ref<mock_allocator<int>> Allocator;
   typedef basic_memory_buffer<int, 10, Allocator> Base;
   mock_allocator<int> alloc;
   struct TestMemoryBuffer : Base {
@@ -359,8 +392,7 @@ TEST(MemoryBufferTest, Grow) {
   } buffer((Allocator(&alloc)));
   buffer.resize(7);
   using fmt::internal::to_unsigned;
-  for (int i = 0; i < 7; ++i)
-    buffer[to_unsigned(i)] = i * i;
+  for (int i = 0; i < 7; ++i) buffer[to_unsigned(i)] = i * i;
   EXPECT_EQ(10u, buffer.capacity());
   int mem[20];
   mem[7] = 0xdead;
@@ -368,21 +400,21 @@ TEST(MemoryBufferTest, Grow) {
   buffer.grow(20);
   EXPECT_EQ(20u, buffer.capacity());
   // Check if size elements have been copied
-  for (int i = 0; i < 7; ++i)
-    EXPECT_EQ(i * i, buffer[to_unsigned(i)]);
+  for (int i = 0; i < 7; ++i) EXPECT_EQ(i * i, buffer[to_unsigned(i)]);
   // and no more than that.
   EXPECT_EQ(0xdead, buffer[7]);
   EXPECT_CALL(alloc, deallocate(mem, 20));
 }
 
 TEST(MemoryBufferTest, Allocator) {
-  typedef allocator_ref< mock_allocator<char> > TestAllocator;
+  typedef allocator_ref<mock_allocator<char>> TestAllocator;
   basic_memory_buffer<char, 10, TestAllocator> buffer;
   EXPECT_EQ(FMT_NULL, buffer.get_allocator().get());
-  StrictMock< mock_allocator<char> > alloc;
+  StrictMock<mock_allocator<char>> alloc;
   char mem;
   {
-    basic_memory_buffer<char, 10, TestAllocator> buffer2((TestAllocator(&alloc)));
+    basic_memory_buffer<char, 10, TestAllocator> buffer2(
+        (TestAllocator(&alloc)));
     EXPECT_EQ(&alloc, buffer2.get_allocator().get());
     std::size_t size = 2 * fmt::inline_buffer_size;
     EXPECT_CALL(alloc, allocate(size)).WillOnce(Return(&mem));
@@ -392,8 +424,8 @@ TEST(MemoryBufferTest, Allocator) {
 }
 
 TEST(MemoryBufferTest, ExceptionInDeallocate) {
-  typedef allocator_ref< mock_allocator<char> > TestAllocator;
-  StrictMock< mock_allocator<char> > alloc;
+  typedef allocator_ref<mock_allocator<char>> TestAllocator;
+  StrictMock<mock_allocator<char>> alloc;
   basic_memory_buffer<char, 10, TestAllocator> buffer((TestAllocator(&alloc)));
   std::size_t size = 2 * fmt::inline_buffer_size;
   std::vector<char> mem(size);
@@ -410,8 +442,7 @@ TEST(MemoryBufferTest, ExceptionInDeallocate) {
     EXPECT_THROW(buffer.reserve(2 * size), std::exception);
     EXPECT_EQ(&mem2[0], &buffer[0]);
     // Check that the data has been copied.
-    for (std::size_t i = 0; i < size; ++i)
-      EXPECT_EQ('x', buffer[i]);
+    for (std::size_t i = 0; i < size; ++i) EXPECT_EQ('x', buffer[i]);
   }
   EXPECT_CALL(alloc, deallocate(&mem2[0], 2 * size));
 }
@@ -447,8 +478,8 @@ TEST(UtilTest, UTF8ToUTF16EmptyString) {
 
 template <typename Converter, typename Char>
 void check_utf_conversion_error(
-        const char *message,
-        fmt::basic_string_view<Char> str = fmt::basic_string_view<Char>(0, 1)) {
+    const char *message,
+    fmt::basic_string_view<Char> str = fmt::basic_string_view<Char>(0, 1)) {
   fmt::memory_buffer out;
   fmt::internal::format_windows_error(out, ERROR_INVALID_PARAMETER, message);
   fmt::system_error error(0, "");
@@ -470,19 +501,20 @@ TEST(UtilTest, UTF8ToUTF16Error) {
   const char *message = "cannot convert string from UTF-8 to UTF-16";
   check_utf_conversion_error<fmt::internal::utf8_to_utf16, char>(message);
   check_utf_conversion_error<fmt::internal::utf8_to_utf16, char>(
-    message, fmt::string_view("foo", INT_MAX + 1u));
+      message, fmt::string_view("foo", INT_MAX + 1u));
 }
 
 TEST(UtilTest, UTF16ToUTF8Convert) {
   fmt::internal::utf16_to_utf8 u;
   EXPECT_EQ(ERROR_INVALID_PARAMETER, u.convert(fmt::wstring_view(0, 1)));
-  EXPECT_EQ(ERROR_INVALID_PARAMETER,
-            u.convert(fmt::wstring_view(L"foo", INT_MAX + 1u)));
+  EXPECT_EQ(
+      ERROR_INVALID_PARAMETER,
+      u.convert(fmt::wstring_view(L"foo", INT_MAX + 1u)));
 }
 #endif  // _WIN32
 
 typedef void (*FormatErrorMessage)(
-        fmt::internal::buffer &out, int error_code, string_view message);
+    fmt::internal::buffer &out, int error_code, string_view message);
 
 template <typename Error>
 void check_throw_error(int error_code, FormatErrorMessage format) {
@@ -501,8 +533,8 @@ void check_throw_error(int error_code, FormatErrorMessage format) {
 TEST(UtilTest, FormatSystemError) {
   fmt::memory_buffer message;
   fmt::format_system_error(message, EDOM, "test");
-  EXPECT_EQ(fmt::format("test: {}", get_system_error(EDOM)),
-            to_string(message));
+  EXPECT_EQ(
+      fmt::format("test: {}", get_system_error(EDOM)), to_string(message));
   message = fmt::memory_buffer();
 
   // Check if std::allocator throws on allocating max size_t / 2 chars.
@@ -511,7 +543,7 @@ TEST(UtilTest, FormatSystemError) {
   try {
     std::allocator<char> alloc;
     alloc.deallocate(alloc.allocate(max_size), max_size);
-  } catch (const std::bad_alloc&) {
+  } catch (const std::bad_alloc &) {
     throws_on_alloc = true;
   }
   if (!throws_on_alloc) {
@@ -533,31 +565,39 @@ TEST(UtilTest, ReportSystemError) {
   fmt::memory_buffer out;
   fmt::format_system_error(out, EDOM, "test error");
   out.push_back('\n');
-  EXPECT_WRITE(stderr, fmt::report_system_error(EDOM, "test error"),
-               to_string(out));
+  EXPECT_WRITE(
+      stderr, fmt::report_system_error(EDOM, "test error"), to_string(out));
 }
 
 #ifdef _WIN32
 
 TEST(UtilTest, FormatWindowsError) {
   LPWSTR message = 0;
-  FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER |
-      FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, 0,
-      ERROR_FILE_EXISTS, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-      reinterpret_cast<LPWSTR>(&message), 0, 0);
+  FormatMessageW(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+          FORMAT_MESSAGE_IGNORE_INSERTS,
+      0,
+      ERROR_FILE_EXISTS,
+      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      reinterpret_cast<LPWSTR>(&message),
+      0,
+      0);
   fmt::internal::utf16_to_utf8 utf8_message(message);
   LocalFree(message);
   fmt::memory_buffer actual_message;
   fmt::internal::format_windows_error(
       actual_message, ERROR_FILE_EXISTS, "test");
-  EXPECT_EQ(fmt::format("test: {}", utf8_message.str()),
+  EXPECT_EQ(
+      fmt::format("test: {}", utf8_message.str()),
       fmt::to_string(actual_message));
   actual_message.resize(0);
   fmt::internal::format_windows_error(
-        actual_message, ERROR_FILE_EXISTS,
-        fmt::string_view(0, std::numeric_limits<size_t>::max()));
-  EXPECT_EQ(fmt::format("error {}", ERROR_FILE_EXISTS),
-            fmt::to_string(actual_message));
+      actual_message,
+      ERROR_FILE_EXISTS,
+      fmt::string_view(0, std::numeric_limits<size_t>::max()));
+  EXPECT_EQ(
+      fmt::format("error {}", ERROR_FILE_EXISTS),
+      fmt::to_string(actual_message));
 }
 
 TEST(UtilTest, FormatLongWindowsError) {
@@ -565,12 +605,17 @@ TEST(UtilTest, FormatLongWindowsError) {
   // this error code is not available on all Windows platforms and
   // Windows SDKs, so do not fail the test if the error string cannot
   // be retrieved.
-  const int provisioning_not_allowed = 0x80284013L /*TBS_E_PROVISIONING_NOT_ALLOWED*/;
-  if (FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER |
-      FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, 0,
-      static_cast<DWORD>(provisioning_not_allowed),
-      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-      reinterpret_cast<LPWSTR>(&message), 0, 0) == 0) {
+  const int provisioning_not_allowed =
+      0x80284013L /*TBS_E_PROVISIONING_NOT_ALLOWED*/;
+  if (FormatMessageW(
+          FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+              FORMAT_MESSAGE_IGNORE_INSERTS,
+          0,
+          static_cast<DWORD>(provisioning_not_allowed),
+          MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+          reinterpret_cast<LPWSTR>(&message),
+          0,
+          0) == 0) {
     return;
   }
   fmt::internal::utf16_to_utf8 utf8_message(message);
@@ -578,7 +623,8 @@ TEST(UtilTest, FormatLongWindowsError) {
   fmt::memory_buffer actual_message;
   fmt::internal::format_windows_error(
       actual_message, provisioning_not_allowed, "test");
-  EXPECT_EQ(fmt::format("test: {}", utf8_message.str()),
+  EXPECT_EQ(
+      fmt::format("test: {}", utf8_message.str()),
       fmt::to_string(actual_message));
 }
 
@@ -591,9 +637,10 @@ TEST(UtilTest, ReportWindowsError) {
   fmt::memory_buffer out;
   fmt::internal::format_windows_error(out, ERROR_FILE_EXISTS, "test error");
   out.push_back('\n');
-  EXPECT_WRITE(stderr,
+  EXPECT_WRITE(
+      stderr,
       fmt::report_windows_error(ERROR_FILE_EXISTS, "test error"),
-               fmt::to_string(out));
+      fmt::to_string(out));
 }
 
 #endif  // _WIN32
@@ -662,41 +709,35 @@ TEST(WriterTest, WriteLongDouble) {
 TEST(WriterTest, WriteDoubleAtBufferBoundary) {
   memory_buffer buf;
   fmt::writer writer(buf);
-  for (int i = 0; i < 100; ++i)
-    writer.write(1.23456789);
+  for (int i = 0; i < 100; ++i) writer.write(1.23456789);
 }
 
 TEST(WriterTest, WriteDoubleWithFilledBuffer) {
   memory_buffer buf;
   fmt::writer writer(buf);
   // Fill the buffer.
-  for (int i = 0; i < fmt::inline_buffer_size; ++i)
-    writer.write(' ');
+  for (int i = 0; i < fmt::inline_buffer_size; ++i) writer.write(' ');
   writer.write(1.2);
   fmt::string_view sv(buf.data(), buf.size());
   sv.remove_prefix(fmt::inline_buffer_size);
   EXPECT_EQ("1.2", sv);
 }
 
-TEST(WriterTest, WriteChar) {
-  CHECK_WRITE('a');
-}
+TEST(WriterTest, WriteChar) { CHECK_WRITE('a'); }
 
-TEST(WriterTest, WriteWideChar) {
-  CHECK_WRITE_WCHAR(L'a');
-}
+TEST(WriterTest, WriteWideChar) { CHECK_WRITE_WCHAR(L'a'); }
 
 TEST(WriterTest, WriteString) {
   CHECK_WRITE_CHAR("abc");
   CHECK_WRITE_WCHAR("abc");
   // The following line shouldn't compile:
-  //std::declval<fmt::basic_writer<fmt::buffer>>().write(L"abc");
+  // std::declval<fmt::basic_writer<fmt::buffer>>().write(L"abc");
 }
 
 TEST(WriterTest, WriteWideString) {
   CHECK_WRITE_WCHAR(L"abc");
   // The following line shouldn't compile:
-  //std::declval<fmt::basic_writer<fmt::wbuffer>>().write("abc");
+  // std::declval<fmt::basic_writer<fmt::wbuffer>>().write("abc");
 }
 
 TEST(FormatToTest, FormatWithoutArgs) {
@@ -755,9 +796,7 @@ TEST(FormatterTest, UnmatchedBraces) {
   EXPECT_THROW_MSG(format("{0{}"), format_error, "invalid format string");
 }
 
-TEST(FormatterTest, NoArgs) {
-  EXPECT_EQ("test", format("test"));
-}
+TEST(FormatterTest, NoArgs) { EXPECT_EQ("test", format("test")); }
 
 TEST(FormatterTest, ArgsInDifferentPositions) {
   EXPECT_EQ("42", format("{0}", 42));
@@ -780,8 +819,8 @@ TEST(FormatterTest, ArgErrors) {
   safe_sprintf(format_str, "{%u", INT_MAX);
   EXPECT_THROW_MSG(format(format_str), format_error, "invalid format string");
   safe_sprintf(format_str, "{%u}", INT_MAX);
-  EXPECT_THROW_MSG(format(format_str), format_error,
-      "argument index out of range");
+  EXPECT_THROW_MSG(
+      format(format_str), format_error, "argument index out of range");
 
   safe_sprintf(format_str, "{%u", INT_MAX + 1u);
   EXPECT_THROW_MSG(format(format_str), format_error, "number is too big");
@@ -807,47 +846,79 @@ struct TestFormat<0> {
 
 TEST(FormatterTest, ManyArgs) {
   EXPECT_EQ("19", TestFormat<20>::format("{19}"));
-  EXPECT_THROW_MSG(TestFormat<20>::format("{20}"),
-                   format_error, "argument index out of range");
-  EXPECT_THROW_MSG(TestFormat<21>::format("{21}"),
-                   format_error, "argument index out of range");
+  EXPECT_THROW_MSG(
+      TestFormat<20>::format("{20}"),
+      format_error,
+      "argument index out of range");
+  EXPECT_THROW_MSG(
+      TestFormat<21>::format("{21}"),
+      format_error,
+      "argument index out of range");
   enum { max_packed_args = fmt::internal::max_packed_args };
   std::string format_str = fmt::format("{{{}}}", max_packed_args + 1);
-  EXPECT_THROW_MSG(TestFormat<max_packed_args>::format(format_str),
-                   format_error, "argument index out of range");
+  EXPECT_THROW_MSG(
+      TestFormat<max_packed_args>::format(format_str),
+      format_error,
+      "argument index out of range");
 }
 
 TEST(FormatterTest, NamedArg) {
-  EXPECT_EQ("1/a/A", format("{_1}/{a_}/{A_}", fmt::arg("a_", 'a'),
-                            fmt::arg("A_", "A"), fmt::arg("_1", 1)));
+  EXPECT_EQ(
+      "1/a/A",
+      format(
+          "{_1}/{a_}/{A_}",
+          fmt::arg("a_", 'a'),
+          fmt::arg("A_", "A"),
+          fmt::arg("_1", 1)));
   EXPECT_THROW_MSG(format("{a}"), format_error, "argument not found");
   EXPECT_EQ(" -42", format("{0:{width}}", -42, fmt::arg("width", 4)));
   EXPECT_EQ("st", format("{0:.{precision}}", "str", fmt::arg("precision", 2)));
   EXPECT_EQ("1 2", format("{} {two}", 1, fmt::arg("two", 2)));
-  EXPECT_EQ("42", format("{c}",
-        fmt::arg("a", 0), fmt::arg("b", 0), fmt::arg("c", 42), fmt::arg("d", 0),
-        fmt::arg("e", 0), fmt::arg("f", 0), fmt::arg("g", 0), fmt::arg("h", 0),
-        fmt::arg("i", 0), fmt::arg("j", 0), fmt::arg("k", 0), fmt::arg("l", 0),
-        fmt::arg("m", 0), fmt::arg("n", 0), fmt::arg("o", 0), fmt::arg("p", 0)));
+  EXPECT_EQ(
+      "42",
+      format(
+          "{c}",
+          fmt::arg("a", 0),
+          fmt::arg("b", 0),
+          fmt::arg("c", 42),
+          fmt::arg("d", 0),
+          fmt::arg("e", 0),
+          fmt::arg("f", 0),
+          fmt::arg("g", 0),
+          fmt::arg("h", 0),
+          fmt::arg("i", 0),
+          fmt::arg("j", 0),
+          fmt::arg("k", 0),
+          fmt::arg("l", 0),
+          fmt::arg("m", 0),
+          fmt::arg("n", 0),
+          fmt::arg("o", 0),
+          fmt::arg("p", 0)));
 }
 
 TEST(FormatterTest, AutoArgIndex) {
   EXPECT_EQ("abc", format("{}{}{}", 'a', 'b', 'c'));
-  EXPECT_THROW_MSG(format("{0}{}", 'a', 'b'),
-      format_error, "cannot switch from manual to automatic argument indexing");
-  EXPECT_THROW_MSG(format("{}{0}", 'a', 'b'),
-      format_error, "cannot switch from automatic to manual argument indexing");
+  EXPECT_THROW_MSG(
+      format("{0}{}", 'a', 'b'),
+      format_error,
+      "cannot switch from manual to automatic argument indexing");
+  EXPECT_THROW_MSG(
+      format("{}{0}", 'a', 'b'),
+      format_error,
+      "cannot switch from automatic to manual argument indexing");
   EXPECT_EQ("1.2", format("{:.{}}", 1.2345, 2));
-  EXPECT_THROW_MSG(format("{0}:.{}", 1.2345, 2),
-      format_error, "cannot switch from manual to automatic argument indexing");
-  EXPECT_THROW_MSG(format("{:.{0}}", 1.2345, 2),
-      format_error, "cannot switch from automatic to manual argument indexing");
+  EXPECT_THROW_MSG(
+      format("{0}:.{}", 1.2345, 2),
+      format_error,
+      "cannot switch from manual to automatic argument indexing");
+  EXPECT_THROW_MSG(
+      format("{:.{0}}", 1.2345, 2),
+      format_error,
+      "cannot switch from automatic to manual argument indexing");
   EXPECT_THROW_MSG(format("{}"), format_error, "argument index out of range");
 }
 
-TEST(FormatterTest, EmptySpecs) {
-  EXPECT_EQ("42", format("{0:}", 42));
-}
+TEST(FormatterTest, EmptySpecs) { EXPECT_EQ("42", format("{0:}", 42)); }
 
 TEST(FormatterTest, LeftAlign) {
   EXPECT_EQ("42  ", format("{0:<4}", 42));
@@ -863,7 +934,7 @@ TEST(FormatterTest, LeftAlign) {
   EXPECT_EQ("-42  ", format("{0:<5}", -42.0l));
   EXPECT_EQ("c    ", format("{0:<5}", 'c'));
   EXPECT_EQ("abc  ", format("{0:<5}", "abc"));
-  EXPECT_EQ("0xface  ", format("{0:<8}", reinterpret_cast<void*>(0xface)));
+  EXPECT_EQ("0xface  ", format("{0:<8}", reinterpret_cast<void *>(0xface)));
 }
 
 TEST(FormatterTest, RightAlign) {
@@ -880,7 +951,7 @@ TEST(FormatterTest, RightAlign) {
   EXPECT_EQ("  -42", format("{0:>5}", -42.0l));
   EXPECT_EQ("    c", format("{0:>5}", 'c'));
   EXPECT_EQ("  abc", format("{0:>5}", "abc"));
-  EXPECT_EQ("  0xface", format("{0:>8}", reinterpret_cast<void*>(0xface)));
+  EXPECT_EQ("  0xface", format("{0:>8}", reinterpret_cast<void *>(0xface)));
 }
 
 TEST(FormatterTest, NumericAlign) {
@@ -898,14 +969,18 @@ TEST(FormatterTest, NumericAlign) {
   EXPECT_EQ("   42", format("{0:=5}", 42ull));
   EXPECT_EQ("-  42", format("{0:=5}", -42.0));
   EXPECT_EQ("-  42", format("{0:=5}", -42.0l));
-  EXPECT_THROW_MSG(format("{0:=5", 'c'),
-      format_error, "missing '}' in format string");
-  EXPECT_THROW_MSG(format("{0:=5}", 'c'),
-      format_error, "invalid format specifier for char");
-  EXPECT_THROW_MSG(format("{0:=5}", "abc"),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{0:=8}", reinterpret_cast<void*>(0xface)),
-      format_error, "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:=5", 'c'), format_error, "missing '}' in format string");
+  EXPECT_THROW_MSG(
+      format("{0:=5}", 'c'), format_error, "invalid format specifier for char");
+  EXPECT_THROW_MSG(
+      format("{0:=5}", "abc"),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:=8}", reinterpret_cast<void *>(0xface)),
+      format_error,
+      "format specifier requires numeric argument");
   EXPECT_EQ(" 1", fmt::format("{:= }", 1.0));
 }
 
@@ -923,14 +998,14 @@ TEST(FormatterTest, CenterAlign) {
   EXPECT_EQ(" -42 ", format("{0:^5}", -42.0l));
   EXPECT_EQ("  c  ", format("{0:^5}", 'c'));
   EXPECT_EQ(" abc  ", format("{0:^6}", "abc"));
-  EXPECT_EQ(" 0xface ", format("{0:^8}", reinterpret_cast<void*>(0xface)));
+  EXPECT_EQ(" 0xface ", format("{0:^8}", reinterpret_cast<void *>(0xface)));
 }
 
 TEST(FormatterTest, Fill) {
-  EXPECT_THROW_MSG(format("{0:{<5}", 'c'),
-      format_error, "invalid fill character '{'");
-  EXPECT_THROW_MSG(format("{0:{<5}}", 'c'),
-      format_error, "invalid fill character '{'");
+  EXPECT_THROW_MSG(
+      format("{0:{<5}", 'c'), format_error, "invalid fill character '{'");
+  EXPECT_THROW_MSG(
+      format("{0:{<5}}", 'c'), format_error, "invalid fill character '{'");
   EXPECT_EQ("**42", format("{0:*>4}", 42));
   EXPECT_EQ("**-42", format("{0:*>5}", -42));
   EXPECT_EQ("***42", format("{0:*>5}", 42u));
@@ -942,7 +1017,7 @@ TEST(FormatterTest, Fill) {
   EXPECT_EQ("**-42", format("{0:*>5}", -42.0l));
   EXPECT_EQ("c****", format("{0:*<5}", 'c'));
   EXPECT_EQ("abc**", format("{0:*<5}", "abc"));
-  EXPECT_EQ("**0xface", format("{0:*>8}", reinterpret_cast<void*>(0xface)));
+  EXPECT_EQ("**0xface", format("{0:*>8}", reinterpret_cast<void *>(0xface)));
   EXPECT_EQ("foo=", format("{:}=", "foo"));
   EXPECT_EQ(std::string("\0\0\0*", 4), format(string_view("{:\0>4}", 6), '*'));
 }
@@ -951,72 +1026,102 @@ TEST(FormatterTest, PlusSign) {
   EXPECT_EQ("+42", format("{0:+}", 42));
   EXPECT_EQ("-42", format("{0:+}", -42));
   EXPECT_EQ("+42", format("{0:+}", 42));
-  EXPECT_THROW_MSG(format("{0:+}", 42u),
-      format_error, "format specifier requires signed argument");
+  EXPECT_THROW_MSG(
+      format("{0:+}", 42u),
+      format_error,
+      "format specifier requires signed argument");
   EXPECT_EQ("+42", format("{0:+}", 42l));
-  EXPECT_THROW_MSG(format("{0:+}", 42ul),
-      format_error, "format specifier requires signed argument");
+  EXPECT_THROW_MSG(
+      format("{0:+}", 42ul),
+      format_error,
+      "format specifier requires signed argument");
   EXPECT_EQ("+42", format("{0:+}", 42ll));
-  EXPECT_THROW_MSG(format("{0:+}", 42ull),
-      format_error, "format specifier requires signed argument");
+  EXPECT_THROW_MSG(
+      format("{0:+}", 42ull),
+      format_error,
+      "format specifier requires signed argument");
   EXPECT_EQ("+42", format("{0:+}", 42.0));
   EXPECT_EQ("+42", format("{0:+}", 42.0l));
-  EXPECT_THROW_MSG(format("{0:+", 'c'),
-      format_error, "missing '}' in format string");
-  EXPECT_THROW_MSG(format("{0:+}", 'c'),
-      format_error, "invalid format specifier for char");
-  EXPECT_THROW_MSG(format("{0:+}", "abc"),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{0:+}", reinterpret_cast<void*>(0x42)),
-      format_error, "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:+", 'c'), format_error, "missing '}' in format string");
+  EXPECT_THROW_MSG(
+      format("{0:+}", 'c'), format_error, "invalid format specifier for char");
+  EXPECT_THROW_MSG(
+      format("{0:+}", "abc"),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:+}", reinterpret_cast<void *>(0x42)),
+      format_error,
+      "format specifier requires numeric argument");
 }
 
 TEST(FormatterTest, MinusSign) {
   EXPECT_EQ("42", format("{0:-}", 42));
   EXPECT_EQ("-42", format("{0:-}", -42));
   EXPECT_EQ("42", format("{0:-}", 42));
-  EXPECT_THROW_MSG(format("{0:-}", 42u),
-      format_error, "format specifier requires signed argument");
+  EXPECT_THROW_MSG(
+      format("{0:-}", 42u),
+      format_error,
+      "format specifier requires signed argument");
   EXPECT_EQ("42", format("{0:-}", 42l));
-  EXPECT_THROW_MSG(format("{0:-}", 42ul),
-      format_error, "format specifier requires signed argument");
+  EXPECT_THROW_MSG(
+      format("{0:-}", 42ul),
+      format_error,
+      "format specifier requires signed argument");
   EXPECT_EQ("42", format("{0:-}", 42ll));
-  EXPECT_THROW_MSG(format("{0:-}", 42ull),
-      format_error, "format specifier requires signed argument");
+  EXPECT_THROW_MSG(
+      format("{0:-}", 42ull),
+      format_error,
+      "format specifier requires signed argument");
   EXPECT_EQ("42", format("{0:-}", 42.0));
   EXPECT_EQ("42", format("{0:-}", 42.0l));
-  EXPECT_THROW_MSG(format("{0:-", 'c'),
-      format_error, "missing '}' in format string");
-  EXPECT_THROW_MSG(format("{0:-}", 'c'),
-      format_error, "invalid format specifier for char");
-  EXPECT_THROW_MSG(format("{0:-}", "abc"),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{0:-}", reinterpret_cast<void*>(0x42)),
-      format_error, "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:-", 'c'), format_error, "missing '}' in format string");
+  EXPECT_THROW_MSG(
+      format("{0:-}", 'c'), format_error, "invalid format specifier for char");
+  EXPECT_THROW_MSG(
+      format("{0:-}", "abc"),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:-}", reinterpret_cast<void *>(0x42)),
+      format_error,
+      "format specifier requires numeric argument");
 }
 
 TEST(FormatterTest, SpaceSign) {
   EXPECT_EQ(" 42", format("{0: }", 42));
   EXPECT_EQ("-42", format("{0: }", -42));
   EXPECT_EQ(" 42", format("{0: }", 42));
-  EXPECT_THROW_MSG(format("{0: }", 42u),
-      format_error, "format specifier requires signed argument");
+  EXPECT_THROW_MSG(
+      format("{0: }", 42u),
+      format_error,
+      "format specifier requires signed argument");
   EXPECT_EQ(" 42", format("{0: }", 42l));
-  EXPECT_THROW_MSG(format("{0: }", 42ul),
-      format_error, "format specifier requires signed argument");
+  EXPECT_THROW_MSG(
+      format("{0: }", 42ul),
+      format_error,
+      "format specifier requires signed argument");
   EXPECT_EQ(" 42", format("{0: }", 42ll));
-  EXPECT_THROW_MSG(format("{0: }", 42ull),
-      format_error, "format specifier requires signed argument");
+  EXPECT_THROW_MSG(
+      format("{0: }", 42ull),
+      format_error,
+      "format specifier requires signed argument");
   EXPECT_EQ(" 42", format("{0: }", 42.0));
   EXPECT_EQ(" 42", format("{0: }", 42.0l));
-  EXPECT_THROW_MSG(format("{0: ", 'c'),
-      format_error, "missing '}' in format string");
-  EXPECT_THROW_MSG(format("{0: }", 'c'),
-      format_error, "invalid format specifier for char");
-  EXPECT_THROW_MSG(format("{0: }", "abc"),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{0: }", reinterpret_cast<void*>(0x42)),
-      format_error, "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0: ", 'c'), format_error, "missing '}' in format string");
+  EXPECT_THROW_MSG(
+      format("{0: }", 'c'), format_error, "invalid format specifier for char");
+  EXPECT_THROW_MSG(
+      format("{0: }", "abc"),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0: }", reinterpret_cast<void *>(0x42)),
+      format_error,
+      "format specifier requires numeric argument");
 }
 
 TEST(FormatterTest, HashFlag) {
@@ -1057,14 +1162,18 @@ TEST(FormatterTest, HashFlag) {
   else
     EXPECT_EQ("-42.0000", format("{0:#}", -42.0));
   EXPECT_EQ("-42.0000", format("{0:#}", -42.0l));
-  EXPECT_THROW_MSG(format("{0:#", 'c'),
-      format_error, "missing '}' in format string");
-  EXPECT_THROW_MSG(format("{0:#}", 'c'),
-      format_error, "invalid format specifier for char");
-  EXPECT_THROW_MSG(format("{0:#}", "abc"),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{0:#}", reinterpret_cast<void*>(0x42)),
-      format_error, "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:#", 'c'), format_error, "missing '}' in format string");
+  EXPECT_THROW_MSG(
+      format("{0:#}", 'c'), format_error, "invalid format specifier for char");
+  EXPECT_THROW_MSG(
+      format("{0:#}", "abc"),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:#}", reinterpret_cast<void *>(0x42)),
+      format_error,
+      "format specifier requires numeric argument");
 }
 
 TEST(FormatterTest, ZeroFlag) {
@@ -1077,14 +1186,18 @@ TEST(FormatterTest, ZeroFlag) {
   EXPECT_EQ("00042", format("{0:05}", 42ull));
   EXPECT_EQ("-0042", format("{0:05}", -42.0));
   EXPECT_EQ("-0042", format("{0:05}", -42.0l));
-  EXPECT_THROW_MSG(format("{0:0", 'c'),
-      format_error, "missing '}' in format string");
-  EXPECT_THROW_MSG(format("{0:05}", 'c'),
-      format_error, "invalid format specifier for char");
-  EXPECT_THROW_MSG(format("{0:05}", "abc"),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{0:05}", reinterpret_cast<void*>(0x42)),
-      format_error, "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:0", 'c'), format_error, "missing '}' in format string");
+  EXPECT_THROW_MSG(
+      format("{0:05}", 'c'), format_error, "invalid format specifier for char");
+  EXPECT_THROW_MSG(
+      format("{0:05}", "abc"),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:05}", reinterpret_cast<void *>(0x42)),
+      format_error,
+      "format specifier requires numeric argument");
 }
 
 TEST(FormatterTest, Width) {
@@ -1109,7 +1222,7 @@ TEST(FormatterTest, Width) {
   EXPECT_EQ("     42", format("{0:7}", 42ull));
   EXPECT_EQ("   -1.23", format("{0:8}", -1.23));
   EXPECT_EQ("    -1.23", format("{0:9}", -1.23l));
-  EXPECT_EQ("    0xcafe", format("{0:10}", reinterpret_cast<void*>(0xcafe)));
+  EXPECT_EQ("    0xcafe", format("{0:10}", reinterpret_cast<void *>(0xcafe)));
   EXPECT_EQ("x          ", format("{0:11}", 'x'));
   EXPECT_EQ("str         ", format("{0:12}", "str"));
 }
@@ -1127,36 +1240,34 @@ TEST(FormatterTest, RuntimeWidth) {
   format_str[size + 2] = 0;
   EXPECT_THROW_MSG(format(format_str, 0), format_error, "number is too big");
 
-  EXPECT_THROW_MSG(format("{0:{", 0),
-      format_error, "invalid format string");
-  EXPECT_THROW_MSG(format("{0:{}", 0),
-      format_error, "cannot switch from manual to automatic argument indexing");
-  EXPECT_THROW_MSG(format("{0:{?}}", 0),
-      format_error, "invalid format string");
-  EXPECT_THROW_MSG(format("{0:{1}}", 0),
-      format_error, "argument index out of range");
+  EXPECT_THROW_MSG(format("{0:{", 0), format_error, "invalid format string");
+  EXPECT_THROW_MSG(
+      format("{0:{}", 0),
+      format_error,
+      "cannot switch from manual to automatic argument indexing");
+  EXPECT_THROW_MSG(format("{0:{?}}", 0), format_error, "invalid format string");
+  EXPECT_THROW_MSG(
+      format("{0:{1}}", 0), format_error, "argument index out of range");
 
-  EXPECT_THROW_MSG(format("{0:{0:}}", 0),
-      format_error, "invalid format string");
+  EXPECT_THROW_MSG(
+      format("{0:{0:}}", 0), format_error, "invalid format string");
 
-  EXPECT_THROW_MSG(format("{0:{1}}", 0, -1),
-      format_error, "negative width");
-  EXPECT_THROW_MSG(format("{0:{1}}", 0, (INT_MAX + 1u)),
-      format_error, "number is too big");
-  EXPECT_THROW_MSG(format("{0:{1}}", 0, -1l),
-      format_error, "negative width");
+  EXPECT_THROW_MSG(format("{0:{1}}", 0, -1), format_error, "negative width");
+  EXPECT_THROW_MSG(
+      format("{0:{1}}", 0, (INT_MAX + 1u)), format_error, "number is too big");
+  EXPECT_THROW_MSG(format("{0:{1}}", 0, -1l), format_error, "negative width");
   if (fmt::internal::const_check(sizeof(long) > sizeof(int))) {
     long value = INT_MAX;
-    EXPECT_THROW_MSG(format("{0:{1}}", 0, (value + 1)),
-        format_error, "number is too big");
+    EXPECT_THROW_MSG(
+        format("{0:{1}}", 0, (value + 1)), format_error, "number is too big");
   }
-  EXPECT_THROW_MSG(format("{0:{1}}", 0, (INT_MAX + 1ul)),
-      format_error, "number is too big");
+  EXPECT_THROW_MSG(
+      format("{0:{1}}", 0, (INT_MAX + 1ul)), format_error, "number is too big");
 
-  EXPECT_THROW_MSG(format("{0:{1}}", 0, '0'),
-      format_error, "width is not integer");
-  EXPECT_THROW_MSG(format("{0:{1}}", 0, 0.0),
-      format_error, "width is not integer");
+  EXPECT_THROW_MSG(
+      format("{0:{1}}", 0, '0'), format_error, "width is not integer");
+  EXPECT_THROW_MSG(
+      format("{0:{1}}", 0, 0.0), format_error, "width is not integer");
 
   EXPECT_EQ(" -42", format("{0:{1}}", -42, 4));
   EXPECT_EQ("   42", format("{0:{1}}", 42u, 5));
@@ -1166,8 +1277,8 @@ TEST(FormatterTest, RuntimeWidth) {
   EXPECT_EQ("     42", format("{0:{1}}", 42ull, 7));
   EXPECT_EQ("   -1.23", format("{0:{1}}", -1.23, 8));
   EXPECT_EQ("    -1.23", format("{0:{1}}", -1.23l, 9));
-  EXPECT_EQ("    0xcafe",
-            format("{0:{1}}", reinterpret_cast<void*>(0xcafe), 10));
+  EXPECT_EQ(
+      "    0xcafe", format("{0:{1}}", reinterpret_cast<void *>(0xcafe), 10));
   EXPECT_EQ("x          ", format("{0:{1}}", 'x', 11));
   EXPECT_EQ("str         ", format("{0:{1}}", "str", 12));
 }
@@ -1187,46 +1298,78 @@ TEST(FormatterTest, Precision) {
   safe_sprintf(format_str, "{0:.%u}", INT_MAX + 1u);
   EXPECT_THROW_MSG(format(format_str, 0), format_error, "number is too big");
 
-  EXPECT_THROW_MSG(format("{0:.", 0),
-      format_error, "missing precision specifier");
-  EXPECT_THROW_MSG(format("{0:.}", 0),
-      format_error, "missing precision specifier");
+  EXPECT_THROW_MSG(
+      format("{0:.", 0), format_error, "missing precision specifier");
+  EXPECT_THROW_MSG(
+      format("{0:.}", 0), format_error, "missing precision specifier");
 
-  EXPECT_THROW_MSG(format("{0:.2", 0),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.2}", 42),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.2f}", 42),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.2}", 42u),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.2f}", 42u),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.2}", 42l),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.2f}", 42l),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.2}", 42ul),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.2f}", 42ul),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.2}", 42ll),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.2f}", 42ll),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.2}", 42ull),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.2f}", 42ull),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:3.0}", 'x'),
-      format_error, "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2", 0),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2}", 42),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2f}", 42),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2}", 42u),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2f}", 42u),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2}", 42l),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2f}", 42l),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2}", 42ul),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2f}", 42ul),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2}", 42ll),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2f}", 42ll),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2}", 42ull),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2f}", 42ull),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:3.0}", 'x'),
+      format_error,
+      "precision not allowed for this argument type");
   EXPECT_EQ("1.2", format("{0:.2}", 1.2345));
   EXPECT_EQ("1.2", format("{0:.2}", 1.2345l));
 
-  EXPECT_THROW_MSG(format("{0:.2}", reinterpret_cast<void*>(0xcafe)),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.2f}", reinterpret_cast<void*>(0xcafe)),
-      format_error, "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2}", reinterpret_cast<void *>(0xcafe)),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.2f}", reinterpret_cast<void *>(0xcafe)),
+      format_error,
+      "precision not allowed for this argument type");
 
   EXPECT_EQ("st", format("{0:.2}", "str"));
 }
@@ -1244,72 +1387,107 @@ TEST(FormatterTest, RuntimePrecision) {
   format_str[size + 2] = 0;
   EXPECT_THROW_MSG(format(format_str, 0), format_error, "number is too big");
 
-  EXPECT_THROW_MSG(format("{0:.{", 0),
-      format_error, "invalid format string");
-  EXPECT_THROW_MSG(format("{0:.{}", 0),
-      format_error, "cannot switch from manual to automatic argument indexing");
-  EXPECT_THROW_MSG(format("{0:.{?}}", 0),
-      format_error, "invalid format string");
-  EXPECT_THROW_MSG(format("{0:.{1}", 0, 0),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.{1}}", 0),
-      format_error, "argument index out of range");
+  EXPECT_THROW_MSG(format("{0:.{", 0), format_error, "invalid format string");
+  EXPECT_THROW_MSG(
+      format("{0:.{}", 0),
+      format_error,
+      "cannot switch from manual to automatic argument indexing");
+  EXPECT_THROW_MSG(
+      format("{0:.{?}}", 0), format_error, "invalid format string");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}", 0, 0),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", 0), format_error, "argument index out of range");
 
-  EXPECT_THROW_MSG(format("{0:.{0:}}", 0),
-      format_error, "invalid format string");
+  EXPECT_THROW_MSG(
+      format("{0:.{0:}}", 0), format_error, "invalid format string");
 
-  EXPECT_THROW_MSG(format("{0:.{1}}", 0, -1),
-      format_error, "negative precision");
-  EXPECT_THROW_MSG(format("{0:.{1}}", 0, (INT_MAX + 1u)),
-      format_error, "number is too big");
-  EXPECT_THROW_MSG(format("{0:.{1}}", 0, -1l),
-      format_error, "negative precision");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", 0, -1), format_error, "negative precision");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", 0, (INT_MAX + 1u)), format_error, "number is too big");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", 0, -1l), format_error, "negative precision");
   if (fmt::internal::const_check(sizeof(long) > sizeof(int))) {
     long value = INT_MAX;
-    EXPECT_THROW_MSG(format("{0:.{1}}", 0, (value + 1)),
-        format_error, "number is too big");
+    EXPECT_THROW_MSG(
+        format("{0:.{1}}", 0, (value + 1)), format_error, "number is too big");
   }
-  EXPECT_THROW_MSG(format("{0:.{1}}", 0, (INT_MAX + 1ul)),
-      format_error, "number is too big");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", 0, (INT_MAX + 1ul)),
+      format_error,
+      "number is too big");
 
-  EXPECT_THROW_MSG(format("{0:.{1}}", 0, '0'),
-      format_error, "precision is not integer");
-  EXPECT_THROW_MSG(format("{0:.{1}}", 0, 0.0),
-      format_error, "precision is not integer");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", 0, '0'), format_error, "precision is not integer");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", 0, 0.0), format_error, "precision is not integer");
 
-  EXPECT_THROW_MSG(format("{0:.{1}}", 42, 2),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.{1}f}", 42, 2),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.{1}}", 42u, 2),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.{1}f}", 42u, 2),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.{1}}", 42l, 2),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.{1}f}", 42l, 2),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.{1}}", 42ul, 2),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.{1}f}", 42ul, 2),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.{1}}", 42ll, 2),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.{1}f}", 42ll, 2),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.{1}}", 42ull, 2),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.{1}f}", 42ull, 2),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:3.{1}}", 'x', 0),
-      format_error, "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", 42, 2),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}f}", 42, 2),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", 42u, 2),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}f}", 42u, 2),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", 42l, 2),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}f}", 42l, 2),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", 42ul, 2),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}f}", 42ul, 2),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", 42ll, 2),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}f}", 42ll, 2),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", 42ull, 2),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}f}", 42ull, 2),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:3.{1}}", 'x', 0),
+      format_error,
+      "precision not allowed for this argument type");
   EXPECT_EQ("1.2", format("{0:.{1}}", 1.2345, 2));
   EXPECT_EQ("1.2", format("{1:.{0}}", 2, 1.2345l));
 
-  EXPECT_THROW_MSG(format("{0:.{1}}", reinterpret_cast<void*>(0xcafe), 2),
-      format_error, "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(format("{0:.{1}f}", reinterpret_cast<void*>(0xcafe), 2),
-      format_error, "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}}", reinterpret_cast<void *>(0xcafe), 2),
+      format_error,
+      "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:.{1}f}", reinterpret_cast<void *>(0xcafe), 2),
+      format_error,
+      "precision not allowed for this argument type");
 
   EXPECT_EQ("st", format("{0:.{1}}", "str", 2));
 }
@@ -1320,11 +1498,12 @@ void check_unknown_types(const T &value, const char *types, const char *) {
   const char *special = ".0123456789}";
   for (int i = CHAR_MIN; i <= CHAR_MAX; ++i) {
     char c = static_cast<char>(i);
-    if (std::strchr(types, c) || std::strchr(special, c) || !c) continue;
+    if (std::strchr(types, c) || std::strchr(special, c) || !c)
+      continue;
     safe_sprintf(format_str, "{0:10%c}", c);
     const char *message = "invalid type specifier";
     EXPECT_THROW_MSG(format(format_str, value), format_error, message)
-      << format_str << " " << message;
+        << format_str << " " << message;
   }
 }
 
@@ -1344,8 +1523,8 @@ TEST(FormatterTest, FormatShort) {
 }
 
 TEST(FormatterTest, FormatInt) {
-  EXPECT_THROW_MSG(format("{0:v", 42),
-      format_error, "missing '}' in format string");
+  EXPECT_THROW_MSG(
+      format("{0:v", 42), format_error, "missing '}' in format string");
   check_unknown_types(42, "bBdoxXn", "integer");
 }
 
@@ -1357,8 +1536,9 @@ TEST(FormatterTest, FormatBin) {
   EXPECT_EQ("11000000111001", format("{0:b}", 12345));
   EXPECT_EQ("10010001101000101011001111000", format("{0:b}", 0x12345678));
   EXPECT_EQ("10010000101010111100110111101111", format("{0:b}", 0x90ABCDEF));
-  EXPECT_EQ("11111111111111111111111111111111",
-            format("{0:b}", std::numeric_limits<uint32_t>::max()));
+  EXPECT_EQ(
+      "11111111111111111111111111111111",
+      format("{0:b}", std::numeric_limits<uint32_t>::max()));
 }
 
 TEST(FormatterTest, FormatDec) {
@@ -1434,8 +1614,8 @@ TEST(FormatterTest, FormatIntLocale) {
   EXPECT_EQ("123", format("{:n}", 123));
   EXPECT_EQ("1,234", format("{:n}", 1234));
   EXPECT_EQ("1,234,567", format("{:n}", 1234567));
-  EXPECT_EQ("4,294,967,295",
-            format("{:n}", std::numeric_limits<uint32_t>::max()));
+  EXPECT_EQ(
+      "4,294,967,295", format("{:n}", std::numeric_limits<uint32_t>::max()));
 }
 
 struct ConvertibleToLongLong {
@@ -1537,7 +1717,7 @@ TEST(FormatterTest, FormatUnsignedChar) {
 TEST(FormatterTest, FormatWChar) {
   EXPECT_EQ(L"a", format(L"{0}", L'a'));
   // This shouldn't compile:
-  //format("{}", L'a');
+  // format("{}", L'a');
 }
 
 TEST(FormatterTest, FormatCString) {
@@ -1546,8 +1726,10 @@ TEST(FormatterTest, FormatCString) {
   EXPECT_EQ("test", format("{0:s}", "test"));
   char nonconst[] = "nonconst";
   EXPECT_EQ("nonconst", format("{0}", nonconst));
-  EXPECT_THROW_MSG(format("{0}", static_cast<const char*>(FMT_NULL)),
-      format_error, "string pointer is null");
+  EXPECT_THROW_MSG(
+      format("{0}", static_cast<const char *>(FMT_NULL)),
+      format_error,
+      "string pointer is null");
 }
 
 TEST(FormatterTest, FormatSCharString) {
@@ -1567,13 +1749,14 @@ TEST(FormatterTest, FormatUCharString) {
 }
 
 TEST(FormatterTest, FormatPointer) {
-  check_unknown_types(reinterpret_cast<void*>(0x1234), "p", "pointer");
-  EXPECT_EQ("0x0", format("{0}", static_cast<void*>(FMT_NULL)));
-  EXPECT_EQ("0x1234", format("{0}", reinterpret_cast<void*>(0x1234)));
-  EXPECT_EQ("0x1234", format("{0:p}", reinterpret_cast<void*>(0x1234)));
-  EXPECT_EQ("0x" + std::string(sizeof(void*) * CHAR_BIT / 4, 'f'),
-      format("{0}", reinterpret_cast<void*>(~uintptr_t())));
-  EXPECT_EQ("0x1234", format("{}", fmt::ptr(reinterpret_cast<int*>(0x1234))));
+  check_unknown_types(reinterpret_cast<void *>(0x1234), "p", "pointer");
+  EXPECT_EQ("0x0", format("{0}", static_cast<void *>(FMT_NULL)));
+  EXPECT_EQ("0x1234", format("{0}", reinterpret_cast<void *>(0x1234)));
+  EXPECT_EQ("0x1234", format("{0:p}", reinterpret_cast<void *>(0x1234)));
+  EXPECT_EQ(
+      "0x" + std::string(sizeof(void *) * CHAR_BIT / 4, 'f'),
+      format("{0}", reinterpret_cast<void *>(~uintptr_t())));
+  EXPECT_EQ("0x1234", format("{}", fmt::ptr(reinterpret_cast<int *>(0x1234))));
 #if FMT_USE_NULLPTR
   EXPECT_EQ("0x0", format("{}", FMT_NULL));
 #endif
@@ -1614,8 +1797,8 @@ FMT_END_NAMESPACE
 
 TEST(FormatterTest, FormatCustom) {
   Date date(2012, 12, 9);
-  EXPECT_THROW_MSG(fmt::format("{:s}", date), format_error,
-                   "unknown format specifier");
+  EXPECT_THROW_MSG(
+      fmt::format("{:s}", date), format_error, "unknown format specifier");
 }
 
 class Answer {};
@@ -1637,8 +1820,8 @@ TEST(FormatterTest, CustomFormat) {
 
 TEST(FormatterTest, CustomFormatTo) {
   char buf[10] = {};
-  auto end = &*fmt::format_to(
-        fmt::internal::make_checked(buf, 10), "{}", Answer());
+  auto end =
+      &*fmt::format_to(fmt::internal::make_checked(buf, 10), "{}", Answer());
   EXPECT_EQ(end, buf + 2);
   EXPECT_STREQ(buf, "42");
 }
@@ -1651,9 +1834,16 @@ TEST(FormatterTest, WideFormatString) {
 }
 
 TEST(FormatterTest, FormatStringFromSpeedTest) {
-  EXPECT_EQ("1.2340000000:0042:+3.13:str:0x3e8:X:%",
-      format("{0:0.10f}:{1:04}:{2:+g}:{3}:{4}:{5}:%",
-          1.234, 42, 3.13, "str", reinterpret_cast<void*>(1000), 'X'));
+  EXPECT_EQ(
+      "1.2340000000:0042:+3.13:str:0x3e8:X:%",
+      format(
+          "{0:0.10f}:{1:04}:{2:+g}:{3}:{4}:{5}:%",
+          1.234,
+          42,
+          3.13,
+          "str",
+          reinterpret_cast<void *>(1000),
+          'X'));
 }
 
 TEST(FormatterTest, FormatExamples) {
@@ -1669,22 +1859,26 @@ TEST(FormatterTest, FormatExamples) {
 
   const char *filename = "nonexistent";
   FILE *ftest = safe_fopen(filename, "r");
-  if (ftest) fclose(ftest);
+  if (ftest)
+    fclose(ftest);
   int error_code = errno;
   EXPECT_TRUE(ftest == FMT_NULL);
-  EXPECT_SYSTEM_ERROR({
-    FILE *f = safe_fopen(filename, "r");
-    if (!f)
-      throw fmt::system_error(errno, "Cannot open file '{}'", filename);
-    fclose(f);
-  }, error_code, "Cannot open file 'nonexistent'");
+  EXPECT_SYSTEM_ERROR(
+      {
+        FILE *f = safe_fopen(filename, "r");
+        if (!f)
+          throw fmt::system_error(errno, "Cannot open file '{}'", filename);
+        fclose(f);
+      },
+      error_code,
+      "Cannot open file 'nonexistent'");
 }
 
 TEST(FormatterTest, Examples) {
-  EXPECT_EQ("First, thou shalt count to three",
+  EXPECT_EQ(
+      "First, thou shalt count to three",
       format("First, thou shalt count to {0}", "three"));
-  EXPECT_EQ("Bring me a shrubbery",
-      format("Bring me a {}", "shrubbery"));
+  EXPECT_EQ("Bring me a shrubbery", format("Bring me a {}", "shrubbery"));
   EXPECT_EQ("From 1 to 3", format("From {} to {}", 1, 3));
 
   char buffer[BUFFER_SIZE];
@@ -1696,37 +1890,33 @@ TEST(FormatterTest, Examples) {
   EXPECT_EQ("c, b, a", format("{2}, {1}, {0}", 'a', 'b', 'c'));
   EXPECT_EQ("abracadabra", format("{0}{1}{0}", "abra", "cad"));
 
-  EXPECT_EQ("left aligned                  ",
-      format("{:<30}", "left aligned"));
-  EXPECT_EQ("                 right aligned",
-      format("{:>30}", "right aligned"));
-  EXPECT_EQ("           centered           ",
-      format("{:^30}", "centered"));
-  EXPECT_EQ("***********centered***********",
-      format("{:*^30}", "centered"));
+  EXPECT_EQ("left aligned                  ", format("{:<30}", "left aligned"));
+  EXPECT_EQ(
+      "                 right aligned", format("{:>30}", "right aligned"));
+  EXPECT_EQ("           centered           ", format("{:^30}", "centered"));
+  EXPECT_EQ("***********centered***********", format("{:*^30}", "centered"));
 
-  EXPECT_EQ("+3.140000; -3.140000",
-      format("{:+f}; {:+f}", 3.14, -3.14));
-  EXPECT_EQ(" 3.140000; -3.140000",
-      format("{: f}; {: f}", 3.14, -3.14));
-  EXPECT_EQ("3.140000; -3.140000",
-      format("{:-f}; {:-f}", 3.14, -3.14));
+  EXPECT_EQ("+3.140000; -3.140000", format("{:+f}; {:+f}", 3.14, -3.14));
+  EXPECT_EQ(" 3.140000; -3.140000", format("{: f}; {: f}", 3.14, -3.14));
+  EXPECT_EQ("3.140000; -3.140000", format("{:-f}; {:-f}", 3.14, -3.14));
 
-  EXPECT_EQ("int: 42;  hex: 2a;  oct: 52",
+  EXPECT_EQ(
+      "int: 42;  hex: 2a;  oct: 52",
       format("int: {0:d};  hex: {0:x};  oct: {0:o}", 42));
-  EXPECT_EQ("int: 42;  hex: 0x2a;  oct: 052",
+  EXPECT_EQ(
+      "int: 42;  hex: 0x2a;  oct: 052",
       format("int: {0:d};  hex: {0:#x};  oct: {0:#o}", 42));
 
   EXPECT_EQ("The answer is 42", format("The answer is {}", 42));
   EXPECT_THROW_MSG(
-    format("The answer is {:d}", "forty-two"), format_error,
-    "invalid type specifier");
+      format("The answer is {:d}", "forty-two"),
+      format_error,
+      "invalid type specifier");
 
-  EXPECT_EQ(L"Cyrillic letter \x42e",
-    format(L"Cyrillic letter {}", L'\x42e'));
+  EXPECT_EQ(L"Cyrillic letter \x42e", format(L"Cyrillic letter {}", L'\x42e'));
 
-  EXPECT_WRITE(stdout,
-      fmt::print("{}", std::numeric_limits<double>::infinity()), "inf");
+  EXPECT_WRITE(
+      stdout, fmt::print("{}", std::numeric_limits<double>::infinity()), "inf");
 }
 
 TEST(FormatIntTest, Data) {
@@ -1745,8 +1935,8 @@ TEST(FormatIntTest, FormatInt) {
   EXPECT_EQ("-42", fmt::format_int(-42ll).str());
   std::ostringstream os;
   os << std::numeric_limits<int64_t>::max();
-  EXPECT_EQ(os.str(),
-            fmt::format_int(std::numeric_limits<int64_t>::max()).str());
+  EXPECT_EQ(
+      os.str(), fmt::format_int(std::numeric_limits<int64_t>::max()).str());
 }
 
 template <typename T>
@@ -1762,8 +1952,8 @@ TEST(FormatIntTest, FormatDec) {
   EXPECT_EQ("-42", format_decimal(static_cast<short>(-42)));
   std::ostringstream os;
   os << std::numeric_limits<unsigned short>::max();
-  EXPECT_EQ(os.str(),
-            format_decimal(std::numeric_limits<unsigned short>::max()));
+  EXPECT_EQ(
+      os.str(), format_decimal(std::numeric_limits<unsigned short>::max()));
   EXPECT_EQ("1", format_decimal(1));
   EXPECT_EQ("-1", format_decimal(-1));
   EXPECT_EQ("42", format_decimal(42));
@@ -1777,8 +1967,8 @@ TEST(FormatIntTest, FormatDec) {
 TEST(FormatTest, Print) {
 #if FMT_USE_FILE_DESCRIPTORS
   EXPECT_WRITE(stdout, fmt::print("Don't {}!", "panic"), "Don't panic!");
-  EXPECT_WRITE(stderr,
-      fmt::print(stderr, "Don't {}!", "panic"), "Don't panic!");
+  EXPECT_WRITE(
+      stderr, fmt::print(stderr, "Don't {}!", "panic"), "Don't panic!");
 #endif
 }
 
@@ -1794,34 +1984,35 @@ TEST(FormatTest, Dynamic) {
   args.emplace_back(fmt::internal::make_arg<ctx>("abc1"));
   args.emplace_back(fmt::internal::make_arg<ctx>(1.2f));
 
-  std::string result = fmt::vformat("{} and {} and {}",
-                                    fmt::basic_format_args<ctx>(
-                                        args.data(),
-                                        static_cast<unsigned>(args.size())));
+  std::string result = fmt::vformat(
+      "{} and {} and {}",
+      fmt::basic_format_args<ctx>(
+          args.data(), static_cast<unsigned>(args.size())));
 
   EXPECT_EQ("42 and abc1 and 1.2", result);
 }
 
 TEST(FormatTest, JoinArg) {
   using fmt::join;
-  int v1[3] = { 1, 2, 3 };
+  int v1[3] = {1, 2, 3};
   std::vector<float> v2;
   v2.push_back(1.2f);
   v2.push_back(3.4f);
-  void *v3[2] = { &v1[0], &v1[1] };
+  void *v3[2] = {&v1[0], &v1[1]};
 
   EXPECT_EQ("(1, 2, 3)", format("({})", join(v1, v1 + 3, ", ")));
   EXPECT_EQ("(1)", format("({})", join(v1, v1 + 1, ", ")));
   EXPECT_EQ("()", format("({})", join(v1, v1, ", ")));
   EXPECT_EQ("(001, 002, 003)", format("({:03})", join(v1, v1 + 3, ", ")));
-  EXPECT_EQ("(+01.20, +03.40)",
-            format("({:+06.2f})", join(v2.begin(), v2.end(), ", ")));
+  EXPECT_EQ(
+      "(+01.20, +03.40)",
+      format("({:+06.2f})", join(v2.begin(), v2.end(), ", ")));
 
   EXPECT_EQ(L"(1, 2, 3)", format(L"({})", join(v1, v1 + 3, L", ")));
   EXPECT_EQ("1, 2, 3", format("{0:{1}}", join(v1, v1 + 3, ", "), 1));
 
-  EXPECT_EQ(format("{}, {}", v3[0], v3[1]),
-            format("{}", join(v3, v3 + 2, ", ")));
+  EXPECT_EQ(
+      format("{}, {}", v3[0], v3[1]), format("{}", join(v3, v3 + 2, ", ")));
 
 #if FMT_USE_TRAILING_RETURN && (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 405)
   EXPECT_EQ("(1, 2, 3)", format("({})", join(v1, ", ")));
@@ -1848,28 +2039,46 @@ std::string vformat_message(int id, const char *format, fmt::format_args args) {
 }
 
 template <typename... Args>
-std::string format_message(int id, const char *format, const Args & ... args) {
+std::string format_message(int id, const char *format, const Args &... args) {
   auto va = fmt::make_format_args(args...);
   return vformat_message(id, format, va);
 }
 
 TEST(FormatTest, FormatMessageExample) {
-  EXPECT_EQ("[42] something happened",
+  EXPECT_EQ(
+      "[42] something happened",
       format_message(42, "{} happened", "something"));
 }
 
-template<typename... Args>
-void print_error(const char *file, int line, const char *format,
-                 const Args & ... args) {
+template <typename... Args>
+void print_error(
+    const char *file, int line, const char *format, const Args &... args) {
   fmt::print("{}: {}: ", file, line);
   fmt::print(format, args...);
 }
 
 TEST(FormatTest, UnpackedArgs) {
-  EXPECT_EQ("0123456789abcdefg",
-            fmt::format("{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
-                        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'a', 'b', 'c', 'd', 'e',
-                        'f', 'g'));
+  EXPECT_EQ(
+      "0123456789abcdefg",
+      fmt::format(
+          "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          'a',
+          'b',
+          'c',
+          'd',
+          'e',
+          'f',
+          'g'));
 }
 
 #if FMT_USE_USER_DEFINED_LITERALS
@@ -1887,18 +2096,30 @@ TEST(LiteralsTest, Format) {
 }
 
 TEST(LiteralsTest, NamedArg) {
-  auto udl_a = format("{first}{second}{first}{third}",
-                      "first"_a="abra", "second"_a="cad", "third"_a=99);
-  EXPECT_EQ(format("{first}{second}{first}{third}",
-                   fmt::arg("first", "abra"), fmt::arg("second", "cad"),
-                   fmt::arg("third", 99)),
-            udl_a);
-  auto udl_a_w = format(L"{first}{second}{first}{third}",
-                        L"first"_a=L"abra", L"second"_a=L"cad", L"third"_a=99);
-  EXPECT_EQ(format(L"{first}{second}{first}{third}",
-                   fmt::arg(L"first", L"abra"), fmt::arg(L"second", L"cad"),
-                   fmt::arg(L"third", 99)),
-            udl_a_w);
+  auto udl_a = format(
+      "{first}{second}{first}{third}",
+      "first"_a = "abra",
+      "second"_a = "cad",
+      "third"_a = 99);
+  EXPECT_EQ(
+      format(
+          "{first}{second}{first}{third}",
+          fmt::arg("first", "abra"),
+          fmt::arg("second", "cad"),
+          fmt::arg("third", 99)),
+      udl_a);
+  auto udl_a_w = format(
+      L"{first}{second}{first}{third}",
+      L"first"_a = L"abra",
+      L"second"_a = L"cad",
+      L"third"_a = 99);
+  EXPECT_EQ(
+      format(
+          L"{first}{second}{first}{third}",
+          fmt::arg(L"first", L"abra"),
+          fmt::arg(L"second", L"cad"),
+          fmt::arg(L"third", 99)),
+      udl_a_w);
 }
 
 TEST(FormatTest, UdlTemplate) {
@@ -1907,54 +2128,48 @@ TEST(FormatTest, UdlTemplate) {
   EXPECT_EQ("42", fmt::format(FMT_STRING("{}"), 42));
   EXPECT_EQ(L"42", fmt::format(FMT_STRING(L"{}"), 42));
 }
-#endif // FMT_USE_USER_DEFINED_LITERALS
+#endif  // FMT_USE_USER_DEFINED_LITERALS
 
 enum TestEnum { A };
 
-TEST(FormatTest, Enum) {
-  EXPECT_EQ("0", fmt::format("{}", A));
-}
+TEST(FormatTest, Enum) { EXPECT_EQ("0", fmt::format("{}", A)); }
 
-TEST(FormatTest, EnumFormatterUnambiguous) {
-  fmt::formatter<TestEnum> f;
-}
+TEST(FormatTest, EnumFormatterUnambiguous) { fmt::formatter<TestEnum> f; }
 
 #if FMT_HAS_FEATURE(cxx_strong_enums)
 enum TestFixedEnum : short { B };
 
-TEST(FormatTest, FixedEnum) {
-  EXPECT_EQ("0", fmt::format("{}", B));
-}
+TEST(FormatTest, FixedEnum) { EXPECT_EQ("0", fmt::format("{}", B)); }
 #endif
 
 typedef fmt::back_insert_range<fmt::internal::buffer> buffer_range;
 
-class mock_arg_formatter:
-    public fmt::internal::function<
-      fmt::internal::arg_formatter_base<buffer_range>::iterator>,
-    public fmt::internal::arg_formatter_base<buffer_range> {
+class mock_arg_formatter
+    : public fmt::internal::function<
+          fmt::internal::arg_formatter_base<buffer_range>::iterator>,
+      public fmt::internal::arg_formatter_base<buffer_range> {
  private:
-  MOCK_METHOD1(call, void (long long value));
+  MOCK_METHOD1(call, void(long long value));
 
  public:
   typedef fmt::internal::arg_formatter_base<buffer_range> base;
   typedef buffer_range range;
 
   mock_arg_formatter(fmt::format_context &ctx, fmt::format_specs *s = FMT_NULL)
-    : base(fmt::internal::get_container(ctx.out()), s, ctx.locale()) {
+      : base(fmt::internal::get_container(ctx.out()), s, ctx.locale()) {
     EXPECT_CALL(*this, call(42));
   }
 
   template <typename T>
   typename std::enable_if<std::is_integral<T>::value, iterator>::type
-      operator()(T value) {
+  operator()(T value) {
     call(value);
     return base::operator()(value);
   }
 
   template <typename T>
   typename std::enable_if<!std::is_integral<T>::value, iterator>::type
-      operator()(T value) {
+  operator()(T value) {
     return base::operator()(value);
   }
 
@@ -1969,21 +2184,19 @@ static void custom_vformat(fmt::string_view format_str, fmt::format_args args) {
 }
 
 template <typename... Args>
-void custom_format(const char *format_str, const Args & ... args) {
+void custom_format(const char *format_str, const Args &... args) {
   auto va = fmt::make_format_args(args...);
   return custom_vformat(format_str, va);
 }
 
-TEST(FormatTest, CustomArgFormatter) {
-  custom_format("{}", 42);
-}
+TEST(FormatTest, CustomArgFormatter) { custom_format("{}", 42); }
 
 TEST(FormatTest, NonNullTerminatedFormatString) {
   EXPECT_EQ("42", format(string_view("{}foo", 2), 42));
 }
 
 struct variant {
-  enum {INT, STRING} type;
+  enum { INT, STRING } type;
   explicit variant(int) : type(INT) {}
   explicit variant(const char *) : type(STRING) {}
 };
@@ -1991,7 +2204,7 @@ struct variant {
 FMT_BEGIN_NAMESPACE
 template <>
 struct formatter<variant> : dynamic_formatter<> {
-  auto format(variant value, format_context& ctx) -> decltype(ctx.out()) {
+  auto format(variant value, format_context &ctx) -> decltype(ctx.out()) {
     if (value.type == variant::INT)
       return dynamic_formatter<>::format(42, ctx);
     return dynamic_formatter<>::format("foo", ctx);
@@ -2005,34 +2218,50 @@ TEST(FormatTest, DynamicFormatter) {
   EXPECT_EQ("42", format("{:d}", num));
   EXPECT_EQ("foo", format("{:s}", str));
   EXPECT_EQ(" 42 foo ", format("{:{}} {:{}}", num, 3, str, 4));
-  EXPECT_THROW_MSG(format("{0:{}}", num),
-      format_error, "cannot switch from manual to automatic argument indexing");
-  EXPECT_THROW_MSG(format("{:{0}}", num),
-      format_error, "cannot switch from automatic to manual argument indexing");
-  EXPECT_THROW_MSG(format("{:=}", str),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{:+}", str),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{:-}", str),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{: }", str),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{:#}", str),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{:0}", str),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{:.2}", num),
-      format_error, "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(
+      format("{0:{}}", num),
+      format_error,
+      "cannot switch from manual to automatic argument indexing");
+  EXPECT_THROW_MSG(
+      format("{:{0}}", num),
+      format_error,
+      "cannot switch from automatic to manual argument indexing");
+  EXPECT_THROW_MSG(
+      format("{:=}", str),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{:+}", str),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{:-}", str),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{: }", str),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{:#}", str),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{:0}", str),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{:.2}", num),
+      format_error,
+      "precision not allowed for this argument type");
 }
 
 TEST(FormatTest, ToString) {
   EXPECT_EQ("42", fmt::to_string(42));
-  EXPECT_EQ("0x1234", fmt::to_string(reinterpret_cast<void*>(0x1234)));
+  EXPECT_EQ("0x1234", fmt::to_string(reinterpret_cast<void *>(0x1234)));
 }
 
-TEST(FormatTest, ToWString) {
-  EXPECT_EQ(L"42", fmt::to_wstring(42));
-}
+TEST(FormatTest, ToWString) { EXPECT_EQ(L"42", fmt::to_wstring(42)); }
 
 TEST(FormatTest, OutputIterators) {
   std::list<char> out;
@@ -2123,11 +2352,16 @@ struct test_format_specs_handler {
   // Workaround for MSVC2017 bug that results in "expression did not evaluate
   // to a constant" with compiler-generated copy ctor.
   FMT_CONSTEXPR test_format_specs_handler() {}
-  FMT_CONSTEXPR test_format_specs_handler(const test_format_specs_handler &other)
-  : res(other.res), align_(other.align_), fill(other.fill),
-    width(other.width), width_ref(other.width_ref),
-    precision(other.precision), precision_ref(other.precision_ref),
-    type(other.type) {}
+  FMT_CONSTEXPR test_format_specs_handler(
+      const test_format_specs_handler &other)
+      : res(other.res),
+        align_(other.align_),
+        fill(other.fill),
+        width(other.width),
+        width_ref(other.width_ref),
+        precision(other.precision),
+        precision_ref(other.precision_ref),
+        type(other.type) {}
 
   FMT_CONSTEXPR void on_align(fmt::alignment a) { align_ = a; }
   FMT_CONSTEXPR void on_fill(char f) { fill = f; }
@@ -2228,8 +2462,8 @@ TEST(FormatTest, ConstexprSpecsHandler) {
 }
 
 template <size_t N>
-FMT_CONSTEXPR fmt::internal::dynamic_format_specs<char>
-    parse_dynamic_specs(const char (&s)[N]) {
+FMT_CONSTEXPR fmt::internal::dynamic_format_specs<char> parse_dynamic_specs(
+    const char (&s)[N]) {
   fmt::internal::dynamic_format_specs<char> specs;
   test_context ctx{};
   fmt::internal::dynamic_specs_handler<test_context> h(specs, ctx);
@@ -2256,8 +2490,8 @@ TEST(FormatTest, ConstexprDynamicSpecsHandler) {
 
 template <size_t N>
 FMT_CONSTEXPR test_format_specs_handler check_specs(const char (&s)[N]) {
-  fmt::internal::specs_checker<test_format_specs_handler>
-      checker(test_format_specs_handler(), fmt::internal::double_type);
+  fmt::internal::specs_checker<test_format_specs_handler> checker(
+      test_format_specs_handler(), fmt::internal::double_type);
   parse_format_specs(s, s + N, checker);
   return checker;
 }
@@ -2289,7 +2523,7 @@ struct test_format_string_handler {
 
   FMT_CONSTEXPR void on_replacement_field(const char *) {}
 
-  FMT_CONSTEXPR const char *on_format_specs(const char *begin, const char*) {
+  FMT_CONSTEXPR const char *on_format_specs(const char *begin, const char *) {
     return begin;
   }
 
@@ -2317,10 +2551,10 @@ TEST(FormatTest, ConstexprParseFormatString) {
 struct test_error_handler {
   const char *&error;
 
-  FMT_CONSTEXPR test_error_handler(const char *&err): error(err) {}
+  FMT_CONSTEXPR test_error_handler(const char *&err) : error(err) {}
 
   FMT_CONSTEXPR test_error_handler(const test_error_handler &other)
-    : error(other.error) {}
+      : error(other.error) {}
 
   FMT_CONSTEXPR void on_error(const char *message) {
     if (!error)
@@ -2330,8 +2564,7 @@ struct test_error_handler {
 
 FMT_CONSTEXPR size_t len(const char *s) {
   size_t len = 0;
-  while (*s++)
-    ++len;
+  while (*s++) ++len;
   return len;
 }
 
@@ -2349,7 +2582,7 @@ template <typename... Args>
 FMT_CONSTEXPR bool test_error(const char *fmt, const char *expected_error) {
   const char *actual_error = FMT_NULL;
   fmt::internal::do_check_format_string<char, test_error_handler, Args...>(
-        string_view(fmt, len(fmt)), test_error_handler(actual_error));
+      string_view(fmt, len(fmt)), test_error_handler(actual_error));
   return equal(actual_error, expected_error);
 }
 
@@ -2369,18 +2602,18 @@ TEST(FormatTest, FormatStringErrors) {
   EXPECT_ERROR("{:10000000000}", "number is too big", int);
   EXPECT_ERROR("{:.10000000000}", "number is too big", int);
   EXPECT_ERROR_NOARGS("{:x}", "argument index out of range");
-  EXPECT_ERROR("{:=}", "format specifier requires numeric argument",
-               const char *);
-  EXPECT_ERROR("{:+}", "format specifier requires numeric argument",
-               const char *);
-  EXPECT_ERROR("{:-}", "format specifier requires numeric argument",
-               const char *);
-  EXPECT_ERROR("{:#}", "format specifier requires numeric argument",
-               const char *);
-  EXPECT_ERROR("{: }", "format specifier requires numeric argument",
-               const char *);
-  EXPECT_ERROR("{:0}", "format specifier requires numeric argument",
-               const char *);
+  EXPECT_ERROR(
+      "{:=}", "format specifier requires numeric argument", const char *);
+  EXPECT_ERROR(
+      "{:+}", "format specifier requires numeric argument", const char *);
+  EXPECT_ERROR(
+      "{:-}", "format specifier requires numeric argument", const char *);
+  EXPECT_ERROR(
+      "{:#}", "format specifier requires numeric argument", const char *);
+  EXPECT_ERROR(
+      "{: }", "format specifier requires numeric argument", const char *);
+  EXPECT_ERROR(
+      "{:0}", "format specifier requires numeric argument", const char *);
   EXPECT_ERROR("{:+}", "format specifier requires signed argument", unsigned);
   EXPECT_ERROR("{:-}", "format specifier requires signed argument", unsigned);
   EXPECT_ERROR("{: }", "format specifier requires signed argument", unsigned);
@@ -2405,12 +2638,16 @@ TEST(FormatTest, FormatStringErrors) {
   EXPECT_ERROR("{:.x}", "missing precision specifier", int);
   EXPECT_ERROR_NOARGS("{}", "argument index out of range");
   EXPECT_ERROR("{1}", "argument index out of range", int);
-  EXPECT_ERROR("{1}{}",
-               "cannot switch from manual to automatic argument indexing",
-               int, int);
-  EXPECT_ERROR("{}{1}",
-               "cannot switch from automatic to manual argument indexing",
-               int, int);
+  EXPECT_ERROR(
+      "{1}{}",
+      "cannot switch from manual to automatic argument indexing",
+      int,
+      int);
+  EXPECT_ERROR(
+      "{}{1}",
+      "cannot switch from automatic to manual argument indexing",
+      int,
+      int);
 }
 
 TEST(FormatTest, VFormatTo) {

--- a/test/gtest-extra-test.cc
+++ b/test/gtest-extra-test.cc
@@ -7,14 +7,14 @@
 
 #include "gtest-extra.h"
 
-#include <cstring>
-#include <algorithm>
-#include <stdexcept>
 #include <gtest/gtest-spi.h>
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
 
 #if defined(_WIN32) && !defined(__MINGW32__)
-# include <crtdbg.h>  // for _CrtSetReportMode
-#endif  // _WIN32
+#include <crtdbg.h>  // for _CrtSetReportMode
+#endif               // _WIN32
 
 #include "util.h"
 
@@ -23,7 +23,7 @@ using testing::internal::scoped_ptr;
 namespace {
 
 // This is used to suppress coverity warnings about untrusted values.
-std::string sanitize(const std::string &s) {
+std::string sanitize(const std::string& s) {
   std::string result;
   for (std::string::const_iterator i = s.begin(), end = s.end(); i != end; ++i)
     result.push_back(static_cast<char>(*i & 0xff));
@@ -53,13 +53,9 @@ int SingleEvaluationTest::b_;
 
 void do_nothing() {}
 
-void throw_exception() {
-  throw std::runtime_error("test");
-}
+void throw_exception() { throw std::runtime_error("test"); }
 
-void throw_system_error() {
-  throw fmt::system_error(EDOM, "test");
-}
+void throw_system_error() { throw fmt::system_error(EDOM, "test"); }
 
 // Tests that when EXPECT_THROW_MSG fails, it evaluates its message argument
 // exactly once.
@@ -88,26 +84,38 @@ TEST_F(SingleEvaluationTest, FailedEXPECT_WRITE) {
 // Tests that assertion arguments are evaluated exactly once.
 TEST_F(SingleEvaluationTest, ExceptionTests) {
   // successful EXPECT_THROW_MSG
-  EXPECT_THROW_MSG({  // NOLINT
-    a_++;
-    throw_exception();
-  }, std::exception, (b_++, "test"));
+  EXPECT_THROW_MSG(
+      {  // NOLINT
+        a_++;
+        throw_exception();
+      },
+      std::exception,
+      (b_++, "test"));
   EXPECT_EQ(1, a_);
   EXPECT_EQ(1, b_);
 
   // failed EXPECT_THROW_MSG, throws different type
-  EXPECT_NONFATAL_FAILURE(EXPECT_THROW_MSG({  // NOLINT
-    a_++;
-    throw_exception();
-  }, std::logic_error, (b_++, "test")), "throws a different type");
+  EXPECT_NONFATAL_FAILURE(
+      EXPECT_THROW_MSG(
+          {  // NOLINT
+            a_++;
+            throw_exception();
+          },
+          std::logic_error,
+          (b_++, "test")),
+      "throws a different type");
   EXPECT_EQ(2, a_);
   EXPECT_EQ(2, b_);
 
   // failed EXPECT_THROW_MSG, throws an exception with different message
-  EXPECT_NONFATAL_FAILURE(EXPECT_THROW_MSG({  // NOLINT
-    a_++;
-    throw_exception();
-  }, std::exception, (b_++, "other")),
+  EXPECT_NONFATAL_FAILURE(
+      EXPECT_THROW_MSG(
+          {  // NOLINT
+            a_++;
+            throw_exception();
+          },
+          std::exception,
+          (b_++, "other")),
       "throws an exception with a different message");
   EXPECT_EQ(3, a_);
   EXPECT_EQ(3, b_);
@@ -121,26 +129,38 @@ TEST_F(SingleEvaluationTest, ExceptionTests) {
 
 TEST_F(SingleEvaluationTest, SystemErrorTests) {
   // successful EXPECT_SYSTEM_ERROR
-  EXPECT_SYSTEM_ERROR({  // NOLINT
-    a_++;
-    throw_system_error();
-  }, EDOM, (b_++, "test"));
+  EXPECT_SYSTEM_ERROR(
+      {  // NOLINT
+        a_++;
+        throw_system_error();
+      },
+      EDOM,
+      (b_++, "test"));
   EXPECT_EQ(1, a_);
   EXPECT_EQ(1, b_);
 
   // failed EXPECT_SYSTEM_ERROR, throws different type
-  EXPECT_NONFATAL_FAILURE(EXPECT_SYSTEM_ERROR({  // NOLINT
-    a_++;
-    throw_exception();
-  }, EDOM, (b_++, "test")), "throws a different type");
+  EXPECT_NONFATAL_FAILURE(
+      EXPECT_SYSTEM_ERROR(
+          {  // NOLINT
+            a_++;
+            throw_exception();
+          },
+          EDOM,
+          (b_++, "test")),
+      "throws a different type");
   EXPECT_EQ(2, a_);
   EXPECT_EQ(2, b_);
 
   // failed EXPECT_SYSTEM_ERROR, throws an exception with different message
-  EXPECT_NONFATAL_FAILURE(EXPECT_SYSTEM_ERROR({  // NOLINT
-    a_++;
-    throw_system_error();
-  }, EDOM, (b_++, "other")),
+  EXPECT_NONFATAL_FAILURE(
+      EXPECT_SYSTEM_ERROR(
+          {  // NOLINT
+            a_++;
+            throw_system_error();
+          },
+          EDOM,
+          (b_++, "other")),
       "throws an exception with a different message");
   EXPECT_EQ(3, a_);
   EXPECT_EQ(3, b_);
@@ -155,18 +175,26 @@ TEST_F(SingleEvaluationTest, SystemErrorTests) {
 // Tests that assertion arguments are evaluated exactly once.
 TEST_F(SingleEvaluationTest, WriteTests) {
   // successful EXPECT_WRITE
-  EXPECT_WRITE(stdout, {  // NOLINT
-    a_++;
-    std::printf("test");
-  }, (b_++, "test"));
+  EXPECT_WRITE(
+      stdout,
+      {  // NOLINT
+        a_++;
+        std::printf("test");
+      },
+      (b_++, "test"));
   EXPECT_EQ(1, a_);
   EXPECT_EQ(1, b_);
 
   // failed EXPECT_WRITE
-  EXPECT_NONFATAL_FAILURE(EXPECT_WRITE(stdout, {  // NOLINT
-    a_++;
-    std::printf("test");
-  }, (b_++, "other")), "Actual: test");
+  EXPECT_NONFATAL_FAILURE(
+      EXPECT_WRITE(
+          stdout,
+          {  // NOLINT
+            a_++;
+            std::printf("test");
+          },
+          (b_++, "other")),
+      "Actual: test");
   EXPECT_EQ(2, a_);
   EXPECT_EQ(2, b_);
 }
@@ -179,8 +207,8 @@ TEST(ExpectThrowTest, DoesNotGenerateUnreachableCodeWarning) {
   EXPECT_THROW_MSG(throw runtime_error(""), runtime_error, "");
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW_MSG(n++, runtime_error, ""), "");
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW_MSG(throw 1, runtime_error, ""), "");
-  EXPECT_NONFATAL_FAILURE(EXPECT_THROW_MSG(
-      throw runtime_error("a"), runtime_error, "b"), "");
+  EXPECT_NONFATAL_FAILURE(
+      EXPECT_THROW_MSG(throw runtime_error("a"), runtime_error, "b"), "");
 }
 
 // Tests that the compiler will not complain about unreachable code in the
@@ -190,8 +218,9 @@ TEST(ExpectSystemErrorTest, DoesNotGenerateUnreachableCodeWarning) {
   EXPECT_SYSTEM_ERROR(throw fmt::system_error(EDOM, "test"), EDOM, "test");
   EXPECT_NONFATAL_FAILURE(EXPECT_SYSTEM_ERROR(n++, EDOM, ""), "");
   EXPECT_NONFATAL_FAILURE(EXPECT_SYSTEM_ERROR(throw 1, EDOM, ""), "");
-  EXPECT_NONFATAL_FAILURE(EXPECT_SYSTEM_ERROR(
-      throw fmt::system_error(EDOM, "aaa"), EDOM, "bbb"), "");
+  EXPECT_NONFATAL_FAILURE(
+      EXPECT_SYSTEM_ERROR(throw fmt::system_error(EDOM, "aaa"), EDOM, "bbb"),
+      "");
 }
 
 TEST(AssertionSyntaxTest, ExceptionAssertionBehavesLikeSingleStatement) {
@@ -279,7 +308,8 @@ TEST(StreamingAssertionsTest, EXPECT_THROW_MSG) {
       << "unexpected failure";
   EXPECT_NONFATAL_FAILURE(
       EXPECT_THROW_MSG(throw_exception(), std::exception, "other")
-      << "expected failure", "expected failure");
+          << "expected failure",
+      "expected failure");
 }
 
 TEST(StreamingAssertionsTest, EXPECT_SYSTEM_ERROR) {
@@ -287,15 +317,15 @@ TEST(StreamingAssertionsTest, EXPECT_SYSTEM_ERROR) {
       << "unexpected failure";
   EXPECT_NONFATAL_FAILURE(
       EXPECT_SYSTEM_ERROR(throw_system_error(), EDOM, "other")
-      << "expected failure", "expected failure");
+          << "expected failure",
+      "expected failure");
 }
 
 TEST(StreamingAssertionsTest, EXPECT_WRITE) {
-  EXPECT_WRITE(stdout, std::printf("test"), "test")
-      << "unexpected failure";
+  EXPECT_WRITE(stdout, std::printf("test"), "test") << "unexpected failure";
   EXPECT_NONFATAL_FAILURE(
-      EXPECT_WRITE(stdout, std::printf("test"), "other")
-      << "expected failure", "expected failure");
+      EXPECT_WRITE(stdout, std::printf("test"), "other") << "expected failure",
+      "expected failure");
 }
 
 TEST(UtilTest, FormatSystemError) {
@@ -341,8 +371,8 @@ TEST(OutputRedirectTest, FlushErrorInCtor) {
   EXPECT_EQ('x', fputc('x', f.get()));
   FMT_POSIX(close(write_fd));
   scoped_ptr<OutputRedirect> redir{FMT_NULL};
-  EXPECT_SYSTEM_ERROR_NOASSERT(redir.reset(new OutputRedirect(f.get())),
-      EBADF, "cannot flush stream");
+  EXPECT_SYSTEM_ERROR_NOASSERT(
+      redir.reset(new OutputRedirect(f.get())), EBADF, "cannot flush stream");
   redir.reset(FMT_NULL);
   write_copy.dup2(write_fd);  // "undo" close or dtor will fail
 }
@@ -353,8 +383,10 @@ TEST(OutputRedirectTest, DupErrorInCtor) {
   file copy = file::dup(fd);
   FMT_POSIX(close(fd));
   scoped_ptr<OutputRedirect> redir{FMT_NULL};
-  EXPECT_SYSTEM_ERROR_NOASSERT(redir.reset(new OutputRedirect(f.get())),
-      EBADF, fmt::format("cannot duplicate file descriptor {}", fd));
+  EXPECT_SYSTEM_ERROR_NOASSERT(
+      redir.reset(new OutputRedirect(f.get())),
+      EBADF,
+      fmt::format("cannot duplicate file descriptor {}", fd));
   copy.dup2(fd);  // "undo" close or dtor will fail
 }
 
@@ -383,8 +415,8 @@ TEST(OutputRedirectTest, FlushErrorInRestoreAndRead) {
   // Put a character in a file buffer.
   EXPECT_EQ('x', fputc('x', f.get()));
   FMT_POSIX(close(write_fd));
-  EXPECT_SYSTEM_ERROR_NOASSERT(redir.restore_and_read(),
-      EBADF, "cannot flush stream");
+  EXPECT_SYSTEM_ERROR_NOASSERT(
+      redir.restore_and_read(), EBADF, "cannot flush stream");
   write_copy.dup2(write_fd);  // "undo" close or dtor will fail
 }
 
@@ -397,15 +429,18 @@ TEST(OutputRedirectTest, ErrorInDtor) {
   scoped_ptr<OutputRedirect> redir(new OutputRedirect(f.get()));
   // Put a character in a file buffer.
   EXPECT_EQ('x', fputc('x', f.get()));
-  EXPECT_WRITE(stderr, {
-      // The close function must be called inside EXPECT_WRITE, otherwise
-      // the system may recycle closed file descriptor when redirecting the
-      // output in EXPECT_STDERR and the second close will break output
-      // redirection.
-      FMT_POSIX(close(write_fd));
-      SUPPRESS_ASSERT(redir.reset(FMT_NULL));
-  }, format_system_error(EBADF, "cannot flush stream"));
-  write_copy.dup2(write_fd); // "undo" close or dtor of buffered_file will fail
+  EXPECT_WRITE(
+      stderr,
+      {
+        // The close function must be called inside EXPECT_WRITE, otherwise
+        // the system may recycle closed file descriptor when redirecting the
+        // output in EXPECT_STDERR and the second close will break output
+        // redirection.
+        FMT_POSIX(close(write_fd));
+        SUPPRESS_ASSERT(redir.reset(FMT_NULL));
+      },
+      format_system_error(EBADF, "cannot flush stream"));
+  write_copy.dup2(write_fd);  // "undo" close or dtor of buffered_file will fail
 }
 
 #endif  // FMT_USE_FILE_DESCRIPTORS

--- a/test/gtest-extra.cc
+++ b/test/gtest-extra.cc
@@ -13,7 +13,7 @@ using fmt::file;
 
 void OutputRedirect::flush() {
 #if EOF != -1
-# error "FMT_RETRY assumes return value of -1 indicating failure"
+#error "FMT_RETRY assumes return value of -1 indicating failure"
 #endif
   int result = 0;
   FMT_RETRY(result, fflush(file_));

--- a/test/gtest-extra.h
+++ b/test/gtest-extra.h
@@ -14,58 +14,59 @@
 #include "fmt/core.h"
 
 #ifndef FMT_USE_FILE_DESCRIPTORS
-# define FMT_USE_FILE_DESCRIPTORS 0
+#define FMT_USE_FILE_DESCRIPTORS 0
 #endif
 
 #if FMT_USE_FILE_DESCRIPTORS
-# include "fmt/posix.h"
+#include "fmt/posix.h"
 #endif
 
 #define FMT_TEST_THROW_(statement, expected_exception, expected_message, fail) \
-  GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
-  if (::testing::AssertionResult gtest_ar = ::testing::AssertionSuccess()) { \
-    std::string gtest_expected_message = expected_message; \
-    bool gtest_caught_expected = false; \
-    try { \
-      GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement); \
-    } \
-    catch (expected_exception const& e) { \
-      if (gtest_expected_message != e.what()) { \
-        gtest_ar \
-          << #statement " throws an exception with a different message.\n" \
-          << "Expected: " << gtest_expected_message << "\n" \
-          << "  Actual: " << e.what(); \
-        goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
-      } \
-      gtest_caught_expected = true; \
-    } \
-    catch (...) { \
-      gtest_ar << \
-          "Expected: " #statement " throws an exception of type " \
-          #expected_exception ".\n  Actual: it throws a different type."; \
-      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
-    } \
-    if (!gtest_caught_expected) { \
-      gtest_ar << \
-          "Expected: " #statement " throws an exception of type " \
-          #expected_exception ".\n  Actual: it throws nothing."; \
-      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
-    } \
-  } else \
-    GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__): \
-      fail(gtest_ar.failure_message())
+  GTEST_AMBIGUOUS_ELSE_BLOCKER_                                                \
+  if (::testing::AssertionResult gtest_ar = ::testing::AssertionSuccess()) {   \
+    std::string gtest_expected_message = expected_message;                     \
+    bool gtest_caught_expected = false;                                        \
+    try {                                                                      \
+      GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement);               \
+    } catch (expected_exception const &e) {                                    \
+      if (gtest_expected_message != e.what()) {                                \
+        gtest_ar << #statement                                                 \
+            " throws an exception with a different message.\n"                 \
+                 << "Expected: " << gtest_expected_message << "\n"             \
+                 << "  Actual: " << e.what();                                  \
+        goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__);            \
+      }                                                                        \
+      gtest_caught_expected = true;                                            \
+    } catch (...) {                                                            \
+      gtest_ar << "Expected: " #statement                                      \
+                  " throws an exception of type " #expected_exception          \
+                  ".\n  Actual: it throws a different type.";                  \
+      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__);              \
+    }                                                                          \
+    if (!gtest_caught_expected) {                                              \
+      gtest_ar << "Expected: " #statement                                      \
+                  " throws an exception of type " #expected_exception          \
+                  ".\n  Actual: it throws nothing.";                           \
+      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__);              \
+    }                                                                          \
+  } else                                                                       \
+    GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__)                      \
+        : fail(gtest_ar.failure_message())
 
 // Tests that the statement throws the expected exception and the exception's
 // what() method returns expected message.
 #define EXPECT_THROW_MSG(statement, expected_exception, expected_message) \
-  FMT_TEST_THROW_(statement, expected_exception, \
-      expected_message, GTEST_NONFATAL_FAILURE_)
+  FMT_TEST_THROW_(                                                        \
+      statement,                                                          \
+      expected_exception,                                                 \
+      expected_message,                                                   \
+      GTEST_NONFATAL_FAILURE_)
 
 std::string format_system_error(int error_code, fmt::string_view message);
 
 #define EXPECT_SYSTEM_ERROR(statement, error_code, message) \
-  EXPECT_THROW_MSG(statement, fmt::system_error, \
-      format_system_error(error_code, message))
+  EXPECT_THROW_MSG(                                         \
+      statement, fmt::system_error, format_system_error(error_code, message))
 
 #if FMT_USE_FILE_DESCRIPTORS
 
@@ -91,27 +92,26 @@ class OutputRedirect {
   std::string restore_and_read();
 };
 
-#define FMT_TEST_WRITE_(statement, expected_output, file, fail) \
-  GTEST_AMBIGUOUS_ELSE_BLOCKER_ \
+#define FMT_TEST_WRITE_(statement, expected_output, file, fail)              \
+  GTEST_AMBIGUOUS_ELSE_BLOCKER_                                              \
   if (::testing::AssertionResult gtest_ar = ::testing::AssertionSuccess()) { \
-    std::string gtest_expected_output = expected_output; \
-    OutputRedirect gtest_redir(file); \
-    GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement); \
-    std::string gtest_output = gtest_redir.restore_and_read(); \
-    if (gtest_output != gtest_expected_output) { \
-      gtest_ar \
-        << #statement " produces different output.\n" \
-        << "Expected: " << gtest_expected_output << "\n" \
-        << "  Actual: " << gtest_output; \
-      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__); \
-    } \
-  } else \
-    GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__): \
-      fail(gtest_ar.failure_message())
+    std::string gtest_expected_output = expected_output;                     \
+    OutputRedirect gtest_redir(file);                                        \
+    GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement);               \
+    std::string gtest_output = gtest_redir.restore_and_read();               \
+    if (gtest_output != gtest_expected_output) {                             \
+      gtest_ar << #statement " produces different output.\n"                 \
+               << "Expected: " << gtest_expected_output << "\n"              \
+               << "  Actual: " << gtest_output;                              \
+      goto GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__);            \
+    }                                                                        \
+  } else                                                                     \
+    GTEST_CONCAT_TOKEN_(gtest_label_testthrow_, __LINE__)                    \
+        : fail(gtest_ar.failure_message())
 
 // Tests that the statement writes the expected output to file.
 #define EXPECT_WRITE(file, statement, expected_output) \
-    FMT_TEST_WRITE_(statement, expected_output, file, GTEST_NONFATAL_FAILURE_)
+  FMT_TEST_WRITE_(statement, expected_output, file, GTEST_NONFATAL_FAILURE_)
 
 #ifdef _MSC_VER
 
@@ -122,23 +122,27 @@ class SuppressAssert {
   _invalid_parameter_handler original_handler_;
   int original_report_mode_;
 
-  static void handle_invalid_parameter(const wchar_t *,
-      const wchar_t *, const wchar_t *, unsigned , uintptr_t) {}
+  static void handle_invalid_parameter(
+      const wchar_t *, const wchar_t *, const wchar_t *, unsigned, uintptr_t) {}
 
  public:
   SuppressAssert()
-  : original_handler_(_set_invalid_parameter_handler(handle_invalid_parameter)),
-    original_report_mode_(_CrtSetReportMode(_CRT_ASSERT, 0)) {
-  }
+      : original_handler_(
+            _set_invalid_parameter_handler(handle_invalid_parameter)),
+        original_report_mode_(_CrtSetReportMode(_CRT_ASSERT, 0)) {}
   ~SuppressAssert() {
     _set_invalid_parameter_handler(original_handler_);
     _CrtSetReportMode(_CRT_ASSERT, original_report_mode_);
   }
 };
 
-# define SUPPRESS_ASSERT(statement) { SuppressAssert sa; statement; }
+#define SUPPRESS_ASSERT(statement) \
+  {                                \
+    SuppressAssert sa;             \
+    statement;                     \
+  }
 #else
-# define SUPPRESS_ASSERT(statement) statement
+#define SUPPRESS_ASSERT(statement) statement
 #endif  // _MSC_VER
 
 #define EXPECT_SYSTEM_ERROR_NOASSERT(statement, error_code, message) \

--- a/test/mock-allocator.h
+++ b/test/mock-allocator.h
@@ -8,8 +8,8 @@
 #ifndef FMT_MOCK_ALLOCATOR_H_
 #define FMT_MOCK_ALLOCATOR_H_
 
-#include "gmock.h"
 #include "fmt/format.h"
+#include "gmock.h"
 
 template <typename T>
 class mock_allocator {
@@ -17,8 +17,8 @@ class mock_allocator {
   mock_allocator() {}
   mock_allocator(const mock_allocator &) {}
   typedef T value_type;
-  MOCK_METHOD1_T(allocate, T* (std::size_t n));
-  MOCK_METHOD2_T(deallocate, void (T* p, std::size_t n));
+  MOCK_METHOD1_T(allocate, T *(std::size_t n));
+  MOCK_METHOD2_T(deallocate, void(T *p, std::size_t n));
 };
 
 template <typename Allocator>
@@ -39,13 +39,13 @@ class allocator_ref {
   allocator_ref(const allocator_ref &other) : alloc_(other.alloc_) {}
   allocator_ref(allocator_ref &&other) { move(other); }
 
-  allocator_ref& operator=(allocator_ref &&other) {
+  allocator_ref &operator=(allocator_ref &&other) {
     assert(this != &other);
     move(other);
     return *this;
   }
 
-  allocator_ref& operator=(const allocator_ref &other) {
+  allocator_ref &operator=(const allocator_ref &other) {
     alloc_ = other.alloc_;
     return *this;
   }
@@ -53,10 +53,10 @@ class allocator_ref {
  public:
   Allocator *get() const { return alloc_; }
 
-  value_type* allocate(std::size_t n) {
+  value_type *allocate(std::size_t n) {
     return fmt::internal::allocate(*alloc_, n);
   }
-  void deallocate(value_type* p, std::size_t n) { alloc_->deallocate(p, n); }
+  void deallocate(value_type *p, std::size_t n) { alloc_->deallocate(p, n); }
 };
 
 #endif  // FMT_MOCK_ALLOCATOR_H_

--- a/test/ostream-test.cc
+++ b/test/ostream-test.cc
@@ -35,7 +35,7 @@ static std::wostream &operator<<(std::wostream &os, TestEnum) {
   return os << L"TestEnum";
 }
 
-enum TestEnum2 {A};
+enum TestEnum2 { A };
 
 TEST(OStreamTest, Enum) {
   EXPECT_FALSE((fmt::convert_to_int<TestEnum, char>::value));
@@ -48,9 +48,9 @@ TEST(OStreamTest, Enum) {
 
 typedef fmt::back_insert_range<fmt::internal::buffer> range;
 
-struct test_arg_formatter: fmt::arg_formatter<range> {
+struct test_arg_formatter : fmt::arg_formatter<range> {
   test_arg_formatter(fmt::format_context &ctx, fmt::format_specs &s)
-    : fmt::arg_formatter<range>(ctx, &s) {}
+      : fmt::arg_formatter<range>(ctx, &s) {}
 };
 
 TEST(OStreamTest, CustomArg) {
@@ -68,27 +68,39 @@ TEST(OStreamTest, Format) {
   std::string s = format("The date is {0}", Date(2012, 12, 9));
   EXPECT_EQ("The date is 2012-12-9", s);
   Date date(2012, 12, 9);
-  EXPECT_EQ(L"The date is 2012-12-9",
-            format(L"The date is {0}", Date(2012, 12, 9)));
+  EXPECT_EQ(
+      L"The date is 2012-12-9", format(L"The date is {0}", Date(2012, 12, 9)));
 }
 
 TEST(OStreamTest, FormatSpecs) {
   EXPECT_EQ("def  ", format("{0:<5}", TestString("def")));
   EXPECT_EQ("  def", format("{0:>5}", TestString("def")));
-  EXPECT_THROW_MSG(format("{0:=5}", TestString("def")),
-      format_error, "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:=5}", TestString("def")),
+      format_error,
+      "format specifier requires numeric argument");
   EXPECT_EQ(" def ", format("{0:^5}", TestString("def")));
   EXPECT_EQ("def**", format("{0:*<5}", TestString("def")));
-  EXPECT_THROW_MSG(format("{0:+}", TestString()),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{0:-}", TestString()),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{0: }", TestString()),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{0:#}", TestString()),
-      format_error, "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(format("{0:05}", TestString()),
-      format_error, "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:+}", TestString()),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:-}", TestString()),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0: }", TestString()),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:#}", TestString()),
+      format_error,
+      "format specifier requires numeric argument");
+  EXPECT_THROW_MSG(
+      format("{0:05}", TestString()),
+      format_error,
+      "format specifier requires numeric argument");
   EXPECT_EQ("test         ", format("{0:13}", TestString("test")));
   EXPECT_EQ("test         ", format("{0:{1}}", TestString("test"), 13));
   EXPECT_EQ("te", format("{0:.2}", TestString("test")));
@@ -134,7 +146,7 @@ TEST(OStreamTest, WriteToOStreamMaxSize) {
   } buffer(max_size);
 
   struct mock_streambuf : std::streambuf {
-    MOCK_METHOD2(xsputn, std::streamsize (const void *s, std::streamsize n));
+    MOCK_METHOD2(xsputn, std::streamsize(const void *s, std::streamsize n));
     std::streamsize xsputn(const char *s, std::streamsize n) {
       const void *v = s;
       return xsputn(v, n);
@@ -173,11 +185,12 @@ TEST(OStreamTest, ConstexprString) {
 namespace fmt_test {
 struct ABC {};
 
-template <typename Output> Output &operator<<(Output &out, ABC) {
+template <typename Output>
+Output &operator<<(Output &out, ABC) {
   out << "ABC";
   return out;
 }
-} // namespace fmt_test
+}  // namespace fmt_test
 
 TEST(FormatTest, FormatToN) {
   char buffer[4];

--- a/test/posix-mock.h
+++ b/test/posix-mock.h
@@ -12,10 +12,10 @@
 #include <stdio.h>
 
 #ifdef _WIN32
-# include <windows.h>
+#include <windows.h>
 #else
-# include <sys/param.h>  // for FreeBSD version
-# include <sys/types.h>  // for ssize_t
+#include <sys/param.h>  // for FreeBSD version
+#include <sys/types.h>  // for ssize_t
 #endif
 
 #ifndef _MSC_VER
@@ -34,7 +34,7 @@ int fstat(int fd, struct stat *buf);
 typedef unsigned size_t;
 typedef int ssize_t;
 errno_t sopen_s(
-    int* pfh, const char *filename, int oflag, int shflag, int pmode);
+    int *pfh, const char *filename, int oflag, int shflag, int pmode);
 #endif
 
 #ifndef _WIN32
@@ -61,7 +61,7 @@ int pipe(int *pfds, unsigned psize, int textmode);
 
 FILE *fopen(const char *filename, const char *mode);
 int fclose(FILE *stream);
-int (fileno)(FILE *stream);
+int(fileno)(FILE *stream);
 }  // namespace test
 
 #define FMT_SYSTEM(call) test::call

--- a/test/posix-test.cc
+++ b/test/posix-test.cc
@@ -13,7 +13,7 @@
 #include "util.h"
 
 #ifdef fileno
-# undef fileno
+#undef fileno
 #endif
 
 using fmt::buffered_file;
@@ -120,14 +120,17 @@ TEST(BufferedFileTest, CloseFileInDtor) {
 
 TEST(BufferedFileTest, CloseErrorInDtor) {
   scoped_ptr<buffered_file> f(new buffered_file(open_buffered_file()));
-  EXPECT_WRITE(stderr, {
-      // The close function must be called inside EXPECT_WRITE, otherwise
-      // the system may recycle closed file descriptor when redirecting the
-      // output in EXPECT_STDERR and the second close will break output
-      // redirection.
-      FMT_POSIX(close(f->fileno()));
-      SUPPRESS_ASSERT(f.reset(FMT_NULL));
-  }, format_system_error(EBADF, "cannot close file") + "\n");
+  EXPECT_WRITE(
+      stderr,
+      {
+        // The close function must be called inside EXPECT_WRITE, otherwise
+        // the system may recycle closed file descriptor when redirecting the
+        // output in EXPECT_STDERR and the second close will break output
+        // redirection.
+        FMT_POSIX(close(f->fileno()));
+        SUPPRESS_ASSERT(f.reset(FMT_NULL));
+      },
+      format_system_error(EBADF, "cannot close file") + "\n");
 }
 
 TEST(BufferedFileTest, Close) {
@@ -150,13 +153,15 @@ TEST(BufferedFileTest, Fileno) {
 #ifndef __COVERITY__
   // fileno on a null FILE pointer either crashes or returns an error.
   // Disable Coverity because this is intentional.
-  EXPECT_DEATH_IF_SUPPORTED({
-    try {
-      f.fileno();
-    } catch (const fmt::system_error&) {
-      std::exit(1);
-    }
-  }, "");
+  EXPECT_DEATH_IF_SUPPORTED(
+      {
+        try {
+          f.fileno();
+        } catch (const fmt::system_error &) {
+          std::exit(1);
+        }
+      },
+      "");
 #endif
   f = open_buffered_file();
   EXPECT_TRUE(f.fileno() != -1);
@@ -178,8 +183,10 @@ TEST(FileTest, OpenBufferedFileInCtor) {
 }
 
 TEST(FileTest, OpenBufferedFileError) {
-  EXPECT_SYSTEM_ERROR(file("nonexistent", file::RDONLY),
-      ENOENT, "cannot open file nonexistent");
+  EXPECT_SYSTEM_ERROR(
+      file("nonexistent", file::RDONLY),
+      ENOENT,
+      "cannot open file nonexistent");
 }
 
 TEST(FileTest, MoveCtor) {
@@ -247,14 +254,17 @@ TEST(FileTest, CloseFileInDtor) {
 
 TEST(FileTest, CloseErrorInDtor) {
   scoped_ptr<file> f(new file(open_file()));
-  EXPECT_WRITE(stderr, {
-      // The close function must be called inside EXPECT_WRITE, otherwise
-      // the system may recycle closed file descriptor when redirecting the
-      // output in EXPECT_STDERR and the second close will break output
-      // redirection.
-      FMT_POSIX(close(f->descriptor()));
-      SUPPRESS_ASSERT(f.reset(FMT_NULL));
-  }, format_system_error(EBADF, "cannot close file") + "\n");
+  EXPECT_WRITE(
+      stderr,
+      {
+        // The close function must be called inside EXPECT_WRITE, otherwise
+        // the system may recycle closed file descriptor when redirecting the
+        // output in EXPECT_STDERR and the second close will break output
+        // redirection.
+        FMT_POSIX(close(f->descriptor()));
+        SUPPRESS_ASSERT(f.reset(FMT_NULL));
+      },
+      format_system_error(EBADF, "cannot close file") + "\n");
 }
 
 TEST(FileTest, Close) {
@@ -310,8 +320,8 @@ TEST(FileTest, Dup) {
 #ifndef __COVERITY__
 TEST(FileTest, DupError) {
   int value = -1;
-  EXPECT_SYSTEM_ERROR_NOASSERT(file::dup(value),
-      EBADF, "cannot duplicate file descriptor -1");
+  EXPECT_SYSTEM_ERROR_NOASSERT(
+      file::dup(value), EBADF, "cannot duplicate file descriptor -1");
 }
 #endif
 
@@ -325,8 +335,10 @@ TEST(FileTest, Dup2) {
 
 TEST(FileTest, Dup2Error) {
   file f = open_file();
-  EXPECT_SYSTEM_ERROR_NOASSERT(f.dup2(-1), EBADF,
-    fmt::format("cannot duplicate file descriptor {} to -1", f.descriptor()));
+  EXPECT_SYSTEM_ERROR_NOASSERT(
+      f.dup2(-1),
+      EBADF,
+      fmt::format("cannot duplicate file descriptor {} to -1", f.descriptor()));
 }
 
 TEST(FileTest, Dup2NoExcept) {

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -43,9 +43,9 @@ std::wstring test_sprintf(fmt::wstring_view format, const Args &... args) {
   return fmt::sprintf(format, args...);
 }
 
-#define EXPECT_PRINTF(expected_output, format, arg) \
+#define EXPECT_PRINTF(expected_output, format, arg)     \
   EXPECT_EQ(expected_output, test_sprintf(format, arg)) \
-    << "format: " << format; \
+      << "format: " << format;                          \
   EXPECT_EQ(expected_output, fmt::sprintf(make_positional(format), arg))
 
 TEST(PrintfTest, NoArgs) {
@@ -69,11 +69,10 @@ TEST(PrintfTest, Escape) {
 TEST(PrintfTest, PositionalArgs) {
   EXPECT_EQ("42", test_sprintf("%1$d", 42));
   EXPECT_EQ("before 42", test_sprintf("before %1$d", 42));
-  EXPECT_EQ("42 after", test_sprintf("%1$d after",42));
+  EXPECT_EQ("42 after", test_sprintf("%1$d after", 42));
   EXPECT_EQ("before 42 after", test_sprintf("before %1$d after", 42));
   EXPECT_EQ("answer = 42", test_sprintf("%1$s = %2$d", "answer", 42));
-  EXPECT_EQ("42 is the answer",
-      test_sprintf("%2$d is the %1$s", "answer", 42));
+  EXPECT_EQ("42 is the answer", test_sprintf("%2$d is the %1$s", "answer", 42));
   EXPECT_EQ("abracadabra", test_sprintf("%1$s%2$s%1$s", "abra", "cad"));
 }
 
@@ -82,46 +81,68 @@ TEST(PrintfTest, AutomaticArgIndexing) {
 }
 
 TEST(PrintfTest, NumberIsTooBigInArgIndex) {
-  EXPECT_THROW_MSG(test_sprintf(format("%{}$", BIG_NUM)),
-      format_error, "number is too big");
-  EXPECT_THROW_MSG(test_sprintf(format("%{}$d", BIG_NUM)),
-      format_error, "number is too big");
+  EXPECT_THROW_MSG(
+      test_sprintf(format("%{}$", BIG_NUM)), format_error, "number is too big");
+  EXPECT_THROW_MSG(
+      test_sprintf(format("%{}$d", BIG_NUM)),
+      format_error,
+      "number is too big");
 }
 
 TEST(PrintfTest, SwitchArgIndexing) {
-  EXPECT_THROW_MSG(test_sprintf("%1$d%", 1, 2),
-      format_error, "cannot switch from manual to automatic argument indexing");
-  EXPECT_THROW_MSG(test_sprintf(format("%1$d%{}d", BIG_NUM), 1, 2),
-      format_error, "number is too big");
-  EXPECT_THROW_MSG(test_sprintf("%1$d%d", 1, 2),
-      format_error, "cannot switch from manual to automatic argument indexing");
+  EXPECT_THROW_MSG(
+      test_sprintf("%1$d%", 1, 2),
+      format_error,
+      "cannot switch from manual to automatic argument indexing");
+  EXPECT_THROW_MSG(
+      test_sprintf(format("%1$d%{}d", BIG_NUM), 1, 2),
+      format_error,
+      "number is too big");
+  EXPECT_THROW_MSG(
+      test_sprintf("%1$d%d", 1, 2),
+      format_error,
+      "cannot switch from manual to automatic argument indexing");
 
-  EXPECT_THROW_MSG(test_sprintf("%d%1$", 1, 2),
-      format_error, "cannot switch from automatic to manual argument indexing");
-  EXPECT_THROW_MSG(test_sprintf(format("%d%{}$d", BIG_NUM), 1, 2),
-      format_error, "number is too big");
-  EXPECT_THROW_MSG(test_sprintf("%d%1$d", 1, 2),
-      format_error, "cannot switch from automatic to manual argument indexing");
+  EXPECT_THROW_MSG(
+      test_sprintf("%d%1$", 1, 2),
+      format_error,
+      "cannot switch from automatic to manual argument indexing");
+  EXPECT_THROW_MSG(
+      test_sprintf(format("%d%{}$d", BIG_NUM), 1, 2),
+      format_error,
+      "number is too big");
+  EXPECT_THROW_MSG(
+      test_sprintf("%d%1$d", 1, 2),
+      format_error,
+      "cannot switch from automatic to manual argument indexing");
 
   // Indexing errors override width errors.
-  EXPECT_THROW_MSG(test_sprintf(format("%d%1${}d", BIG_NUM), 1, 2),
-      format_error, "number is too big");
-  EXPECT_THROW_MSG(test_sprintf(format("%1$d%{}d", BIG_NUM), 1, 2),
-      format_error, "number is too big");
+  EXPECT_THROW_MSG(
+      test_sprintf(format("%d%1${}d", BIG_NUM), 1, 2),
+      format_error,
+      "number is too big");
+  EXPECT_THROW_MSG(
+      test_sprintf(format("%1$d%{}d", BIG_NUM), 1, 2),
+      format_error,
+      "number is too big");
 }
 
 TEST(PrintfTest, InvalidArgIndex) {
-  EXPECT_THROW_MSG(test_sprintf("%0$d", 42), format_error,
+  EXPECT_THROW_MSG(
+      test_sprintf("%0$d", 42), format_error, "argument index out of range");
+  EXPECT_THROW_MSG(
+      test_sprintf("%2$d", 42), format_error, "argument index out of range");
+  EXPECT_THROW_MSG(
+      test_sprintf(format("%{}$d", INT_MAX), 42),
+      format_error,
       "argument index out of range");
-  EXPECT_THROW_MSG(test_sprintf("%2$d", 42), format_error,
-      "argument index out of range");
-  EXPECT_THROW_MSG(test_sprintf(format("%{}$d", INT_MAX), 42),
-      format_error, "argument index out of range");
 
-  EXPECT_THROW_MSG(test_sprintf("%2$", 42),
-      format_error, "argument index out of range");
-  EXPECT_THROW_MSG(test_sprintf(format("%{}$d", BIG_NUM), 42),
-      format_error, "number is too big");
+  EXPECT_THROW_MSG(
+      test_sprintf("%2$", 42), format_error, "argument index out of range");
+  EXPECT_THROW_MSG(
+      test_sprintf(format("%{}$d", BIG_NUM), 42),
+      format_error,
+      "number is too big");
 }
 
 TEST(PrintfTest, DefaultAlignRight) {
@@ -176,7 +197,7 @@ TEST(PrintfTest, HashFlag) {
   EXPECT_PRINTF("0x42", "%#x", 0x42);
   EXPECT_PRINTF("0X42", "%#X", 0x42);
   EXPECT_PRINTF(
-        fmt::format("0x{:x}", static_cast<unsigned>(-0x42)), "%#x", -0x42);
+      fmt::format("0x{:x}", static_cast<unsigned>(-0x42)), "%#x", -0x42);
   EXPECT_PRINTF("0", "%#x", 0);
 
   EXPECT_PRINTF("0x0042", "%#06x", 0x42);
@@ -207,24 +228,28 @@ TEST(PrintfTest, Width) {
   EXPECT_PRINTF("  abc", "%5s", "abc");
 
   // Width cannot be specified twice.
-  EXPECT_THROW_MSG(test_sprintf("%5-5d", 42), format_error,
-      "invalid type specifier");
+  EXPECT_THROW_MSG(
+      test_sprintf("%5-5d", 42), format_error, "invalid type specifier");
 
-  EXPECT_THROW_MSG(test_sprintf(format("%{}d", BIG_NUM), 42),
-      format_error, "number is too big");
-  EXPECT_THROW_MSG(test_sprintf(format("%1${}d", BIG_NUM), 42),
-      format_error, "number is too big");
+  EXPECT_THROW_MSG(
+      test_sprintf(format("%{}d", BIG_NUM), 42),
+      format_error,
+      "number is too big");
+  EXPECT_THROW_MSG(
+      test_sprintf(format("%1${}d", BIG_NUM), 42),
+      format_error,
+      "number is too big");
 }
 
 TEST(PrintfTest, DynamicWidth) {
   EXPECT_EQ("   42", test_sprintf("%*d", 5, 42));
   EXPECT_EQ("42   ", test_sprintf("%*d", -5, 42));
-  EXPECT_THROW_MSG(test_sprintf("%*d", 5.0, 42), format_error,
-      "width is not integer");
-  EXPECT_THROW_MSG(test_sprintf("%*d"), format_error,
-      "argument index out of range");
-  EXPECT_THROW_MSG(test_sprintf("%*d", BIG_NUM, 42), format_error,
-      "number is too big");
+  EXPECT_THROW_MSG(
+      test_sprintf("%*d", 5.0, 42), format_error, "width is not integer");
+  EXPECT_THROW_MSG(
+      test_sprintf("%*d"), format_error, "argument index out of range");
+  EXPECT_THROW_MSG(
+      test_sprintf("%*d", BIG_NUM, 42), format_error, "number is too big");
 }
 
 TEST(PrintfTest, IntPrecision) {
@@ -266,25 +291,29 @@ TEST(PrintfTest, IgnorePrecisionForNonNumericArg) {
 TEST(PrintfTest, DynamicPrecision) {
   EXPECT_EQ("00042", test_sprintf("%.*d", 5, 42));
   EXPECT_EQ("42", test_sprintf("%.*d", -5, 42));
-  EXPECT_THROW_MSG(test_sprintf("%.*d", 5.0, 42), format_error,
-      "precision is not integer");
-  EXPECT_THROW_MSG(test_sprintf("%.*d"), format_error,
-      "argument index out of range");
-  EXPECT_THROW_MSG(test_sprintf("%.*d", BIG_NUM, 42), format_error,
-      "number is too big");
+  EXPECT_THROW_MSG(
+      test_sprintf("%.*d", 5.0, 42), format_error, "precision is not integer");
+  EXPECT_THROW_MSG(
+      test_sprintf("%.*d"), format_error, "argument index out of range");
+  EXPECT_THROW_MSG(
+      test_sprintf("%.*d", BIG_NUM, 42), format_error, "number is too big");
   if (sizeof(long long) != sizeof(int)) {
     long long prec = static_cast<long long>(INT_MIN) - 1;
-    EXPECT_THROW_MSG(test_sprintf("%.*d", prec, 42), format_error,
-        "number is too big");
- }
+    EXPECT_THROW_MSG(
+        test_sprintf("%.*d", prec, 42), format_error, "number is too big");
+  }
 }
 
 template <typename T>
-struct make_signed { typedef T type; };
+struct make_signed {
+  typedef T type;
+};
 
 #define SPECIALIZE_MAKE_SIGNED(T, S) \
-  template <> \
-  struct make_signed<T> { typedef S type; }
+  template <>                        \
+  struct make_signed<T> {            \
+    typedef S type;                  \
+  }
 
 SPECIALIZE_MAKE_SIGNED(char, signed char);
 SPECIALIZE_MAKE_SIGNED(unsigned char, signed char);
@@ -419,7 +448,7 @@ TEST(PrintfTest, Float) {
 
 TEST(PrintfTest, Inf) {
   double inf = std::numeric_limits<double>::infinity();
-  for (const char* type = "fega"; *type; ++type) {
+  for (const char *type = "fega"; *type; ++type) {
     EXPECT_PRINTF("inf", fmt::format("%{}", *type), inf);
     char upper = static_cast<char>(std::toupper(*type));
     EXPECT_PRINTF("INF", fmt::format("%{}", upper), inf);
@@ -430,7 +459,7 @@ TEST(PrintfTest, Char) {
   EXPECT_PRINTF("x", "%c", 'x');
   int max = std::numeric_limits<int>::max();
   EXPECT_PRINTF(fmt::format("{}", static_cast<char>(max)), "%c", max);
-  //EXPECT_PRINTF("x", "%lc", L'x');
+  // EXPECT_PRINTF("x", "%lc", L'x');
   EXPECT_PRINTF(L"x", L"%c", L'x');
   EXPECT_PRINTF(fmt::format(L"{}", static_cast<wchar_t>(max)), L"%c", max);
 }
@@ -475,17 +504,17 @@ TEST(PrintfTest, Location) {
 
 enum E { A = 42 };
 
-TEST(PrintfTest, Enum) {
-  EXPECT_PRINTF("42", "%d", A);
-}
+TEST(PrintfTest, Enum) { EXPECT_PRINTF("42", "%d", A); }
 
 #if FMT_USE_FILE_DESCRIPTORS
 TEST(PrintfTest, Examples) {
   const char *weekday = "Thursday";
   const char *month = "August";
   int day = 21;
-  EXPECT_WRITE(stdout, fmt::printf("%1$s, %3$d %2$s", weekday, month, day),
-               "Thursday, 21 August");
+  EXPECT_WRITE(
+      stdout,
+      fmt::printf("%1$s, %3$d %2$s", weekday, month, day),
+      "Thursday, 21 August");
 }
 
 TEST(PrintfTest, PrintfError) {
@@ -496,9 +525,7 @@ TEST(PrintfTest, PrintfError) {
 }
 #endif
 
-TEST(PrintfTest, WideString) {
-  EXPECT_EQ(L"abc", fmt::sprintf(L"%s", L"abc"));
-}
+TEST(PrintfTest, WideString) { EXPECT_EQ(L"abc", fmt::sprintf(L"%s", L"abc")); }
 
 TEST(PrintfTest, PrintfCustom) {
   EXPECT_EQ("abc", test_sprintf("%s", TestString("abc")));
@@ -520,8 +547,8 @@ TEST(PrintfTest, VPrintf) {
   EXPECT_WRITE(stdout, fmt::vfprintf(std::cout, "%d", args), "42");
 }
 
-template<typename... Args>
-void check_format_string_regression(fmt::string_view s, const Args&... args) {
+template <typename... Args>
+void check_format_string_regression(fmt::string_view s, const Args &... args) {
   fmt::sprintf(s, args...);
 }
 
@@ -530,17 +557,16 @@ TEST(PrintfTest, CheckFormatStringRegression) {
 }
 
 TEST(PrintfTest, VSPrintfMakeArgsExample) {
-  fmt::format_arg_store<fmt::printf_context, int, const char *> as{
-      42, "something"};
+  fmt::format_arg_store<fmt::printf_context, int, const char *> as{42,
+                                                                   "something"};
   fmt::basic_format_args<fmt::printf_context> args(as);
-  EXPECT_EQ(
-      "[42] something happened", fmt::vsprintf("[%d] %s happened", args));
+  EXPECT_EQ("[42] something happened", fmt::vsprintf("[%d] %s happened", args));
   auto as2 = fmt::make_printf_args(42, "something");
   fmt::basic_format_args<fmt::printf_context> args2(as2);
   EXPECT_EQ(
       "[42] something happened", fmt::vsprintf("[%d] %s happened", args2));
-  //the older gcc versions can't cast the return value
-#if !defined(__GNUC__) || (__GNUC__ > 4) 
+  // the older gcc versions can't cast the return value
+#if !defined(__GNUC__) || (__GNUC__ > 4)
   EXPECT_EQ(
       "[42] something happened",
       fmt::vsprintf(
@@ -550,12 +576,11 @@ TEST(PrintfTest, VSPrintfMakeArgsExample) {
 
 TEST(PrintfTest, VSPrintfMakeWArgsExample) {
   fmt::format_arg_store<fmt::wprintf_context, int, const wchar_t *> as{
-     42, L"something"};
+      42, L"something"};
   fmt::basic_format_args<fmt::wprintf_context> args(as);
   EXPECT_EQ(
-     L"[42] something happened",
-     fmt::vsprintf(L"[%d] %s happened", args));
-  auto  as2 = fmt::make_wprintf_args(42, L"something");
+      L"[42] something happened", fmt::vsprintf(L"[%d] %s happened", args));
+  auto as2 = fmt::make_wprintf_args(42, L"something");
   fmt::basic_format_args<fmt::wprintf_context> args2(as2);
   EXPECT_EQ(
       L"[42] something happened", fmt::vsprintf(L"[%d] %s happened", args2));

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -16,10 +16,10 @@
 #include "fmt/ranges.h"
 #include "gtest.h"
 
-#include <vector>
 #include <array>
 #include <map>
 #include <string>
+#include <vector>
 
 TEST(RangesTest, FormatVector) {
   std::vector<int32_t> iv{1, 2, 3, 5, 7, 11};
@@ -44,8 +44,8 @@ TEST(RangesTest, FormatPair) {
 }
 
 TEST(RangesTest, FormatTuple) {
-  std::tuple<int64_t, float, std::string, char> tu1{42, 3.14159265358979f,
-                                              "this is tuple", 'i'};
+  std::tuple<int64_t, float, std::string, char> tu1{
+      42, 3.14159265358979f, "this is tuple", 'i'};
   EXPECT_EQ("(42, 3.14159, \"this is tuple\", 'i')", fmt::format("{}", tu1));
 }
 

--- a/test/test-assert.h
+++ b/test/test-assert.h
@@ -17,7 +17,8 @@ class assertion_failure : public std::logic_error {
 };
 
 #define FMT_ASSERT(condition, message) \
-  if (!(condition)) throw assertion_failure(message);
+  if (!(condition))                    \
+    throw assertion_failure(message);
 
 // Expects an assertion failure.
 #define EXPECT_ASSERT(stmt, message) \

--- a/test/test-main.cc
+++ b/test/test-main.cc
@@ -9,14 +9,14 @@
 #include "gtest.h"
 
 #ifdef _WIN32
-# include <windows.h>
+#include <windows.h>
 #endif
 
 #ifdef _MSC_VER
-# include <crtdbg.h>
+#include <crtdbg.h>
 #else
-# define _CrtSetReportFile(a, b)
-# define _CrtSetReportMode(a, b)
+#define _CrtSetReportFile(a, b)
+#define _CrtSetReportMode(a, b)
 #endif
 
 int main(int argc, char **argv) {
@@ -24,8 +24,8 @@ int main(int argc, char **argv) {
   // Don't display any error dialogs. This also suppresses message boxes
   // on assertion failures in MinGW where _set_error_mode/CrtSetReportMode
   // doesn't help.
-  SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX |
-    SEM_NOOPENFILEERRORBOX);
+  SetErrorMode(
+      SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
 #endif
   // Disable message boxes on assertion failures.
   _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);

--- a/test/time-test.cc
+++ b/test/time-test.cc
@@ -9,23 +9,22 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include "gmock.h"
-#include "fmt/locale.h"
 #include "fmt/time.h"
+#include "fmt/locale.h"
+#include "gmock.h"
 
 TEST(TimeTest, Format) {
   std::tm tm = std::tm();
   tm.tm_year = 116;
-  tm.tm_mon  = 3;
+  tm.tm_mon = 3;
   tm.tm_mday = 25;
-  EXPECT_EQ("The date is 2016-04-25.",
-            fmt::format("The date is {:%Y-%m-%d}.", tm));
+  EXPECT_EQ(
+      "The date is 2016-04-25.", fmt::format("The date is {:%Y-%m-%d}.", tm));
 }
 
 TEST(TimeTest, GrowBuffer) {
   std::string s = "{:";
-  for (int i = 0; i < 30; ++i)
-    s += "%c";
+  for (int i = 0; i < 30; ++i) s += "%c";
   s += "}\n";
   std::time_t t = std::time(FMT_NULL);
   fmt::format(s, *std::localtime(&t));
@@ -39,19 +38,13 @@ TEST(TimeTest, FormatToEmptyContainer) {
   EXPECT_EQ(s, "42");
 }
 
-TEST(TimeTest, EmptyResult) {
-  EXPECT_EQ("", fmt::format("{}", std::tm()));
-}
+TEST(TimeTest, EmptyResult) { EXPECT_EQ("", fmt::format("{}", std::tm())); }
 
 static bool EqualTime(const std::tm &lhs, const std::tm &rhs) {
-  return lhs.tm_sec == rhs.tm_sec &&
-         lhs.tm_min == rhs.tm_min &&
-         lhs.tm_hour == rhs.tm_hour &&
-         lhs.tm_mday == rhs.tm_mday &&
-         lhs.tm_mon == rhs.tm_mon &&
-         lhs.tm_year == rhs.tm_year &&
-         lhs.tm_wday == rhs.tm_wday &&
-         lhs.tm_yday == rhs.tm_yday &&
+  return lhs.tm_sec == rhs.tm_sec && lhs.tm_min == rhs.tm_min &&
+         lhs.tm_hour == rhs.tm_hour && lhs.tm_mday == rhs.tm_mday &&
+         lhs.tm_mon == rhs.tm_mon && lhs.tm_year == rhs.tm_year &&
+         lhs.tm_wday == rhs.tm_wday && lhs.tm_yday == rhs.tm_yday &&
          lhs.tm_isdst == rhs.tm_isdst;
 }
 

--- a/test/util.h
+++ b/test/util.h
@@ -11,12 +11,12 @@
 
 #include "fmt/posix.h"
 
-enum {BUFFER_SIZE = 256};
+enum { BUFFER_SIZE = 256 };
 
 #ifdef _MSC_VER
-# define FMT_VSNPRINTF vsprintf_s
+#define FMT_VSNPRINTF vsprintf_s
 #else
-# define FMT_VSNPRINTF vsnprintf
+#define FMT_VSNPRINTF vsnprintf
 #endif
 
 template <std::size_t SIZE>
@@ -76,6 +76,7 @@ std::basic_ostream<Char> &operator<<(
 
 class Date {
   int year_, month_, day_;
+
  public:
   Date(int year, int month, int day) : year_(year), month_(month), day_(day) {}
 


### PR DESCRIPTION
## Note
 - Created/Applied `.clang-format` based on Google Style
 - The format to header / src / test files

Each clang format file dominates its sub-directories. So the file had to be placed at the root.  
Consider the style fits your intent and let me know.

You can discard the PR if it feels unnecessary. :)

### History
 - #958
