### PR TITLE
Make localtime() aware of timezone changes

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -47,6 +47,7 @@ inline std::tm localtime(std::time_t time) {
     dispatcher(std::time_t t) : time_(t) {}
 
     bool run() {
+      tzset();
       using namespace fmt::internal;
       return handle(localtime_r(&time_, &tm_));
     }


### PR DESCRIPTION
According to POSIX.1-2004, localtime() is required to behave as though
tzset(3) was called, while localtime_r() does not have this requirement.
For portable code tzset(3) should be called before localtime_r().

See https://stackoverflow.com/questions/19170721/real-time-awareness-of-timezone-change-in-localtime-vs-localtime-r#answer-19170798 for more.


<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.