### PR TITLE
Fix more Visual Studio 2019 pedantic warnings

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -46,7 +46,6 @@
 
 #ifdef _MSC_VER
 #  pragma warning(push)
-#  pragma warning(disable : 4127)  // conditional expression is constant
 #  pragma warning(disable : 4702)  // unreachable code
 #endif
 
@@ -939,7 +938,11 @@ template <int GRISU_VERSION> struct grisu_shortest_handler {
                           uint64_t error, int exp, bool integral) {
     buf[size++] = digit;
     if (remainder >= error) return digits::more;
+#ifdef __cpp_if_constexpr
+    if constexpr (GRISU_VERSION != 3) {
+#else
     if (GRISU_VERSION != 3) {
+#endif
       uint64_t d = integral ? diff : diff * data::powers_of_10_64[-exp];
       round(d, divisor, remainder, error);
       return digits::done;

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -938,11 +938,7 @@ template <int GRISU_VERSION> struct grisu_shortest_handler {
                           uint64_t error, int exp, bool integral) {
     buf[size++] = digit;
     if (remainder >= error) return digits::more;
-#ifdef __cpp_if_constexpr
-    if constexpr (GRISU_VERSION != 3) {
-#else
-    if (GRISU_VERSION != 3) {
-#endif
+    if (const_check(GRISU_VERSION != 3)) {
       uint64_t d = integral ? diff : diff * data::powers_of_10_64[-exp];
       round(d, divisor, remainder, error);
       return digits::done;

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -441,7 +441,7 @@ class fp {
                                       std::numeric_limits<float>::digits - 1);
     if (min_normal_e > e) half_ulp <<= min_normal_e - e;
     upper = normalize<0>(fp(f + half_ulp, e));
-    lower = fp(f - (half_ulp >> (f == implicit_bit && e > min_normal_e)), e);
+    lower = fp(f - (half_ulp >> ((f == implicit_bit && e > min_normal_e) ? 1 : 0)), e);
     lower.f <<= lower.e - upper.e;
     lower.e = upper.e;
   }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -192,6 +192,10 @@ FMT_END_NAMESPACE
 FMT_BEGIN_NAMESPACE
 namespace internal {
 
+// A helper function to suppress bogus "conditional expression is constant"
+// warnings.
+template <typename T> inline T const_check(T value) { return value; }
+
 // A fallback implementation of uintptr_t for systems that lack it.
 struct fallback_uintptr {
   unsigned char value[sizeof(void*)];

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -71,11 +71,6 @@
 #  define FMT_HAS_BUILTIN(x) 0
 #endif
 
-#ifdef _MSC_VER
-#  pragma warning(push)
-#  pragma warning(disable : 4127)  // conditional expression is constant
-#endif
-
 #ifndef FMT_THROW
 #  if FMT_EXCEPTIONS
 #    if FMT_MSC_VER
@@ -2810,7 +2805,11 @@ void internal::basic_writer<Range>::write_fp(T value,
   int precision = specs.precision >= 0 || !specs.type ? specs.precision : 6;
   unsigned options = 0;
   if (handler.fixed) options |= grisu_options::fixed;
+#ifdef __cpp_if_constexpr
+  if constexpr (sizeof(value) == sizeof(float)) options |= grisu_options::binary32;
+#else
   if (sizeof(value) == sizeof(float)) options |= grisu_options::binary32;
+#endif
   bool use_grisu =
       USE_GRISU &&
       (specs.type != 'a' && specs.type != 'A' && specs.type != 'e' &&
@@ -3581,10 +3580,6 @@ FMT_CONSTEXPR internal::udl_arg<wchar_t> operator"" _a(const wchar_t* s,
 }  // namespace literals
 #endif  // FMT_USE_USER_DEFINED_LITERALS
 FMT_END_NAMESPACE
-
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
 
 /**
   \rst

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2809,11 +2809,7 @@ void internal::basic_writer<Range>::write_fp(T value,
   int precision = specs.precision >= 0 || !specs.type ? specs.precision : 6;
   unsigned options = 0;
   if (handler.fixed) options |= grisu_options::fixed;
-#ifdef __cpp_if_constexpr
-  if constexpr (sizeof(value) == sizeof(float)) options |= grisu_options::binary32;
-#else
-  if (sizeof(value) == sizeof(float)) options |= grisu_options::binary32;
-#endif
+  if (const_check(sizeof(value) == sizeof(float))) options |= grisu_options::binary32;
   bool use_grisu =
       USE_GRISU &&
       (specs.type != 'a' && specs.type != 'A' && specs.type != 'e' &&

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -71,6 +71,11 @@
 #  define FMT_HAS_BUILTIN(x) 0
 #endif
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable : 4127)  // conditional expression is constant
+#endif
+
 #ifndef FMT_THROW
 #  if FMT_EXCEPTIONS
 #    if FMT_MSC_VER
@@ -2805,7 +2810,7 @@ void internal::basic_writer<Range>::write_fp(T value,
   int precision = specs.precision >= 0 || !specs.type ? specs.precision : 6;
   unsigned options = 0;
   if (handler.fixed) options |= grisu_options::fixed;
-  if constexpr (sizeof(value) == sizeof(float)) options |= grisu_options::binary32;
+  if (sizeof(value) == sizeof(float)) options |= grisu_options::binary32;
   bool use_grisu =
       USE_GRISU &&
       (specs.type != 'a' && specs.type != 'A' && specs.type != 'e' &&
@@ -3576,6 +3581,10 @@ FMT_CONSTEXPR internal::udl_arg<wchar_t> operator"" _a(const wchar_t* s,
 }  // namespace literals
 #endif  // FMT_USE_USER_DEFINED_LITERALS
 FMT_END_NAMESPACE
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 /**
   \rst

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2805,7 +2805,7 @@ void internal::basic_writer<Range>::write_fp(T value,
   int precision = specs.precision >= 0 || !specs.type ? specs.precision : 6;
   unsigned options = 0;
   if (handler.fixed) options |= grisu_options::fixed;
-  if (sizeof(value) == sizeof(float)) options |= grisu_options::binary32;
+  if constexpr (sizeof(value) == sizeof(float)) options |= grisu_options::binary32;
   bool use_grisu =
       USE_GRISU &&
       (specs.type != 'a' && specs.type != 'A' && specs.type != 'e' &&

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -16,10 +16,6 @@
 FMT_BEGIN_NAMESPACE
 namespace internal {
 
-// A helper function to suppress bogus "conditional expression is constant"
-// warnings.
-template <typename T> inline T const_check(T value) { return value; }
-
 // Checks if a value fits in int - used to avoid warnings about comparing
 // signed and unsigned integers.
 template <bool IsSigned> struct int_checker {


### PR DESCRIPTION
…n operation

format.h(2808,1): warning C4127: conditional expression is constant

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
