### PR TITLE
Replace 'std::result_of' by 'std::invoke_result' where possible (#1025)

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -217,11 +217,17 @@ typename std::add_rvalue_reference<T>::type declval() FMT_NOEXCEPT;
 
 template <typename> struct result_of;
 
-template <typename F, typename... Args> struct result_of<F(Args...)> {
-  // A workaround for gcc 4.4 that doesn't allow F to be a reference.
-  typedef typename std::result_of<typename std::remove_reference<F>::type(
-      Args...)>::type type;
-};
+#if (__cplusplus >= 201703L ||                          \
+     (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)) && \
+    __cpp_lib_is_invocable >= 201703L
+template <typename F, typename... Args>
+struct result_of<F(Args...)> : std::invoke_result<F, Args...> {};
+#else
+// A workaround for gcc 4.4 that doesn't allow F to be a reference.
+template <typename F, typename... Args>
+struct result_of<F(Args...)>
+  : std::result_of<typename std::remove_reference<F>::type(Args...)> {};
+#endif
 
 // Casts nonnegative integer to unsigned.
 template <typename Int>


### PR DESCRIPTION
C++17 deprecated 'std::result_of' in favour of 'std::invoke_result' and will ban it outright in C++20. Therefore
- implement 'internal::result_of' in terms of 'std::invoke_result' when compiling C++17 mode.
- implement 'internal::result_of' in terms of 'std::result_of' when compiling in modes C++11 or C++14.

Signed-off-by: Daniela Engert <dani@ngrt.de>