### PR TITLE
Fix errors in fmt/compile.h

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -331,11 +331,12 @@ template <typename... Args> struct type_list {};
 
 // Returns a reference to the argument at index N from [first, rest...].
 template <int N, typename T, typename... Args>
-const auto& get(const T& first, const Args&... rest) {
-  if constexpr (sizeof...(Args) == 0)
+constexpr const auto& get(const T& first, const Args&... rest) {
+  static_assert(N < 1 + sizeof...(Args), "index is out of bounds");
+  if constexpr (N == 0)
     return first;
   else
-    return get(rest...);
+    return get<N - 1>(rest...);
 }
 
 template <int N, typename> struct get_type_impl;

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -414,7 +414,7 @@ constexpr concat<L, R> make_concat(L lhs, R rhs) {
   return {lhs, rhs};
 }
 
-struct unknown {};
+struct unknown_format {};
 
 template <typename Char>
 constexpr size_t parse_text(basic_string_view<Char> str, size_t pos) {
@@ -431,7 +431,8 @@ template <typename Args, size_t POS, int ID, typename T, typename S>
 constexpr auto parse_tail(T head, S format_str) {
   if constexpr (POS != to_string_view(format_str).size()) {
     constexpr auto tail = compile_format_string<Args, POS, ID>(format_str);
-    if constexpr (std::is_same<remove_cvref_t<decltype(tail)>, unknown>())
+    if constexpr (std::is_same<remove_cvref_t<decltype(tail)>,
+                               unknown_format>())
       return tail;
     else
       return make_concat(head, tail);
@@ -441,7 +442,7 @@ constexpr auto parse_tail(T head, S format_str) {
 }
 
 // Compiles a non-empty format string and returns the compiled representation
-// or unknown() on unrecognized input.
+// or unknown_format() on unrecognized input.
 template <typename Args, size_t POS, int ID, typename S>
 constexpr auto compile_format_string(S format_str) {
   using char_type = typename S::char_type;
@@ -457,10 +458,10 @@ constexpr auto compile_format_string(S format_str) {
         return parse_tail<Args, POS + 2, ID + 1>(field<char_type, type, ID>(),
                                                  format_str);
       } else {
-        return unknown();
+        return unknown_format();
       }
     } else {
-      return unknown();
+      return unknown_format();
     }
   } else if constexpr (str[POS] == '}') {
     if (POS + 1 == str.size())
@@ -488,7 +489,7 @@ constexpr auto compile(S format_str) {
         internal::compile_format_string<internal::type_list<Args...>, 0, 0>(
             format_str);
     if constexpr (std::is_same<remove_cvref_t<decltype(result)>,
-                               internal::unknown>()) {
+                               internal::unknown_format>()) {
       return internal::compiled_format<S, Args...>(to_string_view(format_str));
     } else {
       return result;

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -117,6 +117,11 @@ TEST(CompileTest, FormattedSize) {
   EXPECT_EQ(fmt::formatted_size(f, 42), 10);
 }
 
+TEST(CompileTest, MultipleTypes) {
+  auto f = fmt::compile<int, int>("{} {}");
+  EXPECT_EQ(fmt::format(f, 42, 42), "42 42");
+}
+
 struct formattable {};
 
 FMT_BEGIN_NAMESPACE


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

Fixes `get` and `struct unknown` name clash in header-only mode (see #1324). Also added a simple test for multiple types in `fmt::compile` since `get` works now.

Also, `get` should probably take universal references of arguments and forward them.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
