### PR TITLE
Fix handling of types with custom formatters that are convertible to std::string_view

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -878,7 +878,9 @@ template <typename Context> struct arg_mapper {
       FMT_ENABLE_IF(
           std::is_constructible<std_string_view<char_type>, T>::value &&
           !std::is_constructible<basic_string_view<char_type>, T>::value &&
-          !is_string<T>::value)>
+          !is_string<T>::value &&
+          !has_formatter<T, Context>::value &&
+          !has_fallback_formatter<T, Context>::value)>
   FMT_CONSTEXPR basic_string_view<char_type> map(const T& val) {
     return std_string_view<char_type>(val);
   }

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1685,6 +1685,28 @@ TEST(FormatterTest, FormatStdStringView) {
   EXPECT_EQ("test", format("{}", std::string_view("test")));
   EXPECT_EQ("foo", format("{}", string_viewable()));
 }
+
+struct explicitly_convertible_to_std_string_view {
+  explicit operator std::string_view() const { return "foo"; }
+};
+
+namespace fmt {
+
+template <>
+struct formatter<explicitly_convertible_to_std_string_view>
+    : formatter<std::string_view> {
+  auto format(const explicitly_convertible_to_std_string_view& v,
+              format_context& ctx) {
+    return format_to(ctx.out(), "'{}'", std::string_view(v));
+  }
+};
+
+}  // namespace fmt
+
+TEST(FormatterTest, FormatExplicitlyConvertibleToStdStringView) {
+  EXPECT_EQ("'foo'",
+            fmt::format("{}", explicitly_convertible_to_std_string_view()));
+}
 #endif
 
 FMT_BEGIN_NAMESPACE


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

I commented at the PR (https://github.com/fmtlib/fmt/pull/1342) as well but types that are convertible to `std::string_view` have ambiguous lookup after that change.

I am not sure if this is the right solution but I wanted to start the discussion here. And this change fixes the ambiguous lookup in my case.
