### PR TITLE
Template memory_buffer aliases

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -700,8 +700,11 @@ void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
   if (old_data != store_) Allocator::deallocate(old_data, old_capacity);
 }
 
-using memory_buffer = basic_memory_buffer<char>;
-using wmemory_buffer = basic_memory_buffer<wchar_t>;
+template<std::size_t SIZE = inline_buffer_size, typename Allocator = std::allocator<T>>
+using memory_buffer = basic_memory_buffer<char, SIZE, Allocator>;
+
+template<std::size_t SIZE = inline_buffer_size, typename Allocator = std::allocator<T>>
+using wmemory_buffer = basic_memory_buffer<wchar_t, SIZE, Allocator>;
 
 /** A formatting error such as invalid format string. */
 FMT_CLASS_API

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -700,6 +700,7 @@ void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
   if (old_data != store_) Allocator::deallocate(old_data, old_capacity);
 }
 
+#if defined(__cpp_deduction_guides) && __cpp_deduction_guides >= 201907L
 template <std::size_t SIZE = inline_buffer_size,
           typename Allocator = std::allocator<char>>
 using memory_buffer = basic_memory_buffer<char, SIZE, Allocator>;
@@ -707,6 +708,10 @@ using memory_buffer = basic_memory_buffer<char, SIZE, Allocator>;
 template <std::size_t SIZE = inline_buffer_size,
           typename Allocator = std::allocator<wchar_t>>
 using wmemory_buffer = basic_memory_buffer<wchar_t, SIZE, Allocator>;
+#else
+using memory_buffer = basic_memory_buffer<char>;
+using wmemory_buffer = basic_memory_buffer<wchar_t>;
+#endif // defined(__cpp_deduction_guides) && __cpp_deduction_guides >= 201907L
 
 /** A formatting error such as invalid format string. */
 FMT_CLASS_API

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -701,11 +701,11 @@ void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
 }
 
 template <std::size_t SIZE = inline_buffer_size,
-          typename Allocator = std::allocator<T>>
+          typename Allocator = std::allocator<char>>
 using memory_buffer = basic_memory_buffer<char, SIZE, Allocator>;
 
 template <std::size_t SIZE = inline_buffer_size,
-          typename Allocator = std::allocator<T>>
+          typename Allocator = std::allocator<wchar_t>>
 using wmemory_buffer = basic_memory_buffer<wchar_t, SIZE, Allocator>;
 
 /** A formatting error such as invalid format string. */

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -700,10 +700,12 @@ void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
   if (old_data != store_) Allocator::deallocate(old_data, old_capacity);
 }
 
-template<std::size_t SIZE = inline_buffer_size, typename Allocator = std::allocator<T>>
+template <std::size_t SIZE = inline_buffer_size,
+          typename Allocator = std::allocator<T>>
 using memory_buffer = basic_memory_buffer<char, SIZE, Allocator>;
 
-template<std::size_t SIZE = inline_buffer_size, typename Allocator = std::allocator<T>>
+template <std::size_t SIZE = inline_buffer_size,
+          typename Allocator = std::allocator<T>>
 using wmemory_buffer = basic_memory_buffer<wchar_t, SIZE, Allocator>;
 
 /** A formatting error such as invalid format string. */


### PR DESCRIPTION
This allows consumers to write something like `fmt::memory_buffer<50>` instead of `fmt::basic_memory_buffer<char, 50>` to save stack space when they know that the result of the formatting cannot be bigger than 50 characters.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
