### PR TITLE
Move FMT_CLANG_VERSION definition to core.h

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -36,6 +36,12 @@
 #  define FMT_HAS_CPP_ATTRIBUTE(x) 0
 #endif
 
+#ifdef __clang__
+#  define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
+#else
+#  define FMT_CLANG_VERSION 0
+#endif
+
 #if defined(__GNUC__) && !defined(__clang__)
 #  define FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #else

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -43,12 +43,6 @@
 
 #include "core.h"
 
-#ifdef __clang__
-#  define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
-#else
-#  define FMT_CLANG_VERSION 0
-#endif
-
 #ifdef __INTEL_COMPILER
 #  define FMT_ICC_VERSION __INTEL_COMPILER
 #elif defined(__ICL)


### PR DESCRIPTION
Previously format.h defined FMT_CLANG_VERSION after including core.h, however core.h tests FMT_CLANG_VERSION when it defines FMT_API.

format.h still defines FMT_ICC_VERSION and FMT_CUDA_VERSION, however given that core.h now defines clang/gcc/msc versions it may be worth moving that version detection into core.h too.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.