### PR TITLE
Add support for '%' type to output floating point values as a percentage.

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -656,7 +656,14 @@ void sprintf_format(Double value, internal::buffer& buf,
     *format_ptr++ = '*';
   }
   if (std::is_same<Double, long double>::value) *format_ptr++ = 'L';
-  char type = spec.type ? spec.type : 'g';
+
+  char type = spec.type;
+
+  if (type == '%') {
+      type = 'f';
+  } else if (type == 0) {
+      type = 'g';
+  }
 #if FMT_MSC_VER
   if (type == 'F') {
     // MSVC's printf doesn't support 'F'.

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -539,8 +539,7 @@ struct fixed_stop {
   void on_exp(int exp) {
     if (!fixed) return;
     exp += exp10;
-    if (exp >= 0)
-      precision += exp;
+    if (exp >= 0) precision += exp;
   }
 
   bool operator()(char*, int& size, uint64_t remainder, uint64_t divisor,
@@ -660,9 +659,9 @@ void sprintf_format(Double value, internal::buffer& buf,
   char type = spec.type;
 
   if (type == '%') {
-      type = 'f';
+    type = 'f';
   } else if (type == 0) {
-      type = 'g';
+    type = 'g';
   }
 #if FMT_MSC_VER
   if (type == 'F') {

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1274,6 +1274,9 @@ FMT_CONSTEXPR void handle_float_type_spec(char spec, Handler&& handler) {
   case 'F':
     handler.on_fixed();
     break;
+  case '%':
+    handler.on_percent();
+    break;
   case 'a':
   case 'A':
     handler.on_hex();
@@ -1338,6 +1341,7 @@ class float_type_checker : private ErrorHandler {
   FMT_CONSTEXPR void on_general() {}
   FMT_CONSTEXPR void on_exp() {}
   FMT_CONSTEXPR void on_fixed() {}
+  FMT_CONSTEXPR void on_percent() {}
   FMT_CONSTEXPR void on_hex() {}
 
   FMT_CONSTEXPR void on_error() {
@@ -2808,10 +2812,11 @@ template <typename Range> class basic_writer {
 
 struct float_spec_handler {
   char type;
-  bool upper;
-  bool fixed;
+  bool upper{false};
+  bool fixed{false};
+  bool as_percentage{false};
 
-  explicit float_spec_handler(char t) : type(t), upper(false), fixed(false) {}
+  explicit float_spec_handler(char t) : type(t) {}
 
   void on_general() {
     if (type == 'G') upper = true;
@@ -2824,6 +2829,11 @@ struct float_spec_handler {
   void on_fixed() {
     fixed = true;
     if (type == 'F') upper = true;
+  }
+
+  void on_percent() {
+      fixed = true;
+      as_percentage = true;
   }
 
   void on_hex() {
@@ -2869,11 +2879,19 @@ void basic_writer<Range>::write_double(T value, const format_specs& spec) {
   memory_buffer buffer;
   int exp = 0;
   int precision = spec.has_precision() || !spec.type ? spec.precision : 6;
+
+  if (handler.as_percentage) value *= 100.;
+
   bool use_grisu = fmt::internal::use_grisu<T>() &&
                    (!spec.type || handler.fixed) &&
                    internal::grisu2_format(static_cast<double>(value), buffer,
                                            precision, handler.fixed, exp);
   if (!use_grisu) internal::sprintf_format(value, buffer, spec);
+
+  if (handler.as_percentage) {
+      buffer.push_back('%');
+      --exp; // Adjust decimal place position.
+  }
   align_spec as = spec;
   if (spec.align() == ALIGN_NUMERIC) {
     if (sign) {

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2815,11 +2815,11 @@ template <typename Range> class basic_writer {
 
 struct float_spec_handler {
   char type;
-  bool upper{false};
-  bool fixed{false};
-  bool as_percentage{false};
+  bool upper;
+  bool fixed;
+  bool as_percentage;
 
-  explicit float_spec_handler(char t) : type(t) {}
+  explicit float_spec_handler(char t) : type(t), upper(false), fixed(false), as_percentage(false) {}
 
   void on_general() {
     if (type == 'G') upper = true;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2875,14 +2875,10 @@ void basic_writer<Range>::write_double(T value, const format_specs& spec) {
 
   // Format NaN and ininity ourselves because sprintf's output is not consistent
   // across platforms.
-  if (internal::fputil::isnotanumber(value)) {
-    write_inf_or_nan(handler.upper ? "NAN" : "nan");
-    return;
-  }
-  if (internal::fputil::isinfinity(value)) {
-    write_inf_or_nan(handler.upper ? "INF" : "inf");
-    return;
-  }
+  if (internal::fputil::isnotanumber(value))
+    return write_inf_or_nan(handler.upper ? "NAN" : "nan");
+  if (internal::fputil::isinfinity(value))
+    return write_inf_or_nan(handler.upper ? "INF" : "inf");
 
   memory_buffer buffer;
   int exp = 0;

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1443,7 +1443,7 @@ TEST(FormatterTest, FormatFloat) {
 }
 
 TEST(FormatterTest, FormatDouble) {
-  check_unknown_types(1.2, "eEfFgGaA", "double");
+  check_unknown_types(1.2, "eEfFgGaA%", "double");
   EXPECT_EQ("0.0", format("{:}", 0.0));
   EXPECT_EQ("0.000000", format("{:f}", 0.0));
   EXPECT_EQ("0", format("{:g}", 0.0));

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1207,6 +1207,8 @@ TEST(FormatterTest, Precision) {
                    "precision not allowed for this argument type");
   EXPECT_THROW_MSG(format("{0:.2f}", 42ull), format_error,
                    "precision not allowed for this argument type");
+  EXPECT_THROW_MSG(format("{0:.2%}", 42), format_error,
+                   "precision not allowed for this argument type");
   EXPECT_THROW_MSG(format("{0:3.0}", 'x'), format_error,
                    "precision not allowed for this argument type");
   EXPECT_EQ("1.2", format("{0:.2}", 1.2345));
@@ -1440,6 +1442,7 @@ TEST(FormatterTest, FormatConvertibleToLongLong) {
 
 TEST(FormatterTest, FormatFloat) {
   EXPECT_EQ("392.500000", format("{0:f}", 392.5f));
+  EXPECT_EQ("12.500000%", format("{0:%}", 0.125f));
 }
 
 TEST(FormatterTest, FormatDouble) {
@@ -1452,6 +1455,8 @@ TEST(FormatterTest, FormatDouble) {
   EXPECT_EQ("392.65", format("{:G}", 392.65));
   EXPECT_EQ("392.650000", format("{:f}", 392.65));
   EXPECT_EQ("392.650000", format("{:F}", 392.65));
+  EXPECT_EQ("12.500000%", format("{:%}", 0.125));
+  EXPECT_EQ("12.34%", format("{:.2%}", 0.1234432));
   char buffer[BUFFER_SIZE];
   safe_sprintf(buffer, "%e", 392.65);
   EXPECT_EQ(buffer, format("{0:e}", 392.65));
@@ -1473,6 +1478,7 @@ TEST(FormatterTest, FormatNaN) {
   EXPECT_EQ("nan    ", format("{:<7}", nan));
   EXPECT_EQ("  nan  ", format("{:^7}", nan));
   EXPECT_EQ("    nan", format("{:>7}", nan));
+  EXPECT_EQ("nan%", format("{:%}", nan));
 }
 
 TEST(FormatterTest, FormatInfinity) {
@@ -1485,6 +1491,7 @@ TEST(FormatterTest, FormatInfinity) {
   EXPECT_EQ("inf    ", format("{:<7}", inf));
   EXPECT_EQ("  inf  ", format("{:^7}", inf));
   EXPECT_EQ("    inf", format("{:>7}", inf));
+  EXPECT_EQ("inf%", format("{:%}", inf));
 }
 
 TEST(FormatterTest, FormatLongDouble) {
@@ -1495,6 +1502,8 @@ TEST(FormatterTest, FormatLongDouble) {
   EXPECT_EQ("392.65", format("{0:G}", 392.65l));
   EXPECT_EQ("392.650000", format("{0:f}", 392.65l));
   EXPECT_EQ("392.650000", format("{0:F}", 392.65l));
+  EXPECT_EQ("12.500000%", format("{:%}", 0.125l));
+  EXPECT_EQ("12.34%", format("{:.2%}", 0.1234432l));
   char buffer[BUFFER_SIZE];
   safe_sprintf(buffer, "%Le", 392.65l);
   EXPECT_EQ(buffer, format("{0:e}", 392.65l));


### PR DESCRIPTION
This helps with compatibility with Python's format strings.