### PR TITLE
Use `FMT_THROW` in fmt/color.h.

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -237,7 +237,7 @@ class text_style {
       foreground_color = rhs.foreground_color;
     } else if (rhs.set_foreground_color) {
       if (!foreground_color.is_rgb || !rhs.foreground_color.is_rgb)
-        throw format_error("can't OR a terminal color");
+        FMT_THROW(format_error("can't OR a terminal color"));
       foreground_color.value.rgb_color |= rhs.foreground_color.value.rgb_color;
     }
 
@@ -246,7 +246,7 @@ class text_style {
       background_color = rhs.background_color;
     } else if (rhs.set_background_color) {
       if (!background_color.is_rgb || !rhs.background_color.is_rgb)
-        throw format_error("can't OR a terminal color");
+        FMT_THROW(format_error("can't OR a terminal color"));
       background_color.value.rgb_color |= rhs.background_color.value.rgb_color;
     }
 
@@ -266,7 +266,7 @@ class text_style {
       foreground_color = rhs.foreground_color;
     } else if (rhs.set_foreground_color) {
       if (!foreground_color.is_rgb || !rhs.foreground_color.is_rgb)
-        throw format_error("can't AND a terminal color");
+        FMT_THROW(format_error("can't AND a terminal color"));
       foreground_color.value.rgb_color &= rhs.foreground_color.value.rgb_color;
     }
 
@@ -275,7 +275,7 @@ class text_style {
       background_color = rhs.background_color;
     } else if (rhs.set_background_color) {
       if (!background_color.is_rgb || !rhs.background_color.is_rgb)
-        throw format_error("can't AND a terminal color");
+        FMT_THROW(format_error("can't AND a terminal color"));
       background_color.value.rgb_color &= rhs.background_color.value.rgb_color;
     }
 


### PR DESCRIPTION
This allows fmt to be compiled with `-fno-exceptions`.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
