### PR TITLE
Replaced usage of gtest's internal scoped_ptr with unique_ptr.

### DIFF
--- a/test/gtest-extra-test.cc
+++ b/test/gtest-extra-test.cc
@@ -7,8 +7,9 @@
 
 #include "gtest-extra.h"
 
-#include <cstring>
 #include <algorithm>
+#include <cstring>
+#include <memory>
 #include <stdexcept>
 #include <gtest/gtest-spi.h>
 
@@ -17,8 +18,6 @@
 #endif  // _WIN32
 
 #include "util.h"
-
-using testing::internal::scoped_ptr;
 
 namespace {
 
@@ -340,7 +339,7 @@ TEST(OutputRedirectTest, FlushErrorInCtor) {
   // Put a character in a file buffer.
   EXPECT_EQ('x', fputc('x', f.get()));
   FMT_POSIX(close(write_fd));
-  scoped_ptr<OutputRedirect> redir{FMT_NULL};
+  std::unique_ptr<OutputRedirect> redir{FMT_NULL};
   EXPECT_SYSTEM_ERROR_NOASSERT(redir.reset(new OutputRedirect(f.get())),
       EBADF, "cannot flush stream");
   redir.reset(FMT_NULL);
@@ -352,7 +351,7 @@ TEST(OutputRedirectTest, DupErrorInCtor) {
   int fd = (f.fileno)();
   file copy = file::dup(fd);
   FMT_POSIX(close(fd));
-  scoped_ptr<OutputRedirect> redir{FMT_NULL};
+  std::unique_ptr<OutputRedirect> redir{FMT_NULL};
   EXPECT_SYSTEM_ERROR_NOASSERT(redir.reset(new OutputRedirect(f.get())),
       EBADF, fmt::format("cannot duplicate file descriptor {}", fd));
   copy.dup2(fd);  // "undo" close or dtor will fail
@@ -394,7 +393,7 @@ TEST(OutputRedirectTest, ErrorInDtor) {
   int write_fd = write_end.descriptor();
   file write_copy = write_end.dup(write_fd);
   buffered_file f = write_end.fdopen("w");
-  scoped_ptr<OutputRedirect> redir(new OutputRedirect(f.get()));
+  std::unique_ptr<OutputRedirect> redir(new OutputRedirect(f.get()));
   // Put a character in a file buffer.
   EXPECT_EQ('x', fputc('x', f.get()));
   EXPECT_WRITE(stderr, {

--- a/test/posix-test.cc
+++ b/test/posix-test.cc
@@ -7,6 +7,7 @@
 
 #include <cstdlib>  // std::exit
 #include <cstring>
+#include <memory>
 
 #include "fmt/posix.h"
 #include "gtest-extra.h"
@@ -19,8 +20,6 @@
 using fmt::buffered_file;
 using fmt::error_code;
 using fmt::file;
-
-using testing::internal::scoped_ptr;
 
 // Checks if the file is open by reading one character from it.
 static bool isopen(int fd) {
@@ -119,7 +118,7 @@ TEST(BufferedFileTest, CloseFileInDtor) {
 }
 
 TEST(BufferedFileTest, CloseErrorInDtor) {
-  scoped_ptr<buffered_file> f(new buffered_file(open_buffered_file()));
+  std::unique_ptr<buffered_file> f(new buffered_file(open_buffered_file()));
   EXPECT_WRITE(stderr, {
       // The close function must be called inside EXPECT_WRITE, otherwise
       // the system may recycle closed file descriptor when redirecting the
@@ -246,7 +245,7 @@ TEST(FileTest, CloseFileInDtor) {
 }
 
 TEST(FileTest, CloseErrorInDtor) {
-  scoped_ptr<file> f(new file(open_file()));
+  std::unique_ptr<file> f(new file(open_file()));
   EXPECT_WRITE(stderr, {
       // The close function must be called inside EXPECT_WRITE, otherwise
       // the system may recycle closed file descriptor when redirecting the


### PR DESCRIPTION
scoped_ptr was removed in with gtest google/googletest@e857f9cdd998136b9aad634272301f5b2d0476ea.