### PR TITLE
Clarify lifetimes of named_arg parameters

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -54,7 +54,7 @@ participate in an overload resolution if the latter is not a string.
 Named arguments
 ---------------
 
-.. doxygenfunction:: fmt::arg(string_view, const T&)
+.. doxygenfunction:: fmt::arg(const S&, const T&)
 
 Named arguments are not supported in compile-time checks at the moment.
 

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1385,10 +1385,10 @@ typename buffer_context<Char>::type::iterator vformat_to(
   \rst
   Returns a named argument to be used in a formatting function.
 
-  Usage is analogous to `std::reference_wrapper
-  <https://en.cppreference.com/w/cpp/utility/functional/reference_wrapper>`_,
-  except that rvalues references are not disabled.
-  The user should take care to only pass in temporaries when
+  The named argument holds a reference and does not extend the lifetime
+  of its arguments.
+  Consequently, a dangling reference can accidentally be created.
+  The user should take care to only pass this function temporaries when
   the named argument is itself a temporary, as per the following example.
 
   **Example**::
@@ -1401,11 +1401,9 @@ inline internal::named_arg<T, FMT_CHAR(S)> arg(const S& name, const T& arg) {
   return {name, arg};
 }
 
-/// \cond
 // Disable nested named arguments, e.g. ``arg("a", arg("b", 42))``.
 template <typename S, typename T, typename Char>
 void arg(S, internal::named_arg<T, Char>) = delete;
-/// \endcond
 
 template <typename Container> struct is_contiguous : std::false_type {};
 

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1200,6 +1200,7 @@ const unsigned long long format_arg_store<Context, Args...>::TYPES =
   Constructs an `~fmt::format_arg_store` object that contains references to
   arguments and can be implicitly converted to `~fmt::format_args`. `Context`
   can be omitted in which case it defaults to `~fmt::context`.
+  See `~fmt::arg` for lifetime considerations.
   \endrst
  */
 template <typename Context = format_context, typename... Args>
@@ -1384,6 +1385,12 @@ typename buffer_context<Char>::type::iterator vformat_to(
   \rst
   Returns a named argument to be used in a formatting function.
 
+  Usage is analogous to `std::reference_wrapper
+  <https://en.cppreference.com/w/cpp/utility/functional/reference_wrapper>`_,
+  except that rvalues references are not disabled.
+  The user should take care to only pass in temporaries when
+  the named argument is itself a temporary, as per the following example.
+
   **Example**::
 
     fmt::print("Elapsed time: {s:.2f} seconds", fmt::arg("s", 1.23));
@@ -1394,9 +1401,11 @@ inline internal::named_arg<T, FMT_CHAR(S)> arg(const S& name, const T& arg) {
   return {name, arg};
 }
 
+/// \cond
 // Disable nested named arguments, e.g. ``arg("a", arg("b", 42))``.
 template <typename S, typename T, typename Char>
 void arg(S, internal::named_arg<T, Char>) = delete;
+/// \endcond
 
 template <typename Container> struct is_contiguous : std::false_type {};
 


### PR DESCRIPTION
Document that fmt::arg takes a non-owning
reference, even if that reference is to
a temporary. As such, users should make sure
the lifetime of the reference lasts as long
as the named argument.

Disable doxygen for deleted overload.