### PR TITLE
Eliminate unreachable code warnings

### DIFF
--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -45,10 +45,7 @@ class printf_precision_handler {
 
   template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
   int operator()(T) {
-    FMT_THROW(format_error("precision is not integer"));
-#if FMT_MSC_VER
-    return 0;
-#endif
+    throw format_error("precision is not integer");
   }
 };
 
@@ -168,10 +165,7 @@ template <typename Char> class printf_width_handler {
 
   template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
   unsigned operator()(T) {
-    FMT_THROW(format_error("width is not integer"));
-#if FMT_MSC_VER
-    return 0;
-#endif
+    throw format_error("width is not integer");
   }
 };
 

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -46,6 +46,9 @@ class printf_precision_handler {
   template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
   int operator()(T) {
     FMT_THROW(format_error("precision is not integer"));
+#if FMT_MSC_VER
+    return 0;
+#endif
   }
 };
 
@@ -166,6 +169,9 @@ template <typename Char> class printf_width_handler {
   template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
   unsigned operator()(T) {
     FMT_THROW(format_error("width is not integer"));
+#if FMT_MSC_VER
+    return 0;
+#endif
   }
 };
 

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -46,7 +46,6 @@ class printf_precision_handler {
   template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
   int operator()(T) {
     FMT_THROW(format_error("precision is not integer"));
-    return 0;
   }
 };
 
@@ -167,7 +166,6 @@ template <typename Char> class printf_width_handler {
   template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
   unsigned operator()(T) {
     FMT_THROW(format_error("width is not integer"));
-    return 0;
   }
 };
 


### PR DESCRIPTION
The code following a `FMT_THROW` is unreachable since the exception does not return.  Some compilers (e.g. Nvidia) emit "Unreachable Code" warnings for this construct.  Since this is in an include file, the warning can be emitted many many times.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
