### PR TITLE
Gradle 4.10 >> Gradle 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,8 +83,8 @@ matrix:
             - g++-4.4
           sources:
             - ubuntu-toolchain-r-test
-      # Android
-    - language: android
+    - name: Android NDK (Gradle)
+      language: android
       addons:
         apt:
           update: true
@@ -92,23 +92,24 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - ninja-build
-            - wget
-            - unzip
+            - curl
             - tree
       android:
         components:
           - tools
           - platform-tools
-          - android-21
-      env:
-        - ANDROID=true
+          - android-25 # 7.0
+          - android-27 # 8.1
+          - android-28 # 9.0
+          - build-tools-28.0.3
       before_install:
-        # Download/Install Gradle 
-        - wget https://services.gradle.org/distributions/gradle-4.10.2-bin.zip
-        - mkdir -p gradle
-        - unzip -q -d ./gradle gradle-4.10.2-bin.zip
-        - export GRADLE=gradle/gradle-4.10.2/bin/gradle
-        - bash $GRADLE --version
+        # Install Gradle from https://sdkman.io/
+        - curl -s "https://get.sdkman.io" | bash > /dev/null
+        - source "$HOME/.sdkman/bin/sdkman-init.sh"
+        - sdk version
+        - sdk install gradle
+        - sdk use gradle
+        - gradle --version
       install:
         # Accept SDK Licenses + Install NDK
         - yes | sdkmanager --update > /dev/null 2>&1
@@ -116,7 +117,8 @@ matrix:
       before_script:
         - pushd ./support
       script:
-        - bash ../$GRADLE clean assemble
+        - gradle clean
+        - gradle assemble
       after_success:
         - popd;
         - tree ./libs

--- a/support/build.gradle
+++ b/support/build.gradle
@@ -9,10 +9,12 @@ buildscript {
         //
         // https://developer.android.com/studio/releases/gradle-plugin
         //
-        // Notice that 3.1.3 here is the version of [Android Gradle Plugin]
-        // Accroding to URL above you will need Gradle 4.4 or higher
+        // Notice that 3.3.0 here is the version of [Android Gradle Plugin]
+        // Accroding to URL above you will need Gradle 5.0 or higher
         //
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        // If you are using Android Studio, and it is using Gradle's lower 
+        // version, Use the plugin version 3.1.3 ~ 3.2.0 for Gradle 4.4 ~ 4.10
+        classpath 'com.android.tools.build:gradle:3.3.0'
     }
 }
 repositories {
@@ -43,8 +45,8 @@ android {
     defaultConfig {
         minSdkVersion 21    // Android 5.0+
         targetSdkVersion 25 // Follow Compile SDK
-        versionCode 20      // Follow release count
-        versionName "5.2.1" // Follow Official version
+        versionCode 21      // Follow release count
+        versionName "5.3.0" // Follow Official version
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         
         externalNativeBuild {


### PR DESCRIPTION
### Summary

Updated Android NDK build with Gradle.  
[Build Log](https://travis-ci.org/luncliff/fmt/jobs/491193775) 

  * Changed install method of Gradle
    * from: `wget` + `unzip`
    * to: [sdkman](https://sdkman.io/)
  * Android Gradle Plugin version
    * [`3.1.3` >> `3.3.0`](https://github.com/fmtlib/fmt/pull/1039/commits/c60e452f354c7f6f7bfa0ab7620da03535e70fc5#diff-033fc341eae12ca4178f216c37b66148R17) 
  * Name for the build matrix item
    * [`Android NDK (Gradle)`](https://github.com/fmtlib/fmt/pull/1039/commits/c60e452f354c7f6f7bfa0ab7620da03535e70fc5#diff-354f30a63fb0907d4ad57269548329e3R86)

### Note

Previous builds with 4.10.2 generated [**humongous** log](https://travis-ci.org/fmtlib/fmt/jobs/490982331) for review and debug. I applied later version(5.x) to reduce them. Please reference the build log. However, as far as I know, most of Android Studio users use Gradle 4.x (usually 4.4 and 4.10 for the latest users).  
So the new configuration is a kind of early adapting to them. I'd like to hear your opinion about this.

There are multiple ways to install Gradle in ubuntu. What we have used was downloading a specific version with `wget`.
This PR adopted [the official way](https://gradle.org/install/). 

### History
  * #926
  * #649 

