### PR TITLE
Add compile features for cmake 3.8+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 include(cxx14)
 include(CheckCXXCompilerFlag)
 
+set(FMT_REQUIRED_FEATURES cxx_auto_type cxx_variadic_templates)
+
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   set(PEDANTIC_COMPILE_FLAGS -pedantic-errors -Wall -Wextra -pedantic
       -Wold-style-cast -Wundef
@@ -158,10 +160,7 @@ if (FMT_PEDANTIC)
   target_compile_options(fmt PRIVATE ${PEDANTIC_COMPILE_FLAGS})
 endif ()
 
-if (NOT ${CMAKE_VERSION} VERSION_LESS 3.8)
-  target_compile_features(fmt INTERFACE cxx_std_11)
-endif ()
-
+target_compile_features(fmt INTERFACE ${FMT_REQUIRED_FEATURES})
 
 target_include_directories(fmt PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
@@ -185,9 +184,7 @@ add_library(fmt::fmt-header-only ALIAS fmt-header-only)
 
 target_compile_definitions(fmt-header-only INTERFACE FMT_HEADER_ONLY=1)
 
-if (NOT ${CMAKE_VERSION} VERSION_LESS 3.8)
-  target_compile_features(fmt-header-only INTERFACE cxx_std_11)
-endif ()
+target_compile_features(fmt-header-only INTERFACE ${FMT_REQUIRED_FEATURES})
 
 target_include_directories(fmt-header-only INTERFACE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,11 @@ if (FMT_PEDANTIC)
   target_compile_options(fmt PRIVATE ${PEDANTIC_COMPILE_FLAGS})
 endif ()
 
+if (NOT ${CMAKE_VERSION} VERSION_LESS 3.8)
+  target_compile_features(fmt INTERFACE cxx_std_11)
+endif ()
+
+
 target_include_directories(fmt PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
@@ -179,6 +184,10 @@ add_library(fmt-header-only INTERFACE)
 add_library(fmt::fmt-header-only ALIAS fmt-header-only)
 
 target_compile_definitions(fmt-header-only INTERFACE FMT_HEADER_ONLY=1)
+
+if (NOT ${CMAKE_VERSION} VERSION_LESS 3.8)
+  target_compile_features(fmt-header-only INTERFACE cxx_std_11)
+endif ()
 
 target_include_directories(fmt-header-only INTERFACE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>


### PR DESCRIPTION
This pull requests adds the minimal requirements of `fmtlib` to the CMake targets.
This is needed so that the users don't have to do it on all their target linking with `fmt::*`.
A cmake version check is added since the `cxx_std_11` compile feature is not available before CMake 3.8.

Note that without this feature required by the user, such an error can occur:

    In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/c++/6.5.0/type_traits:35:/usr/bin/../lib/gcc/x86_64-linux-gnu/6.5.0/../../../../include/c++/6.5.0/bits/c++0x_warning.h:32:2: error: This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
    #error This file requires compiler and library support \


I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
