### PR TITLE
Remove const qualification in compile-time checks

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -198,6 +198,8 @@ using conditional_t = typename std::conditional<B, T, F>::type;
 template <bool B> using bool_constant = std::integral_constant<bool, B>;
 template <typename T>
 using remove_reference_t = typename std::remove_reference<T>::type;
+template <typename T>
+using remove_const_t = typename std::remove_const<T>::type;
 
 struct monostate {};
 
@@ -1273,7 +1275,7 @@ make_args_checked(const S& format_str,
   static_assert(all_true<(!std::is_base_of<view, remove_reference_t<Args>>() ||
                           !std::is_reference<Args>())...>::value,
                 "passing views as lvalues is disallowed");
-  check_format_string<remove_reference_t<Args>...>(format_str);
+  check_format_string<remove_const_t<remove_reference_t<Args>>...>(format_str);
   return {args...};
 }
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1854,6 +1854,14 @@ TEST(FormatTest, CompileTimeString) {
   EXPECT_EQ("foo", fmt::format(FMT_STRING("{}"), string_like()));
 }
 
+TEST(FormatTest, CustomFormatCompileTimeString) {
+  EXPECT_EQ("42", fmt::format(FMT_STRING("{}"), Answer()));
+  Answer answer;
+  EXPECT_EQ("42", fmt::format(FMT_STRING("{}"), answer));
+  const Answer const_answer;
+  EXPECT_EQ("42", fmt::format(FMT_STRING("{}"), const_answer));
+}
+
 #if FMT_USE_USER_DEFINED_LITERALS
 // Passing user-defined literals directly to EXPECT_EQ causes problems
 // with macro argument stringification (#) on some versions of GCC.


### PR DESCRIPTION
A regression appeared in dd8cc8b for compile-time checking of const references.

Prior to dd8cc8b, all callers of `make_args_checked` had the equivalent of `remove_const_t` and `remove_reference_t` via parameter type deduction. Now only `remove_reference_t` is present which means custom type formatter specializations will not be selected unless they have been explicitly specialized with a const type. I am assuming that this is not the intended behavior and have added `remove_const_t` in addition to `remove_reference_t`.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
