### PR TITLE
Declare the size of RESET_COLOR.

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -766,8 +766,8 @@ template <typename T = void> struct FMT_API basic_data {
   static const char DIGITS[];
   static const char FOREGROUND_COLOR[];
   static const char BACKGROUND_COLOR[];
-  static const char RESET_COLOR[];
-  static const wchar_t WRESET_COLOR[];
+  static const char RESET_COLOR[5];
+  static const wchar_t WRESET_COLOR[5];
 };
 
 #if FMT_USE_EXTERN_TEMPLATES

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -21,6 +21,7 @@
 #endif
 
 #include "fmt/format.h"
+#include "fmt/color.h"
 #include "gmock.h"
 #include "gtest-extra.h"
 #include "mock-allocator.h"
@@ -2491,4 +2492,10 @@ TEST(FormatTest, U8StringViewLiteral) {
 
 TEST(FormatTest, FormatU8String) {
   EXPECT_EQ(format(fmt::u8string_view("{}"), 42), fmt::u8string_view("42"));
+}
+
+TEST(FormatTest, EmphasisNonHeaderOnly) {
+  // ensure this compiles even if FMT_HEADER_ONLY is not defined.
+  EXPECT_EQ(fmt::format(fmt::emphasis::bold, "bold error"),
+            "\x1b[1mbold error\x1b[0m");
 }


### PR DESCRIPTION
This is so that the format with a text_tyle will compile even if
header-only mode isn't enabled. Addresses #1063.