### PR TITLE
Squelch MSVC warning exporting subclasses of runtime_error (fix for PR #1433)

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -167,9 +167,9 @@
 
 #if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
 #  ifdef FMT_EXPORT
-#    define FMT_API __declspec(dllexport)
+#    define FMT_API __pragma(warning(suppress : 4275)) __declspec(dllexport)
 #  elif defined(FMT_SHARED)
-#    define FMT_API __declspec(dllimport)
+#    define FMT_API __pragma(warning(suppress : 4275)) __declspec(dllimport)
 #    define FMT_EXTERN_TEMPLATE_API FMT_API
 #  endif
 #endif

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -166,10 +166,15 @@
 #endif
 
 #if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
+#  if FMT_MSC_VER
+#    define FMT_NO_W4275 __pragma(warning(suppress : 4275))
+#  else
+#    define FMT_NO_W4275
+#  endif
 #  ifdef FMT_EXPORT
-#    define FMT_API __pragma(warning(suppress : 4275)) __declspec(dllexport)
+#    define FMT_API FMT_NO_W4275 __declspec(dllexport)
 #  elif defined(FMT_SHARED)
-#    define FMT_API __pragma(warning(suppress : 4275)) __declspec(dllimport)
+#    define FMT_API FMT_NO_W4275 __declspec(dllimport)
 #    define FMT_EXTERN_TEMPLATE_API FMT_API
 #  endif
 #endif

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -171,12 +171,16 @@
 #  else
 #    define FMT_NO_W4275
 #  endif
+#  define FMT_CLASS_API FMT_NO_W4275
 #  ifdef FMT_EXPORT
-#    define FMT_API FMT_NO_W4275 __declspec(dllexport)
+#    define FMT_API __declspec(dllexport)
 #  elif defined(FMT_SHARED)
-#    define FMT_API FMT_NO_W4275 __declspec(dllimport)
+#    define FMT_API __declspec(dllimport)
 #    define FMT_EXTERN_TEMPLATE_API FMT_API
 #  endif
+#endif
+#ifndef FMT_CLASS_API
+#  define FMT_CLASS_API
 #endif
 #ifndef FMT_API
 #  define FMT_API

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -688,6 +688,7 @@ using memory_buffer = basic_memory_buffer<char>;
 using wmemory_buffer = basic_memory_buffer<wchar_t>;
 
 /** A formatting error such as invalid format string. */
+FMT_CLASS_API
 class FMT_API format_error : public std::runtime_error {
  public:
   explicit format_error(const char* message) : std::runtime_error(message) {}
@@ -2699,6 +2700,7 @@ class arg_formatter : public internal::arg_formatter_base<Range> {
  An error returned by an operating system or a language runtime,
  for example a file opening error.
 */
+FMT_CLASS_API
 class FMT_API system_error : public std::runtime_error {
  private:
   void init(int err_code, string_view format_str, format_args args);


### PR DESCRIPTION
Based on PR #1433, which was reverted because of issue #1450 (i.e. fails to build under VS2015). This PR fixes that build while keeping the applicable warnings silenced.

VS2015 does not support the __pragma(...) syntax in the midst of a class declaration, so move it to just before the declaration.

original explanation:

> When compiling {fmt} as a DLL, MSVC complains that we are exporting classes that inherit from "std::runtime_error", which we are not exporting.
>     
> In this case, it's not really a problem because that symbol is already exported via the C++ stdlib. So we just add a pragma to silence the warning.

Successful build log:

<details>
<summary>Log</summary>

    cmake -G "Visual Studio 14 2015" -Ax64 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON ..
    -- CMake version: 3.15.5
    -- The CXX compiler identification is MSVC 19.0.24241.7
    -- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/x86_amd64/cl.exe
    -- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/x86_amd64/cl.exe -- works
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Detecting CXX compile features
    -- Detecting CXX compile features - done
    -- Version: 6.1.1
    -- Build type: Release
    -- CXX_STANDARD: 11
    -- Performing Test has_std_11_flag
    -- Performing Test has_std_11_flag - Success
    -- Performing Test has_std_0x_flag
    -- Performing Test has_std_0x_flag - Failed
    -- Performing Test SUPPORTS_VARIADIC_TEMPLATES
    -- Performing Test SUPPORTS_VARIADIC_TEMPLATES - Success
    -- Performing Test SUPPORTS_USER_DEFINED_LITERALS
    -- Performing Test SUPPORTS_USER_DEFINED_LITERALS - Success
    -- Performing Test FMT_HAS_VARIANT
    -- Performing Test FMT_HAS_VARIANT - Failed
    -- Looking for _strtod_l
    -- Looking for _strtod_l - found
    -- Target 'doc' disabled (requires doxygen)
    -- Looking for C++ include pthread.h
    -- Looking for C++ include pthread.h - not found
    -- Found Threads: TRUE  
    -- Performing Test HAVE_FNO_DELETE_NULL_POINTER_CHECKS
    -- Performing Test HAVE_FNO_DELETE_NULL_POINTER_CHECKS - Failed
    -- FMT_PEDANTIC: OFF
    -- Configuring done
    -- Generating done
    -- Build files have been written to: C:/projects/fmt/build
    cmake --build . --config Release
    Microsoft (R) Build Engine version 14.0.25420.1
    Copyright (C) Microsoft Corporation. All rights reserved.
      Checking Build System
      Building Custom Rule C:/projects/fmt/CMakeLists.txt
      format.cc
      posix.cc
      Generating Code...
         Creating library C:/projects/fmt/build/Release/fmt.lib and object C:/projects/fmt/build/Release/fmt.exp
      fmt.vcxproj -> C:\projects\fmt\build\bin\Release\fmt.dll
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      gmock-gtest-all.cc
      gmock.vcxproj -> C:\projects\fmt\build\test\Release\gmock.lib
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      test-main.cc
      gtest-extra.cc
      util.cc
      Generating Code...
      test-main.vcxproj -> C:\projects\fmt\build\test\Release\test-main.lib
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      assert-test.cc
    C:\projects\fmt\test\assert-test.cc(21): warning C4003: not enough actual parameters for macro 'GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_' [C:\projects\fmt\build\test\assert-test.vcxproj]
      assert-test.vcxproj -> C:\projects\fmt\build\bin\Release\assert-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      chrono-test.cc
      chrono-test.vcxproj -> C:\projects\fmt\build\bin\Release\chrono-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      color-test.cc
      color-test.vcxproj -> C:\projects\fmt\build\bin\Release\color-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      compile-test.cc
      compile-test.vcxproj -> C:\projects\fmt\build\bin\Release\compile-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      core-test.cc
      core-test.vcxproj -> C:\projects\fmt\build\bin\Release\core-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      custom-formatter-test.cc
      custom-formatter-test.vcxproj -> C:\projects\fmt\build\bin\Release\custom-formatter-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      format-test.cc
      format-test.vcxproj -> C:\projects\fmt\build\bin\Release\format-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      grisu-test.cc
      grisu-test.vcxproj -> C:\projects\fmt\build\bin\Release\grisu-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      gtest-extra-test.cc
      gtest-extra-test.vcxproj -> C:\projects\fmt\build\bin\Release\gtest-extra-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      header-only-test.cc
      header-only-test2.cc
      test-main.cc
      Generating Code...
      header-only-test.vcxproj -> C:\projects\fmt\build\bin\Release\header-only-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      locale-test.cc
      locale-test.vcxproj -> C:\projects\fmt\build\bin\Release\locale-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      ostream-test.cc
      ostream-test.vcxproj -> C:\projects\fmt\build\bin\Release\ostream-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      posix-mock-test.cc
      format.cc
      test-main.cc
      gtest-extra.cc
      util.cc
      Generating Code...
         Creating library C:/projects/fmt/build/test/Release/posix-mock-test.lib and object C:/projects/fmt/build/test/Release/posix-mock-test.exp
      posix-mock-test.vcxproj -> C:\projects\fmt\build\bin\Release\posix-mock-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      posix-test.cc
      posix-test.vcxproj -> C:\projects\fmt\build\bin\Release\posix-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      printf-test.cc
      printf-test.vcxproj -> C:\projects\fmt\build\bin\Release\printf-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      ranges-test.cc
      ranges-test.vcxproj -> C:\projects\fmt\build\bin\Release\ranges-test.exe
      Building Custom Rule C:/projects/fmt/test/CMakeLists.txt
      scan-test.cc
      scan-test.vcxproj -> C:\projects\fmt\build\bin\Release\scan-test.exe
      Building Custom Rule C:/projects/fmt/CMakeLists.txt
    Discovering tests...OK
    Build success
    
</details>

(build is of shared libraries under VS2015 i.e the config of the associated issue -- including because it's not currently on the auto tests for the repo)

P.S. I'm not sure if I should have cherry-picked, but the commits this one depends on were reverted.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
