### PR TITLE
Use C++ headers instead of deprecated C headers

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -10,7 +10,7 @@
 
 #include "format.h"
 
-#include <string.h>
+#include <cstring>
 
 #include <cctype>
 #include <cerrno>

--- a/include/fmt/posix.h
+++ b/include/fmt/posix.h
@@ -13,11 +13,11 @@
 #  undef __STRICT_ANSI__
 #endif
 
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>   // for O_RDONLY
-#include <locale.h>  // for locale_t
-#include <stdio.h>
-#include <stdlib.h>  // for strtod_l
+#include <clocale>  // for locale_t
+#include <cstdio>
+#include <cstdlib>  // for strtod_l
 
 #include <cstddef>
 

--- a/src/posix.cc
+++ b/src/posix.cc
@@ -12,7 +12,7 @@
 
 #include "fmt/posix.h"
 
-#include <limits.h>
+#include <climits>
 #include <sys/stat.h>
 #include <sys/types.h>
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -5,7 +5,7 @@
 //
 // For the license information refer to format.h.
 
-#include <stdint.h>
+#include <cstdint>
 #include <cctype>
 #include <cfloat>
 #include <climits>

--- a/test/posix-mock-test.cc
+++ b/test/posix-mock-test.cc
@@ -13,7 +13,7 @@
 #include "posix-mock.h"
 #include "../src/posix.cc"
 
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 #include <climits>
 #include <memory>

--- a/test/posix-mock.h
+++ b/test/posix-mock.h
@@ -8,8 +8,8 @@
 #ifndef FMT_POSIX_TEST_H
 #define FMT_POSIX_TEST_H
 
-#include <errno.h>
-#include <stdio.h>
+#include <cerrno>
+#include <cstdio>
 
 #ifdef _WIN32
 #  include <windows.h>

--- a/test/prepare-test.cc
+++ b/test/prepare-test.cc
@@ -5,7 +5,7 @@
 //
 // For the license information refer to prepare.h.
 
-#include <stdint.h>
+#include <cstdint>
 #include <cctype>
 #include <cfloat>
 #include <climits>


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.