### PR TITLE
Fix typo in usage.rst

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -79,7 +79,7 @@ You can detect and use an installed version of {fmt} as follows::
    find_package(fmt)
    target_link_libraries(<your-target> fmt::fmt)
 
-Setting up your target to use a header-only version of ``fmt`` is equaly easy::
+Setting up your target to use a header-only version of ``fmt`` is equally easy::
 
    target_link_libraries(<your-target> PRIVATE fmt-header-only)
 


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
