### PR TITLE
Fix documentation for importing header only target with CMake

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -81,7 +81,7 @@ You can detect and use an installed version of {fmt} as follows::
 
 Setting up your target to use a header-only version of ``fmt`` is equally easy::
 
-   target_link_libraries(<your-target> PRIVATE fmt-header-only)
+   target_link_libraries(<your-target> PRIVATE fmt::fmt-header-only)
 
 Building the Documentation
 ==========================


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.