### PR TITLE
inlines count_code_points(basic_string_view<char8_t>)

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -200,15 +200,6 @@ void report_error(FormatFunc func, int error_code,
 }
 }  // namespace
 
-FMT_FUNC size_t internal::count_code_points(basic_string_view<char8_t> s) {
-  const char8_t* data = s.data();
-  size_t num_code_points = 0;
-  for (size_t i = 0, size = s.size(); i != size; ++i) {
-    if ((data[i] & 0xc0) != 0x80) ++num_code_points;
-  }
-  return num_code_points;
-}
-
 #if !defined(FMT_STATIC_THOUSANDS_SEPARATOR)
 namespace internal {
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -766,7 +766,14 @@ inline size_t count_code_points(basic_string_view<Char> s) {
 }
 
 // Counts the number of code points in a UTF-8 string.
-FMT_API size_t count_code_points(basic_string_view<char8_t> s);
+inline size_t count_code_points(basic_string_view<char8_t> s) {
+  const char8_t* data = s.data();
+  size_t num_code_points = 0;
+  for (size_t i = 0, size = s.size(); i != size; ++i) {
+    if ((data[i] & 0xc0) != 0x80) ++num_code_points;
+  }
+  return num_code_points;
+}
 
 inline char8_t to_char8_t(char c) { return static_cast<char8_t>(c); }
 


### PR DESCRIPTION
count_code_points(basic_string_view<char8_t>) was defined in
fmt/format-inl.h, and only declared in fmt/format.h, but not defined
in src/format.cc. This commit moves the overload to fmt/format.h and
inlines it.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
