### PR TITLE
Repoint one more Python 2 link to Python 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -508,7 +508,7 @@ Some ideas used in the implementation are borrowed from `Loki
 <http://clang.llvm.org/doxygen/classclang_1_1Diagnostic.html>`_ in
 `Clang <http://clang.llvm.org/>`_.
 Format string syntax and the documentation are based on Python's `str.format
-<http://docs.python.org/2/library/stdtypes.html#str.format>`_.
+<https://docs.python.org/3/library/stdtypes.html#str.format>`_.
 Thanks `Doug Turnbull <https://github.com/softwaredoug>`_ for his valuable
 comments and contribution to the design of the type-safe API and
 `Gregory Czajkowski <https://github.com/gcflymoto>`_ for implementing binary


### PR DESCRIPTION
One more python reference, this one acknowledging the `str.format` function.

A grep of the codebase for `python.org` shows no remaining Python 2 references.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
