### PR TITLE
fmt.pc.in: Fix for cross compilation

### DIFF
--- a/support/cmake/fmt.pc.in
+++ b/support/cmake/fmt.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: fmt
 Description: A modern formatting library


### PR DESCRIPTION
These variables get set to /usr/lib and /usr/include , which is totally wrong in a cross compilation
environment.

Changed to standard pkgconfig values consistent with most other ones.