### PR TITLE
Add FMT_NORETURN to assert_fail prototype.

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -253,7 +253,7 @@ namespace internal {
 // A workaround for gcc 4.8 to make void_t work in a SFINAE context.
 template <typename... Ts> struct void_t_impl { using type = void; };
 
-FMT_API void assert_fail(const char* file, int line, const char* message);
+FMT_NORETURN FMT_API void assert_fail(const char* file, int line, const char* message);
 
 #ifndef FMT_ASSERT
 #  ifdef NDEBUG


### PR DESCRIPTION
When building with -Werror,-Wmissing-noreturn clang identifies that assert_fail could be declared with the 'noreturn' attribute.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.