### PR TITLE
Fix compilation with MinGW

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -166,10 +166,15 @@
 #endif
 
 #if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
+#  if FMT_MSC_VER
+#    define FMT_NO_W4275 __pragma(warning(suppress : 4275))
+#  else
+#    define FMT_NO_W4275
+#  endif
 #  ifdef FMT_EXPORT
-#    define FMT_API __pragma(warning(suppress : 4275)) __declspec(dllexport)
+#    define FMT_API FMT_NO_W4275 __declspec(dllexport)
 #  elif defined(FMT_SHARED)
-#    define FMT_API __pragma(warning(suppress : 4275)) __declspec(dllimport)
+#    define FMT_API FMT_NO_W4275 __declspec(dllimport)
 #    define FMT_EXTERN_TEMPLATE_API FMT_API
 #  endif
 #endif


### PR DESCRIPTION
Commit 3bc28fcc6b2a ("Squelch MSVC warning exporting subclasses of
runtime_error", 2019-11-29) silenced a MSVC warning under. The MinGW
compiler also defines _WIN32, but does not support the "warning" pragma.

Introduce a helper macro to squelch the MSVC warning only when using the
Microsoft compiler.

Signed-off-by: Beat Bolli <dev@drbeat.li>

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
