### PR TITLE
Fix undefined in core-test and printf-test

### DIFF
--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -469,6 +469,8 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
 
     // Parse argument index, flags and width.
     unsigned arg_index = parse_header(it, end, specs);
+    if (arg_index == 0)
+      on_error("argument index 0 is out of range");
 
     // Parse precision.
     if (it != end && *it == '.') {

--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -103,7 +103,7 @@ template <typename T> struct mock_buffer : buffer<T> {
 TEST(BufferTest, Ctor) {
   {
     mock_buffer<int> buffer;
-    EXPECT_EQ(nullptr, &buffer[0]);
+    EXPECT_EQ(nullptr, buffer.data());
     EXPECT_EQ(static_cast<size_t>(0), buffer.size());
     EXPECT_EQ(static_cast<size_t>(0), buffer.capacity());
   }

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -337,7 +337,9 @@ template <typename T> void TestLength(const char* length_spec) {
   TestLength<T>(length_spec, -42);
   TestLength<T>(length_spec, min);
   TestLength<T>(length_spec, max);
-  TestLength<T>(length_spec, static_cast<long long>(min) - 1);
+  long long long_long_min = std::numeric_limits<long long>::min();
+  if (static_cast<long long>(min) > long_long_min)
+    TestLength<T>(length_spec, static_cast<long long>(min) - 1);
   unsigned long long long_long_max = max_value<long long>();
   if (static_cast<unsigned long long>(max) < long_long_max)
     TestLength<T>(length_spec, static_cast<long long>(max) + 1);

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -112,7 +112,7 @@ TEST(PrintfTest, SwitchArgIndexing) {
 
 TEST(PrintfTest, InvalidArgIndex) {
   EXPECT_THROW_MSG(test_sprintf("%0$d", 42), format_error,
-                   "argument index out of range");
+                   "argument index 0 is out of range");
   EXPECT_THROW_MSG(test_sprintf("%2$d", 42), format_error,
                    "argument index out of range");
   EXPECT_THROW_MSG(test_sprintf(format("%{}$d", INT_MAX), 42), format_error,


### PR DESCRIPTION
1. The change in include/fmt/core.h fixes "shift exponent -4 is negative" in
   PrintfTest.InvalidArgIndex

   `do_get` is called with index -1 when `basic_printf_context.arg` is called
   with id 4294967295 when basic_printf_context::get_arg subtracts 1 from
   arg_index 0 in the format string "%0$d".

2. The change in test/core-test.cc fixes "reference binding to null pointer" in
   BufferTest.Ctor

   buffer.operator[] attempts to return a reference to `buffer.ptr_[0]` when
   `ptr_` in `mock_buffer<int> buffer` is null.

2. The change in test/printf-test.cc fixes "signed integer overflow" in
   PrintfTest.Length

   This occurs in `TestLength<long long>("ll")`, since its minimum value minus
   one does not fit in long long.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

This fixes all UBSAN reports except one in format-test (#1344).

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
