### PR TITLE
Opt-in macro to enforce use of compile-time format strings

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1256,7 +1256,13 @@ template <typename T, typename Char> struct named_arg : named_arg_base<Char> {
 };
 
 template <typename..., typename S, FMT_ENABLE_IF(!is_compile_string<S>::value)>
-inline void check_format_string(const S&) {}
+inline void check_format_string(const S&) {
+#if defined(FMT_ENFORCE_COMPILE_STRING)
+  static_assert(is_compile_string<S>::value,
+                "FMT_ENFORCE_COMPILE_STRING requires all format strings to "
+                "utilize FMT_STRING() or fmt().");
+#endif
+}
 template <typename..., typename S, FMT_ENABLE_IF(is_compile_string<S>::value)>
 void check_format_string(S);
 


### PR DESCRIPTION
This adds an opt-in macro `FMT_ENFORCE_COMPILE_STRING` to ensure universal usage of compile strings. Some projects may wish to enable this policy in order to catch issues that would otherwise manifest at runtime.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
