### PR TITLE
Add FMT_NOEXCEPT to basic_string_view constructor

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -262,7 +262,7 @@ template <typename Char> class basic_string_view {
     the size with ``std::char_traits<Char>::length``.
     \endrst
    */
-  basic_string_view(const Char* s)
+  basic_string_view(const Char* s) FMT_NOEXCEPT
       : data_(s), size_(std::char_traits<Char>::length(s)) {}
 
   /** Constructs a string reference from a ``std::basic_string`` object. */


### PR DESCRIPTION
This solves clang-tidy warnings when creating static string_view objects (https://github.com/gabime/spdlog/issues/1170), by adding `FMT_NOEXCEPT` to the `basic_string_view(const Char* s)` constructor.

It seems safe because ```std::char_traits<Char>::length(s)``` never throws according to the [standard](https://en.cppreference.com/w/cpp/string/char_traits/length).

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
