### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,6 +236,20 @@ Folly Format             79.9                  445                430
 compare formatting function overhead only. Boost Format is a
 header-only library so it doesn't provide any linkage options.
 
+
+Quick build
+~~~~~~~~~~~~~~~~~
+
+You can download and install fmt using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install fmt
+
+The fmt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Running the tests
 ~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -238,7 +238,7 @@ header-only library so it doesn't provide any linkage options.
 
 
 Quick build
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~
 
 You can download and install fmt using the `vcpkg <https://github.com/Microsoft/vcpkg>`_ dependency manager::
 
@@ -248,7 +248,10 @@ You can download and install fmt using the `vcpkg <https://github.com/Microsoft/
     $ ./vcpkg integrate install
     $ ./vcpkg install fmt
 
-The fmt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg>`_ on the vcpkg repository.
+The fmt port in vcpkg is kept up to date by Microsoft team members and
+community contributors.
+If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg>`_
+on the vcpkg repository.
 
 Running the tests
 ~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -240,7 +240,7 @@ header-only library so it doesn't provide any linkage options.
 Quick build
 ~~~~~~~~~~~~~~~~~
 
-You can download and install fmt using the `vcpkg<https://github.com/Microsoft/vcpkg>`_ dependency manager::
+You can download and install fmt using the `vcpkg <https://github.com/Microsoft/vcpkg>`_ dependency manager::
 
     $ git clone https://github.com/Microsoft/vcpkg.git
     $ cd vcpkg
@@ -248,7 +248,7 @@ You can download and install fmt using the `vcpkg<https://github.com/Microsoft/v
     $ ./vcpkg integrate install
     $ ./vcpkg install fmt
 
-The fmt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please `create an issue or pull request<https://github.com/Microsoft/vcpkg>`_ on the vcpkg repository.
+The fmt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg>`_ on the vcpkg repository.
 
 Running the tests
 ~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -240,7 +240,7 @@ header-only library so it doesn't provide any linkage options.
 Quick build
 ~~~~~~~~~~~~~~~~~
 
-You can download and install fmt using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager::
+You can download and install fmt using the `vcpkg<https://github.com/Microsoft/vcpkg>`_ dependency manager::
 
     $ git clone https://github.com/Microsoft/vcpkg.git
     $ cd vcpkg
@@ -248,7 +248,7 @@ You can download and install fmt using the [vcpkg](https://github.com/Microsoft/
     $ ./vcpkg integrate install
     $ ./vcpkg install fmt
 
-The fmt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The fmt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please `create an issue or pull request<https://github.com/Microsoft/vcpkg>`_ on the vcpkg repository.
 
 Running the tests
 ~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -240,13 +240,13 @@ header-only library so it doesn't provide any linkage options.
 Quick build
 ~~~~~~~~~~~~~~~~~
 
-You can download and install fmt using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+You can download and install fmt using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager::
 
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    vcpkg install fmt
+    $ git clone https://github.com/Microsoft/vcpkg.git
+    $ cd vcpkg
+    $ ./bootstrap-vcpkg.sh
+    $ ./vcpkg integrate install
+    $ ./vcpkg install fmt
 
 The fmt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 


### PR DESCRIPTION
fmt is available as a port in vcpkg, a C++ library manager that simplifies installation for fmt and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build fmt , ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/fmt/portfile.cmake). We try to keep the library maintained as close as possible to the original library.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
