### PR TITLE
Squelch MSVC warning exporting subclasses of runtime_error

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -168,9 +168,9 @@
 
 #if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
 #  ifdef FMT_EXPORT
-#    define FMT_API __declspec(dllexport)
+#    define FMT_API __pragma(warning(suppress : 4275)) __declspec(dllexport)
 #  elif defined(FMT_SHARED)
-#    define FMT_API __declspec(dllimport)
+#    define FMT_API __pragma(warning(suppress : 4275)) __declspec(dllimport)
 #    define FMT_EXTERN_TEMPLATE_API FMT_API
 #  endif
 #endif


### PR DESCRIPTION
When compiling {fmt} as a DLL, MSVC complains that we are exporting
classes that inherit from "std::runtime_error", which we are not
exporting.

In this case, it's not really a problem because that symbol is already
exported via the C++ stdlib. So we just add a pragma to silence the
warning.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
