### PR TITLE
Make underlying type of align_t / sign_t unsigned.

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -997,12 +997,12 @@ template <typename Char> struct fill_t {
 // We cannot use enum classes as bit fields because of a gcc bug
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61414.
 namespace align {
-enum type { none, left, right, center, numeric };
+enum type : uint8_t { none, left, right, center, numeric };
 }
 using align_t = align::type;
 
 namespace sign {
-enum type { none, minus, plus, space };
+enum type : uint8_t { none, minus, plus, space };
 }
 using sign_t = sign::type;
 


### PR DESCRIPTION
When building with -Werror,-Wsigned-enum-bitfield clang reports that "enums in the Microsoft ABI are signed integers by default; consider giving the enum type an unsigned underlying type to make this code portable" for these two types.

Under this ABI one bit of an enum bitfield is used by the sign bit. Enum values large enough to overlap that bit would be seen as negative integers if read out into an integer.

There may not be any such reading out at present, but making the underlying type unsigned ensures consistent results across platforms.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.