### PR TITLE
Add Components for CMake Installation Rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,20 +247,20 @@ if (FMT_INSTALL)
   # Install version, config and target files.
   install(
     FILES ${project_config} ${version_config}
-    DESTINATION ${FMT_CMAKE_DIR})
+    DESTINATION ${FMT_CMAKE_DIR} COMPONENT FMT_Development)
   install(EXPORT ${targets_export_name} DESTINATION ${FMT_CMAKE_DIR}
-          NAMESPACE fmt::)
+          NAMESPACE fmt:: COMPONENT FMT_Development)
 
   # Install the library and headers.
   install(TARGETS ${INSTALL_TARGETS} EXPORT ${targets_export_name}
-          LIBRARY DESTINATION ${FMT_LIB_DIR}
-          ARCHIVE DESTINATION ${FMT_LIB_DIR}
-          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+          LIBRARY DESTINATION ${FMT_LIB_DIR} COMPONENT FMT_Runtime
+	  ARCHIVE DESTINATION ${FMT_LIB_DIR} COMPONENT FMT_Development
+	  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT FMT_Runtime)
 
   install(FILES $<TARGET_PDB_FILE:${INSTALL_TARGETS}>
-          DESTINATION ${FMT_LIB_DIR} OPTIONAL)
-  install(FILES ${FMT_HEADERS} DESTINATION ${FMT_INC_DIR})
-  install(FILES "${pkgconfig}" DESTINATION "${FMT_PKGCONFIG_DIR}")
+          DESTINATION ${FMT_LIB_DIR} OPTIONAL COMPONENT FMT_Development)
+  install(FILES ${FMT_HEADERS} DESTINATION ${FMT_INC_DIR} COMPONENT FMT_Development)
+  install(FILES "${pkgconfig}" DESTINATION "${FMT_PKGCONFIG_DIR}" COMPONENT FMT_Development)
 endif ()
 
 if (FMT_DOC)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -9,4 +9,4 @@ add_custom_target(doc
   SOURCES api.rst syntax.rst usage.rst build.py conf.py _templates/layout.html)
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/
-        DESTINATION share/doc/fmt OPTIONAL)
+        DESTINATION share/doc/fmt OPTIONAL COMPONENT FMT_Documentation)

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -58,6 +58,21 @@ Installing the Library
 After building the library you can install it on a Unix-like system by running
 :command:`sudo make install`.
 
+The installation can be broken up into specific sub-components, if desired.
+The library provides the following components:
+
+* ``FMT_Runtime`` - the shared library
+* ``FMT_Development`` - the static library, headers, and package configuration files
+* ``FMT_Documentation`` - the html documentation
+
+As an example, the shared library can be selectively installed by running::
+
+  cmake -DCOMPONENT=FMT_Runtime -P cmake_install.cmake
+
+If using CMake 3.15 or later, then the CMake install command can be used instead::
+
+  cmake --install . --component FMT_Runtime
+
 Usage with CMake
 ================
 


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

Adding components for the CMake installation rules allows users to selectively install different pieces of the library. These are especially useful by parent projects which wish to only install / package the shared library and not the header files, and do not want to have to write their own install rule(s) for the ```fmt``` target in their project.

All components are still installed by default so this behavior is unchanged. For those who wish to only install a particular component, they can leverage CMake commands to do so. As an example, to install only the shared library:
```bash
$ cmake -DCOMPONENT=FMT_Runtime -P cmake_install.cmake
```
If CMake is at least version 3.15, a built-in cmake command is available:
```bash
$ cmake --install . --component FMT_Runtime
```

The other proposed components are ```FMT_Development``` for headers, the static library, pdb file, and package configuration files and ```FMT_Documentation``` for the html documentation. These CMake components follow standard conventions, which include using a project-specific prefix and the common idiom of ```Runtime``` and ```Development``` components.