### PR TITLE
Compiled format fixes

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -603,6 +603,26 @@ std::size_t formatted_size(const CompiledFormat& cf, const Args&... args) {
       .count();
 }
 
+template <typename CompiledFormat, typename... Args,
+          FMT_ENABLE_IF(internal::is_compiled_format<CompiledFormat>::value)>
+inline void print(std::FILE* f, const CompiledFormat& cf, Args&&... args) {
+  using Char = char_t<CompiledFormat>;
+  using context = buffer_context<Char>;
+  basic_memory_buffer<Char> buffer;
+  format_to(std::back_inserter(buffer), cf, args...);
+  vprint(f, {buffer.begin(), buffer.size()}, {make_format_args<context>()});
+}
+
+template <typename CompiledFormat, typename... Args,
+          FMT_ENABLE_IF(internal::is_compiled_format<CompiledFormat>::value)>
+inline void print(const CompiledFormat& cf, Args&&... args) {
+  using Char = char_t<CompiledFormat>;
+  using context = buffer_context<Char>;
+  basic_memory_buffer<Char> buffer;
+  format_to(std::back_inserter(buffer), cf, args...);
+  vprint({buffer.begin(), buffer.size()}, {make_format_args<context>()});
+}
+
 FMT_END_NAMESPACE
 
 #endif  // FMT_COMPILE_H_

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -492,6 +492,12 @@ template <typename Char>
 struct is_constexpr_compiled_format<text<Char>> : std::true_type {};
 
 #endif  // __cpp_if_constexpr
+
+template <typename T>
+struct char_t_impl<T, enable_if_t<is_compiled_format<T>::value>> {
+  using type = typename T::char_type;
+};
+
 }  // namespace internal
 
 #if FMT_USE_CONSTEXPR

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1409,7 +1409,8 @@ inline std::basic_string<Char> vformat(
 */
 // Pass char_t as a default template parameter instead of using
 // std::basic_string<char_t<S>> to reduce the symbol size.
-template <typename S, typename... Args, typename Char = char_t<S>>
+template <typename S, typename... Args, typename Char = char_t<S>,
+          FMT_ENABLE_IF(internal::is_string<S>::value)>
 inline std::basic_string<Char> format(const S& format_str, Args&&... args) {
   return internal::vformat(
       to_string_view(format_str),

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3351,7 +3351,8 @@ inline typename buffer_context<Char>::iterator vformat_to(
 }
 
 template <typename S, typename... Args, std::size_t SIZE = inline_buffer_size,
-          typename Char = enable_if_t<internal::is_string<S>::value, char_t<S>>>
+          typename Char = char_t<S>,
+          FMT_ENABLE_IF(internal::is_string<S>::value)>
 inline typename buffer_context<Char>::iterator format_to(
     basic_memory_buffer<Char, SIZE>& buf, const S& format_str, Args&&... args) {
   internal::check_format_string<Args...>(format_str);

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -128,11 +128,21 @@ void vprint(std::basic_ostream<Char>& os, basic_string_view<Char> format_str,
     fmt::print(cerr, "Don't {}!", "panic");
   \endrst
  */
-template <typename S, typename... Args,
-          typename Char = enable_if_t<internal::is_string<S>::value, char_t<S>>>
+template <typename S, typename... Args, typename Char = char_t<S>,
+          FMT_ENABLE_IF(internal::is_string<S>::value)>
 void print(std::basic_ostream<Char>& os, const S& format_str, Args&&... args) {
   vprint(os, to_string_view(format_str),
          {internal::make_args_checked<Args...>(format_str, args...)});
+}
+
+// fallback print overload for types that define char_t but are not strings
+// such as compiled format
+template <typename S, typename... Args, typename Char = char_t<S>,
+          FMT_ENABLE_IF(!internal::is_string<S>::value)>
+void print(std::basic_ostream<Char>& os, const S& format, Args&&... args) {
+  basic_memory_buffer<Char> buffer;
+  format_to(std::back_inserter(buffer), format, args...);
+  internal::write(os, buffer);
 }
 FMT_END_NAMESPACE
 

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -22,6 +22,7 @@
 #endif
 
 #include "fmt/compile.h"
+#include "fmt/ostream.h"
 #include "gmock.h"
 #include "gtest-extra.h"
 #include "mock-allocator.h"
@@ -140,4 +141,21 @@ TEST(CompileTest, FormatUserDefinedType) {
 TEST(CompileTest, EmptyFormatString) {
   auto f = fmt::compile<>("");
   EXPECT_EQ(fmt::format(f), "");
+}
+
+TEST(CompileTest, Print) {
+  std::ostringstream os;
+  auto f = fmt::compile<fmt::string_view>("Don't {}!");
+  fmt::print(os, f, "panic");
+  EXPECT_EQ("Don't panic!", os.str());
+
+  auto wf = fmt::compile<fmt::wstring_view>(L"Don't {}!");
+  std::wostringstream wos;
+  fmt::print(wos, wf, L"panic");
+  EXPECT_EQ(L"Don't panic!", wos.str());
+
+#if FMT_USE_FILE_DESCRIPTORS
+  EXPECT_WRITE(stdout, fmt::print(f, "panic"), "Don't panic!");
+  EXPECT_WRITE(stderr, fmt::print(stderr, f, "panic"), "Don't panic!");
+#endif
 }


### PR DESCRIPTION
* Added more meaningful names for compiled format SFINAE rather than repeating `FMT_ENABLE_IF(std::is_base_of<internal::basic_compiled_format, CompiledFormat>::value)` everywhere
* Fixed `fmt::format` and `fmt::format_to` ambigous overloads with compiled format
* Added `fmt::print` overloads for compiled format with tests