### PR TITLE
Distinguish float type formatting from double

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -657,6 +657,7 @@ enum type {
   char_type,
   last_integer_type = char_type,
   // followed by floating-point types.
+  float_type,
   double_type,
   long_double_type,
   last_numeric_type = long_double_type,
@@ -683,6 +684,7 @@ FMT_TYPE_CONSTANT(int128_t, int128_type);
 FMT_TYPE_CONSTANT(uint128_t, uint128_type);
 FMT_TYPE_CONSTANT(bool, bool_type);
 FMT_TYPE_CONSTANT(Char, char_type);
+FMT_TYPE_CONSTANT(float, float_type);
 FMT_TYPE_CONSTANT(double, double_type);
 FMT_TYPE_CONSTANT(long double, long_double_type);
 FMT_TYPE_CONSTANT(const Char*, cstring_type);
@@ -724,6 +726,7 @@ template <typename Context> class value {
     uint128_t uint128_value;
     bool bool_value;
     char_type char_value;
+    float float_value;
     double double_value;
     long double long_double_value;
     const void* pointer;
@@ -738,6 +741,7 @@ template <typename Context> class value {
   value(unsigned long long val) : ulong_long_value(val) {}
   value(int128_t val) : int128_value(val) {}
   value(uint128_t val) : uint128_value(val) {}
+  value(float val) : float_value(val) {}
   value(double val) : double_value(val) {}
   value(long double val) : long_double_value(val) {}
   value(bool val) : bool_value(val) {}
@@ -809,7 +813,7 @@ template <typename Context> struct arg_mapper {
     return val;
   }
 
-  FMT_CONSTEXPR double map(float val) { return static_cast<double>(val); }
+  FMT_CONSTEXPR float map(float val) { return val; }
   FMT_CONSTEXPR double map(double val) { return val; }
   FMT_CONSTEXPR long double map(long double val) { return val; }
 
@@ -985,6 +989,8 @@ FMT_CONSTEXPR auto visit_format_arg(Visitor&& vis,
     return vis(arg.value_.bool_value);
   case internal::char_type:
     return vis(arg.value_.char_value);
+  case internal::float_type:
+    return vis(arg.value_.float_value);
   case internal::double_type:
     return vis(arg.value_.double_value);
   case internal::long_double_type:

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -889,7 +889,7 @@ using mapped_type_constant =
                   typename Context::char_type>;
 
 // Maximum number of arguments with packed types.
-enum { max_packed_args = 15 };
+enum { max_packed_args = 12 };
 enum : unsigned long long { is_unpacked_bit = 1ull << 63 };
 
 template <typename Context> class arg_map;
@@ -1052,7 +1052,7 @@ template <typename> constexpr unsigned long long encode_types() { return 0; }
 template <typename Context, typename Arg, typename... Args>
 constexpr unsigned long long encode_types() {
   return mapped_type_constant<Arg, Context>::value |
-         (encode_types<Context, Args...>() << 4);
+         (encode_types<Context, Args...>() << 5);
 }
 
 template <typename Context, typename T>
@@ -1197,8 +1197,8 @@ template <typename Context> class basic_format_args {
   bool is_packed() const { return (types_ & internal::is_unpacked_bit) == 0; }
 
   internal::type type(int index) const {
-    int shift = index * 4;
-    return static_cast<internal::type>((types_ & (0xfull << shift)) >> shift);
+    int shift = index * 5;
+    return static_cast<internal::type>((types_ >> shift) & 0x1f);
   }
 
   friend class internal::arg_map<Context>;

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -980,6 +980,13 @@ FMT_API bool grisu_format(Double value, buffer<char>& buf, int precision,
   return true;
 }
 
+template <>
+char* sprintf_format<float>(float value, internal::buffer<char>& buf,
+                            sprintf_specs specs) {
+  // printf does not have a float format modifier, it only supports double.
+  return sprintf_format<double>(value, buf, specs);
+}
+
 template <typename Double>
 char* sprintf_format(Double value, internal::buffer<char>& buf,
                      sprintf_specs specs) {

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1663,6 +1663,10 @@ template <typename Range> class basic_writer {
                                    int_writer<T, Spec>(*this, value, spec));
   }
 
+  void write(float value, const format_specs& specs = format_specs()) {
+    write_double(value, specs);
+  }
+
   void write(double value, const format_specs& specs = format_specs()) {
     write_double(value, specs);
   }
@@ -1677,7 +1681,7 @@ template <typename Range> class basic_writer {
     write_double(value, specs);
   }
 
-  // Formats a floating-point number (double or long double).
+  // Formats a floating-point number (float, double, or long double).
   template <typename T, bool USE_GRISU = fmt::internal::use_grisu<T>()>
   void write_double(T value, const format_specs& specs);
 
@@ -3006,6 +3010,7 @@ struct formatter<T, Char,
       handle_char_specs(
           &specs_, internal::char_specs_checker<decltype(eh)>(specs_.type, eh));
       break;
+    case internal::float_type:
     case internal::double_type:
     case internal::long_double_type:
       handle_float_type_spec(specs_.type,
@@ -3061,7 +3066,6 @@ FMT_FORMAT_AS(short, int);
 FMT_FORMAT_AS(unsigned short, unsigned);
 FMT_FORMAT_AS(long, long long);
 FMT_FORMAT_AS(unsigned long, unsigned long long);
-FMT_FORMAT_AS(float, double);
 FMT_FORMAT_AS(Char*, const Char*);
 FMT_FORMAT_AS(std::basic_string<Char>, basic_string_view<Char>);
 FMT_FORMAT_AS(std::nullptr_t, const void*);

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1664,11 +1664,11 @@ template <typename Range> class basic_writer {
   }
 
   void write(float value, const format_specs& specs = format_specs()) {
-    write_double(value, specs);
+    write_fp(value, specs);
   }
 
   void write(double value, const format_specs& specs = format_specs()) {
-    write_double(value, specs);
+    write_fp(value, specs);
   }
 
   /**
@@ -1678,12 +1678,12 @@ template <typename Range> class basic_writer {
     \endrst
    */
   void write(long double value, const format_specs& specs = format_specs()) {
-    write_double(value, specs);
+    write_fp(value, specs);
   }
 
   // Formats a floating-point number (float, double, or long double).
   template <typename T, bool USE_GRISU = fmt::internal::use_grisu<T>()>
-  void write_double(T value, const format_specs& specs);
+  void write_fp(T value, const format_specs& specs);
 
   /** Writes a character to the buffer. */
   void write(char value) {
@@ -1830,7 +1830,7 @@ class arg_formatter_base {
 
   template <typename T, FMT_ENABLE_IF(std::is_floating_point<T>::value)>
   iterator operator()(T value) {
-    writer_.write_double(value, specs_ ? *specs_ : format_specs());
+    writer_.write_fp(value, specs_ ? *specs_ : format_specs());
     return out();
   }
 
@@ -2770,8 +2770,8 @@ struct float_spec_handler {
 
 template <typename Range>
 template <typename T, bool USE_GRISU>
-void internal::basic_writer<Range>::write_double(T value,
-                                                 const format_specs& specs) {
+void internal::basic_writer<Range>::write_fp(T value,
+                                             const format_specs& specs) {
   // Check type.
   float_spec_handler handler(static_cast<char>(specs.type));
   internal::handle_float_type_spec(handler.type, handler);

--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -290,8 +290,6 @@ VISIT_TYPE(long, long long);
 VISIT_TYPE(unsigned long, unsigned long long);
 #endif
 
-VISIT_TYPE(float, double);
-
 #define CHECK_ARG_(Char, expected, value)                                     \
   {                                                                           \
     testing::StrictMock<mock_visitor<decltype(expected)>> visitor;            \

--- a/test/locale-test.cc
+++ b/test/locale-test.cc
@@ -23,7 +23,7 @@ TEST(LocaleTest, DoubleDecimalPoint) {
   fmt::internal::writer w(buf, fmt::internal::locale_ref(loc));
   auto specs = fmt::format_specs();
   specs.type = 'n';
-  w.write_double<double, false>(1.23, specs);
+  w.write_fp<double, false>(1.23, specs);
   EXPECT_EQ(fmt::to_string(buf), "1?23");
 }
 


### PR DESCRIPTION
This fixes #1353 and is the first half of the fix for #1336.

I suggest reviewing commits one by one.