### PR TITLE
Compile-time error on too many arguments provided

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -82,6 +82,8 @@ template <typename Char> struct part_counter {
     return begin;
   }
 
+  FMT_CONSTEXPR void on_end_of_string() {}
+
   FMT_CONSTEXPR void on_error(const char*) {}
 };
 
@@ -148,6 +150,8 @@ class format_string_compiler : public error_handler {
     handler_(part);
     return it;
   }
+
+  FMT_CONSTEXPR void on_end_of_string() {}
 };
 
 // Compiles a format string and invokes handler(part) for each parsed part.

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -489,6 +489,9 @@ class basic_parse_context : private ErrorHandler {
 
   FMT_CONSTEXPR void check_arg_id(basic_string_view<Char>) {}
 
+  FMT_CONSTEXPR bool is_auto_arg_indexing() { return next_arg_id_ >= 0; }
+  FMT_CONSTEXPR int num_auto_args() { return next_arg_id_; }
+
   FMT_CONSTEXPR void on_error(const char* message) {
     ErrorHandler::on_error(message);
   }

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2377,6 +2377,8 @@ struct test_format_string_handler {
     return begin;
   }
 
+  FMT_CONSTEXPR void on_end_of_string() {}
+
   FMT_CONSTEXPR void on_error(const char*) { error = true; }
 
   bool error = false;
@@ -2496,6 +2498,8 @@ TEST(FormatTest, FormatStringErrors) {
   EXPECT_ERROR("{}{1}",
                "cannot switch from automatic to manual argument indexing", int,
                int);
+  EXPECT_ERROR("", "number of arguments in format string is less than number of arguments provided", int);
+  EXPECT_ERROR("{}", "number of arguments in format string is less than number of arguments provided", int, int);
 }
 
 TEST(FormatTest, VFormatTo) {

--- a/test/scan.h
+++ b/test/scan.h
@@ -212,6 +212,8 @@ struct scan_handler : error_handler {
     arg_.custom.scan(arg_.custom.value, parse_ctx_, scan_ctx_);
     return parse_ctx_.begin();
   }
+
+  void on_end_of_string() {}
 };
 }  // namespace internal
 


### PR DESCRIPTION
Adds a compile time error if the number of arguments provided to the
format function is larger than the number of braces in the format
string.
Only works in automatic argument indexing mode.

This check deliberately only works for compile-time format string
checking, not at runtime. This is because we don't want existing code to
have unexpected runtime errors after upgrades. There are also scenarios
imaginable where either the arguments or the format string is generated
at runtime, and the ability to have less braces in the format string can
actually be a feature. At the same time, compile-time format calls are
guaranteed to be constant. In other words, having too many arguments will
always mean there's a bug in the code.

The new feature works by adding a on_end_of_string() function to
formatting handlers. This function is called after the whole format
string has been parsed, and needs to be implemented by all parsing
handlers.

----------------------

Both a first-time {fmt} contributor and a first-time user, so my knowledge here is limited. I may easily have missed some important code changes or tests. Happy to change the code wherever necessary.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
