### PR TITLE
Better compiler errors for invalid ""_format usage

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3566,14 +3566,17 @@ namespace internal {
 
 #  if FMT_USE_UDL_TEMPLATE
 template <typename Char, Char... CHARS> class udl_formatter {
- public:
   template <typename... Args>
+  FMT_CONSTEXPR11 static bool is_valid() {
+    return do_check_format_string<Char, error_handler, Args...>(
+      basic_string_view<Char>(
+        std::initializer_list<Char>{CHARS...}.begin(),
+        sizeof...(CHARS)));
+  }
+ public:
+  template <typename... Args, FMT_ENABLE_IF(is_valid<Args...>())>
   std::basic_string<Char> operator()(const Args&... args) const {
     FMT_CONSTEXPR_DECL Char s[] = {CHARS..., '\0'};
-    FMT_CONSTEXPR_DECL bool invalid_format =
-        do_check_format_string<Char, error_handler, Args...>(
-            basic_string_view<Char>(s, sizeof...(CHARS)));
-    (void)invalid_format;
     return format(s, args...);
   }
 };


### PR DESCRIPTION
In particular, this uses FMT_ENABLE_IF() to constrain the function to only
valid combinations of the format string and arguments. This ensures that there
is an actual error at the usage site, which puts the red squiggles on the
incorrect code, rather than inside the library.

This follows a pattern we've been using in our code to make templates less painful to consume.

Example new error messages:
Clang:
```
src/mongo/base/string_data_test.cpp:324:5: error: no matching function for call to object of type 'internal::udl_formatter<char, '-', '{', ':', 'z', 'z', '}', '-'>'
    "-{:zz}-"_format("abc");
    ^~~~~~~~~~~~~~~~
src/third_party/fmt/dist/include/fmt/format.h:3547:27: note: candidate template ignored: substitution failure [with Args = <char [4]>]: non-type template argument is not a constant expression
  std::basic_string<Char> operator()(const Args&... args) const {
                          ^
1 error generated.
```

g++:
```
src/mongo/base/string_data_test.cpp:324:27: error: no match for call to ‘(fmt::v5::internal::udl_formatter<char, '-', '{', ':', 'z', 'z', '}', '-'>) (const char [4])’
     "-{:zz}-"_format("abc");
                           ^
In file included from src/mongo/base/string_data.h:39,
                 from src/mongo/base/string_data_comparator_interface.h:34,
                 from src/mongo/base/simple_string_data_comparator.h:32,
                 from src/mongo/base/string_data_test.cpp:34:
src/third_party/fmt/dist/include/fmt/format.h:3547:27: note: candidate: ‘template<class ... Args, typename std::enable_if<is_valid<Args ...>(), int>::type <anonymous> > std::__cxx11::basic_string<_CharT> fmt::v5::internal::udl_formatter<Char, CHARS>::operator()(const Args& ...) const [with Args = {Args ...}; typename std::enable_if<is_valid<Args ...>(), int>::type <anonymous> = <enumerator>; Char = char; Char ...CHARS = {'-', '{', ':', 'z', 'z', '}', '-'}]’
   std::basic_string<Char> operator()(const Args&... args) const {
                           ^~~~~~~~
src/third_party/fmt/dist/include/fmt/format.h:3547:27: note:   template argument deduction/substitution failed:
src/third_party/fmt/dist/include/fmt/format.h:3546:31:   in ‘constexpr’ expansion of ‘fmt::v5::internal::udl_formatter<char, '-', '{', ':', 'z', 'z', '}', '-'>::is_valid<char [4]>()’
src/third_party/fmt/dist/include/fmt/format.h:3540:68:   in ‘constexpr’ expansion of ‘fmt::v5::internal::do_check_format_string<char, fmt::v5::internal::error_handler, char [4]>(fmt::v5::basic_string_view<char>(((std::initializer_list<char>::const_iterator)(& ._125)), 7), fmt::v5::internal::error_handler())’
src/third_party/fmt/dist/include/fmt/format.h:2210:28:   in ‘constexpr’ expansion of ‘fmt::v5::internal::parse_format_string<true, char, fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>&>(s, checker)’
src/third_party/fmt/dist/include/fmt/format.h:2133:11:   in ‘constexpr’ expansion of ‘(& handler)->fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>::on_format_specs((p + 1), end)’
src/third_party/fmt/dist/include/fmt/format.h:2183:45:   in ‘constexpr’ expansion of ‘((fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>*)this)->fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>::parse_funcs_[((fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>*)this)->fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>::arg_id_](((fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>*)this)->fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>::context_)’
src/third_party/fmt/dist/include/fmt/format.h:2152:21:   in ‘constexpr’ expansion of ‘f.fmt::v5::formatter<char [4], char, void>::parse<fmt::v5::basic_parse_context<char> >(ctx)’
src/third_party/fmt/dist/include/fmt/format.h:3070:41:   in ‘constexpr’ expansion of ‘fmt::v5::internal::handle_cstring_type_spec<char, fmt::v5::internal::cstring_type_checker<fmt::v5::internal::error_handler> >(((int)type_spec), fmt::v5::internal::cstring_type_checker<fmt::v5::internal::error_handler>(fmt::v5::internal::error_handler(((const fmt::v5::internal::error_handler&)(& eh)))))’
src/third_party/fmt/dist/include/fmt/format.h:1263:5: error: call to non-‘constexpr’ function ‘void fmt::v5::internal::error_handler::on_error(const char*)’
     handler.on_error("invalid type specifier");
     ^~~~~~~
In file included from src/third_party/fmt/dist/include/fmt/format.h:60,
                 from src/mongo/base/string_data.h:39,
                 from src/mongo/base/string_data_comparator_interface.h:34,
                 from src/mongo/base/simple_string_data_comparator.h:32,
                 from src/mongo/base/string_data_test.cpp:34:
src/third_party/fmt/dist/include/fmt/format.h:3546:62: note: in template argument for type ‘bool’
   template <typename... Args, FMT_ENABLE_IF(is_valid<Args...>())>
                                             ~~~~~~~~~~~~~~~~~^~
src/third_party/fmt/dist/include/fmt/core.h:213:52: note: in definition of macro ‘FMT_ENABLE_IF’
 #define FMT_ENABLE_IF(...) typename std::enable_if<__VA_ARGS__, int>::type = 0
```

Old error messages for same code:
Clang:
```
In file included from src/mongo/base/string_data_test.cpp:34:
In file included from src/mongo/base/simple_string_data_comparator.h:32:
In file included from src/mongo/base/string_data_comparator_interface.h:34:
In file included from src/mongo/base/string_data.h:39:
src/third_party/fmt/dist/include/fmt/format.h:3542:29: error: constexpr variable 'invalid_format' must be initialized by a constant expression
    FMT_CONSTEXPR_DECL bool invalid_format =
                            ^
src/mongo/base/string_data_test.cpp:324:21: note: in instantiation of function template specialization 'fmt::v5::internal::udl_formatter<char, '-', '{', ':', 'z', 'z', '}', '-'>::operator()<char [4]>' requested here
    "-{:zz}-"_format("abc");
                    ^
src/third_party/fmt/dist/include/fmt/format.h:1263:13: note: non-constexpr function 'on_error' cannot be used in a constant expression
    handler.on_error("invalid type specifier");
            ^
src/third_party/fmt/dist/include/fmt/format.h:3070:7: note: in call to 'handle_cstring_type_spec(122, internal::cstring_type_checker<decltype(eh)>(eh))'
      internal::handle_cstring_type_spec(
      ^
src/third_party/fmt/dist/include/fmt/format.h:2152:12: note: in call to '&f->parse(checker.context_)'
  return f.parse(ctx);
           ^
src/third_party/fmt/dist/include/fmt/format.h:2183:33: note: in call to 'parse_format_specs(checker.context_)'
    return arg_id_ < NUM_ARGS ? parse_funcs_[arg_id_](context_) : begin;
                                ^
src/third_party/fmt/dist/include/fmt/format.h:2133:21: note: in call to '&checker->on_format_specs(&s[3], &s[7])'
        p = handler.on_format_specs(p + 1, end);
                    ^
src/third_party/fmt/dist/include/fmt/format.h:2210:3: note: in call to 'parse_format_string({&s[0], 7}, checker)'
  parse_format_string<true>(s, checker);
  ^
src/third_party/fmt/dist/include/fmt/format.h:3543:9: note: in call to 'do_check_format_string({&s[0], 7}, {})'
        do_check_format_string<Char, error_handler, Args...>(
        ^
src/third_party/fmt/dist/include/fmt/core.h:356:16: note: declared here
  FMT_API void on_error(const char* message);
               ^
1 error generated.
```

gcc:
```
In file included from src/mongo/base/string_data.h:39,
                 from src/mongo/base/string_data_comparator_interface.h:34,
                 from src/mongo/base/simple_string_data_comparator.h:32,
                 from src/mongo/base/string_data_test.cpp:34:
src/third_party/fmt/dist/include/fmt/format.h: In instantiation of ‘std::__cxx11::basic_string<_CharT> fmt::v5::internal::udl_formatter<Char, CHARS>::operator()(const Args& ...) const [with Args = {char [4]}; Char = char; Char ...CHARS = {'-', '{', ':', 'z', 'z', '}', '-'}]’:
src/mongo/base/string_data_test.cpp:324:27:   required from here
src/third_party/fmt/dist/include/fmt/format.h:3543:61:   in ‘constexpr’ expansion of ‘fmt::v5::internal::do_check_format_string<char, fmt::v5::internal::error_handler, char [4]>(fmt::v5::basic_string_view<char>(((const char*)(& s)), 7), fmt::v5::internal::error_handler())’
src/third_party/fmt/dist/include/fmt/format.h:2210:28:   in ‘constexpr’ expansion of ‘fmt::v5::internal::parse_format_string<true, char, fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>&>(s, checker)’
src/third_party/fmt/dist/include/fmt/format.h:2133:11:   in ‘constexpr’ expansion of ‘(& handler)->fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>::on_format_specs((p + 1), end)’
src/third_party/fmt/dist/include/fmt/format.h:2183:45:   in ‘constexpr’ expansion of ‘((fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>*)this)->fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>::parse_funcs_[((fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>*)this)->fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>::arg_id_](((fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>*)this)->fmt::v5::internal::format_string_checker<char, fmt::v5::internal::error_handler, char [4]>::context_)’
src/third_party/fmt/dist/include/fmt/format.h:2152:21:   in ‘constexpr’ expansion of ‘f.fmt::v5::formatter<char [4], char, void>::parse<fmt::v5::basic_parse_context<char> >(ctx)’
src/third_party/fmt/dist/include/fmt/format.h:3070:41:   in ‘constexpr’ expansion of ‘fmt::v5::internal::handle_cstring_type_spec<char, fmt::v5::internal::cstring_type_checker<fmt::v5::internal::error_handler> >(((int)type_spec), fmt::v5::internal::cstring_type_checker<fmt::v5::internal::error_handler>(fmt::v5::internal::error_handler(((const fmt::v5::internal::error_handler&)(& eh)))))’
src/third_party/fmt/dist/include/fmt/format.h:1263:5: error: call to non-‘constexpr’ function ‘void fmt::v5::internal::error_handler::on_error(const char*)’
     handler.on_error("invalid type specifier");
     ^~~~~~~
```
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

**ACK:** I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.


