### PR TITLE
Implement 'chrono' formatting specifiers '%Q' and '%q' (#1004)

### DIFF
--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -135,6 +135,8 @@ TEST(ChronoTest, FormatSpecs) {
             fmt::format("{:%H:%M:%S}", std::chrono::seconds(12345)));
   EXPECT_EQ("03:25", fmt::format("{:%R}", std::chrono::seconds(12345)));
   EXPECT_EQ("03:25:45", fmt::format("{:%T}", std::chrono::seconds(12345)));
+  EXPECT_EQ("12345", fmt::format("{:%Q}", std::chrono::seconds(12345)));
+  EXPECT_EQ("s", fmt::format("{:%q}", std::chrono::seconds(12345)));
 }
 
 TEST(ChronoTest, InvalidSpecs) {
@@ -155,8 +157,6 @@ TEST(ChronoTest, InvalidSpecs) {
   EXPECT_THROW_MSG(fmt::format("{:%B}", sec), fmt::format_error, "no date");
   EXPECT_THROW_MSG(fmt::format("{:%z}", sec), fmt::format_error, "no date");
   EXPECT_THROW_MSG(fmt::format("{:%Z}", sec), fmt::format_error, "no date");
-  EXPECT_THROW_MSG(fmt::format("{:%q}", sec), fmt::format_error,
-                   "invalid format");
   EXPECT_THROW_MSG(fmt::format("{:%Eq}", sec), fmt::format_error,
                    "invalid format");
   EXPECT_THROW_MSG(fmt::format("{:%Oq}", sec), fmt::format_error,
@@ -215,7 +215,34 @@ TEST(ChronoTest, FormatFullSpecs) {
   EXPECT_EQ(" 1.2ms ", fmt::format("{:^{}.{}}", dms(1.234), 7, 1));
   EXPECT_EQ(" 1.23ms ", fmt::format("{0:^{2}.{1}}", dms(1.234), 2, 8));
   EXPECT_EQ("=1.234ms=", fmt::format("{:=^{}.{}}", dms(1.234), 9, 3));
-  EXPECT_EQ("*1.2340ms*", fmt::format("{:*^10.4}", dms(1.234), 10, 4));
+  EXPECT_EQ("*1.2340ms*", fmt::format("{:*^10.4}", dms(1.234)));
+}
+
+TEST(ChronoTest, FormatSimpleQq) {
+  typedef std::chrono::duration<float> fs;
+  EXPECT_EQ("1.234 s", fmt::format("{:%Q %q}", fs(1.234)));
+  typedef std::chrono::duration<float, std::milli> fms;
+  EXPECT_EQ("1.234 ms", fmt::format("{:%Q %q}", fms(1.234)));
+  typedef std::chrono::duration<double> ds;
+  EXPECT_EQ("1.234 s", fmt::format("{:%Q %q}", ds(1.234)));
+  EXPECT_EQ("1.234 ms", fmt::format("{:%Q %q}", dms(1.234)));
+}
+
+TEST(ChronoTest, FormatPrecisionQq) {
+  EXPECT_THROW_MSG(fmt::format("{:.2%Q %q}", std::chrono::seconds(42)),
+    fmt::format_error,
+    "precision not allowed for this argument type");
+  EXPECT_EQ("1.2 ms", fmt::format("{:.1%Q %q}", dms(1.234)));
+  EXPECT_EQ("1.23 ms", fmt::format("{:.{}%Q %q}", dms(1.234), 2));
+}
+
+TEST(ChronoTest, FormatFullSpecsQq) {
+  EXPECT_EQ("1.2 ms ", fmt::format("{:7.1%Q %q}", dms(1.234)));
+  EXPECT_EQ(" 1.23 ms", fmt::format("{:>8.{}%Q %q}", dms(1.234), 2));
+  EXPECT_EQ(" 1.2 ms ", fmt::format("{:^{}.{}%Q %q}", dms(1.234), 8, 1));
+  EXPECT_EQ(" 1.23 ms ", fmt::format("{0:^{2}.{1}%Q %q}", dms(1.234), 2, 9));
+  EXPECT_EQ("=1.234 ms=", fmt::format("{:=^{}.{}%Q %q}", dms(1.234), 10, 3));
+  EXPECT_EQ("*1.2340 ms*", fmt::format("{:*^11.4%Q %q}", dms(1.234)));
 }
 
 #endif  // FMT_STATIC_THOUSANDS_SEPARATOR


### PR DESCRIPTION
Howard Hinnant's 'date' library recently gained these two new formatting specifiers. This implementation in {fmt} includes support for 'std::chrono::duration' specializations with floating-point representation types and user-definable precision.

Signed-off-by: Daniela Engert <dani@ngrt.de>