### PR TITLE
fix bad oss fuzz link in the oss-fuzz badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@
 
 .. image:: https://oss-fuzz-build-logs.storage.googleapis.com/badges/libfmt.svg
    :alt: fmt is continuously fuzzed att oss-fuzz
-   :target: https://bugs.chromium.org/p/oss-fuzz/issues/list?colspec=ID%20Type%20Component%20Status%20Proj%20Reported%20Owner%20Summary&q=proj%3Dfmt&can=1
+   :target: https://bugs.chromium.org/p/oss-fuzz/issues/list?colspec=ID%20Type%20Component%20Status%20Proj%20Reported%20Owner%20Summary&q=proj%3Dlibfmt&can=1
 
 **{fmt}** is an open-source formatting library for C++.
 It can be used as a safe and fast alternative to (s)printf and iostreams.


### PR DESCRIPTION
Finally a bug crept in, so we could verify that the bug tracker link worked properly :-)
