### PR TITLE
Fix Visual Studio 2019 pedantic warning C4334: '<<': result of 32-bit…

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -981,7 +981,7 @@ FMT_FUNC void fallback_format(Double v, buffer<char>& buf, int& exp10) {
     denominator <<= 1 - fp_value.e;
     lower.assign(1);
     if (shift != 0) {
-      upper_store.assign(1 << shift);
+      upper_store.assign(1ull << shift);
       upper = &upper_store;
     }
   }


### PR DESCRIPTION
warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
