### PR TITLE
Added missing typename to FMT_STRING.

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3619,7 +3619,8 @@ FMT_END_NAMESPACE
       }                                                                   \
     } result;                                                             \
     /* Suppress Qt Creator warning about unused operator. */              \
-    (void)static_cast<fmt::basic_string_view<str::char_type>>(result);    \
+    (void)static_cast<fmt::basic_string_view<typename str::char_type>>(   \
+        result);                                                          \
     return result;                                                        \
   }()
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2475,8 +2475,6 @@ TEST(FormatTest, VFormatTo) {
   EXPECT_EQ(L"42", w);
 }
 
-#endif  // FMT_USE_CONSTEXPR
-
 template <typename T> static std::string FmtToString(const T& t) {
   return fmt::format(FMT_STRING("{}"), t);
 }
@@ -2485,6 +2483,8 @@ TEST(FormatTest, FmtStringInTemplate) {
   EXPECT_EQ(FmtToString(1), "1");
   EXPECT_EQ(FmtToString(0), "0");
 }
+
+#endif  // FMT_USE_CONSTEXPR
 
 TEST(FormatTest, ConstructU8StringViewFromCString) {
   fmt::u8string_view s("ab");

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2477,6 +2477,15 @@ TEST(FormatTest, VFormatTo) {
 
 #endif  // FMT_USE_CONSTEXPR
 
+template <typename T> static std::string FmtToString(const T& t) {
+  return fmt::format(FMT_STRING("{}"), t);
+}
+
+TEST(FormatTest, FmtStringInTemplate) {
+  EXPECT_EQ(FmtToString(1), "1");
+  EXPECT_EQ(FmtToString(0), "0");
+}
+
 TEST(FormatTest, ConstructU8StringViewFromCString) {
   fmt::u8string_view s("ab");
   EXPECT_EQ(s.size(), 2u);


### PR DESCRIPTION
This is so that FMT_STRING can be used in a template.



I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
