### PR TITLE
Add compile-time check for too many arguments:

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -9,6 +9,7 @@
 #define FMT_COMPILE_H_
 
 #include <vector>
+
 #include "format.h"
 
 FMT_BEGIN_NAMESPACE
@@ -108,6 +109,8 @@ class format_preparation_handler : public internal::error_handler {
     const auto size = end - begin;
     parts_.push_back(part(string_view_metadata(offset, size)));
   }
+
+  FMT_CONSTEXPR void on_text_end() {}
 
   FMT_CONSTEXPR void on_arg_id() {
     parts_.push_back(part(parse_context_.next_arg_id()));
@@ -266,6 +269,8 @@ template <typename Char> struct part_counter {
   FMT_CONSTEXPR void on_text(const Char* begin, const Char* end) {
     if (begin != end) ++num_parts;
   }
+
+  FMT_CONSTEXPR void on_text_end() {}
 
   FMT_CONSTEXPR void on_arg_id() { ++num_parts; }
   FMT_CONSTEXPR void on_arg_id(unsigned) { ++num_parts; }

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -6,6 +6,7 @@
 // For the license information refer to format.h.
 
 #include <stdint.h>
+
 #include <cctype>
 #include <cfloat>
 #include <climits>
@@ -34,12 +35,12 @@
 using std::size_t;
 
 using fmt::basic_memory_buffer;
-using fmt::internal::basic_writer;
 using fmt::format;
 using fmt::format_error;
 using fmt::memory_buffer;
 using fmt::string_view;
 using fmt::wmemory_buffer;
+using fmt::internal::basic_writer;
 
 using testing::Return;
 using testing::StrictMock;
@@ -673,9 +674,7 @@ TEST(WriterTest, WriteString) {
   CHECK_WRITE_WCHAR("abc");
 }
 
-TEST(WriterTest, WriteWideString) {
-  CHECK_WRITE_WCHAR(L"abc");
-}
+TEST(WriterTest, WriteWideString) { CHECK_WRITE_WCHAR(L"abc"); }
 
 TEST(FormatToTest, FormatWithoutArgs) {
   std::string s;
@@ -2294,6 +2293,8 @@ TEST(FormatTest, ConstexprSpecsChecker) {
 
 struct test_format_string_handler {
   FMT_CONSTEXPR void on_text(const char*, const char*) {}
+
+  FMT_CONSTEXPR void on_text_end() {}
 
   FMT_CONSTEXPR void on_arg_id() {}
 

--- a/test/scan.h
+++ b/test/scan.h
@@ -168,6 +168,8 @@ struct scan_handler : error_handler {
     scan_ctx_.advance_to(it + size);
   }
 
+  void on_text_end() {}
+
   void on_arg_id() { on_arg_id(next_arg_id_++); }
   void on_arg_id(int id) {
     if (id >= args_.size) on_error("argument index out of range");


### PR DESCRIPTION
* Check only for automatic argument indexing.
* Tests not included as I am not sure how compile failures should be tested (I haven't seen any death test in the repo).

All the following lines fail to compile after applying this patch:
```
    fmt::print(FMT_STRING(""), 1); // too many
    fmt::print(FMT_STRING("too many\n"), 1);
    fmt::print(FMT_STRING("too many {}\n"), 1, 2);
    fmt::print(FMT_STRING("too many {}\n"), 1, 2, 3);
    fmt::print(FMT_STRING("too few {}-{}-{}bal\n"), 1, 2);
```

Tested on GCC and clang (https://wandbox.org/permlink/f7Pf9ERBskTWfFQx).