### PR TITLE
fix for warning when using -Wswitch-default

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1067,6 +1067,8 @@ FMT_CONSTEXPR auto visit_format_arg(Visitor&& vis,
     return vis(arg.value_.pointer);
   case internal::custom_type:
     return vis(typename basic_format_arg<Context>::handle(arg.value_.custom));
+  default:
+    break;
   }
   return vis(monostate());
 }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2347,6 +2347,8 @@ FMT_CONSTEXPR const Char* parse_align(const Char* begin, const Char* end,
     case '^':
       align = align::center;
       break;
+    default:
+      break;
     }
     if (align != align::none) {
       if (i > 0) {
@@ -2426,6 +2428,8 @@ FMT_CONSTEXPR const Char* parse_format_specs(const Char* begin, const Char* end,
   case ' ':
     handler.on_space();
     ++begin;
+    break;
+  default:
     break;
   }
   if (begin == end) return begin;


### PR DESCRIPTION
first time contribution ==> my code is your code ;-)

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

In our code base we build with the warning level "-Wswitch-default". As a result switch statements which do not have a default will give rise to a warning.

While using the fmt library a few of these warning popped up (in 3 locations) ,at least in the first usage we have of the library. They are very trivial to fix,and this patch adds in those 3 location and default case in the switch statement.
It would be nice if this could be incorporated, many thanks.

kind regards,
Lieven