### PR TITLE
Fix compile errors due to name-hiding and an unused function argument.

### DIFF
--- a/include/fmt/prepare.h
+++ b/include/fmt/prepare.h
@@ -263,10 +263,10 @@ class prepared_format {
       switch (part.which) {
       case format_part_t::which_value::text: {
         const auto text = value.text.to_view(format_view);
-        auto out = ctx.out();
-        auto&& it = internal::reserve(out, text.size());
+        auto output = ctx.out();
+        auto&& it = internal::reserve(output, text.size());
         it = std::copy_n(text.begin(), text.size(), it);
-        ctx.advance_to(out);
+        ctx.advance_to(output);
       } break;
 
       case format_part_t::which_value::argument_id: {

--- a/test/prepare-test.cc
+++ b/test/prepare-test.cc
@@ -627,7 +627,7 @@ template <typename T> struct user_allocator {
     return new value_type[cnt];
   }
 
-  void deallocate(pointer p, size_type cnt) { delete[] p; }
+  void deallocate(pointer p, size_type) { delete[] p; }
 
   void construct(pointer p, const value_type& val) { new (p) value_type(val); }
 


### PR DESCRIPTION
These problems are pointed out by clang-tidy and fail compilation on msvc at /W4 /WX.