### PR TITLE
Remove no-op destructor definitions to opt-in for compiler generated ones

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -223,9 +223,6 @@ FMT_FUNC Char internal::decimal_point_impl(locale_ref) {
 }
 #endif
 
-FMT_API FMT_FUNC format_error::~format_error() FMT_NOEXCEPT {}
-FMT_API FMT_FUNC system_error::~system_error() FMT_NOEXCEPT {}
-
 FMT_FUNC void system_error::init(int err_code, string_view format_str,
                                  format_args args) {
   error_code_ = err_code;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -630,7 +630,6 @@ class FMT_API format_error : public std::runtime_error {
   explicit format_error(const char* message) : std::runtime_error(message) {}
   explicit format_error(const std::string& message)
       : std::runtime_error(message) {}
-  ~format_error() FMT_NOEXCEPT;
 };
 
 namespace internal {
@@ -2689,7 +2688,6 @@ class FMT_API system_error : public std::runtime_error {
       : std::runtime_error("") {
     init(error_code, message, make_format_args(args...));
   }
-  ~system_error() FMT_NOEXCEPT;
 
   int error_code() const { return error_code_; }
 };


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

Use rule of 0 and avoid `-Wdeprecated` warnings when the exception objects are copied.