### PR TITLE
Fix is_string<> to allow string like class

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -74,15 +74,8 @@ OutputIterator copy(char ch, OutputIterator out) {
 }
 
 /// Return true value if T has std::string interface, like std::string_view.
-template <typename T> class is_like_std_string {
-  template <typename U>
-  static auto check(U* p)
-      -> decltype((void)p->find('a'), p->length(), (void)p->data(), int());
-  template <typename> static void check(...);
-
- public:
-  static FMT_CONSTEXPR_DECL const bool value =
-      is_string<T>::value || !std::is_void<decltype(check<T>(nullptr))>::value;
+template <typename T> struct is_like_std_string {
+  static FMT_CONSTEXPR_DECL const bool value = is_string<T>::value;
 };
 
 template <typename Char>

--- a/test/custom-formatter-test.cc
+++ b/test/custom-formatter-test.cc
@@ -53,4 +53,29 @@ std::string custom_format(const char* format_str, const Args&... args) {
 TEST(CustomFormatterTest, Format) {
   EXPECT_EQ("0.00", custom_format("{:.2f}", -.00001));
 }
+
+template <typename T> class string_wrapper : std::string {
+ public:
+  string_wrapper(std::string const& s) : std::string(s) {}
+
+  std::string const& string() const { return *this; }
+};
+
+FMT_BEGIN_NAMESPACE
+template <typename Tag>
+struct formatter<string_wrapper<Tag>, char>
+    : formatter<fmt::basic_string_view<char>, char> {
+  template <typename FormatContext>
+  auto format(string_wrapper<Tag> const& str, FormatContext& ctx)
+      -> decltype(ctx.out()) {
+    return formatter<fmt::basic_string_view<char>, char>::format(str.string(),
+                                                                 ctx);
+  }
+};
+FMT_END_NAMESPACE
+
+TEST(CustomFormatterTest, FormatStringWrapperPrivateInheritance) {
+  // static_assert(fmt::internal::is_string<string_wrapper<struct Tag>>::value);
+  EXPECT_EQ("foo", fmt::format("{}", string_wrapper<struct Tag>("foo")));
+}
 #endif

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -120,6 +120,31 @@ TEST(RangesTest, PathLike) {
 #endif  // (__cplusplus > 201402L) || (defined(_MSVC_LANG) && _MSVC_LANG >
         // 201402L && _MSC_VER >= 1910)
 
+template <typename T> class string_wrapper : std::string {
+ public:
+  string_wrapper(std::string const& s) : std::string(s) {}
+
+  std::string const& string() const { return *this; }
+};
+
+FMT_BEGIN_NAMESPACE
+template <typename Tag>
+struct formatter<string_wrapper<Tag>, char>
+    : formatter<fmt::basic_string_view<char>, char> {
+  template <typename FormatContext>
+  auto format(string_wrapper<Tag> const& str, FormatContext& ctx)
+      -> decltype(ctx.out()) {
+    return formatter<fmt::basic_string_view<char>, char>::format(str.string(),
+                                                                 ctx);
+  }
+};
+FMT_END_NAMESPACE
+
+TEST(RangesTest, FormatStringWrapperPrivateInheritance) {
+  std::vector<string_wrapper<struct Tag2>> strs = {{"foo"}, {"bar"}};
+  EXPECT_EQ("foo, bar", fmt::format("{}", fmt::join(strs, ", ")));
+}
+
 #ifdef FMT_USE_STRING_VIEW
 struct string_like {
   const char* begin();


### PR DESCRIPTION
The previous implementation did not compile while formatting a type with private inheritance of std::string.

The problem is that you cannot put SFINAE code in the inheriting declaration of a class/struct. It will trigger an error instead of disabling the overload.

This is the proper fix for  #1380.
