### PR TITLE
Export assert_fail with FMT_API. This fixes dll build.

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -229,7 +229,7 @@ namespace internal {
 // A workaround for gcc 4.8 to make void_t work in a SFINAE context.
 template <typename... Ts> struct void_t_impl { using type = void; };
 
-void assert_fail(const char* file, int line, const char* message);
+FMT_API void assert_fail(const char* file, int line, const char* message);
 
 #ifndef FMT_ASSERT
 #  ifdef NDEBUG

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -55,7 +55,7 @@ inline fmt::internal::null<> strerror_s(char*, std::size_t, ...) { return {}; }
 FMT_BEGIN_NAMESPACE
 namespace internal {
 
-FMT_API FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
+FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
   print(stderr, "{}:{}: assertion failed: {}", file, line, message);
   std::abort();
 }

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -55,7 +55,7 @@ inline fmt::internal::null<> strerror_s(char*, std::size_t, ...) { return {}; }
 FMT_BEGIN_NAMESPACE
 namespace internal {
 
-FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
+FMT_API FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
   print(stderr, "{}:{}: assertion failed: {}", file, line, message);
   std::abort();
 }


### PR DESCRIPTION
See https://github.com/fmtlib/fmt/issues/1445

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
