### PR TITLE
User-defined literals improvements

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3455,13 +3455,13 @@ namespace internal {
 template <typename Char, Char... CHARS> class udl_formatter {
  public:
   template <typename... Args>
-  std::basic_string<Char> operator()(const Args&... args) const {
+  std::basic_string<Char> operator()(Args&&... args) const {
     FMT_CONSTEXPR_DECL Char s[] = {CHARS..., '\0'};
     FMT_CONSTEXPR_DECL bool invalid_format =
         do_check_format_string<Char, error_handler, Args...>(
             basic_string_view<Char>(s, sizeof...(CHARS)));
     (void)invalid_format;
-    return format(s, args...);
+    return format(s, std::forward<Args>(args)...);
   }
 };
 #  else

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3527,11 +3527,13 @@ FMT_CONSTEXPR internal::udl_formatter<wchar_t> operator"" _format(
     fmt::print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
   \endrst
  */
-inline internal::udl_arg<char> operator"" _a(const char* s, std::size_t) {
-  return {s};
+FMT_CONSTEXPR internal::udl_arg<char> operator"" _a(const char* s,
+                                                    std::size_t n) {
+  return {{s, n}};
 }
-inline internal::udl_arg<wchar_t> operator"" _a(const wchar_t* s, std::size_t) {
-  return {s};
+FMT_CONSTEXPR internal::udl_arg<wchar_t> operator"" _a(const wchar_t* s,
+                                                       std::size_t n) {
+  return {{s, n}};
 }
 }  // namespace literals
 #endif  // FMT_USE_USER_DEFINED_LITERALS

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3466,7 +3466,7 @@ template <typename Char, Char... CHARS> class udl_formatter {
 };
 #  else
 template <typename Char> struct udl_formatter {
-  const Char* str;
+  basic_string_view<Char> str;
 
   template <typename... Args>
   auto operator()(Args&&... args) const
@@ -3477,7 +3477,7 @@ template <typename Char> struct udl_formatter {
 #  endif  // FMT_USE_UDL_TEMPLATE
 
 template <typename Char> struct udl_arg {
-  const Char* str;
+  basic_string_view<Char> str;
 
   template <typename T> named_arg<T, Char> operator=(T&& value) const {
     return {str, std::forward<T>(value)};
@@ -3508,13 +3508,13 @@ FMT_CONSTEXPR internal::udl_formatter<Char, CHARS...> operator""_format() {
     std::string message = "The answer is {}"_format(42);
   \endrst
  */
-inline internal::udl_formatter<char> operator"" _format(const char* s,
-                                                        std::size_t) {
-  return {s};
+FMT_CONSTEXPR internal::udl_formatter<char> operator"" _format(const char* s,
+                                                               std::size_t n) {
+  return {{s, n}};
 }
-inline internal::udl_formatter<wchar_t> operator"" _format(const wchar_t* s,
-                                                           std::size_t) {
-  return {s};
+FMT_CONSTEXPR internal::udl_formatter<wchar_t> operator"" _format(
+    const wchar_t* s, std::size_t n) {
+  return {{s, n}};
 }
 #  endif  // FMT_USE_UDL_TEMPLATE
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3469,8 +3469,7 @@ template <typename Char> struct udl_formatter {
   basic_string_view<Char> str;
 
   template <typename... Args>
-  auto operator()(Args&&... args) const
-      -> decltype(format(str, std::forward<Args>(args)...)) {
+  std::basic_string<Char> operator()(Args&&... args) const {
     return format(str, std::forward<Args>(args)...);
   }
 };


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

This is a few couple improvements to literals formatting API.
- It uses forwarding references in the UDL template version instead of const references.
- Simplifies the overly verbose return type of `udl_formatter`.
- Makes use of `basic_string_view` to store the format string and argument name instead of raw character pointers.
- Makes all the literal operators `constexpr`.
- ~~Adds the possibility of defining `FMT_USING_LITERALS` to allow all code at a project level to use the `_format` and `_a` operator.~~