### PR TITLE
Eliminate shadowed variable warnings from gcc-7.2

### DIFF
--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -22,7 +22,7 @@ template <class Char> class formatbuf : public std::basic_streambuf<Char> {
   buffer<Char>& buffer_;
 
  public:
-  formatbuf(buffer<Char>& buffer) : buffer_(buffer) {}
+  formatbuf(buffer<Char>& buf) : buffer_(buf) {}
 
  protected:
   // The put-area is actually always empty. This makes the implementation
@@ -72,26 +72,26 @@ template <typename T, typename Char> class is_streamable {
 // Write the content of buf to os.
 template <typename Char>
 void write(std::basic_ostream<Char>& os, buffer<Char>& buf) {
-  const Char* data = buf.data();
+  const Char* buf_data = buf.data();
   typedef std::make_unsigned<std::streamsize>::type UnsignedStreamSize;
   UnsignedStreamSize size = buf.size();
   UnsignedStreamSize max_size =
       internal::to_unsigned((std::numeric_limits<std::streamsize>::max)());
   do {
     UnsignedStreamSize n = size <= max_size ? size : max_size;
-    os.write(data, static_cast<std::streamsize>(n));
-    data += n;
+    os.write(buf_data, static_cast<std::streamsize>(n));
+    buf_data += n;
     size -= n;
   } while (size != 0);
 }
 
 template <typename Char, typename T>
-void format_value(buffer<Char>& buffer, const T& value) {
-  internal::formatbuf<Char> format_buf(buffer);
+void format_value(buffer<Char>& buf, const T& value) {
+  internal::formatbuf<Char> format_buf(buf);
   std::basic_ostream<Char> output(&format_buf);
   output.exceptions(std::ios_base::failbit | std::ios_base::badbit);
   output << value;
-  buffer.resize(buffer.size());
+  buf.resize(buf.size());
 }
 
 // Formats an object of type T that has an overloaded ostream operator<<.


### PR DESCRIPTION
The gcc-7.2.0 compiler (and others) were giving shadowed variable warnings for this include file.  A simple renaming of a couple local variables eliminates the warnings.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
