### PR TITLE
Avoid possible namespace clash for fmt

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -251,7 +251,7 @@ FMT_API void assert_fail(const char* file, int line, const char* message);
 #    define FMT_ASSERT(condition, message) \
       ((condition)                         \
            ? void()                        \
-           : fmt::internal::assert_fail(__FILE__, __LINE__, (message)))
+           : ::fmt::internal::assert_fail(__FILE__, __LINE__, (message)))
 #  endif
 #endif
 


### PR DESCRIPTION
## Problem

In the case of an existing `fmt` namespace (in my project this looks like `Project::fmt`) it is possible to get a namespace clash in debug builds (MSVC 2017)

## Proposed Solution

When referencing `fmt` internally, be explicit that it is relative to the global namespace using `::fmt`

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
