### PR TITLE
Documentation/api.rst: Use same template argument order as in the pro…

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -165,8 +165,8 @@ You can also write a formatter for a hierarchy of classes::
     virtual std::string name() const { return "B"; }
   };
 
-  template <typename T>
-  struct fmt::formatter<T, std::enable_if_t<std::is_base_of<A, T>::value, char>> :
+  template <typename T, typename Char>
+  struct fmt::formatter<T, Char, std::enable_if_t<std::is_base_of<A, T>::value>> :
       fmt::formatter<std::string> {
     template <typename FormatCtx>
     auto format(const A& a, FormatCtx& ctx) {


### PR DESCRIPTION
…totype

The formatter prototype is

// A formatter for objects of type T.
template <typename T, typename Char = char, typename Enable = void>
struct formatter {
  explicit formatter(internal::dummy_formatter_arg);
  };

so we should use this order in the example as well.

In addition we use Char instead of plain char to not confuse the reader
as this name is totally arbitrary.