### PR TITLE
Silence Warnings when using FMT_STRING()

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -111,6 +111,22 @@
 # define FMT_USE_NULLPTR 0
 #endif
 
+#ifndef FMT_MAYBE_UNUSED
+# ifdef __has_cpp_attribute
+#  if __has_cpp_attribute(maybe_unused)
+#   define FMT_MAYBE_UNUSED [[maybe_unused]]
+#  endif
+# else
+#  if (__cplusplus >= 201603L && FMT_GCC_VERSION >= 700) || \
+    FMT_MSC_VER >= 1911
+#    define FMT_MAYBE_UNUSED [[maybe_unused]]
+#  endif
+# endif
+#endif
+#ifndef FMT_MAYBE_UNUSED
+# define FMT_MAYBE_UNUSED
+#endif
+
 // Check if exceptions are disabled.
 #ifndef FMT_EXCEPTIONS
 # if (defined(__GNUC__) && !defined(__EXCEPTIONS)) || \

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3514,8 +3514,8 @@ FMT_END_NAMESPACE
     typedef typename std::remove_cv<std::remove_pointer< \
       typename std::decay<decltype(s)>::type>::type>::type ct; \
     struct str : fmt::compile_string { \
-      typedef ct char_type; \
-      FMT_CONSTEXPR operator fmt::basic_string_view<ct>() const { \
+      FMT_MAYBE_UNUSED typedef ct char_type; \
+      FMT_MAYBE_UNUSED FMT_CONSTEXPR operator fmt::basic_string_view<ct>() const { \
         return {s, sizeof(s) / sizeof(ct) - 1}; \
       } \
     }; \


### PR DESCRIPTION
Clang 7 (or atleast QtCreator's Clang Code Model) says:
Warning: unused member function 'operator basic_string_view'
[-Wunused-member-function]

And MinGW 8.1 says:
Warning: typedef '<Name where Macro is used>::<lambda()>::str::char_type' locally defined but not used
[-Wunused-local-typedefs]