### PR TITLE
Map not int enum to correct underlying_type

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -824,8 +824,8 @@ template <typename Context> struct arg_mapper {
             FMT_ENABLE_IF(std::is_enum<T>::value &&
                           !has_formatter<T, Context>::value &&
                           !has_fallback_formatter<T, Context>::value)>
-  FMT_CONSTEXPR int map(const T& val) {
-    return static_cast<int>(val);
+  FMT_CONSTEXPR auto map(const T& val) -> decltype(map(static_cast<typename std::underlying_type<T>::type>(val))) {
+    return map(static_cast<typename std::underlying_type<T>::type>(val));
   }
   template <typename T,
             FMT_ENABLE_IF(!is_string<T>::value && !is_char<T>::value &&

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1906,9 +1906,9 @@ TEST(FormatTest, FormatterNotSpecialized) {
 }
 
 #if FMT_HAS_FEATURE(cxx_strong_enums)
-enum TestFixedEnum : short { B };
+enum TestFixedEnum : short { B = 1 };
 
-TEST(FormatTest, FixedEnum) { EXPECT_EQ("0", fmt::format("{}", B)); }
+TEST(FormatTest, FixedEnum) { EXPECT_EQ("1", fmt::format("{}", B)); }
 #endif
 
 using buffer_range = fmt::buffer_range<char>;


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

This PR correctly prints values of such enums:
`
enum E{
    I = 5000000000ULL
};
`

Test update is needed because "0" may not detect an error.