### PR TITLE
In my PC, the test failed at format-test.cc because of `non-constexpr`

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -684,7 +684,7 @@ template <int GRISU_VERSION> struct grisu_shortest_handler {
 
 template <typename Double, FMT_ENABLE_IF_T(sizeof(Double) == sizeof(uint64_t))>
 FMT_API bool grisu_format(Double value, buffer<char>& buf, int precision,
-                           unsigned options, int& exp) {
+                          unsigned options, int& exp) {
   FMT_ASSERT(value >= 0, "value is negative");
   bool fixed = (options & grisu_options::fixed) != 0;
   if (value <= 0) {  // <= instead of == to silence a warning.

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2207,7 +2207,7 @@ class format_string_checker {
   FMT_CONSTEXPR void on_replacement_field(const Char*) {}
 
   FMT_CONSTEXPR const Char* on_format_specs(const Char* begin, const Char*) {
-    context_.advance_to(begin);
+    advance_to(context_, begin);
     return arg_id_ < NUM_ARGS ? parse_funcs_[arg_id_](context_) : begin;
   }
 
@@ -3215,6 +3215,12 @@ basic_format_context<Range, Char>::arg(basic_string_view<char_type> name) {
   return arg;
 }
 
+template <typename Char, typename ErrorHandler>
+inline void advance_to(basic_parse_context<Char, ErrorHandler>& ctx,
+                       const Char* p) {
+  ctx.advance_to(ctx.begin() + (p - &*ctx.begin()));
+}
+
 template <typename ArgFormatter, typename Char, typename Context>
 struct format_handler : internal::error_handler {
   typedef typename ArgFormatter::range range;
@@ -3242,7 +3248,7 @@ struct format_handler : internal::error_handler {
   void on_arg_id(basic_string_view<Char> id) { arg = context.arg(id); }
 
   void on_replacement_field(const Char* p) {
-    parse_context.advance_to(p);
+    advance_to(parse_context, p);
     internal::custom_formatter<Context> f(parse_context, context);
     if (!visit_format_arg(f, arg))
       context.advance_to(
@@ -3250,7 +3256,7 @@ struct format_handler : internal::error_handler {
   }
 
   const Char* on_format_specs(const Char* begin, const Char* end) {
-    parse_context.advance_to(begin);
+    advance_to(parse_context, begin);
     internal::custom_formatter<Context> f(parse_context, context);
     if (visit_format_arg(f, arg)) return parse_context.begin();
     basic_format_specs<Char> specs;
@@ -3261,7 +3267,7 @@ struct format_handler : internal::error_handler {
         arg.type());
     begin = parse_format_specs(begin, end, handler);
     if (begin == end || *begin != '}') on_error("missing '}' in format string");
-    parse_context.advance_to(begin);
+    advance_to(parse_context, begin);
     context.advance_to(
         visit_format_arg(ArgFormatter(context, &parse_context, &specs), arg));
     return begin;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3216,7 +3216,7 @@ basic_format_context<Range, Char>::arg(basic_string_view<char_type> name) {
 }
 
 template <typename Char, typename ErrorHandler>
-inline void advance_to(basic_parse_context<Char, ErrorHandler>& ctx,
+FMT_CONSTEXPR inline void advance_to(basic_parse_context<Char, ErrorHandler>& ctx,
                        const Char* p) {
   ctx.advance_to(ctx.begin() + (p - &*ctx.begin()));
 }

--- a/include/fmt/prepare.h
+++ b/include/fmt/prepare.h
@@ -310,7 +310,7 @@ class prepared_format {
       const format_part_t& part) const {
     const auto view = to_string_view(format_);
     const auto specification_begin = view.data() + part.end_of_argument_id;
-    parse_ctx.advance_to(specification_begin);
+    advance_to(parse_ctx, specification_begin);
   }
 
   template <typename Range, typename Context, typename Id>


### PR DESCRIPTION
```
C:\Users\User\AppData\Roaming\fmt>ninja -j 2
[3/47] Building CXX object test\CMakeFiles\format-test.dir\format-test.cc.obj
FAILED: test/CMakeFiles/format-test.dir/format-test.cc.obj
C:\PROGRA~1\LLVM\bin\clang-cl.exe  /nologo -TP -DFMT_SHARED -DFMT_USE_FILE_DESCRIPTORS=1 -DGTEST_HAS_STD_WSTRING=1 -DGTEST_USE_OWN_TR1_TUPLE=1 -D_CRT_SECURE_NO_WARNINGS -D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING=1 -D_VARIADIC_MAX=10 -IC:\Users\User\AppData\Roaming\fmt-advance\include -IC:\Users\User\AppData\Roaming\fmt-advance\test\gtest -IC:\Users\User\AppData\Roaming\fmt-advance\test\gmock -IC:\Users\User\AppData\Roaming\fmt-advance\test\. -Xclang -std=c++2a -fms-compatibility-version=19.20.27508 --target=x86_64-pc-windows-msvc19.20.27508 /EHsc /Zc:__cplusplus /MD /O2 /Ob2 /DNDEBUG   -Wno-deprecated-declarations -std:c++latest /showIncludes /Fotest\CMakeFiles\format-test.dir\format-test.cc.obj /Fdtest\CMakeFiles\format-test.dir\ -c C:\Users\User\AppData\Roaming\fmt-advance\test\format-test.cc
C:\Users\User\AppData\Roaming\fmt-advance\test\format-test.cc(2397,3): error: static_assert expression is not an integral constant expression
  EXPECT_ERROR("{0:s", "unknown format specifier", Date);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\Users\User\AppData\Roaming\fmt-advance\test\format-test.cc(2392,19): note: expanded from macro 'EXPECT_ERROR'
    static_assert(test_error<__VA_ARGS__>(fmt, error), "")
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\Users\User\AppData\Roaming\fmt-advance\include\fmt/format.h(2210,5): note: non-constexpr function 'advance_to<char, test_error_handler>' cannot be used in a constant expression
    advance_to(context_, begin);
    ^
C:\Users\User\AppData\Roaming\fmt-advance\include\fmt/format.h(2161,21): note: in call to '&checker->on_format_specs(&"{0:s"[3], &"{0:s"[4])'
        p = handler.on_format_specs(p + 1, end);
                    ^
C:\Users\User\AppData\Roaming\fmt-advance\include\fmt/format.h(2238,3): note: in call to 'parse_format_string({&"{0:s"[0], 4}, checker)'
  parse_format_string<true>(s, checker);
  ^
C:\Users\User\AppData\Roaming\fmt-advance\test\format-test.cc(2384,3): note: in call to 'do_check_format_string({&"{0:s"[0], 4}, {actual_error})'
  fmt::internal::do_check_format_string<char, test_error_handler, Args...>(
  ^
C:\Users\User\AppData\Roaming\fmt-advance\test\format-test.cc(2397,3): note: in call to 'test_error(&"{0:s"[0], &"unknown format specifier"[0])'
  EXPECT_ERROR("{0:s", "unknown format specifier", Date);
  ^
C:\Users\User\AppData\Roaming\fmt-advance\test\format-test.cc(2392,19): note: expanded from macro 'EXPECT_ERROR'
    static_assert(test_error<__VA_ARGS__>(fmt, error), "")
                  ^
C:\Users\User\AppData\Roaming\fmt-advance\include\fmt/format.h(3219,13): note: declared here
inline void advance_to(basic_parse_context<Char, ErrorHandler>& ctx,
            ^
```

I wonder how come it passed in the AppVeyor?!

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
