### PR TITLE
Move has_formatter into the public fmt namespace.

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -541,13 +541,13 @@ struct FMT_DEPRECATED convert_to_int
     : bool_constant<!std::is_arithmetic<T>::value &&
                     std::is_convertible<T, int>::value> {};
 
-namespace internal {
-
 // Specifies if T has an enabled formatter specialization. A type can be
 // formattable even if it doesn't have a formatter e.g. via a conversion.
 template <typename T, typename Context>
 using has_formatter =
     std::is_constructible<typename Context::template formatter_type<T>>;
+
+namespace internal {
 
 /** A contiguous memory buffer with an optional growing ability. */
 template <typename T> class buffer {

--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -455,9 +455,9 @@ FMT_END_NAMESPACE
 TEST(CoreTest, HasFormatter) {
   using fmt::has_formatter;
   using context = fmt::format_context;
-  static_assert(has_formatter<enabled_formatter, context>::value);
-  static_assert(!has_formatter<disabled_formatter, context>::value);
-  static_assert(!has_formatter<disabled_formatter_convertible, context>::value);
+  static_assert(has_formatter<enabled_formatter, context>::value, "");
+  static_assert(!has_formatter<disabled_formatter, context>::value, "");
+  static_assert(!has_formatter<disabled_formatter_convertible, context>::value, "");
 }
 
 struct convertible_to_int {

--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -453,11 +453,11 @@ template <> struct formatter<enabled_formatter> {
 FMT_END_NAMESPACE
 
 TEST(CoreTest, HasFormatter) {
-  using fmt::internal::has_formatter;
+  using fmt::has_formatter;
   using context = fmt::format_context;
-  EXPECT_TRUE((has_formatter<enabled_formatter, context>::value));
-  EXPECT_FALSE((has_formatter<disabled_formatter, context>::value));
-  EXPECT_FALSE((has_formatter<disabled_formatter_convertible, context>::value));
+  static_assert(has_formatter<enabled_formatter, context>::value);
+  static_assert(!has_formatter<disabled_formatter, context>::value);
+  static_assert(!has_formatter<disabled_formatter_convertible, context>::value);
 }
 
 struct convertible_to_int {

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1975,7 +1975,7 @@ TEST(FormatTest, Enum) { EXPECT_EQ("0", fmt::format("{}", A)); }
 
 TEST(FormatTest, FormatterNotSpecialized) {
   static_assert(!fmt::has_formatter<fmt::formatter<TestEnum>,
-                                    fmt::format_context>::value);
+                                    fmt::format_context>::value, "");
 }
 
 #if FMT_HAS_FEATURE(cxx_strong_enums)

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1974,8 +1974,8 @@ enum TestEnum { A };
 TEST(FormatTest, Enum) { EXPECT_EQ("0", fmt::format("{}", A)); }
 
 TEST(FormatTest, FormatterNotSpecialized) {
-  EXPECT_FALSE((fmt::internal::has_formatter<fmt::formatter<TestEnum>,
-                                             fmt::format_context>::value));
+  static_assert(!fmt::has_formatter<fmt::formatter<TestEnum>,
+                                    fmt::format_context>::value);
 }
 
 #if FMT_HAS_FEATURE(cxx_strong_enums)


### PR DESCRIPTION
This will allow users to do SFINAE-friendly checks for
the formattability of a type.

Fixes #1369