### PR TITLE
workaround VS2019 Update 3 compiler bug.

### DIFF
--- a/include/fmt/safe-duration-cast.h
+++ b/include/fmt/safe-duration-cast.h
@@ -161,7 +161,7 @@ To safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from,
   ec = 0;
   // the basic idea is that we need to convert from count() in the from type
   // to count() in the To type, by multiplying it with this:
-  using Factor = std::ratio_divide<typename From::period, typename To::period>;
+  struct Factor : std::ratio_divide<typename From::period, typename To::period>{};
 
   static_assert(Factor::num > 0, "num must be positive");
   static_assert(Factor::den > 0, "den must be positive");
@@ -232,7 +232,7 @@ To safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from,
 
   // the basic idea is that we need to convert from count() in the from type
   // to count() in the To type, by multiplying it with this:
-  using Factor = std::ratio_divide<typename From::period, typename To::period>;
+  struct Factor : std::ratio_divide<typename From::period, typename To::period>{};
 
   static_assert(Factor::num > 0, "num must be positive");
   static_assert(Factor::den > 0, "den must be positive");

--- a/include/fmt/safe-duration-cast.h
+++ b/include/fmt/safe-duration-cast.h
@@ -161,7 +161,8 @@ To safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from,
   ec = 0;
   // the basic idea is that we need to convert from count() in the from type
   // to count() in the To type, by multiplying it with this:
-  struct Factor : std::ratio_divide<typename From::period, typename To::period>{};
+  struct Factor
+      : std::ratio_divide<typename From::period, typename To::period> {};
 
   static_assert(Factor::num > 0, "num must be positive");
   static_assert(Factor::den > 0, "den must be positive");
@@ -232,7 +233,8 @@ To safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from,
 
   // the basic idea is that we need to convert from count() in the from type
   // to count() in the To type, by multiplying it with this:
-  struct Factor : std::ratio_divide<typename From::period, typename To::period>{};
+  struct Factor
+      : std::ratio_divide<typename From::period, typename To::period> {};
 
   static_assert(Factor::num > 0, "num must be positive");
   static_assert(Factor::den > 0, "den must be positive");


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

Bug reported here seven weeks ago:
https://developercommunity.visualstudio.com/content/problem/675854/fmtlibs-safe-duration-cast-doesnt-compile-in-vs201.html
But even calling attention to it by saying "you can't compile a library that's the basis for a C++20 proposal" wasn't enough to get any attention.
