### PR TITLE
 Add defaulted copy and move operations to format_error and system_error 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ endif ()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(PEDANTIC_COMPILE_FLAGS -Wall -Wextra -pedantic -Wconversion
-      -Wno-sign-conversion)
+      -Wno-sign-conversion -Wweak-vtables)
   check_cxx_compiler_flag(-Wzero-as-null-pointer-constant HAS_NULLPTR_WARNING)
   if (HAS_NULLPTR_WARNING)
     set(PEDANTIC_COMPILE_FLAGS ${PEDANTIC_COMPILE_FLAGS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ endif ()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(PEDANTIC_COMPILE_FLAGS -Wall -Wextra -pedantic -Wconversion
-      -Wno-sign-conversion -Wweak-vtables)
+      -Wno-sign-conversion -Wdeprecated -Wweak-vtables)
   check_cxx_compiler_flag(-Wzero-as-null-pointer-constant HAS_NULLPTR_WARNING)
   if (HAS_NULLPTR_WARNING)
     set(PEDANTIC_COMPILE_FLAGS ${PEDANTIC_COMPILE_FLAGS}

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -630,6 +630,10 @@ class FMT_API format_error : public std::runtime_error {
   explicit format_error(const char* message) : std::runtime_error(message) {}
   explicit format_error(const std::string& message)
       : std::runtime_error(message) {}
+  format_error(const format_error&) = default;
+  format_error& operator=(const format_error&) = default;
+  format_error(format_error&&) = default;
+  format_error& operator=(format_error&&) = default;
   ~format_error() FMT_NOEXCEPT;
 };
 
@@ -2689,6 +2693,10 @@ class FMT_API system_error : public std::runtime_error {
       : std::runtime_error("") {
     init(error_code, message, make_format_args(args...));
   }
+  system_error(const system_error&) = default;
+  system_error& operator=(const system_error&) = default;
+  system_error(system_error&&) = default;
+  system_error& operator=(system_error&&) = default;
   ~system_error() FMT_NOEXCEPT;
 
   int error_code() const { return error_code_; }

--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -127,7 +127,12 @@ TEST(BufferTest, Ctor) {
 struct dying_buffer : test_buffer<int> {
   MOCK_METHOD0(die, void());
   ~dying_buffer() { die(); }
+
+ private:
+  virtual void avoid_weak_vtable();
 };
+
+void dying_buffer::avoid_weak_vtable() {}
 
 TEST(BufferTest, VirtualDtor) {
   typedef StrictMock<dying_buffer> stict_mock_buffer;

--- a/test/test-assert.h
+++ b/test/test-assert.h
@@ -14,7 +14,12 @@
 class assertion_failure : public std::logic_error {
  public:
   explicit assertion_failure(const char* message) : std::logic_error(message) {}
+
+ private:
+  virtual void avoid_weak_vtable();
 };
+
+void assertion_failure::avoid_weak_vtable() {}
 
 #define FMT_ASSERT(condition, message) \
   if (!(condition)) throw assertion_failure(message);


### PR DESCRIPTION
Another approach to not trigger `-Wdeprecated` and `-Wweak-vtables` after the discussion in #1334.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
