### PR TITLE
trigger assertion in to_unsigned

### DIFF
--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -296,4 +296,13 @@ TEST(ChronoTest, FormatFullSpecsQq) {
   EXPECT_EQ("*1.2340 ms*", fmt::format("{:*^11.4%Q %q}", dms(1.234)));
 }
 
+TEST(ChronoTest, InvalidWidthId) {
+  EXPECT_THROW(fmt::format("{:{o}", std::chrono::seconds(0)),
+               fmt::format_error);
+}
+
+TEST(ChronoTest, InvalidColons) {
+  EXPECT_THROW(fmt::format("{0}=:{0::", std::chrono::seconds(0)),
+               fmt::format_error);
+}
 #endif  // FMT_STATIC_THOUSANDS_SEPARATOR


### PR DESCRIPTION
The following assertion was triggered by fuzzing with chrono duration:
```
constexpr typename std::make_unsigned<_Tp>::type fmt::v5::internal::to_unsigned(Int) [with Int = long int; typename std::make_unsigned<_Tp>::type = long unsigned int]: Assertion `(value >= 0) && "negative value"' failed.
```

This pull request adds a unit test that triggers the same assertion.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
