### PR TITLE
cmake: default FMT_PKGCONFIG_DIR to a relative path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ if (FMT_INSTALL)
   set(FMT_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR}/fmt CACHE STRING
       "Installation directory for include files, relative to ${CMAKE_INSTALL_PREFIX}.")
 
-  set(FMT_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/share/pkgconfig" CACHE PATH
+  set(FMT_PKGCONFIG_DIR "share/pkgconfig" CACHE PATH
     "Installation directory for pkgconfig (.pc) files, relative to ${CMAKE_INSTALL_PREFIX}.")
 
   # Generate the version, config and target files into the build directory.


### PR DESCRIPTION
Minor cmake improvement that defaults FMT_PKGCONFIG_DIR properly to a relative path. Currently FMT_PKGCONFIG_DIR will be defaulted to an absolute path based on the initial value of CMAKE_INSTALL_PREFIX, and does not automatically change with it.