### PR TITLE
Use overridden locale in ostream

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1076,6 +1076,8 @@ class locale_ref {
   locale_ref() : locale_(nullptr) {}
   template <typename Locale> explicit locale_ref(const Locale& loc);
 
+  explicit operator bool() const FMT_NOEXCEPT { return locale_ != nullptr; }
+
   template <typename Locale> Locale get() const;
 };
 

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -89,9 +89,11 @@ void write(std::basic_ostream<Char>& os, buffer<Char>& buf) {
 }
 
 template <typename Char, typename T>
-void format_value(buffer<Char>& buf, const T& value) {
+void format_value(buffer<Char>& buf, const T& value,
+                  locale_ref loc = locale_ref()) {
   formatbuf<Char> format_buf(buf);
   std::basic_ostream<Char> output(&format_buf);
+  if (loc) output.imbue(loc.get<std::locale>());
   output.exceptions(std::ios_base::failbit | std::ios_base::badbit);
   output << value;
   buf.resize(buf.size());
@@ -104,7 +106,7 @@ struct fallback_formatter<T, Char, enable_if_t<is_streamable<T, Char>::value>>
   template <typename Context>
   auto format(const T& value, Context& ctx) -> decltype(ctx.out()) {
     basic_memory_buffer<Char> buffer;
-    format_value(buffer, value);
+    format_value(buffer, value, ctx.locale());
     basic_string_view<Char> str(buffer.data(), buffer.size());
     return formatter<basic_string_view<Char>, Char>::format(str, ctx);
   }


### PR DESCRIPTION
I'm wondering if the overridden locale can be passed to ostream. Here is a code with the current behavior:
```cpp
struct S
{
  string a;
  int b;
};

ostream& operator<<(ostream& os, const S& s)
{ return os << "{" << s.a << ": " << s.b << "}"; }

locale::global (locale ("fr-FR"));
format (locale("en-US"), "{} {:n} {}", 1234, 1234, S {"test", 1234});
// gives 1234 1,234 {test: 1 234}
```
For known types (including `chrono`), `format` is using `C` locale or the overridden locale. In this example, I don't see the interest to display the result of ostream with the `global` locale...

I can override the current behavior by implementing the following for each of my own classes:
```cpp
namespace fmt
{
  template <>
  struct formatter<S> : formatter<basic_string_view<char>, char>
  {
    using base_type = formatter<basic_string_view<char>, char>;

    auto format (const S& value, format_context& ctx)
    {
      basic_memory_buffer<char> buffer;
      internal::formatbuf<char> format_buffer (buffer);
      std::basic_ostream<char> out (&format_buffer);
      out.imbue (ctx.locale ().get<std::locale> ());
      out.exceptions (std::ios_base::failbit | std::ios_base::badbit);
      out << value;

      buffer.resize (buffer.size ());
      basic_string_view<char> str (buffer.data (), buffer.size ());
      return base_type::format (str, ctx);
    }
  };
}
```
But I'm wondering if this can be done as standard for ostream.

