### PR TITLE
improved use of find

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2543,7 +2543,7 @@ FMT_CONSTEXPR void parse_format_string(basic_string_view<Char> format_str,
     // Doing two passes with memchr (one for '{' and another for '}') is up to
     // 2.5x faster than the naive one-pass implementation on big format strings.
     const Char* p = begin;
-    if (*begin != '{' && !find<IS_CONSTEXPR>(begin, end, '{', p))
+    if (*begin != '{' && !find<IS_CONSTEXPR>(begin+1, end, '{', p))
       return write(begin, end);
     write(begin, p);
     ++p;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2543,7 +2543,7 @@ FMT_CONSTEXPR void parse_format_string(basic_string_view<Char> format_str,
     // Doing two passes with memchr (one for '{' and another for '}') is up to
     // 2.5x faster than the naive one-pass implementation on big format strings.
     const Char* p = begin;
-    if (*begin != '{' && !find<IS_CONSTEXPR>(begin+1, end, '{', p))
+    if (*begin != '{' && !find<IS_CONSTEXPR>(begin + 1, end, '{', p))
       return write(begin, end);
     write(begin, p);
     ++p;


### PR DESCRIPTION
*begin is supposed to be different from '{' when this find is used, so we can avoid checking it.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
