### PR TITLE
Fix DLL visibility of explicit instantiation "declaration" of internal::basic_data<void> in header format.h and the explicit instantiation "definition" in format.cc

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -189,10 +189,14 @@
 #    define FMT_API __declspec(dllexport)
 #  elif defined(FMT_SHARED)
 #    define FMT_API __declspec(dllimport)
+#    define FMT_EXTERN_TEMPLATE_API FMT_API
 #  endif
 #endif
 #ifndef FMT_API
 #  define FMT_API
+#endif
+#ifndef FMT_EXTERN_TEMPLATE_API
+#  define FMT_EXTERN_TEMPLATE_API
 #endif
 
 #ifndef FMT_ASSERT

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -199,7 +199,7 @@
 #  define FMT_EXTERN_TEMPLATE_API
 #endif
 
-#if !define(FMT_HEADER_ONLY)
+#ifndef FMT_HEADER_ONLY
 #  define FMT_EXTERN extern
 #else
 #  define FMT_EXTERN

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -199,6 +199,12 @@
 #  define FMT_EXTERN_TEMPLATE_API
 #endif
 
+#if !define(FMT_HEADER_ONLY)
+#  define FMT_EXTERN extern
+#else
+#  define FMT_EXTERN
+#endif
+
 #ifndef FMT_ASSERT
 #  define FMT_ASSERT(condition, message) assert((condition) && message)
 #endif

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -716,7 +716,7 @@ template <typename T = void> struct FMT_EXTERN_TEMPLATE_API basic_data {
   static const wchar_t WRESET_COLOR[5];
 };
 
-extern template struct basic_data<void>;
+FMT_EXTERN template struct basic_data<void>;
 
 // This is a struct rather than a typedef to avoid shadowing warnings in gcc.
 struct data : basic_data<> {};

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -169,6 +169,26 @@ FMT_END_NAMESPACE
 #  endif
 #endif
 
+#if FMT_USE_EXTERN_TEMPLATES
+#  if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
+#    ifdef FMT_EXPORT
+//     When DLL exporting an "explicit class template instantiation declaration",
+//     we should not designate __declspec(dllexport) at both 
+//     - class template definition 
+//     - explicit class template instantiation declaration.
+//     
+//     (Instead, designate __declspec(dllexport) somewhere else
+//     and only at a single point where we have
+//     the "explicit class template instantiation definition.")
+#      define FMT_EXTERN_TEMPLATE_HEADER_FILE_API
+#    endif
+#  endif
+#endif
+#ifndef FMT_EXTERN_TEMPLATE_HEADER_FILE_API
+// In other cases, we can just follow FMT_API there.
+#  define FMT_EXTERN_TEMPLATE_HEADER_FILE_API FMT_API
+#endif
+
 #if FMT_HAS_GXX_CXX11 || FMT_HAS_FEATURE(cxx_trailing_return) || \
     FMT_MSC_VER >= 1600
 #  define FMT_USE_TRAILING_RETURN 1
@@ -712,7 +732,7 @@ template <typename T> struct int_traits {
 
 // Static data is placed in this class template to allow header-only
 // configuration.
-template <typename T = void> struct FMT_API basic_data {
+template <typename T = void> struct FMT_EXTERN_TEMPLATE_HEADER_FILE_API basic_data {
   static const uint64_t POWERS_OF_10_64[];
   static const uint32_t ZERO_OR_POWERS_OF_10_32[];
   static const uint64_t ZERO_OR_POWERS_OF_10_64[];
@@ -727,7 +747,7 @@ template <typename T = void> struct FMT_API basic_data {
 };
 
 #if FMT_USE_EXTERN_TEMPLATES
-extern template struct FMT_API basic_data<void>;
+extern template struct basic_data<void>;
 #endif
 
 // This is a struct rather than a typedef to avoid shadowing warnings in gcc.

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -727,7 +727,7 @@ template <typename T = void> struct FMT_API basic_data {
 };
 
 #if FMT_USE_EXTERN_TEMPLATES
-extern template struct basic_data<void>;
+extern template struct FMT_API basic_data<void>;
 #endif
 
 // This is a struct rather than a typedef to avoid shadowing warnings in gcc.

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -159,36 +159,6 @@ FMT_END_NAMESPACE
 #  define FMT_UDL_TEMPLATE 0
 #endif
 
-#ifndef FMT_USE_EXTERN_TEMPLATES
-#  ifndef FMT_HEADER_ONLY
-#    define FMT_USE_EXTERN_TEMPLATES                           \
-      ((FMT_CLANG_VERSION >= 209 && __cplusplus >= 201103L) || \
-       (FMT_GCC_VERSION >= 303 && FMT_HAS_GXX_CXX11))
-#  else
-#    define FMT_USE_EXTERN_TEMPLATES 0
-#  endif
-#endif
-
-#if FMT_USE_EXTERN_TEMPLATES
-#  if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
-#    ifdef FMT_EXPORT
-//     When DLL exporting an "explicit class template instantiation declaration",
-//     we should not designate __declspec(dllexport) at both 
-//     - class template definition 
-//     - explicit class template instantiation declaration.
-//     
-//     (Instead, designate __declspec(dllexport) somewhere else
-//     and only at a single point where we have
-//     the "explicit class template instantiation definition.")
-#      define FMT_EXTERN_TEMPLATE_HEADER_FILE_API
-#    endif
-#  endif
-#endif
-#ifndef FMT_EXTERN_TEMPLATE_HEADER_FILE_API
-// In other cases, we can just follow FMT_API there.
-#  define FMT_EXTERN_TEMPLATE_HEADER_FILE_API FMT_API
-#endif
-
 #if FMT_HAS_GXX_CXX11 || FMT_HAS_FEATURE(cxx_trailing_return) || \
     FMT_MSC_VER >= 1600
 #  define FMT_USE_TRAILING_RETURN 1
@@ -732,7 +702,7 @@ template <typename T> struct int_traits {
 
 // Static data is placed in this class template to allow header-only
 // configuration.
-template <typename T = void> struct FMT_EXTERN_TEMPLATE_HEADER_FILE_API basic_data {
+template <typename T = void> struct FMT_EXTERN_TEMPLATE_API basic_data {
   static const uint64_t POWERS_OF_10_64[];
   static const uint32_t ZERO_OR_POWERS_OF_10_32[];
   static const uint64_t ZERO_OR_POWERS_OF_10_64[];
@@ -746,9 +716,7 @@ template <typename T = void> struct FMT_EXTERN_TEMPLATE_HEADER_FILE_API basic_da
   static const wchar_t WRESET_COLOR[5];
 };
 
-#if FMT_USE_EXTERN_TEMPLATES
 extern template struct basic_data<void>;
-#endif
 
 // This is a struct rather than a typedef to avoid shadowing warnings in gcc.
 struct data : basic_data<> {};

--- a/src/format.cc
+++ b/src/format.cc
@@ -8,7 +8,7 @@
 #include "fmt/format-inl.h"
 
 FMT_BEGIN_NAMESPACE
-template struct internal::basic_data<void>;
+template struct FMT_API internal::basic_data<void>;
 
 // Workaround a bug in MSVC2013 that prevents instantiation of grisu_format.
 bool (*instantiate_grisu_format)(double, internal::buffer<char>&, int, unsigned,


### PR DESCRIPTION
In format.h, the explicit instantiation *declaration* of internal::basic_data<void> should mirror DLL visibility of FMT_API

As the explicit instantiation *declaration* of `internal::basic_data<void>` in format.h, this explicit instantiation *definition* should mirror FMT_API also.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
