### PR TITLE
Fix library deprecation warning

### DIFF
--- a/test/prepare-test.cc
+++ b/test/prepare-test.cc
@@ -618,8 +618,9 @@ template <typename T> struct user_allocator {
   ~user_allocator() = default;
   template <typename U> user_allocator(const user_allocator<U>&) {}
 
-  pointer allocate(size_type cnt,
-                   typename std::allocator<void>::const_pointer = FMT_NULL) {
+  pointer allocate(
+      size_type cnt,
+      typename std::allocator<fmt::monostate>::const_pointer = FMT_NULL) {
     return new value_type[cnt];
   }
 


### PR DESCRIPTION
Since C++17, using template specialization `std::allocator<void>` in any shape or form (even just mentioning it) is deprecated! A simple workaround is replacing `void` by another (preferably empty) type, e.g. `fmt::monostate`.

Found by Clang 9 in Visual Studio.