### PR TITLE
Use C++11-compatible operations

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1426,8 +1426,8 @@ template <typename... Args, typename S, typename Char = char_t<S>>
 inline format_arg_store<buffer_context<Char>, remove_reference_t<Args>...>
 make_args_checked(const S& format_str,
                   const remove_reference_t<Args>&... args) {
-  static_assert(all_true<(!std::is_base_of<view, remove_reference_t<Args>>() ||
-                          !std::is_reference<Args>())...>::value,
+  static_assert(all_true<(!std::is_base_of<view, remove_reference_t<Args>>::value ||
+                          !std::is_reference<Args>::value)...>::value,
                 "passing views as lvalues is disallowed");
   check_format_string<remove_const_t<remove_reference_t<Args>>...>(format_str);
   return {args...};


### PR DESCRIPTION
The `std::is_base_of<T,U>()` and `std::is_reference<T>()` member functions were added in C++14.  To maintain C++11 compatibility, use the `::value` instead.

Current code fails on intel-17 and other compilers if using strict C++11

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
