### PR TITLE
Eliminate NVCC NVidia compiler emits unreachable code warnings

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -117,8 +117,8 @@
 #  endif
 #endif
 
-// [[noreturn]] is disabled on MSVC because of bogus unreachable code warnings.
-#if FMT_EXCEPTIONS && FMT_HAS_CPP_ATTRIBUTE(noreturn) && !FMT_MSC_VER
+// [[noreturn]] is disabled on MSVC and NVCC because of bogus unreachable code warnings.
+#if FMT_EXCEPTIONS && FMT_HAS_CPP_ATTRIBUTE(noreturn) && !FMT_MSC_VER && !FMT_NVCC
 #  define FMT_NORETURN [[noreturn]]
 #else
 #  define FMT_NORETURN

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -86,12 +86,12 @@
 
 #ifndef FMT_THROW
 #  if FMT_EXCEPTIONS
-#    if FMT_MSC_VER
+#    if FMT_MSC_VER || FMT_NVCC
 FMT_BEGIN_NAMESPACE
 namespace internal {
 template <typename Exception> inline void do_throw(const Exception& x) {
-  // Silence unreachable code warnings in MSVC because these are nearly
-  // impossible to fix in a generic code.
+  // Silence unreachable code warnings in MSVC and NVCC because these 
+  // are nearly impossible to fix in a generic code.
   volatile bool b = true;
   if (b) throw x;
 }


### PR DESCRIPTION
Similar to the MSC Compiler, the NVidia NVCC compiler also
emits unreachable code warnings when there is a return
statement following an exception.  These changes eliminate
those warnings.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
