### PR TITLE
Patch compiler error when building using nvcc

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -58,9 +58,11 @@
 // Check if relaxed C++14 constexpr is supported.
 // GCC doesn't allow throw in constexpr until version 6 (bug 67371).
 #ifndef FMT_USE_CONSTEXPR
+#if !defined(__NVCC__)
 #  define FMT_USE_CONSTEXPR                                           \
     (FMT_HAS_FEATURE(cxx_relaxed_constexpr) || FMT_MSC_VER >= 1910 || \
      (FMT_GCC_VERSION >= 600 && __cplusplus >= 201402L))
+#endif
 #endif
 #if FMT_USE_CONSTEXPR
 #  define FMT_CONSTEXPR constexpr


### PR DESCRIPTION
If you compile using `nvcc` and pass the option `--expt-relaxed-constexpr` it will crash with an internal compiler error. This modification prevents using `constexpr` in `fmtlib` when compiling using `nvcc` and prevents the crash.

To clarify, this seems to be necessary on CUDA 10 with `gcc(5->7)` as the host compiler (every `gcc` version I tested). I did not have the chance to validate if other CUDA versions suffer from this same issue.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
