### PR TITLE
Use grouping() from locale for specifier 'n'

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -205,6 +205,9 @@ template <typename Locale> Locale locale_ref::get() const {
   return locale_ ? *static_cast<const std::locale*>(locale_) : std::locale();
 }
 
+template <typename Char> FMT_FUNC std::string grouping_impl(locale_ref loc) {
+  return std::use_facet<std::numpunct<Char>>(loc.get<std::locale>()).grouping();
+}
 template <typename Char> FMT_FUNC Char thousands_sep_impl(locale_ref loc) {
   return std::use_facet<std::numpunct<Char>>(loc.get<std::locale>())
       .thousands_sep();
@@ -215,6 +218,10 @@ template <typename Char> FMT_FUNC Char decimal_point_impl(locale_ref loc) {
 }
 }  // namespace internal
 #else
+template <typename Char>
+FMT_FUNC std::string internal::grouping_impl(locale_ref) {
+  return "\03";
+}
 template <typename Char>
 FMT_FUNC Char internal::thousands_sep_impl(locale_ref) {
   return FMT_STATIC_THOUSANDS_SEPARATOR;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -807,6 +807,14 @@ inline int count_digits(uint32_t n) {
 }
 #endif
 
+template <typename Char> FMT_API std::string grouping_impl(locale_ref loc);
+template <typename Char> inline std::string grouping(locale_ref loc) {
+  return grouping_impl<char>(loc);
+}
+template <> inline std::string grouping<wchar_t>(locale_ref loc) {
+  return grouping_impl<wchar_t>(loc);
+}
+
 template <typename Char> FMT_API Char thousands_sep_impl(locale_ref loc);
 template <typename Char> inline Char thousands_sep(locale_ref loc) {
   return Char(thousands_sep_impl<char>(loc));
@@ -866,7 +874,7 @@ inline Iterator format_decimal(Iterator out, UInt value, int num_digits,
   FMT_ASSERT(num_digits >= 0, "invalid digit count");
   // Buffer should be large enough to hold all digits (<= digits10 + 1).
   enum { max_size = digits10<UInt>() + 1 };
-  Char buffer[max_size + max_size / 3];
+  Char buffer[2 * max_size];
   auto end = format_decimal(buffer, value, num_digits, add_thousands_sep);
   return internal::copy_str<Char>(buffer, end, out);
 }
@@ -1513,6 +1521,7 @@ template <typename Range> class basic_writer {
     struct num_writer {
       unsigned_type abs_value;
       int size;
+      const std::string& groups;
       char_type sep;
 
       template <typename It> void operator()(It&& it) const {
@@ -1520,9 +1529,17 @@ template <typename Range> class basic_writer {
         // Index of a decimal digit with the least significant digit having
         // index 0.
         unsigned digit_index = 0;
+        std::string::const_iterator group = groups.cbegin();
         it = internal::format_decimal<char_type>(
-            it, abs_value, size, [s, &digit_index](char_type*& buffer) {
-              if (++digit_index % 3 != 0) return;
+            it, abs_value, size,
+            [this, s, &group, &digit_index](char_type*& buffer) {
+              if (*group <= 0 || ++digit_index % *group != 0 ||
+                  *group == max_value<char>())
+                return;
+              if (group + 1 != groups.cend()) {
+                digit_index = 0;
+                ++group;
+              }
               buffer -= s.size();
               std::uninitialized_copy(s.data(), s.data() + s.size(),
                                       internal::make_checked(buffer, s.size()));
@@ -1531,12 +1548,23 @@ template <typename Range> class basic_writer {
     };
 
     void on_num() {
+      std::string groups = internal::grouping<char_type>(writer.locale_);
+      if (groups.empty()) return on_dec();
       char_type sep = internal::thousands_sep<char_type>(writer.locale_);
       if (!sep) return on_dec();
       int num_digits = internal::count_digits(abs_value);
-      int size = num_digits + sep_size * ((num_digits - 1) / 3);
+      int size = num_digits;
+      std::string::const_iterator group = groups.cbegin();
+      while (group != groups.cend() && num_digits > *group && *group > 0 &&
+             *group != max_value<char>()) {
+        size += sep_size;
+        num_digits -= *group;
+        ++group;
+      }
+      if (group == groups.cend())
+        size += sep_size * ((num_digits - 1) / groups.back());
       writer.write_int(size, get_prefix(), specs,
-                       num_writer{abs_value, size, sep});
+                       num_writer{abs_value, size, groups, sep});
     }
 
     FMT_NORETURN void on_error() {

--- a/src/format.cc
+++ b/src/format.cc
@@ -21,6 +21,7 @@ template FMT_API std::locale internal::locale_ref::get<std::locale>() const;
 
 // Explicit instantiations for char.
 
+template FMT_API std::string internal::grouping_impl<char>(locale_ref);
 template FMT_API char internal::thousands_sep_impl(locale_ref);
 template FMT_API char internal::decimal_point_impl(locale_ref);
 
@@ -43,6 +44,7 @@ template FMT_API char* internal::sprintf_format(long double,
 
 // Explicit instantiations for wchar_t.
 
+template FMT_API std::string internal::grouping_impl<wchar_t>(locale_ref);
 template FMT_API wchar_t internal::thousands_sep_impl(locale_ref);
 template FMT_API wchar_t internal::decimal_point_impl(locale_ref);
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1475,11 +1475,7 @@ TEST(FormatterTest, FormatOct) {
 }
 
 TEST(FormatterTest, FormatIntLocale) {
-  EXPECT_EQ("123", format("{:n}", 123));
-  EXPECT_EQ("1,234", format("{:n}", 1234));
-  EXPECT_EQ("1,234,567", format("{:n}", 1234567));
-  EXPECT_EQ("4,294,967,295",
-            format("{:n}", max_value<uint32_t>()));
+  EXPECT_EQ("1234", format("{:n}", 1234));
 }
 
 struct ConvertibleToLongLong {

--- a/test/locale-test.cc
+++ b/test/locale-test.cc
@@ -8,11 +8,35 @@
 #include "fmt/locale.h"
 #include "gmock.h"
 
+using fmt::internal::max_value;
+
 #ifndef FMT_STATIC_THOUSANDS_SEPARATOR
 template <typename Char> struct numpunct : std::numpunct<Char> {
  protected:
   Char do_decimal_point() const FMT_OVERRIDE { return '?'; }
+  std::string do_grouping() const FMT_OVERRIDE { return "\03"; }
   Char do_thousands_sep() const FMT_OVERRIDE { return '~'; }
+};
+
+template <typename Char> struct no_grouping : std::numpunct<Char> {
+ protected:
+  Char do_decimal_point() const FMT_OVERRIDE { return '.'; }
+  std::string do_grouping() const FMT_OVERRIDE { return ""; }
+  Char do_thousands_sep() const FMT_OVERRIDE { return ','; }
+};
+
+template <typename Char> struct special_grouping : std::numpunct<Char> {
+ protected:
+  Char do_decimal_point() const FMT_OVERRIDE { return '.'; }
+  std::string do_grouping() const FMT_OVERRIDE { return "\03\02"; }
+  Char do_thousands_sep() const FMT_OVERRIDE { return ','; }
+};
+
+template <typename Char> struct small_grouping : std::numpunct<Char> {
+ protected:
+  Char do_decimal_point() const FMT_OVERRIDE { return '.'; }
+  std::string do_grouping() const FMT_OVERRIDE { return "\01"; }
+  Char do_thousands_sep() const FMT_OVERRIDE { return ','; }
 };
 
 TEST(LocaleTest, DoubleDecimalPoint) {
@@ -29,24 +53,44 @@ TEST(LocaleTest, DoubleDecimalPoint) {
 
 TEST(LocaleTest, Format) {
   std::locale loc(std::locale(), new numpunct<char>());
-  EXPECT_EQ("1,234,567", fmt::format(std::locale(), "{:n}", 1234567));
+  EXPECT_EQ("1234567", fmt::format(std::locale(), "{:n}", 1234567));
   EXPECT_EQ("1~234~567", fmt::format(loc, "{:n}", 1234567));
   fmt::format_arg_store<fmt::format_context, int> as{1234567};
   EXPECT_EQ("1~234~567", fmt::vformat(loc, "{:n}", fmt::format_args(as)));
   std::string s;
   fmt::format_to(std::back_inserter(s), loc, "{:n}", 1234567);
   EXPECT_EQ("1~234~567", s);
+
+  std::locale no_grouping_loc(std::locale(), new no_grouping<char>());
+  EXPECT_EQ("1234567", fmt::format(no_grouping_loc, "{:n}", 1234567));
+
+  std::locale special_grouping_loc(std::locale(), new special_grouping<char>());
+  EXPECT_EQ("1,23,45,678", fmt::format(special_grouping_loc, "{:n}", 12345678));
+
+  std::locale small_grouping_loc(std::locale(), new small_grouping<char>());
+  EXPECT_EQ("4,2,9,4,9,6,7,2,9,5",
+            fmt::format(small_grouping_loc, "{:n}", max_value<uint32_t>()));
 }
 
 TEST(LocaleTest, WFormat) {
   std::locale loc(std::locale(), new numpunct<wchar_t>());
-  EXPECT_EQ(L"1,234,567", fmt::format(std::locale(), L"{:n}", 1234567));
+  EXPECT_EQ(L"1234567", fmt::format(std::locale(), L"{:n}", 1234567));
   EXPECT_EQ(L"1~234~567", fmt::format(loc, L"{:n}", 1234567));
   fmt::format_arg_store<fmt::wformat_context, int> as{1234567};
   EXPECT_EQ(L"1~234~567", fmt::vformat(loc, L"{:n}", fmt::wformat_args(as)));
-  auto sep =
-      std::use_facet<std::numpunct<wchar_t>>(std::locale("C")).thousands_sep();
-  auto result = sep == ',' ? L"1,234,567" : L"1234567";
-  EXPECT_EQ(result, fmt::format(std::locale("C"), L"{:n}", 1234567));
+  EXPECT_EQ(L"1234567", fmt::format(std::locale("C"), L"{:n}", 1234567));
+
+  std::locale no_grouping_loc(std::locale(), new no_grouping<wchar_t>());
+  EXPECT_EQ(L"1234567", fmt::format(no_grouping_loc, L"{:n}", 1234567));
+
+  std::locale special_grouping_loc(std::locale(),
+                                   new special_grouping<wchar_t>());
+  EXPECT_EQ(L"1,23,45,678",
+            fmt::format(special_grouping_loc, L"{:n}", 12345678));
+
+  std::locale small_grouping_loc(std::locale(), new small_grouping<wchar_t>());
+  EXPECT_EQ(L"4,2,9,4,9,6,7,2,9,5",
+            fmt::format(small_grouping_loc, L"{:n}", max_value<uint32_t>()));
 }
+
 #endif  // FMT_STATIC_THOUSANDS_SEPARATOR

--- a/test/std-format-test.cc
+++ b/test/std-format-test.cc
@@ -61,11 +61,11 @@ TEST(StdFormatTest, Int) {
   string s0 = format("{}", 42);                       // s0 == "42"
   string s1 = format("{0:b} {0:d} {0:o} {0:x}", 42);  // s1 == "101010 42 52 2a"
   string s2 = format("{0:#x} {0:#X}", 42);            // s2 == "0x2a 0X2A"
-  string s3 = format("{:n}", 1234);  // s3 == "1,234" (depends on the locale)
+  string s3 = format("{:n}", 1234);  // s3 == "1234" (depends on the locale)
   EXPECT_EQ(s0, "42");
   EXPECT_EQ(s1, "101010 42 52 2a");
   EXPECT_EQ(s2, "0x2a 0X2A");
-  EXPECT_EQ(s3, "1,234");
+  EXPECT_EQ(s3, "1234");
 }
 
 #include <format>


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

PR for [#1393](https://github.com/fmtlib/fmt/issues/1393)