### PR TITLE
(Unwillingly) protect against overloaded comma operators in decltype

### DIFF
--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -56,8 +56,8 @@ template <typename Char> struct test_stream : std::basic_ostream<Char> {
 template <typename T, typename Char> class is_streamable {
  private:
   template <typename U>
-  static decltype(internal::declval<test_stream<Char>&>()
-                      << internal::declval<U>(),
+  static decltype((void)(internal::declval<test_stream<Char>&>()
+                      << internal::declval<U>()),
                   std::true_type())
   test(int);
 

--- a/include/fmt/prepare.h
+++ b/include/fmt/prepare.h
@@ -538,14 +538,15 @@ struct parts_container_concept_check : std::true_type {
 
   template <typename T> static std::false_type has_add_check(check_second);
   template <typename T>
-  static decltype(declval<T>().add(declval<typename T::format_part_type>()),
+  static decltype((void)declval<T>().add(
+                      declval<typename T::format_part_type>()),
                   std::true_type()) has_add_check(check_first);
   typedef decltype(has_add_check<PartsContainer>(check_first())) has_add;
   static_assert(has_add::value, "PartsContainer doesn't provide add() method");
 
   template <typename T> static std::false_type has_last_check(check_second);
   template <typename T>
-  static decltype(declval<T>().last(),
+  static decltype((void)declval<T>().last(),
                   std::true_type()) has_last_check(check_first);
   typedef decltype(has_last_check<PartsContainer>(check_first())) has_last;
   static_assert(has_last::value,
@@ -555,7 +556,8 @@ struct parts_container_concept_check : std::true_type {
   static std::false_type has_substitute_last_check(check_second);
   template <typename T>
   static decltype(
-      declval<T>().substitute_last(declval<typename T::format_part_type>()),
+      (void)declval<T>().substitute_last(
+          declval<typename T::format_part_type>()),
       std::true_type()) has_substitute_last_check(check_first);
   typedef decltype(has_substitute_last_check<PartsContainer>(
       check_first())) has_substitute_last;
@@ -564,7 +566,7 @@ struct parts_container_concept_check : std::true_type {
 
   template <typename T> static std::false_type has_begin_check(check_second);
   template <typename T>
-  static decltype(declval<T>().begin(),
+  static decltype((void)declval<T>().begin(),
                   std::true_type()) has_begin_check(check_first);
   typedef decltype(has_begin_check<PartsContainer>(check_first())) has_begin;
   static_assert(has_begin::value,
@@ -572,7 +574,7 @@ struct parts_container_concept_check : std::true_type {
 
   template <typename T> static std::false_type has_end_check(check_second);
   template <typename T>
-  static decltype(declval<T>().end(),
+  static decltype((void)declval<T>().end(),
                   std::true_type()) has_end_check(check_first);
   typedef decltype(has_end_check<PartsContainer>(check_first())) has_end;
   static_assert(has_end::value, "PartsContainer doesn't provide end() method");

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -76,7 +76,7 @@ template <typename OutputIterator> void copy(char ch, OutputIterator out) {
 template <typename T> class is_like_std_string {
   template <typename U>
   static auto check(U* p)
-      -> decltype(p->find('a'), p->length(), p->data(), int());
+      -> decltype((void)p->find('a'), p->length(), (void)p->data(), int());
   template <typename> static void check(...);
 
  public:
@@ -106,7 +106,8 @@ template <typename T> class is_tuple_like_ {
   template <typename U>
   static auto check(U* p)
       -> decltype(std::tuple_size<U>::value,
-                  internal::declval<typename std::tuple_element<0, U>::type>(),
+                  (void)internal::declval<
+                      typename std::tuple_element<0, U>::type>(),
                   int());
   template <typename> static void check(...);
 

--- a/test/ostream-test.cc
+++ b/test/ostream-test.cc
@@ -26,6 +26,11 @@ static std::wostream& operator<<(std::wostream& os, const Date& d) {
   return os;
 }
 
+// Make sure that overloaded comma operators do no harm to is_streamable.
+struct type_with_comma_op {};
+template <typename T> void operator,(type_with_comma_op, const T&);
+template <typename T> type_with_comma_op operator<<(T&, const Date&);
+
 enum TestEnum {};
 static std::ostream& operator<<(std::ostream& os, TestEnum) {
   return os << "TestEnum";


### PR DESCRIPTION
It seems that the doc doesn't explicitly ban overloading comma operators. So this PR adds guards against overloaded comma operators by sprinkling void casts.

Here is a (nonsense) test case:
```
#include <iostream>

#include "fmt/format.h"
#include "fmt/ostream.h"

template <typename OStream>
struct ostream_with_comma_op
{
    std::ostream& os;

    ostream_with_comma_op(std::ostream& _os) : os(_os) {}

    template <typename T>
    ostream_with_comma_op& operator<<(T const& t)
    {
        os << t;
        return *this;
    }
};

template <typename OStream, typename T>
void operator,(ostream_with_comma_op<OStream> const&, T&&);

struct ouch {};

ostream_with_comma_op<std::ostream> operator<<(std::ostream& os, ouch)
{
    os << "ouch";
    return ostream_with_comma_op<std::ostream>(os);
}

int main ()
{
    std::cout << fmt::format("{}", ouch{}) << '\n';
    
    return 0;
}
```

Another options would be: adding a note to the doc that pathological types are not supported.