### PR TITLE
Add out-of-the-box support for compiling with Intel Compiler v19.0

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -119,7 +119,7 @@
 #endif
 
 #ifndef FMT_DEPRECATED
-#  if defined(__INTEL_COMPILER)
+#  if defined(__INTEL_COMPILER) // Tested with Intel Compiler v19.0 at all available language levels.
 #    define FMT_DEPRECATED [[gnu::deprecated]]
 #  elif (FMT_HAS_CPP_ATTRIBUTE(deprecated) && __cplusplus >= 201402L) || \
       FMT_MSC_VER >= 1900

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -119,17 +119,17 @@
 #endif
 
 #ifndef FMT_DEPRECATED
-#  if (FMT_HAS_CPP_ATTRIBUTE(deprecated) && __cplusplus >= 201402L) || \
+#  if defined(__INTEL_COMPILER)
+#    define FMT_DEPRECATED [[gnu::deprecated]]
+#  elif (FMT_HAS_CPP_ATTRIBUTE(deprecated) && __cplusplus >= 201402L) || \
       FMT_MSC_VER >= 1900
 #    define FMT_DEPRECATED [[deprecated]]
+#  elif defined(__GNUC__) || defined(__clang__)
+#    define FMT_DEPRECATED __attribute__((deprecated))
+#  elif FMT_MSC_VER
+#    define FMT_DEPRECATED __declspec(deprecated)
 #  else
-#    if defined(__GNUC__) || defined(__clang__)
-#      define FMT_DEPRECATED __attribute__((deprecated))
-#    elif FMT_MSC_VER
-#      define FMT_DEPRECATED __declspec(deprecated)
-#    else
-#      define FMT_DEPRECATED /* deprecated */
-#    endif
+#    define FMT_DEPRECATED /* deprecated */
 #  endif
 #endif
 


### PR DESCRIPTION
PR for Issue #1273.

Out of the box, the Intel Compiler v19.0 does not understand the `[[deprecated]]` attribute and generates a compiler error: 

```
1>.\DemoFmt\github\fmt\include\fmt\core.h(478): error : attribute does not apply to any entity
1>  using wparse_context FMT_DEPRECATED = basic_parse_context<wchar_t>;
1>                       ^
```

However, it does accept the `[[gnu:deprecated]]` attribute.

I have updated the following StackOverflow question to document this:
https://stackoverflow.com/questions/295120/c-mark-as-deprecated/57680802#57680802

Tested with the following language levels:

* C++17 Support (/Qstd=c++17)
* C++14 Support (/Qstd=c++14)
* C++11 Support (/Qstd=c++11)
* C11 Support (/Qstd=c11)
* C99 Support (/Qstd=c99)

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
