### PR TITLE
Fix clang -Wsign-conversion warning in fallback_format.

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1004,7 +1004,7 @@ void fallback_format(Double d, buffer<char>& buf, int& exp10) {
   if (!upper) upper = &lower;
   // Invariant: value == (numerator / denominator) * pow(10, exp10).
   bool even = (value.f & 1) == 0;
-  int num_digits = 0;
+  size_t num_digits = 0;
   char* data = buf.data();
   for (;;) {
     int digit = numerator.divmod_assign(denominator);


### PR DESCRIPTION
num_digits is initialised to 0, and is always incremented by 1 prior to usage where at most 1 is subtracted from it.