### PR TITLE
Fixed issue with formatting to an array of chars

### DIFF
--- a/include/fmt/prepare.h
+++ b/include/fmt/prepare.h
@@ -217,7 +217,8 @@ class prepared_format {
   std::basic_string<char_type> format(const Args&... args) const {
     basic_memory_buffer<char_type> buffer;
     typedef back_insert_range<internal::buffer<char_type>> range;
-    this->vformat_to(range(buffer), make_args_checked(format_, args...));
+    this->vformat_to(range(buffer), basic_format_args<context>{
+                                        make_args_checked(format_, args...)});
     return to_string(buffer);
   }
 
@@ -226,7 +227,8 @@ class prepared_format {
       std::back_insert_iterator<Container> out, const Args&... args) const {
     internal::container_buffer<Container> buffer(internal::get_container(out));
     typedef back_insert_range<internal::buffer<char_type>> range;
-    this->vformat_to(range(buffer), make_args_checked(format_, args...));
+    this->vformat_to(range(buffer), basic_format_args<context>{
+                                        make_args_checked(format_, args...)});
     return out;
   }
 
@@ -242,18 +244,20 @@ class prepared_format {
   inline typename buffer_context<char_type>::iterator format_to(
       basic_memory_buffer<char_type, SIZE>& buf, const Args&... args) const {
     typedef back_insert_range<internal::buffer<char_type>> range;
-    return this->vformat_to(range(buf), make_args_checked(format_, args...));
+    return this->vformat_to(
+        range(buf),
+        basic_format_args<context>{make_args_checked(format_, args...)});
   }
 
  private:
   typedef buffer_context<char_type> context;
 
-  template <typename Range>
-  typename context::iterator vformat_to(Range out,
-                                        basic_format_args<context> args) const {
+  template <typename Range, typename Context>
+  auto vformat_to(Range out, basic_format_args<Context> args) const ->
+      typename Context::iterator {
     const auto format_view = internal::to_string_view(format_);
     basic_parse_context<char_type> parse_ctx(format_view);
-    context ctx(out.begin(), args);
+    Context ctx(out.begin(), args);
 
     const auto& parts = parts_provider_.parts();
     for (auto part_it = parts.begin(); part_it != parts.end(); ++part_it) {

--- a/test/prepare-test.cc
+++ b/test/prepare-test.cc
@@ -475,7 +475,7 @@ TEST(PrepareTest, CopyPreparedFormat_InternalStringViewsAreNotInvalidated) {
   }
 }
 
-TEST(PepareTest, ReusedPreparedFormatType) {
+TEST(PrepareTest, ReusedPreparedFormatType) {
   typedef fmt::prepared_format<std::string, int>::type prepared_format;
 
   prepared_format prepared = fmt::prepare<prepared_format>("The {} is {}.");
@@ -636,4 +636,59 @@ TEST(PrepareTest, PassUserTypeFormat) {
       user_format;
   const auto prepared = fmt::prepare<int>(user_format("test {}"));
   EXPECT_EQ("test 42", prepared.format(42));
+}
+
+TEST(PrepareTest, FormatToArrayOfChars) {
+  char buffer[32] = {0};
+  const auto prepared = fmt::prepare<int>("4{}");
+  prepared.format_to(buffer, 2);
+  EXPECT_EQ(std::string("42"), buffer);
+  wchar_t wbuffer[32] = {0};
+  const auto wprepared = fmt::prepare<int>(L"4{}");
+  wprepared.format_to(wbuffer, 2);
+  EXPECT_EQ(std::wstring(L"42"), wbuffer);
+}
+
+TEST(PrepareTest, FormatToIterator) {
+  std::string s(2, ' ');
+  const auto prepared = fmt::prepare<int>("4{}");
+  prepared.format_to(s.begin(), 2);
+  EXPECT_EQ("42", s);
+  std::wstring ws(2, L' ');
+  const auto wprepared = fmt::prepare<int>(L"4{}");
+  wprepared.format_to(ws.begin(), 2);
+  EXPECT_EQ(L"42", ws);
+}
+
+TEST(PrepareTest, FormatToBackInserter) {
+  std::string s;
+  const auto prepared = fmt::prepare<int>("4{}");
+  prepared.format_to(std::back_inserter(s), 2);
+  EXPECT_EQ("42", s);
+  std::wstring ws;
+  const auto wprepared = fmt::prepare<int>(L"4{}");
+  wprepared.format_to(std::back_inserter(ws), 2);
+  EXPECT_EQ(L"42", ws);
+}
+
+TEST(PrepareTest, FormatToBasicMemoryBuffer) {
+  fmt::basic_memory_buffer<char, 100> buffer;
+  const auto prepared = fmt::prepare<int>("4{}");
+  prepared.format_to(buffer, 2);
+  EXPECT_EQ("42", to_string(buffer));
+  fmt::basic_memory_buffer<wchar_t, 100> wbuffer;
+  const auto wprepared = fmt::prepare<int>(L"4{}");
+  wprepared.format_to(wbuffer, 2);
+  EXPECT_EQ(L"42", to_string(wbuffer));
+}
+
+TEST(PrepareTest, FormatToMemoryBuffer) {
+  fmt::memory_buffer buffer;
+  const auto prepared = fmt::prepare<int>("4{}");
+  prepared.format_to(buffer, 2);
+  EXPECT_EQ("42", to_string(buffer));
+  fmt::wmemory_buffer wbuffer;
+  const auto wprepared = fmt::prepare<int>(L"4{}");
+  wprepared.format_to(wbuffer, 2);
+  EXPECT_EQ(L"42", to_string(wbuffer));
 }


### PR DESCRIPTION
It should fix #1169. Added a couple of tests to prevent such issues in the future. Please, let me know if I forgot about any `prepared_format::format_to` use case.