### PR TITLE
Mark deprecated functionality with attributes and remove usage of such features

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -15,21 +15,33 @@ FMT_BEGIN_NAMESPACE
 #ifdef FMT_DEPRECATED_COLORS
 
 // color and (v)print_colored are deprecated.
-enum color { black, red, green, yellow, blue, magenta, cyan, white };
-FMT_API void vprint_colored(color c, string_view format, format_args args);
-FMT_API void vprint_colored(color c, wstring_view format, wformat_args args);
+enum FMT_DEPRECATED color {
+  black,
+  red,
+  green,
+  yellow,
+  blue,
+  magenta,
+  cyan,
+  white
+};
+FMT_DEPRECATED FMT_API void vprint_colored(color c, string_view format,
+                                           format_args args);
+FMT_DEPRECATED FMT_API void vprint_colored(color c, wstring_view format,
+                                           wformat_args args);
 template <typename... Args>
-inline void print_colored(color c, string_view format_str,
-                          const Args&... args) {
+FMT_DEPRECATED inline void print_colored(color c, string_view format_str,
+                                         const Args&... args) {
   vprint_colored(c, format_str, make_format_args(args...));
 }
 template <typename... Args>
-inline void print_colored(color c, wstring_view format_str,
-                          const Args&... args) {
+FMT_DEPRECATED inline void print_colored(color c, wstring_view format_str,
+                                         const Args&... args) {
   vprint_colored(c, format_str, make_format_args<wformat_context>(args...));
 }
 
-inline void vprint_colored(color c, string_view format, format_args args) {
+FMT_DEPRECATED inline void vprint_colored(color c, string_view format,
+                                          format_args args) {
   char escape[] = "\x1b[30m";
   escape[3] = static_cast<char>('0' + c);
   std::fputs(escape, stdout);
@@ -37,7 +49,8 @@ inline void vprint_colored(color c, string_view format, format_args args) {
   std::fputs(internal::data::RESET_COLOR, stdout);
 }
 
-inline void vprint_colored(color c, wstring_view format, wformat_args args) {
+FMT_DEPRECATED inline void vprint_colored(color c, wstring_view format,
+                                          wformat_args args) {
   wchar_t escape[] = L"\x1b[30m";
   escape[3] = static_cast<wchar_t>('0' + c);
   std::fputws(escape, stdout);

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -143,6 +143,21 @@
 #  endif
 #endif
 
+#ifndef FMT_DEPRECATED
+#  if (FMT_HAS_CPP_ATTRIBUTE(deprecated) && __cplusplus >= 201402L) || \
+      FMT_MSC_VER >= 1900
+#    define FMT_DEPRECATED [[deprecated]]
+#  else
+#    if defined(__GNUC__) || defined(__clang__)
+#      define FMT_DEPRECATED __attribute__((deprecated))
+#    elif FMT_MSC_VER
+#      define FMT_DEPRECATED __declspec(deprecated)
+#    else
+#      define FMT_DEPRECATED /*deprecated*/
+#    endif
+#  endif
+#endif
+
 #ifndef FMT_BEGIN_NAMESPACE
 #  if FMT_HAS_FEATURE(cxx_inline_namespaces) || FMT_GCC_VERSION >= 404 || \
       FMT_MSC_VER >= 1900
@@ -922,10 +937,9 @@ FMT_CONSTEXPR typename internal::result_of<Visitor(int)>::type visit_format_arg(
   return vis(monostate());
 }
 
-// DEPRECATED!
 template <typename Visitor, typename Context>
-FMT_CONSTEXPR typename internal::result_of<Visitor(int)>::type visit(
-    Visitor&& vis, const basic_format_arg<Context>& arg) {
+FMT_DEPRECATED FMT_CONSTEXPR typename internal::result_of<Visitor(int)>::type
+visit(Visitor&& vis, const basic_format_arg<Context>& arg) {
   return visit_format_arg(std::forward<Visitor>(vis), arg);
 }
 
@@ -983,9 +997,8 @@ class basic_parse_context : private ErrorHandler {
 typedef basic_parse_context<char> format_parse_context;
 typedef basic_parse_context<wchar_t> wformat_parse_context;
 
-// DEPRECATED!
-typedef basic_parse_context<char> parse_context;
-typedef basic_parse_context<wchar_t> wparse_context;
+FMT_DEPRECATED typedef basic_parse_context<char> parse_context;
+FMT_DEPRECATED typedef basic_parse_context<wchar_t> wparse_context;
 
 namespace internal {
 // A map from argument names to their values for named arguments.
@@ -1074,7 +1087,7 @@ class context_base {
 
  public:
   basic_parse_context<char_type>& parse_context() { return parse_context_; }
-  basic_format_args<Context> args() const { return args_; }  // DEPRECATED!
+  FMT_DEPRECATED basic_format_args<Context> args() const { return args_; }
   basic_format_arg<Context> arg(unsigned id) const { return args_.get(id); }
 
   internal::error_handler error_handler() {
@@ -1085,7 +1098,7 @@ class context_base {
 
   // Returns an iterator to the beginning of the output range.
   iterator out() { return out_; }
-  iterator begin() { return out_; }  // deprecated
+  FMT_DEPRECATED iterator begin() { return out_; }
 
   // Advances the begin iterator to ``it``.
   void advance_to(iterator it) { out_ = it; }
@@ -1174,9 +1187,10 @@ class basic_format_context
   // specified name.
   format_arg arg(basic_string_view<char_type> name);
 
-  // DEPRECATED!
-  format_arg get_arg(unsigned arg_id) { return arg(arg_id); }
-  format_arg get_arg(basic_string_view<char_type> name) { return arg(name); }
+  FMT_DEPRECATED format_arg get_arg(unsigned arg_id) { return arg(arg_id); }
+  FMT_DEPRECATED format_arg get_arg(basic_string_view<char_type> name) {
+    return arg(name);
+  }
 };
 
 template <typename Char> struct buffer_context {

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1087,7 +1087,11 @@ class context_base {
 
  public:
   basic_parse_context<char_type>& parse_context() { return parse_context_; }
-  FMT_DEPRECATED basic_format_args<Context> args() const { return args_; }
+
+  // basic_format_context::arg() depends on this
+  // Cannot be marked as deprecated without causing warnings
+  /*FMT_DEPRECATED*/ basic_format_args<Context> args() const { return args_; }
+
   basic_format_arg<Context> arg(unsigned id) const { return args_.get(id); }
 
   internal::error_handler error_handler() {

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3084,9 +3084,9 @@ struct format_handler : internal::error_handler {
   void on_arg_id() { arg = context.next_arg(); }
   void on_arg_id(unsigned id) {
     context.parse_context().check_arg_id(id);
-    arg = context.get_arg(id);
+    arg = context.arg(id);
   }
-  void on_arg_id(basic_string_view<Char> id) { arg = context.get_arg(id); }
+  void on_arg_id(basic_string_view<Char> id) { arg = context.arg(id); }
 
   void on_replacement_field(const Char* p) {
     context.parse_context().advance_to(p);

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2222,8 +2222,7 @@ class arg_formatter
   explicit arg_formatter(context_type& ctx, format_specs* spec = FMT_NULL)
       : base(Range(ctx.out()), spec, ctx.locale()), ctx_(ctx) {}
 
-  // Deprecated.
-  arg_formatter(context_type& ctx, format_specs& spec)
+  FMT_DEPRECATED arg_formatter(context_type& ctx, format_specs& spec)
       : base(Range(ctx.out()), &spec), ctx_(ctx) {}
 
   using base::operator();
@@ -2892,11 +2891,11 @@ class format_int {
   std::string str() const { return std::string(str_, size()); }
 };
 
-// DEPRECATED!
 // Formats a decimal integer value writing into buffer and returns
 // a pointer to the end of the formatted string. This function doesn't
 // write a terminating null character.
-template <typename T> inline void format_decimal(char*& buffer, T value) {
+template <typename T>
+FMT_DEPRECATED inline void format_decimal(char*& buffer, T value) {
   typedef typename internal::int_traits<T>::main_type main_type;
   main_type abs_value = static_cast<main_type>(value);
   if (internal::is_negative(value)) {

--- a/include/fmt/prepare.h
+++ b/include/fmt/prepare.h
@@ -284,8 +284,8 @@ class prepared_format {
         const auto arg =
             value.spec.arg_id.which ==
                     format_part_t::argument_id::which_arg_id::index
-                ? ctx.get_arg(arg_id_value.index)
-                : ctx.get_arg(arg_id_value.named_index.to_view(format_));
+                ? ctx.arg(arg_id_value.index)
+                : ctx.arg(arg_id_value.named_index.to_view(format_));
 
         auto specs = value.spec.parsed_specs;
 
@@ -317,7 +317,7 @@ class prepared_format {
   void format_arg(Context& ctx, Id arg_id) const {
     ctx.parse_context().check_arg_id(arg_id);
     const auto stopped_at =
-        visit_format_arg(arg_formatter<Range>(ctx), ctx.get_arg(arg_id));
+        visit_format_arg(arg_formatter<Range>(ctx), ctx.arg(arg_id));
     ctx.advance_to(stopped_at);
   }
 

--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -290,13 +290,13 @@ VISIT_TYPE(unsigned long, unsigned long long);
 
 VISIT_TYPE(float, double);
 
-#define CHECK_ARG_(Char, expected, value)                                   \
-  {                                                                         \
-    testing::StrictMock<mock_visitor<decltype(expected)>> visitor;          \
-    EXPECT_CALL(visitor, visit(expected));                                  \
-    typedef std::back_insert_iterator<basic_buffer<Char>> iterator;         \
-    fmt::visit(visitor,                                                     \
-               make_arg<fmt::basic_format_context<iterator, Char>>(value)); \
+#define CHECK_ARG_(Char, expected, value)                                     \
+  {                                                                           \
+    testing::StrictMock<mock_visitor<decltype(expected)>> visitor;            \
+    EXPECT_CALL(visitor, visit(expected));                                    \
+    typedef std::back_insert_iterator<basic_buffer<Char>> iterator;           \
+    fmt::visit_format_arg(                                                    \
+        visitor, make_arg<fmt::basic_format_context<iterator, Char>>(value)); \
   }
 
 #define CHECK_ARG(value, typename_)                          \
@@ -391,14 +391,14 @@ TEST(ArgTest, CustomArg) {
       visitor;
   testing::StrictMock<visitor> v;
   EXPECT_CALL(v, visit(_)).WillOnce(testing::Invoke(check_custom()));
-  fmt::visit(v, make_arg<fmt::format_context>(test));
+  fmt::visit_format_arg(v, make_arg<fmt::format_context>(test));
 }
 
 TEST(ArgTest, VisitInvalidArg) {
   testing::StrictMock<mock_visitor<fmt::monostate>> visitor;
   EXPECT_CALL(visitor, visit(_));
   fmt::basic_format_arg<fmt::format_context> arg;
-  visit(visitor, arg);
+  fmt::visit_format_arg(visitor, arg);
 }
 
 TEST(StringViewTest, Length) {

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -116,9 +116,10 @@ template <typename T> struct ValueExtractor : fmt::internal::function<T> {
 TEST(FormatTest, ArgConverter) {
   long long value = std::numeric_limits<long long>::max();
   auto arg = fmt::internal::make_arg<fmt::format_context>(value);
-  visit(fmt::internal::arg_converter<long long, fmt::format_context>(arg, 'd'),
-        arg);
-  EXPECT_EQ(value, visit(ValueExtractor<long long>(), arg));
+  fmt::visit_format_arg(
+      fmt::internal::arg_converter<long long, fmt::format_context>(arg, 'd'),
+      arg);
+  EXPECT_EQ(value, fmt::visit_format_arg(ValueExtractor<long long>(), arg));
 }
 
 TEST(FormatTest, FormatNegativeNaN) {

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1720,12 +1720,31 @@ TEST(FormatIntTest, FormatInt) {
             fmt::format_int(std::numeric_limits<int64_t>::max()).str());
 }
 
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+#if FMT_MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4996) // Using a deprecated function
+#endif
+
 template <typename T> std::string format_decimal(T value) {
   char buffer[10];
   char* ptr = buffer;
-  fmt::format_decimal(ptr, value);
+  // TODO: Replace with safer, non-deprecated overload
+  fmt::format_decimal(ptr, value); 
   return std::string(buffer, ptr);
 }
+
+#if FMT_MSC_VER
+#pragma warning(pop)
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 TEST(FormatIntTest, FormatDec) {
   EXPECT_EQ("-42", format_decimal(static_cast<signed char>(-42)));

--- a/test/ostream-test.cc
+++ b/test/ostream-test.cc
@@ -59,7 +59,8 @@ TEST(OStreamTest, CustomArg) {
   fmt::format_context ctx(std::back_inserter(base), "", fmt::format_args());
   fmt::format_specs spec;
   test_arg_formatter af(ctx, spec);
-  visit(af, fmt::internal::make_arg<fmt::format_context>(TestEnum()));
+  fmt::visit_format_arg(
+      af, fmt::internal::make_arg<fmt::format_context>(TestEnum()));
   EXPECT_EQ("TestEnum", std::string(buffer.data(), buffer.size()));
 }
 
@@ -178,8 +179,7 @@ template <typename Output> Output& operator<<(Output& out, ABC) {
 }
 }  // namespace fmt_test
 
-template <typename T>
-struct TestTemplate {};
+template <typename T> struct TestTemplate {};
 
 template <typename T>
 std::ostream& operator<<(std::ostream& os, TestTemplate<T>) {
@@ -187,14 +187,13 @@ std::ostream& operator<<(std::ostream& os, TestTemplate<T>) {
 }
 
 namespace fmt {
-template <typename T>
-struct formatter<TestTemplate<T>> : formatter<int> {
+template <typename T> struct formatter<TestTemplate<T>> : formatter<int> {
   template <typename FormatContext>
   typename FormatContext::iterator format(TestTemplate<T>, FormatContext& ctx) {
     return formatter<int>::format(2, ctx);
   }
 };
-}
+}  // namespace fmt
 
 #if !FMT_GCC_VERSION || FMT_GCC_VERSION >= 407
 TEST(OStreamTest, Template) {


### PR DESCRIPTION
This PR marks features commented as deprecated with attributes; `[[deprecated]]` if compiled with C++14 and `__attribute__((deprecated))` or `__declspec(deprecated)` if not.

I was able to replace most of the cases where deprecated functionality was used in the library, but one case lingers: https://github.com/eliaskosunen/fmt/blob/599632ee226d74d6c34d89290ebabd7320c90afe/include/fmt/format.h#L3061

`arg_map::init` takes `const basic_format_args<Context>&` as its sole argument, which can only be extracted from `context_base` with the deprecated member function `args()`.