### PR TITLE
Fix clang -Wsign-conversion warning in grisu_count_digits.

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -756,7 +756,7 @@ enum result {
 }
 
 // A version of count_digits optimized for grisu_gen_digits.
-inline unsigned grisu_count_digits(uint32_t n) {
+inline int grisu_count_digits(uint32_t n) {
   if (n < 10) return 1;
   if (n < 100) return 2;
   if (n < 1000) return 3;


### PR DESCRIPTION
grisu_count_digits is only used by grisu_gen_digits, which assigns the unsigned result to a (signed) int.

Although grisu_count_digits always returns a positive integer this keeps its return type in sync with the type its result is assigned to.