### PR TITLE
Import test for CUDA project

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -133,15 +133,8 @@
 #  endif
 #endif
 
-// Workaround broken [[deprecated]] in the Intel compiler.
-#ifdef __INTEL_COMPILER
-#  define FMT_DEPRECATED_ALIAS
-#else
-#  define FMT_DEPRECATED_ALIAS FMT_DEPRECATED
-#endif
-
-// Workaround broken [[deprecated]] for the NVCC (CUDA with C++14)
-#if defined(__NVCC__) || defined(__CUDACC__)
+// Workaround broken [[deprecated]] in the Intel compiler and NVCC
+#if defined(__INTEL_COMPILER) || defined(__NVCC__) || defined(__CUDACC__)
 #  define FMT_DEPRECATED_ALIAS
 #else
 #  define FMT_DEPRECATED_ALIAS FMT_DEPRECATED

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -132,8 +132,16 @@
 #    endif
 #  endif
 #endif
+
 // Workaround broken [[deprecated]] in the Intel compiler.
 #ifdef __INTEL_COMPILER
+#  define FMT_DEPRECATED_ALIAS
+#else
+#  define FMT_DEPRECATED_ALIAS FMT_DEPRECATED
+#endif
+
+// Workaround broken [[deprecated]] for the NVCC (CUDA with C++14)
+#if defined(__NVCC__) || defined(__CUDACC__)
 #  define FMT_DEPRECATED_ALIAS
 #else
 #  define FMT_DEPRECATED_ALIAS FMT_DEPRECATED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -232,15 +232,6 @@ endif ()
 #
 find_package(CUDA 9.0)
 if(CUDA_FOUND)
-  add_test(cuda-test ${CMAKE_CTEST_COMMAND}
-    -C ${CMAKE_BUILD_TYPE}
-    --build-and-test
-    "${CMAKE_CURRENT_SOURCE_DIR}/cuda-test"
-    "${CMAKE_CURRENT_BINARY_DIR}/cuda-test"
-    --build-generator ${CMAKE_GENERATOR}
-    --build-makeprogram ${CMAKE_MAKE_PROGRAM}
-    --build-options
-      "-DFMT_DIR=${PROJECT_BINARY_DIR}"
-      "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-  )
+  add_subdirectory(cuda-test)
+  add_test(NAME cuda-test COMMAND fmt-in-cuda-test)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -225,3 +225,22 @@ if (FMT_PEDANTIC AND NOT WIN32)
     "-DPEDANTIC_COMPILE_FLAGS=${PEDANTIC_COMPILE_FLAGS}"
     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
 endif ()
+
+#
+# Activate CUDA related tests (Optional)
+# if and only if we can find the CUDA in current CMake run.
+#
+find_package(CUDA 9.2)
+if(CUDA_FOUND)
+  add_test(cuda-test ${CMAKE_CTEST_COMMAND}
+    -C ${CMAKE_BUILD_TYPE}
+    --build-and-test
+    "${CMAKE_CURRENT_SOURCE_DIR}/cuda-test"
+    "${CMAKE_CURRENT_BINARY_DIR}/cuda-test"
+    --build-generator ${CMAKE_GENERATOR}
+    --build-makeprogram ${CMAKE_MAKE_PROGRAM}
+    --build-options
+      "-DFMT_DIR=${PROJECT_BINARY_DIR}"
+      "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+  )
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -227,10 +227,10 @@ if (FMT_PEDANTIC AND NOT WIN32)
 endif ()
 
 #
-# Activate CUDA related tests (Optional)
-# if and only if we can find the CUDA in current CMake run.
+# Activate CUDA related tests if we can find CUDA from CMake. This is optional.
+# For version selection, see https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#cpp14-language-features
 #
-find_package(CUDA 9.2)
+find_package(CUDA 9.0)
 if(CUDA_FOUND)
   add_test(cuda-test ${CMAKE_CTEST_COMMAND}
     -C ${CMAKE_BUILD_TYPE}

--- a/test/cuda-test/CMakeLists.txt
+++ b/test/cuda-test/CMakeLists.txt
@@ -10,20 +10,26 @@
 # And we can't sure most of the CUDA projects are using those latest
 # because the latest C++ standard for NVCC is C++ 14 at this moment.
 #
-# In conclusion, this test will use older version of CMake,
-# and rely on 'find_package(CUDA)'. For its version, do follow the Root CMakeLists.txt.
+# In conclusion, 
+# this test should follow the version of the Root CMakeLists.txt 
+# and rely on 'find_package(CUDA)'. 
 #
 
+#
+# This part is for future update
 #
 # cmake_minimum_required(VERSION 3.10)
 # project(fmt-cuda-test LANGUAGES CXX CUDA) # see 'enable_language(CUDA)'
-cmake_minimum_required(VERSION 3.1) # for C++ 14
+#
+
+# Follow the Root CMakeLists.txt
+cmake_minimum_required(VERSION 3.1) 
 project(fmt-cuda-test LANGUAGES CXX)
 
-# find from ${PROJECT_BINARY_DIR}
+# See 'test/CMakeLists.txt'. It's using ${PROJECT_BINARY_DIR}
 find_package(FMT    REQUIRED) 
 
-# The environment variables(CUDA_BIN_PATH & CUDA_PATH) must be specified at this point
+# The environment variables (CUDA_BIN_PATH & CUDA_PATH) must be specified
 find_package(CUDA   REQUIRED)
 
 #
@@ -44,12 +50,12 @@ endif()
 
 #
 # In this test, we will assume that 
-# the user is going to pre-compile CUDA source codes
-# with some libraries (including this 'fmt').
+# the user is going to compile CUDA source codes with some libraries.
+# Of course, it's 'fmt' in this case.
 #
 # In addition to that, 
-# this test will invoke both C++ Host compiler and NVCC 
-# by providing another (non-CUDA) C++ source code
+# this test will invoke both C++ Host compiler and NVCC by providing 
+# another (non-CUDA) C++ source code
 #
 cuda_add_executable(fmt-in-cuda-test
     cuda-cpp14.cu
@@ -62,12 +68,11 @@ cuda_add_executable(fmt-in-cuda-test
 set_target_properties(fmt-in-cuda-test
 PROPERTIES
     CXX_STANDARD 14 # Notice this is for C++ code
-    POSITION_INDEPENDENT_CODE ON
 )
-# target_compile_features(fmt-in-cuda-test
-# PRIVATE
-#     cxx_std_14 # just make sure of the property is available
-# )
+target_compile_features(fmt-in-cuda-test
+PRIVATE
+    cxx_std_14 # just make sure of the property
+)
 
 get_target_property(cuda_standard 
     fmt-in-cuda-test CUDA_STANDARD
@@ -91,10 +96,13 @@ target_link_libraries(fmt-in-cuda-test
 
 if(MSVC)
     #
-    # MSVC places incorrect '__cplusplus' macro. Follow the guideline.
+    # This part is for (non-CUDA) C++ code.
+    # MSVC can define incorrect '__cplusplus' macro. 
+    # Fix for the issue is to use additional compiler flag. 
     #
-    # https://github.com/Microsoft/vscode-cpptools/issues/2595
+    # See Also:
     # https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+    # https://github.com/Microsoft/vscode-cpptools/issues/2595
     #
     target_compile_options(fmt-in-cuda-test
     PRIVATE

--- a/test/cuda-test/CMakeLists.txt
+++ b/test/cuda-test/CMakeLists.txt
@@ -1,0 +1,104 @@
+
+#
+# We can find some usecases which follows the guide of CMake.
+# The way replaces 'find_package(CUDA)' to 'enable_language(CUDA)'.
+# And let the CMake built-in functions to use NVCC.
+#
+# See: https://cmake.org/cmake/help/latest/module/FindCUDA.html#replacement
+#
+# However, such CMake versions are pretty high (3.10 or later).
+# And we can't sure most of the CUDA projects are using those latest
+# because the latest C++ standard for NVCC is C++ 14 at this moment.
+#
+# In conclusion, this test will use older version of CMake,
+# and rely on 'find_package(CUDA)'. For its version, do follow the Root CMakeLists.txt.
+#
+
+#
+# cmake_minimum_required(VERSION 3.10)
+# project(fmt-cuda-test LANGUAGES CXX CUDA) # see 'enable_language(CUDA)'
+cmake_minimum_required(VERSION 3.1) # for C++ 14
+project(fmt-cuda-test LANGUAGES CXX)
+
+# find from ${PROJECT_BINARY_DIR}
+find_package(FMT    REQUIRED) 
+
+# The environment variables(CUDA_BIN_PATH & CUDA_PATH) must be specified at this point
+find_package(CUDA   REQUIRED)
+
+#
+# Update these when NVCC becomes ready for C++ 17 features
+# https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#cpp14-language-features
+#
+set(CMAKE_CUDA_STANDARD 14)
+set(CMAKE_CUDA_STANDARD_REQUIRED 14)
+
+list(APPEND CUDA_NVCC_FLAGS "-std=c++14")
+if(MSVC)
+    # this is the solution of pytorch
+    #   https://github.com/pytorch/pytorch/pull/7118
+    list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "/std:c++14")
+    list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "/Zc:__cplusplus")
+    # for the reason of this -Xcompiler options, see below ...
+endif()
+
+#
+# In this test, we will assume that 
+# the user is going to pre-compile CUDA source codes
+# with some libraries (including this 'fmt').
+#
+# In addition to that, 
+# this test will invoke both C++ Host compiler and NVCC 
+# by providing another (non-CUDA) C++ source code
+#
+cuda_add_executable(fmt-in-cuda-test
+    cuda-cpp14.cu
+    cpp14.cc
+)
+
+#
+# https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html
+#
+set_target_properties(fmt-in-cuda-test
+PROPERTIES
+    CXX_STANDARD 14 # Notice this is for C++ code
+    POSITION_INDEPENDENT_CODE ON
+)
+# target_compile_features(fmt-in-cuda-test
+# PRIVATE
+#     cxx_std_14 # just make sure of the property is available
+# )
+
+get_target_property(cuda_standard 
+    fmt-in-cuda-test CUDA_STANDARD
+)
+message(STATUS "cuda_standard:          ${cuda_standard}")
+
+get_target_property(cuda_standard_required
+    fmt-in-cuda-test CUDA_STANDARD_REQUIRED
+)
+message(STATUS "cuda_standard_required: ${cuda_standard_required}")
+
+#
+# https://cmake.org/cmake/help/latest/module/FindCUDA.html
+#
+# From the document, you can see "The default is to use no keyword"
+#
+target_link_libraries(fmt-in-cuda-test
+# PUBLIC
+    fmt::fmt
+)
+
+if(MSVC)
+    #
+    # MSVC places incorrect '__cplusplus' macro. Follow the guideline.
+    #
+    # https://github.com/Microsoft/vscode-cpptools/issues/2595
+    # https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+    #
+    target_compile_options(fmt-in-cuda-test
+    PRIVATE
+        /Zc:__cplusplus
+        /permissive-
+    )
+endif()

--- a/test/cuda-test/CMakeLists.txt
+++ b/test/cuda-test/CMakeLists.txt
@@ -24,13 +24,10 @@
 
 # Follow the Root CMakeLists.txt
 cmake_minimum_required(VERSION 3.1) 
-project(fmt-cuda-test LANGUAGES CXX)
 
-# See 'test/CMakeLists.txt'. It's using ${PROJECT_BINARY_DIR}
-find_package(FMT    REQUIRED) 
-
-# The environment variables (CUDA_BIN_PATH & CUDA_PATH) must be specified
-find_package(CUDA   REQUIRED)
+# We already knows the packages. This part shows example.
+# find_package(CUDA 9.0 REQUIRED)
+# find_package(FMT  6.0 REQUIRED)
 
 #
 # Update these when NVCC becomes ready for C++ 17 features
@@ -39,6 +36,9 @@ find_package(CUDA   REQUIRED)
 set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CUDA_STANDARD_REQUIRED 14)
 
+#
+# https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html
+#
 list(APPEND CUDA_NVCC_FLAGS "-std=c++14")
 if(MSVC)
     # this is the solution of pytorch
@@ -62,27 +62,20 @@ cuda_add_executable(fmt-in-cuda-test
     cpp14.cc
 )
 
-#
-# https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html
-#
-set_target_properties(fmt-in-cuda-test
-PROPERTIES
-    CXX_STANDARD 14 # Notice this is for C++ code
-)
 target_compile_features(fmt-in-cuda-test
 PRIVATE
     cxx_std_14 # just make sure of the property
 )
 
-get_target_property(cuda_standard 
+get_target_property(IN_USE_CUDA_STANDARD 
     fmt-in-cuda-test CUDA_STANDARD
 )
-message(STATUS "cuda_standard:          ${cuda_standard}")
+message(STATUS "cuda_standard:          ${IN_USE_CUDA_STANDARD}")
 
-get_target_property(cuda_standard_required
+get_target_property(IN_USE_CUDA_STANDARD_REQUIRED
     fmt-in-cuda-test CUDA_STANDARD_REQUIRED
 )
-message(STATUS "cuda_standard_required: ${cuda_standard_required}")
+message(STATUS "cuda_standard_required: ${IN_USE_CUDA_STANDARD_REQUIRED}")
 
 #
 # https://cmake.org/cmake/help/latest/module/FindCUDA.html

--- a/test/cuda-test/cpp14.cc
+++ b/test/cuda-test/cpp14.cc
@@ -1,8 +1,14 @@
 
 #include <fmt/core.h>
 
-static_assert(__cplusplus >= 201402L, "expect C++ 2014");
+//
+// The purpose of this part is to ensure NVCC's host compiler also supports
+// the standard version. See 'cuda-cpp14.cu'.
+//
+// https://en.cppreference.com/w/cpp/preprocessor/replace#Predefined_macros
+//
+static_assert(__cplusplus >= 201402L, "expect C++ 2014 for host compiler");
 
-auto make_message_cpp() -> std::string{
-    return fmt::format("host compiler\t: __cplusplus == {}", __cplusplus);
+auto make_message_cpp() -> std::string {
+  return fmt::format("host compiler \t: __cplusplus == {}", __cplusplus);
 }

--- a/test/cuda-test/cpp14.cc
+++ b/test/cuda-test/cpp14.cc
@@ -1,0 +1,8 @@
+
+#include <fmt/core.h>
+
+static_assert(__cplusplus >= 201402L, "expect C++ 2014");
+
+auto make_message_cpp() -> std::string{
+    return fmt::format("host compiler\t: __cplusplus == {}", __cplusplus);
+}

--- a/test/cuda-test/cuda-cpp14.cu
+++ b/test/cuda-test/cuda-cpp14.cu
@@ -1,16 +1,31 @@
 
 //
-//  nvcc -x cu -std=c++14 ..\test\cuda-test\include_test.cu -I"../include" -Xcompiler /Zc:__cplusplus  -l"fmtd" -L"../build/Debug"
+//  Direct NVCC command line example:
+//
+//  nvcc.exe ./cuda-cpp14.cu -x cu -I"../include" -l"fmtd" -L"../build/Debug"  \
+//          -std=c++14 -Xcompiler /std:c++14 -Xcompiler /Zc:__cplusplus
 //
 
 //
-// Ensure that we are using the expected standard
+// Ensure that we are using the latest C++ standard for NVCC
+// The version is C++14
+//
+// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#c-cplusplus-language-support
 // https://en.cppreference.com/w/cpp/preprocessor/replace#Predefined_macros
 //
 static_assert(__cplusplus >= 201402L, "expect C++ 2014 for nvcc");
 
-#if defined(__CUDACC__)
-#   define FMT_DEPRECATED
+//
+// https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#nvcc-identification-macro
+//
+// __NVCC__ is for NVCC compiler
+// __CUDACC__ is for CUDA(.cu) source code
+//
+// Since we don't know the actual case in this header, checking both macro
+// will prevent possible pitfalls ...
+//
+#if defined(__NVCC__) || defined(__CUDACC__)
+#  define FMT_DEPRECATED
 #endif
 #include <fmt/core.h>
 
@@ -22,11 +37,11 @@ using namespace std;
 extern auto make_message_cpp() -> std::string;
 extern auto make_message_cuda() -> std::string;
 
-int main(int, char*[]){
-    cout << make_message_cuda() << endl;
-    cout << make_message_cpp() << endl;
+int main(int, char*[]) {
+  cout << make_message_cuda() << endl;
+  cout << make_message_cpp() << endl;
 }
 
-auto make_message_cuda() -> std::string{
-    return fmt::format("nvcc         \t: __cplusplus == {}", __cplusplus);
+auto make_message_cuda() -> std::string {
+  return fmt::format("nvcc compiler \t: __cplusplus == {}", __cplusplus);
 }

--- a/test/cuda-test/cuda-cpp14.cu
+++ b/test/cuda-test/cuda-cpp14.cu
@@ -1,0 +1,32 @@
+
+//
+//  nvcc -x cu -std=c++14 ..\test\cuda-test\include_test.cu -I"../include" -Xcompiler /Zc:__cplusplus  -l"fmtd" -L"../build/Debug"
+//
+
+//
+// Ensure that we are using the expected standard
+// https://en.cppreference.com/w/cpp/preprocessor/replace#Predefined_macros
+//
+static_assert(__cplusplus >= 201402L, "expect C++ 2014 for nvcc");
+
+#if defined(__CUDACC__)
+#   define FMT_DEPRECATED
+#endif
+#include <fmt/core.h>
+
+#include <cuda.h>
+#include <iostream>
+
+using namespace std;
+
+extern auto make_message_cpp() -> std::string;
+extern auto make_message_cuda() -> std::string;
+
+int main(int, char*[]){
+    cout << make_message_cuda() << endl;
+    cout << make_message_cpp() << endl;
+}
+
+auto make_message_cuda() -> std::string{
+    return fmt::format("nvcc         \t: __cplusplus == {}", __cplusplus);
+}

--- a/test/cuda-test/cuda-cpp14.cu
+++ b/test/cuda-test/cuda-cpp14.cu
@@ -24,9 +24,11 @@ static_assert(__cplusplus >= 201402L, "expect C++ 2014 for nvcc");
 // Since we don't know the actual case in this header, checking both macro
 // will prevent possible pitfalls ...
 //
-#if defined(__NVCC__) || defined(__CUDACC__)
-#  define FMT_DEPRECATED
-#endif
+// --- this check is moved into the <fmt/core.h> ---
+//
+// #if defined(__NVCC__) || defined(__CUDACC__)
+// #  define FMT_DEPRECATED // suppress [[deprecated]] attribute
+// #endif
 #include <fmt/core.h>
 
 #include <cuda.h>

--- a/test/cuda-test/cuda-cpp14.cu
+++ b/test/cuda-test/cuda-cpp14.cu
@@ -34,14 +34,12 @@ static_assert(__cplusplus >= 201402L, "expect C++ 2014 for nvcc");
 #include <cuda.h>
 #include <iostream>
 
-using namespace std;
-
 extern auto make_message_cpp() -> std::string;
 extern auto make_message_cuda() -> std::string;
 
 int main(int, char*[]) {
-  cout << make_message_cuda() << endl;
-  cout << make_message_cpp() << endl;
+  std::cout << make_message_cuda() << std::endl;
+  std::cout << make_message_cpp() << std::endl;
 }
 
 auto make_message_cuda() -> std::string {


### PR DESCRIPTION
## Summary

This PR adds a new test(`fmt-cuda-test`) for the library.  
It imports fmt in the CUDA(`.cu`) source file and build it with C++ 14 standard.

```cmake
find_package(CUDA 9.0)
if(CUDA_FOUND)
  add_subdirectory(cuda-test)
  add_test(NAME cuda-test COMMAND fmt-in-cuda-test)
endif()
```

### Related Issues

* #1149 #1080(CUDA) 

## Note

The change of each files... 

#### [test/CMakeLists.txt](https://github.com/fmtlib/fmt/pull/1285/files#diff-15547c54d3d4898a882b4ab7b3cee381)

Try to find if the environment has CUDA and add a new test for it(`fmt-cuda-test`). 

```cmake
find_package(CUDA 9.0)
if(CUDA_FOUND)
  add_test(...) # ... see the change below ...
endif()
```

The structure followed that of the `find-package-test`.

#### [test/cuda-test/CMakeLists.txt](https://github.com/fmtlib/fmt/pull/1285/files#diff-ffa2ffe9272fdbac2ad8d8f4bf2d5686)

The original issue(#1149) was about the case when NVCC's host compiler is MSVC.
However, the case can't be tested always since Windows CI services don't support CUDA build/test.

Instead, the file contains detailed comments. I wish future visitors can read it and solve their issue with it.

#### [test/cuda-test/cpp14.cc](https://github.com/fmtlib/fmt/pull/1285/files#diff-ba0ca00b83b7850ea2f623403a2f3584)

C++ source code for CMake target which requires CUDA compilation

#### [test/cuda-test/cuda-cpp14.cu](https://github.com/fmtlib/fmt/pull/1285/files#diff-2399e8a4d4031a62110d506b7e55155b)

CUDA source code for CMake target. This file is a peer of [test/cuda-test/cpp14.cc](https://github.com/fmtlib/fmt/pull/1285/files#diff-2399e8a4d4031a62110d506b7e55155b).

#### [`<fmt/core.h>`](https://github.com/fmtlib/fmt/pull/1285/files#diff-5cbf8b22d9e434ef6ff82c6a34023053)

Reviewed #1273.  
Following https://github.com/fmtlib/fmt/commit/744302add085f30120c57f73cddbcb826cc92de9, the header file checks for NVCC and CUDA source code. 

* `__NVCC__`: if the compiler is from NVIDIA
* `__CUDACC__`: if the source code is CUDA(.cu) file

## License Agreement

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
