### PR TITLE
fmt::ptr: support unique_ptr and shared_ptr.

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3290,6 +3290,12 @@ typename Context::iterator vformat_to(
 // Example:
 //   auto s = format("{}", ptr(p));
 template <typename T> inline const void* ptr(const T* p) { return p; }
+template <typename T> inline const void* ptr(const std::unique_ptr<T>& p) {
+  return p.get();
+}
+template <typename T> inline const void* ptr(const std::shared_ptr<T>& p) {
+  return p.get();
+}
 
 template <typename It, typename Char> struct arg_join {
   It begin;

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1600,6 +1600,10 @@ TEST(FormatterTest, FormatPointer) {
   EXPECT_EQ("0x" + std::string(sizeof(void*) * CHAR_BIT / 4, 'f'),
             format("{0}", reinterpret_cast<void*>(~uintptr_t())));
   EXPECT_EQ("0x1234", format("{}", fmt::ptr(reinterpret_cast<int*>(0x1234))));
+  std::unique_ptr<int> up(new int(1));
+  EXPECT_EQ(format("{}", fmt::ptr(up.get())), format("{}", fmt::ptr(up)));
+  std::shared_ptr<int> sp(new int(1));
+  EXPECT_EQ(format("{}", fmt::ptr(sp.get())), format("{}", fmt::ptr(sp)));
 #if FMT_USE_NULLPTR
   EXPECT_EQ("0x0", format("{}", FMT_NULL));
 #endif


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

It is a bit noisy to add `.get()` when formatting unique_ptr and shared_ptr. This patch also convert `std::unique_ptr/std::shared_ptr` to `const void *` in `fmt::ptr`.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
