### PR TITLE
Allow for different begin/end types

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -8,13 +8,13 @@
 #ifndef FMT_CHRONO_H_
 #define FMT_CHRONO_H_
 
-#include "format.h"
-#include "locale.h"
-
 #include <chrono>
 #include <ctime>
 #include <locale>
 #include <sstream>
+
+#include "format.h"
+#include "locale.h"
 
 FMT_BEGIN_NAMESPACE
 
@@ -1038,8 +1038,11 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
 
   using iterator = typename basic_format_parse_context<Char>::iterator;
   struct parse_range {
-    iterator begin;
-    iterator end;
+    iterator first;
+    iterator last;
+
+    iterator begin() const { return first; }
+    iterator end() const { return last; }
   };
 
   FMT_CONSTEXPR parse_range do_parse(basic_format_parse_context<Char>& ctx) {
@@ -1067,8 +1070,8 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
       -> decltype(ctx.begin()) {
     auto range = do_parse(ctx);
     format_str = basic_string_view<Char>(
-        &*range.begin, internal::to_unsigned(range.end - range.begin));
-    return range.end;
+        &*range.begin(), internal::to_unsigned(range.end() - range.begin()));
+    return range.end();
   }
 
   template <typename FormatContext>

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3217,22 +3217,22 @@ template <typename T> inline const void* ptr(const std::shared_ptr<T>& p) {
   return p.get();
 }
 
-template <typename It, typename Char>
+template <typename It, typename S, typename Char>
 struct arg_join : internal::view {
   It first;
-  It last;
+  S last;
   basic_string_view<Char> sep;
 
-  arg_join(It b, It e, basic_string_view<Char> s) : first(b), last(e), sep(s) {}
+  arg_join(It f, S l, basic_string_view<Char> s) : first(f), last(l), sep(s) {}
   It begin() const { return first; }
-  It end() const { return last; }
+  S end() const { return last; }
 };
 
-template <typename It, typename Char>
-struct formatter<arg_join<It, Char>, Char>
+template <typename It, typename S, typename Char>
+struct formatter<arg_join<It, S, Char>, Char>
     : formatter<typename std::iterator_traits<It>::value_type, Char> {
   template <typename FormatContext>
-  auto format(const arg_join<It, Char>& value, FormatContext& ctx)
+  auto format(const arg_join<It, S, Char>& value, FormatContext& ctx)
       -> decltype(ctx.out()) {
     using base = formatter<typename std::iterator_traits<It>::value_type, Char>;
     auto it = value.begin();
@@ -3253,13 +3253,13 @@ struct formatter<arg_join<It, Char>, Char>
   Returns an object that formats the iterator range `[begin, end)` with elements
   separated by `sep`.
  */
-template <typename It>
-arg_join<It, char> join(It begin, It end, string_view sep) {
+template <typename It, typename S = It>
+arg_join<It, S, char> join(It begin, S end, string_view sep) {
   return {begin, end, sep};
 }
 
-template <typename It>
-arg_join<It, wchar_t> join(It begin, It end, wstring_view sep) {
+template <typename It, typename S = It>
+arg_join<It, S, wchar_t> join(It begin, S end, wstring_view sep) {
   return {begin, end, sep};
 }
 
@@ -3275,13 +3275,15 @@ arg_join<It, wchar_t> join(It begin, It end, wstring_view sep) {
   \endrst
  */
 template <typename Range>
-arg_join<internal::iterator_t<const Range>, char>
+arg_join<internal::iterator_t<const Range>, internal::iterator_t<const Range>,
+         char>
 join(const Range& range, string_view sep) {
   return join(std::begin(range), std::end(range), sep);
 }
 
 template <typename Range>
-arg_join<internal::iterator_t<const Range>, wchar_t>
+arg_join<internal::iterator_t<const Range>, internal::iterator_t<const Range>,
+         wchar_t>
 join(const Range& range, wstring_view sep) {
   return join(std::begin(range), std::end(range), sep);
 }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -33,8 +33,6 @@
 #ifndef FMT_FORMAT_H_
 #define FMT_FORMAT_H_
 
-#include "core.h"
-
 #include <algorithm>
 #include <cerrno>
 #include <cmath>
@@ -42,6 +40,8 @@
 #include <limits>
 #include <memory>
 #include <stdexcept>
+
+#include "core.h"
 
 #ifdef __clang__
 #  define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
@@ -3217,12 +3217,15 @@ template <typename T> inline const void* ptr(const std::shared_ptr<T>& p) {
   return p.get();
 }
 
-template <typename It, typename Char> struct arg_join : internal::view {
-  It begin;
-  It end;
+template <typename It, typename Char>
+struct arg_join : internal::view {
+  It first;
+  It last;
   basic_string_view<Char> sep;
 
-  arg_join(It b, It e, basic_string_view<Char> s) : begin(b), end(e), sep(s) {}
+  arg_join(It b, It e, basic_string_view<Char> s) : first(b), last(e), sep(s) {}
+  It begin() const { return first; }
+  It end() const { return last; }
 };
 
 template <typename It, typename Char>
@@ -3232,11 +3235,11 @@ struct formatter<arg_join<It, Char>, Char>
   auto format(const arg_join<It, Char>& value, FormatContext& ctx)
       -> decltype(ctx.out()) {
     using base = formatter<typename std::iterator_traits<It>::value_type, Char>;
-    auto it = value.begin;
+    auto it = value.begin();
     auto out = ctx.out();
-    if (it != value.end) {
+    if (it != value.end()) {
       out = base::format(*it++, ctx);
-      while (it != value.end) {
+      while (it != value.end()) {
         out = std::copy(value.sep.begin(), value.sep.end(), out);
         ctx.advance_to(out);
         out = base::format(*it++, ctx);
@@ -3272,14 +3275,14 @@ arg_join<It, wchar_t> join(It begin, It end, wstring_view sep) {
   \endrst
  */
 template <typename Range>
-arg_join<internal::iterator_t<const Range>, char> join(const Range& range,
-                                                       string_view sep) {
+arg_join<internal::iterator_t<const Range>, char>
+join(const Range& range, string_view sep) {
   return join(std::begin(range), std::end(range), sep);
 }
 
 template <typename Range>
-arg_join<internal::iterator_t<const Range>, wchar_t> join(const Range& range,
-                                                          wstring_view sep) {
+arg_join<internal::iterator_t<const Range>, wchar_t>
+join(const Range& range, wstring_view sep) {
   return join(std::begin(range), std::end(range), sep);
 }
 


### PR DESCRIPTION
Different types for begin/end iterators are possible for the same range. Multiple libraries have such containers/ranges defined; including range-v3 and C++20 standard ranges.

This issue presented itself as a ghastly template compile error when I tried to use a specific range-v3 view with the fmt library; whereas other views worked just fine. On inspection, it was due to begin/end having different types; and fmt not being able to hand it.

This patch adds the ability to pass a "range" to `fmt::join` and `fmt::arg_join` which has different types.

Whilst making the change, I noticed a couple of structs using `begin` and `end` as member variables rather than member functions. This is not ideal, and breaks compatibility with many libraries, including the standard. Keeping them as structs, would require a different name; to keep consistent naming conventions, `first` and `last` were chosen.

Member functions `begin()` and `end()` were added for clarity and consistency, and to improve usability of the objects with other libraries.

This technically is a breaking change because these were structs, and thus these members were public. If some poor soul is using the `begin` and `end` member variables directly (which they are allowed to do); this change would result in a compile error; which can be fixed by adding parens.

Feel free to cherry pick around the patches that make that change; however, I suggest it is kept, as it improves usability with most libraries that follow the standard's practice.

My suggestion would be to make them classes, and to make `first` and `last` private; and thus can be changed to `begin_` and `end_` to be consistent with the class member variable naming, and be true to their original names. This of course has the added benefit of allowing internal changes, without disrupting the public API.

Technically the addition of allowing a different type is a breaking change, for any code that has explicitly stored `fmt::arg_join` without an `auto`. This *can* be "fixed", either by moving the template parameter to the end of the list, and adding a default:

    template <typename It, typename Char, typename S = It>

The alternative of:

    template <typename It, typename S = It, typename Char = char>

fixes that, but alas, still will break the code of someone who has hardcoded the type.

The only suggestion I would have would be to `std::move` the iterators into `fmt::arg_join` (both from `fmt::join` and `fmt::arg_join::arg_join`. These days iterators may not be as light weight as a pointer (or two); especially smart iterators. Thus copying may be a little expensive. fmt forces these copies with it's value interface; this is fine (and preferred), for sinks; but `std::move`ing the copy into the structure can prevent unnecessary copies (up to 2 if using `fmt::join`).

I played with it, but it caused issues with some of the tests, and wouldn't compile; which is perplexing; and indicates to me that the tests might be relying on something they ought not.

On a similar note, `fmt::arg_join` should not need a constructor, at least as it stands. It should match the criteria of an aggregate type, without the constructor; thus not needing it. However, returning the braced-initializer-lists from `fmt::join` cause compile errors when the constructor is removed. This should not occur for aggregate types; but I cannot determine why.


Touched files were run through `clang-format`.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
