### PR TITLE
Fix formatting std::chrono::duration types to wide strings

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -441,49 +441,26 @@ template <typename Char> struct formatter<std::tm, Char> {
 
 namespace internal {
 
-template <typename Char, typename Period> FMT_CONSTEXPR const Char* get_units() { return nullptr; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::atto>() { return "as"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::atto>() { return L"as"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::femto>() { return "fs"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::femto>() { return L"fs"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::pico>() { return "ps"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::pico>() { return L"ps"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::nano>() { return "ns"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::nano>() { return L"ns"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::micro>() { 
-  return "µs"; 
-}
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::micro>() { 
-  return L"\u00B5s"; 
-}
-template <> FMT_CONSTEXPR const char* get_units<char, std::milli>() { return "ms"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::milli>() { return L"ms"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::centi>() { return "cs"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::centi>() { return L"cs"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::deci>() { return "ds"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::deci>() { return L"ds"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::ratio<1>>() { return "s"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::ratio<1>>() { return L"s"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::deca>() { return "das"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::deca>() { return L"das"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::hecto>() { return "hs"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::hecto>() { return L"hs"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::kilo>() { return "ks"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::kilo>() { return L"ks"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::mega>() { return "Ms"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::mega>() { return L"Ms"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::giga>() { return "Gs"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::giga>() { return L"Gs"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::tera>() { return "Ts"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::tera>() { return L"Ts"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::peta>() { return "Ps"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::peta>() { return L"Ps"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::exa>() { return "Es"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::exa>() { return L"Es"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::ratio<60>>() { return "m"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::ratio<60>>() { return L"m"; }
-template <> FMT_CONSTEXPR const char* get_units<char, std::ratio<3600>>() { return "h"; }
-template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::ratio<3600>>() { return L"h"; }
+template <typename Period> FMT_CONSTEXPR const char* get_units() { return nullptr; }
+template <> FMT_CONSTEXPR const char* get_units<std::atto>() { return "as"; }
+template <> FMT_CONSTEXPR const char* get_units<std::femto>() { return "fs"; }
+template <> FMT_CONSTEXPR const char* get_units<std::pico>() { return "ps"; }
+template <> FMT_CONSTEXPR const char* get_units<std::nano>() { return "ns"; }
+template <> FMT_CONSTEXPR const char* get_units<std::micro>() { return "µs"; }
+template <> FMT_CONSTEXPR const char* get_units<std::milli>() { return "ms"; }
+template <> FMT_CONSTEXPR const char* get_units<std::centi>() { return "cs"; }
+template <> FMT_CONSTEXPR const char* get_units<std::deci>() { return "ds"; }
+template <> FMT_CONSTEXPR const char* get_units<std::ratio<1>>() { return "s"; }
+template <> FMT_CONSTEXPR const char* get_units<std::deca>() { return "das"; }
+template <> FMT_CONSTEXPR const char* get_units<std::hecto>() { return "hs"; }
+template <> FMT_CONSTEXPR const char* get_units<std::kilo>() { return "ks"; }
+template <> FMT_CONSTEXPR const char* get_units<std::mega>() { return "Ms"; }
+template <> FMT_CONSTEXPR const char* get_units<std::giga>() { return "Gs"; }
+template <> FMT_CONSTEXPR const char* get_units<std::tera>() { return "Ts"; }
+template <> FMT_CONSTEXPR const char* get_units<std::peta>() { return "Ps"; }
+template <> FMT_CONSTEXPR const char* get_units<std::exa>() { return "Es"; }
+template <> FMT_CONSTEXPR const char* get_units<std::ratio<60>>() { return "m"; }
+template <> FMT_CONSTEXPR const char* get_units<std::ratio<3600>>() { return "h"; }
 
 enum class numeric_system {
   standard,
@@ -788,8 +765,15 @@ OutputIt format_duration_value(OutputIt out, Rep val, int precision) {
 
 template <typename Char, typename Period, typename OutputIt>
 OutputIt format_duration_unit(OutputIt out) {
-  const Char format[] { '{', '}', 0 };
-  if (const Char* unit = get_units<Char, Period>()) return format_to(out, format, unit);
+  if (const char* unit = get_units<Period>()) {
+    string_view s(unit);
+    if FMT_CONSTEXPR (std::is_same<Char, wchar_t>::value) {
+      utf8_to_utf16 u(s);
+      return std::copy(u.c_str(), u.c_str() + u.size(), out);
+    } else {
+      return std::copy(s.begin(), s.end(), out);
+    }
+  }
   const Char num_f[] { '[', '{', '}', ']', 's', 0 };
   if (Period::den == 1) return format_to(out, num_f, Period::num);
   const Char num_def_f[] { '[', '{', '}', '/', '{', '}', ']', 's', 0 };

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -894,13 +894,13 @@ struct chrono_formatter {
   void write_pinf() { std::copy_n("inf", 3, out); }
   void write_ninf() { std::copy_n("-inf", 4, out); }
 
-  void format_localized(const tm& time, const char* format) {
+  void format_localized(const tm& time, char format, char modifier = 0) {
     if (isnan(val)) return write_nan();
     auto locale = context.locale().template get<std::locale>();
     auto& facet = std::use_facet<std::time_put<char_type>>(locale);
     std::basic_ostringstream<char_type> os;
     os.imbue(locale);
-    facet.put(os, os, ' ', &time, format, format + std::char_traits<char_type>::length(format));
+    facet.put(os, os, ' ', &time, format, modifier);
     auto str = os.str();
     std::copy(str.begin(), str.end(), out);
   }
@@ -930,8 +930,7 @@ struct chrono_formatter {
     if (ns == numeric_system::standard) return write(hour(), 2);
     auto time = tm();
     time.tm_hour = to_nonnegative_int(hour(), 24);
-    const char_type format[] { '%', 'O', 'H', 0 };
-    format_localized(time, format);
+    format_localized(time,  'H', 'O');
   }
 
   void on_12_hour(numeric_system ns) {
@@ -940,8 +939,7 @@ struct chrono_formatter {
     if (ns == numeric_system::standard) return write(hour12(), 2);
     auto time = tm();
     time.tm_hour = to_nonnegative_int(hour12(), 12);
-    const char_type format[] { '%', 'O', 'I', 0 };
-    format_localized(time, format);
+    format_localized(time, 'I', 'O');
   }
 
   void on_minute(numeric_system ns) {
@@ -950,8 +948,7 @@ struct chrono_formatter {
     if (ns == numeric_system::standard) return write(minute(), 2);
     auto time = tm();
     time.tm_min = to_nonnegative_int(minute(), 60);
-    const char_type format[] { '%', 'O', 'M', 0 };
-    format_localized(time, format);
+    format_localized(time, 'M', 'O');
   }
 
   void on_second(numeric_system ns) {
@@ -976,14 +973,12 @@ struct chrono_formatter {
     }
     auto time = tm();
     time.tm_sec = to_nonnegative_int(second(), 60);
-    const char_type format[] { '%', 'O', 'S', 0 };
-    format_localized(time, format);
+    format_localized(time, 'S', 'O');
   }
 
   void on_12_hour_time() {
     if (handle_nan_inf()) return;
-    const char_type format[] { '%', 'r', 0 };
-    format_localized(time(), format);
+    format_localized(time(), 'r');
   }
 
   void on_24_hour_time() {
@@ -1007,8 +1002,7 @@ struct chrono_formatter {
 
   void on_am_pm() {
     if (handle_nan_inf()) return;
-    const char_type format[] { '%', 'p', 0 };
-    format_localized(time(), format);
+    format_localized(time(), 'p');
   }
 
   void on_duration_value() {

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -495,12 +495,12 @@ FMT_CONSTEXPR const Char* parse_chrono_format(const Char* begin,
       handler.on_text(ptr - 1, ptr);
       break;
     case 'n': {
-      const char newline[] = "\n";
+      const Char newline[] { '\n', 0 };
       handler.on_text(newline, newline + 1);
       break;
     }
     case 't': {
-      const char tab[] = "\t";
+      const Char tab[] { '\t', 0 };
       handler.on_text(tab, tab + 1);
       break;
     }
@@ -871,13 +871,13 @@ struct chrono_formatter {
   void write_pinf() { std::copy_n("inf", 3, out); }
   void write_ninf() { std::copy_n("-inf", 4, out); }
 
-  void format_localized(const tm& time, const char* format) {
+  void format_localized(const tm& time, const char_type* format) {
     if (isnan(val)) return write_nan();
     auto locale = context.locale().template get<std::locale>();
     auto& facet = std::use_facet<std::time_put<char_type>>(locale);
     std::basic_ostringstream<char_type> os;
     os.imbue(locale);
-    facet.put(os, os, ' ', &time, format, format + std::strlen(format));
+    facet.put(os, os, ' ', &time, format, format + std::char_traits<char_type>::length(format));
     auto str = os.str();
     std::copy(str.begin(), str.end(), out);
   }
@@ -907,7 +907,8 @@ struct chrono_formatter {
     if (ns == numeric_system::standard) return write(hour(), 2);
     auto time = tm();
     time.tm_hour = to_nonnegative_int(hour(), 24);
-    format_localized(time, "%OH");
+    char_type format[] { '%', 'O', 'H', 0 };
+    format_localized(time, format);
   }
 
   void on_12_hour(numeric_system ns) {
@@ -916,7 +917,8 @@ struct chrono_formatter {
     if (ns == numeric_system::standard) return write(hour12(), 2);
     auto time = tm();
     time.tm_hour = to_nonnegative_int(hour12(), 12);
-    format_localized(time, "%OI");
+    char_type format[] { '%', 'O', 'I', 0 };
+    format_localized(time, format);
   }
 
   void on_minute(numeric_system ns) {
@@ -925,7 +927,8 @@ struct chrono_formatter {
     if (ns == numeric_system::standard) return write(minute(), 2);
     auto time = tm();
     time.tm_min = to_nonnegative_int(minute(), 60);
-    format_localized(time, "%OM");
+    char_type format[] { '%', 'O', 'M', 0 };
+    format_localized(time, format);
   }
 
   void on_second(numeric_system ns) {
@@ -950,13 +953,15 @@ struct chrono_formatter {
     }
     auto time = tm();
     time.tm_sec = to_nonnegative_int(second(), 60);
-    format_localized(time, "%OS");
+    char_type format[] { '%', 'O', 'S', 0 };
+    format_localized(time, format);
   }
 
   void on_12_hour_time() {
     if (handle_nan_inf()) return;
 
-    format_localized(time(), "%r");
+    char_type format[] { '%', 'r', 0 };
+    format_localized(time(), format);
   }
 
   void on_24_hour_time() {
@@ -980,7 +985,8 @@ struct chrono_formatter {
 
   void on_am_pm() {
     if (handle_nan_inf()) return;
-    format_localized(time(), "%p");
+    char_type format[] { '%', 'p', 0 };
+    format_localized(time(), format);
   }
 
   void on_duration_value() {

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -8,13 +8,13 @@
 #ifndef FMT_CHRONO_H_
 #define FMT_CHRONO_H_
 
-#include "format.h"
-#include "locale.h"
-
 #include <chrono>
 #include <ctime>
 #include <locale>
 #include <sstream>
+
+#include "format.h"
+#include "locale.h"
 
 FMT_BEGIN_NAMESPACE
 
@@ -440,7 +440,9 @@ template <typename Char> struct formatter<std::tm, Char> {
 };
 
 namespace internal {
-template <typename Period> FMT_CONSTEXPR const char* get_units() { return nullptr; }
+template <typename Period> FMT_CONSTEXPR const char* get_units() {
+  return nullptr;
+}
 template <> FMT_CONSTEXPR const char* get_units<std::atto>() { return "as"; }
 template <> FMT_CONSTEXPR const char* get_units<std::femto>() { return "fs"; }
 template <> FMT_CONSTEXPR const char* get_units<std::pico>() { return "ps"; }
@@ -458,8 +460,12 @@ template <> FMT_CONSTEXPR const char* get_units<std::giga>() { return "Gs"; }
 template <> FMT_CONSTEXPR const char* get_units<std::tera>() { return "Ts"; }
 template <> FMT_CONSTEXPR const char* get_units<std::peta>() { return "Ps"; }
 template <> FMT_CONSTEXPR const char* get_units<std::exa>() { return "Es"; }
-template <> FMT_CONSTEXPR const char* get_units<std::ratio<60>>() { return "m"; }
-template <> FMT_CONSTEXPR const char* get_units<std::ratio<3600>>() { return "h"; }
+template <> FMT_CONSTEXPR const char* get_units<std::ratio<60>>() {
+  return "m";
+}
+template <> FMT_CONSTEXPR const char* get_units<std::ratio<3600>>() {
+  return "h";
+}
 
 enum class numeric_system {
   standard,
@@ -489,12 +495,12 @@ FMT_CONSTEXPR const Char* parse_chrono_format(const Char* begin,
       handler.on_text(ptr - 1, ptr);
       break;
     case 'n': {
-      const Char newline[] { '\n', 0 };
+      const Char newline[]{'\n', 0};
       handler.on_text(newline, newline + 1);
       break;
     }
     case 't': {
-      const Char tab[] { '\t', 0 };
+      const Char tab[]{'\t', 0};
       handler.on_text(tab, tab + 1);
       break;
     }
@@ -755,11 +761,12 @@ inline std::chrono::duration<Rep, std::milli> get_milliseconds(
 
 template <typename Char, typename Rep, typename OutputIt>
 OutputIt format_duration_value(OutputIt out, Rep val, int precision) {
-  const Char pr_f[] { '{', ':', '.', '{', '}', 'f', '}', 0 };
+  const Char pr_f[]{'{', ':', '.', '{', '}', 'f', '}', 0};
   if (precision >= 0) return format_to(out, pr_f, val, precision);
-  const Char fp_f[] { '{', ':', 'g', '}', 0 };
-  const Char format[] { '{', '}', 0 };
-  return format_to(out, std::is_floating_point<Rep>::value ? fp_f : format, val);
+  const Char fp_f[]{'{', ':', 'g', '}', 0};
+  const Char format[]{'{', '}', 0};
+  return format_to(out, std::is_floating_point<Rep>::value ? fp_f : format,
+                   val);
 }
 
 template <typename Char, typename Period, typename OutputIt>
@@ -771,9 +778,9 @@ OutputIt format_duration_unit(OutputIt out) {
     }
     return std::copy(unit.begin(), unit.end(), out);
   }
-  const Char num_f[] { '[', '{', '}', ']', 's', 0 };
+  const Char num_f[]{'[', '{', '}', ']', 's', 0};
   if (Period::den == 1) return format_to(out, num_f, Period::num);
-  const Char num_def_f[] { '[', '{', '}', '/', '{', '}', ']', 's', 0 };
+  const Char num_def_f[]{'[', '{', '}', '/', '{', '}', ']', 's', 0};
   return format_to(out, num_def_f, Period::num, Period::den);
 }
 
@@ -911,7 +918,7 @@ struct chrono_formatter {
     if (ns == numeric_system::standard) return write(hour(), 2);
     auto time = tm();
     time.tm_hour = to_nonnegative_int(hour(), 24);
-    format_localized(time,  'H', 'O');
+    format_localized(time, 'H', 'O');
   }
 
   void on_12_hour(numeric_system ns) {
@@ -992,7 +999,9 @@ struct chrono_formatter {
     out = format_duration_value<char_type>(out, val, precision);
   }
 
-  void on_duration_unit() { out = format_duration_unit<char_type, Period>(out); }
+  void on_duration_unit() {
+    out = format_duration_unit<char_type, Period>(out);
+  }
 };
 }  // namespace internal
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -907,7 +907,7 @@ struct chrono_formatter {
     if (ns == numeric_system::standard) return write(hour(), 2);
     auto time = tm();
     time.tm_hour = to_nonnegative_int(hour(), 24);
-    char_type format[] { '%', 'O', 'H', 0 };
+    const char_type format[] { '%', 'O', 'H', 0 };
     format_localized(time, format);
   }
 
@@ -917,7 +917,7 @@ struct chrono_formatter {
     if (ns == numeric_system::standard) return write(hour12(), 2);
     auto time = tm();
     time.tm_hour = to_nonnegative_int(hour12(), 12);
-    char_type format[] { '%', 'O', 'I', 0 };
+    const char_type format[] { '%', 'O', 'I', 0 };
     format_localized(time, format);
   }
 
@@ -927,7 +927,7 @@ struct chrono_formatter {
     if (ns == numeric_system::standard) return write(minute(), 2);
     auto time = tm();
     time.tm_min = to_nonnegative_int(minute(), 60);
-    char_type format[] { '%', 'O', 'M', 0 };
+    const char_type format[] { '%', 'O', 'M', 0 };
     format_localized(time, format);
   }
 
@@ -953,14 +953,14 @@ struct chrono_formatter {
     }
     auto time = tm();
     time.tm_sec = to_nonnegative_int(second(), 60);
-    char_type format[] { '%', 'O', 'S', 0 };
+    const char_type format[] { '%', 'O', 'S', 0 };
     format_localized(time, format);
   }
 
   void on_12_hour_time() {
     if (handle_nan_inf()) return;
 
-    char_type format[] { '%', 'r', 0 };
+    const char_type format[] { '%', 'r', 0 };
     format_localized(time(), format);
   }
 
@@ -985,7 +985,7 @@ struct chrono_formatter {
 
   void on_am_pm() {
     if (handle_nan_inf()) return;
-    char_type format[] { '%', 'p', 0 };
+    const char_type format[] { '%', 'p', 0 };
     format_localized(time(), format);
   }
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -766,7 +766,7 @@ template <typename Char, typename Period, typename OutputIt>
 OutputIt format_duration_unit(OutputIt out) {
   if (const char* unit = get_units<Period>()) {
     string_view s(unit);
-    if FMT_CONSTEXPR (std::is_same<Char, wchar_t>::value) {
+    if (std::is_same<Char, wchar_t>::value) {
       utf8_to_utf16 u(s);
       return std::copy(u.c_str(), u.c_str() + u.size(), out);
     } else {

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -440,7 +440,6 @@ template <typename Char> struct formatter<std::tm, Char> {
 };
 
 namespace internal {
-
 template <typename Period> FMT_CONSTEXPR const char* get_units() { return nullptr; }
 template <> FMT_CONSTEXPR const char* get_units<std::atto>() { return "as"; }
 template <> FMT_CONSTEXPR const char* get_units<std::femto>() { return "fs"; }
@@ -491,12 +490,12 @@ FMT_CONSTEXPR const Char* parse_chrono_format(const Char* begin,
       break;
     case 'n': {
       const Char newline[] { '\n', 0 };
-      handler.on_text(newline, &newline[1]);
+      handler.on_text(newline, newline + 1);
       break;
     }
     case 't': {
       const Char tab[] { '\t', 0 };
-      handler.on_text(tab, &tab[1]);
+      handler.on_text(tab, tab + 1);
       break;
     }
     // Day of the week:

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -764,14 +764,12 @@ OutputIt format_duration_value(OutputIt out, Rep val, int precision) {
 
 template <typename Char, typename Period, typename OutputIt>
 OutputIt format_duration_unit(OutputIt out) {
-  if (const char* unit = get_units<Period>()) {
-    string_view s(unit);
-    if (std::is_same<Char, wchar_t>::value) {
-      utf8_to_utf16 u(s);
+  if (string_view unit = get_units<Period>()) {
+    if (const_check(std::is_same<Char, wchar_t>())) {
+      utf8_to_utf16 u(unit);
       return std::copy(u.c_str(), u.c_str() + u.size(), out);
-    } else {
-      return std::copy(s.begin(), s.end(), out);
     }
+    return std::copy(unit.begin(), unit.end(), out);
   }
   const Char num_f[] { '[', '{', '}', ']', 's', 0 };
   if (Period::den == 1) return format_to(out, num_f, Period::num);

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -894,7 +894,7 @@ struct chrono_formatter {
   void write_pinf() { std::copy_n("inf", 3, out); }
   void write_ninf() { std::copy_n("-inf", 4, out); }
 
-  void format_localized(const tm& time, const char_type* format) {
+  void format_localized(const tm& time, const char* format) {
     if (isnan(val)) return write_nan();
     auto locale = context.locale().template get<std::locale>();
     auto& facet = std::use_facet<std::time_put<char_type>>(locale);

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -440,32 +440,50 @@ template <typename Char> struct formatter<std::tm, Char> {
 };
 
 namespace internal {
-template <typename Period> FMT_CONSTEXPR const char* get_units() {
-  return nullptr;
+
+template <typename Char, typename Period> FMT_CONSTEXPR const Char* get_units() { return nullptr; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::atto>() { return "as"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::atto>() { return L"as"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::femto>() { return "fs"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::femto>() { return L"fs"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::pico>() { return "ps"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::pico>() { return L"ps"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::nano>() { return "ns"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::nano>() { return L"ns"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::micro>() { 
+  return "µs"; 
 }
-template <> FMT_CONSTEXPR const char* get_units<std::atto>() { return "as"; }
-template <> FMT_CONSTEXPR const char* get_units<std::femto>() { return "fs"; }
-template <> FMT_CONSTEXPR const char* get_units<std::pico>() { return "ps"; }
-template <> FMT_CONSTEXPR const char* get_units<std::nano>() { return "ns"; }
-template <> FMT_CONSTEXPR const char* get_units<std::micro>() { return "µs"; }
-template <> FMT_CONSTEXPR const char* get_units<std::milli>() { return "ms"; }
-template <> FMT_CONSTEXPR const char* get_units<std::centi>() { return "cs"; }
-template <> FMT_CONSTEXPR const char* get_units<std::deci>() { return "ds"; }
-template <> FMT_CONSTEXPR const char* get_units<std::ratio<1>>() { return "s"; }
-template <> FMT_CONSTEXPR const char* get_units<std::deca>() { return "das"; }
-template <> FMT_CONSTEXPR const char* get_units<std::hecto>() { return "hs"; }
-template <> FMT_CONSTEXPR const char* get_units<std::kilo>() { return "ks"; }
-template <> FMT_CONSTEXPR const char* get_units<std::mega>() { return "Ms"; }
-template <> FMT_CONSTEXPR const char* get_units<std::giga>() { return "Gs"; }
-template <> FMT_CONSTEXPR const char* get_units<std::tera>() { return "Ts"; }
-template <> FMT_CONSTEXPR const char* get_units<std::peta>() { return "Ps"; }
-template <> FMT_CONSTEXPR const char* get_units<std::exa>() { return "Es"; }
-template <> FMT_CONSTEXPR const char* get_units<std::ratio<60>>() {
-  return "m";
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::micro>() { 
+  return L"\u00B5s"; 
 }
-template <> FMT_CONSTEXPR const char* get_units<std::ratio<3600>>() {
-  return "h";
-}
+template <> FMT_CONSTEXPR const char* get_units<char, std::milli>() { return "ms"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::milli>() { return L"ms"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::centi>() { return "cs"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::centi>() { return L"cs"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::deci>() { return "ds"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::deci>() { return L"ds"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::ratio<1>>() { return "s"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::ratio<1>>() { return L"s"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::deca>() { return "das"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::deca>() { return L"das"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::hecto>() { return "hs"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::hecto>() { return L"hs"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::kilo>() { return "ks"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::kilo>() { return L"ks"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::mega>() { return "Ms"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::mega>() { return L"Ms"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::giga>() { return "Gs"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::giga>() { return L"Gs"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::tera>() { return "Ts"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::tera>() { return L"Ts"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::peta>() { return "Ps"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::peta>() { return L"Ps"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::exa>() { return "Es"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::exa>() { return L"Es"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::ratio<60>>() { return "m"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::ratio<60>>() { return L"m"; }
+template <> FMT_CONSTEXPR const char* get_units<char, std::ratio<3600>>() { return "h"; }
+template <> FMT_CONSTEXPR const wchar_t* get_units<wchar_t, std::ratio<3600>>() { return L"h"; }
 
 enum class numeric_system {
   standard,
@@ -496,12 +514,12 @@ FMT_CONSTEXPR const Char* parse_chrono_format(const Char* begin,
       break;
     case 'n': {
       const Char newline[] { '\n', 0 };
-      handler.on_text(newline, newline + 1);
+      handler.on_text(newline, &newline[1]);
       break;
     }
     case 't': {
       const Char tab[] { '\t', 0 };
-      handler.on_text(tab, tab + 1);
+      handler.on_text(tab, &tab[1]);
       break;
     }
     // Day of the week:
@@ -759,18 +777,23 @@ inline std::chrono::duration<Rep, std::milli> get_milliseconds(
   return std::chrono::duration<Rep, std::milli>(static_cast<Rep>(ms));
 }
 
-template <typename Rep, typename OutputIt>
+template <typename Char, typename Rep, typename OutputIt>
 OutputIt format_duration_value(OutputIt out, Rep val, int precision) {
-  if (precision >= 0) return format_to(out, "{:.{}f}", val, precision);
-  return format_to(out, std::is_floating_point<Rep>::value ? "{:g}" : "{}",
-                   val);
+  const Char pr_f[] { '{', ':', '.', '{', '}', 'f', '}', 0 };
+  if (precision >= 0) return format_to(out, pr_f, val, precision);
+  const Char fp_f[] { '{', ':', 'g', '}', 0 };
+  const Char format[] { '{', '}', 0 };
+  return format_to(out, std::is_floating_point<Rep>::value ? fp_f : format, val);
 }
 
-template <typename Period, typename OutputIt>
+template <typename Char, typename Period, typename OutputIt>
 OutputIt format_duration_unit(OutputIt out) {
-  if (const char* unit = get_units<Period>()) return format_to(out, "{}", unit);
-  if (Period::den == 1) return format_to(out, "[{}]s", Period::num);
-  return format_to(out, "[{}/{}]s", Period::num, Period::den);
+  const Char format[] { '{', '}', 0 };
+  if (const Char* unit = get_units<Char, Period>()) return format_to(out, format, unit);
+  const Char num_f[] { '[', '{', '}', ']', 's', 0 };
+  if (Period::den == 1) return format_to(out, num_f, Period::num);
+  const Char num_def_f[] { '[', '{', '}', '/', '{', '}', ']', 's', 0 };
+  return format_to(out, num_def_f, Period::num, Period::den);
 }
 
 template <typename FormatContext, typename OutputIt, typename Rep,
@@ -959,7 +982,6 @@ struct chrono_formatter {
 
   void on_12_hour_time() {
     if (handle_nan_inf()) return;
-
     const char_type format[] { '%', 'r', 0 };
     format_localized(time(), format);
   }
@@ -992,10 +1014,10 @@ struct chrono_formatter {
   void on_duration_value() {
     if (handle_nan_inf()) return;
     write_sign();
-    out = format_duration_value(out, val, precision);
+    out = format_duration_value<char_type>(out, val, precision);
   }
 
-  void on_duration_unit() { out = format_duration_unit<Period>(out); }
+  void on_duration_unit() { out = format_duration_unit<char_type, Period>(out); }
 };
 }  // namespace internal
 
@@ -1094,8 +1116,8 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
     internal::handle_dynamic_spec<internal::precision_checker>(
         precision, precision_ref, ctx);
     if (begin == end || *begin == '}') {
-      out = internal::format_duration_value(out, d.count(), precision);
-      internal::format_duration_unit<Period>(out);
+      out = internal::format_duration_value<Char>(out, d.count(), precision);
+      internal::format_duration_unit<Char, Period>(out);
     } else {
       internal::chrono_formatter<FormatContext, decltype(out), Rep, Period> f(
           ctx, out, d);

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -771,12 +771,13 @@ OutputIt format_duration_value(OutputIt out, Rep val, int precision) {
 
 template <typename Char, typename Period, typename OutputIt>
 OutputIt format_duration_unit(OutputIt out) {
-  if (string_view unit = get_units<Period>()) {
+  if (const char* unit = get_units<Period>()) {
+    string_view s(unit);
     if (const_check(std::is_same<Char, wchar_t>())) {
-      utf8_to_utf16 u(unit);
+      utf8_to_utf16 u(s);
       return std::copy(u.c_str(), u.c_str() + u.size(), out);
     }
-    return std::copy(unit.begin(), unit.end(), out);
+    return std::copy(s.begin(), s.end(), out);
   }
   const Char num_f[]{'[', '{', '}', ']', 's', 0};
   if (Period::den == 1) return format_to(out, num_f, Period::num);

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -154,7 +154,7 @@ TEST(ChronoTest, FormatWide) {
   EXPECT_EQ(L"42ps",
             fmt::format(L"{}", std::chrono::duration<int, std::pico>(42)));
   EXPECT_EQ(L"42ns", fmt::format(L"{}", std::chrono::nanoseconds(42)));
-  EXPECT_EQ(L"42µs", fmt::format(L"{}", std::chrono::microseconds(42)));
+  EXPECT_EQ(L"42\u00B5s", fmt::format(L"{}", std::chrono::microseconds(42)));
   EXPECT_EQ(L"42ms", fmt::format(L"{}", std::chrono::milliseconds(42)));
   EXPECT_EQ(L"42cs",
             fmt::format(L"{}", std::chrono::duration<int, std::centi>(42)));

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -145,6 +145,48 @@ TEST(ChronoTest, FormatDefault) {
       fmt::format("{}", std::chrono::duration<int, std::ratio<15, 4>>(42)));
 }
 
+TEST(ChronoTest, FormatWide) {
+  EXPECT_EQ(L"42s", fmt::format(L"{}", std::chrono::seconds(42)));
+  EXPECT_EQ(L"42as",
+            fmt::format(L"{}", std::chrono::duration<int, std::atto>(42)));
+  EXPECT_EQ(L"42fs",
+            fmt::format(L"{}", std::chrono::duration<int, std::femto>(42)));
+  EXPECT_EQ(L"42ps",
+            fmt::format(L"{}", std::chrono::duration<int, std::pico>(42)));
+  EXPECT_EQ(L"42ns", fmt::format(L"{}", std::chrono::nanoseconds(42)));
+  EXPECT_EQ(L"42µs", fmt::format(L"{}", std::chrono::microseconds(42)));
+  EXPECT_EQ(L"42ms", fmt::format(L"{}", std::chrono::milliseconds(42)));
+  EXPECT_EQ(L"42cs",
+            fmt::format(L"{}", std::chrono::duration<int, std::centi>(42)));
+  EXPECT_EQ(L"42ds",
+            fmt::format(L"{}", std::chrono::duration<int, std::deci>(42)));
+  EXPECT_EQ(L"42s", fmt::format(L"{}", std::chrono::seconds(42)));
+  EXPECT_EQ(L"42das",
+            fmt::format(L"{}", std::chrono::duration<int, std::deca>(42)));
+  EXPECT_EQ(L"42hs",
+            fmt::format(L"{}", std::chrono::duration<int, std::hecto>(42)));
+  EXPECT_EQ(L"42ks",
+            fmt::format(L"{}", std::chrono::duration<int, std::kilo>(42)));
+  EXPECT_EQ(L"42Ms",
+            fmt::format(L"{}", std::chrono::duration<int, std::mega>(42)));
+  EXPECT_EQ(L"42Gs",
+            fmt::format(L"{}", std::chrono::duration<int, std::giga>(42)));
+  EXPECT_EQ(L"42Ts",
+            fmt::format(L"{}", std::chrono::duration<int, std::tera>(42)));
+  EXPECT_EQ(L"42Ps",
+            fmt::format(L"{}", std::chrono::duration<int, std::peta>(42)));
+  EXPECT_EQ(L"42Es",
+            fmt::format(L"{}", std::chrono::duration<int, std::exa>(42)));
+  EXPECT_EQ(L"42m", fmt::format(L"{}", std::chrono::minutes(42)));
+  EXPECT_EQ(L"42h", fmt::format(L"{}", std::chrono::hours(42)));
+  EXPECT_EQ(
+      L"42[15]s",
+      fmt::format(L"{}", std::chrono::duration<int, std::ratio<15, 1>>(42)));
+  EXPECT_EQ(
+      L"42[15/4]s",
+      fmt::format(L"{}", std::chrono::duration<int, std::ratio<15, 4>>(42)));
+}
+
 TEST(ChronoTest, Align) {
   auto s = std::chrono::seconds(42);
   EXPECT_EQ("42s  ", fmt::format("{:5}", s));


### PR DESCRIPTION
I was getting several compiler errors when trying to format a `std::chrono::duration` to a wide string, and found that various parts of `chrono.h` had a hard dependency on narrow chars. I tried to make it agnostic as possible, and it seems to work fine for me now, although I haven't tested it with anything besides `std::chrono::duration<double, std::milli>`.

If anything needs to be changed or fixed to get this merged just let me know.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
