### PR TITLE
Restructure printf_arg_formatter to make it customizable

### DIFF
--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -554,3 +554,51 @@ TEST(PrintfTest, VSPrintfMakeWArgsExample) {
                           fmt::make_wprintf_args(42, L"something")));
 #endif
 }
+
+typedef fmt::printf_arg_formatter<
+    fmt::back_insert_range<fmt::internal::buffer<char>>> formatter_t;
+typedef fmt::basic_printf_context<formatter_t::iterator, char> context_t;
+
+// A custom printf argument formatter that doesn't print `-` for floating-point
+// values rounded to 0.
+class custom_printf_arg_formatter : public formatter_t {
+ public:
+    using formatter_t::iterator;
+
+  custom_printf_arg_formatter(formatter_t::iterator iter, formatter_t::format_specs& spec, context_t& ctx)
+      : formatter_t(iter, spec, ctx) {}
+
+  using formatter_t::operator();
+
+#if FMT_MSC_VER > 0 && FMT_MSC_VER <= 1804
+      template <typename T, FMT_ENABLE_IF(std::is_floating_point<T>::value)>
+      iterator operator()(T value) {
+#else
+      iterator operator()(double value) {
+#endif
+     // Comparing a float to 0.0 is safe.
+     if (round(value * pow(10, spec()->precision)) == 0.0) value = 0;
+     return formatter_t::operator()(value);
+  }
+};
+
+typedef fmt::basic_format_args<context_t> format_args_t;
+
+std::string custom_vformat(fmt::string_view format_str, format_args_t args) {
+  fmt::memory_buffer buffer;
+  fmt::vprintf<custom_printf_arg_formatter>(buffer, format_str, args);
+  return std::string(buffer.data(), buffer.size());
+}
+
+template <typename... Args>
+std::string custom_format(const char* format_str, const Args&... args) {
+  auto va = fmt::make_printf_args (args...);
+  return custom_vformat(format_str, va);
+}
+
+TEST(CustomFormatterTest, Format) {
+  EXPECT_EQ("0.00", custom_format("%.2f", -.00001));
+  EXPECT_EQ("0.00", custom_format("%.2f", .00001));
+  EXPECT_EQ("1.00", custom_format("%.2f", 1.00001));
+  EXPECT_EQ("-1.00", custom_format("%.2f", -1.00001));
+}


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

I work for the Profidata AG which is using the libfmt version 4.1.0. A former colleague of mine (spacemoose) requested the expandability of the PrintfArgFormatter (now printf_arg_formatter) in the following issue: https://github.com/fmtlib/fmt/issues/335.

I have the task to update the libfmt dependency to 5.3.0 and ensure that we still have this feature available. Since I have a little bit of time pressure to finish this I had to balance the time of learning the code structure and the fixing itself. So I hope my approach in this change is ok.

Brief explanation what I did:
In order to be able to override the behaviour of the printf_arg_formatter I had to decouple the printf_arg_formatter and the basic_printf_context by creating a new class printf_arg_formatter_proxy. This new class keeps the context (so we can remove it from printf_arg_formatter) and decides either to call the basic_format_arg<Context>::handle with its context instance or a argument formatter which is passed by a template parameter. To simplify the setup I overloaded vprintf which accepts an argument formatter as template argument. I wrote a test (custom-printf-formatter-test.cc) for it.

Looking forward hearing from you.