### PR TITLE
Forward declare is_string<FILE*> specializations

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -618,6 +618,10 @@ struct is_string
                               decltype(to_string_view(declval<S>()))>::value> {
 };
 
+// Forward declare FILE* specialization defined in color.h
+template <> struct is_string<std::FILE*>;
+template <> struct is_string<const std::FILE*>;
+
 template <typename S> struct char_t {
   typedef decltype(to_string_view(declval<S>())) result;
   typedef typename result::char_type type;


### PR DESCRIPTION
Not sure if this is the ideal or correct solution, but this is how I got around issue #1085 

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
