### PR TITLE
Fix a couple of deprecated things.

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -111,11 +111,13 @@ template and implement ``parse`` and ``format`` methods::
   template <>
   struct formatter<point> {
     template <typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto parse(ParseContext &ctx) -> decltype(ctx.begin()) {
+      return ctx.begin();
+    }
 
     template <typename FormatContext>
-    auto format(const point &p, FormatContext &ctx) {
-      return format_to(ctx.begin(), "({:.1f}, {:.1f})", p.x, p.y);
+    auto format(const point &p, FormatContext &ctx) -> decltype(ctx.out()) {
+      return format_to(ctx.out(), "({:.1f}, {:.1f})", p.x, p.y);
     }
   };
   }
@@ -129,7 +131,7 @@ Then you can pass objects of type ``point`` to any formatting function::
 In the example above the ``formatter<point>::parse`` function ignores the
 contents of the format string referred to by ``ctx.begin()`` so the object will
 always be formatted in the same way. See ``formatter<tm>::parse`` in
-:file:`fmt/time.h` for an advanced example of how to parse the format string and
+:file:`fmt/chrono.h` for an advanced example of how to parse the format string and
 customize the formatted output.
 
 You can also reuse existing formatters, for example::


### PR DESCRIPTION
Fixes #1101

- `ctx.begin()` is deprecated in favor of `ctx.out()`
- `fmt/time.h` is deprecated in favor of `fmt/chrono.h`
- The library is compiled with C++11, but auto deduced return types is a C++14 feature. This is only in the docs, but we should be consistent

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
