### PR TITLE
install pkg-config file into libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ if (FMT_INSTALL)
   set(FMT_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR}/fmt CACHE STRING
       "Installation directory for include files, relative to ${CMAKE_INSTALL_PREFIX}.")
 
-  set(FMT_PKGCONFIG_DIR "share/pkgconfig" CACHE PATH
+  set(FMT_PKGCONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/pkgconfig CACHE PATH
     "Installation directory for pkgconfig (.pc) files, relative to ${CMAKE_INSTALL_PREFIX}.")
 
   # Generate the version, config and target files into the build directory.


### PR DESCRIPTION
Most pkgconfig files contain a Libs: variable, which is either /usr/lib
or /usr/lib64. If a 32bit and a 64bit variant of fmt libraries is
installed, the last one wins. As a result compiling for the other
bitsize will fail.

Instead of sharedir use libdir as install target.

Fixes commit 9d0c9c4bb145a286f725cd38c90331eee7addc7f
Fixes commit 287342dab10a5a96479b3e21cd11ce671ed8125c

Signed-off-by: Olaf Hering <olaf@aepfle.de>

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
