### PR TITLE
Mirror visibility of explicit instantiation declaration

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -727,7 +727,7 @@ template <typename T = void> struct FMT_API basic_data {
 };
 
 #if FMT_USE_EXTERN_TEMPLATES
-extern template struct basic_data<void>;
+extern template struct FMT_API basic_data<void>;
 #endif
 
 // This is a struct rather than a typedef to avoid shadowing warnings in gcc.


### PR DESCRIPTION
explicit instantiation declaration of internal::basic_data<void> should mirror visibility of FMT_API

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
