### PR TITLE
Workaround for issue #1455 (gcc error on FMT_STRING within if constexpr).

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -542,12 +542,19 @@ constexpr auto compile(S format_str) -> internal::compiled_format<S, Args...> {
 #  endif  // __cpp_if_constexpr
 #endif    // FMT_USE_CONSTEXPR
 
-// Compiles the format string which must be a string literal.
+// Compiles the format string which must be a string literal or view.
 template <typename... Args, typename Char, size_t N>
 auto compile(const Char (&format_str)[N])
     -> internal::compiled_format<const Char*, Args...> {
   return internal::compiled_format<const Char*, Args...>(
       basic_string_view<Char>(format_str, N - 1));
+}
+
+template <typename Char>
+auto compile(const basic_string_view<Char>& format_str)
+    -> internal::compiled_format<const Char*> {
+  return internal::compiled_format<const Char*>(
+      format_str);
 }
 
 template <typename CompiledFormat, typename... Args,

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -542,19 +542,12 @@ constexpr auto compile(S format_str) -> internal::compiled_format<S, Args...> {
 #  endif  // __cpp_if_constexpr
 #endif    // FMT_USE_CONSTEXPR
 
-// Compiles the format string which must be a string literal or view.
+// Compiles the format string which must be a string literal.
 template <typename... Args, typename Char, size_t N>
 auto compile(const Char (&format_str)[N])
     -> internal::compiled_format<const Char*, Args...> {
   return internal::compiled_format<const Char*, Args...>(
       basic_string_view<Char>(format_str, N - 1));
-}
-
-template <typename Char>
-auto compile(const basic_string_view<Char>& format_str)
-    -> internal::compiled_format<const Char*> {
-  return internal::compiled_format<const Char*>(
-      format_str);
 }
 
 template <typename CompiledFormat, typename... Args,

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3544,18 +3544,18 @@ FMT_CONSTEXPR internal::udl_arg<wchar_t> operator"" _a(const wchar_t* s,
 #endif  // FMT_USE_USER_DEFINED_LITERALS
 FMT_END_NAMESPACE
 
-#define FMT_STRING_IMPL(s, ...)                              \
-  [] {                                                       \
-    /* Use a macro-like name to avoid shadowing warnings. */ \
-    struct FMT_COMPILE_STRING : fmt::compile_string {        \
-      using char_type = fmt::remove_cvref_t<decltype(*s)>;   \
-      __VA_ARGS__ FMT_CONSTEXPR                              \
-      operator fmt::basic_string_view<char_type>() const {   \
-        /* FMT_STRING only accepts string literals. */       \
-        return fmt::internal::literal_to_view(s);            \
-      }                                                      \
-    };                                                       \
-    return FMT_COMPILE_STRING();                             \
+#define FMT_STRING_IMPL(s, ...)                                       \
+  []() -> fmt::basic_string_view<fmt::remove_cvref_t<decltype(*s)>> { \
+    /* Use a macro-like name to avoid shadowing warnings. */          \
+    struct FMT_COMPILE_STRING : fmt::compile_string {                 \
+      using char_type = fmt::remove_cvref_t<decltype(*s)>;            \
+      __VA_ARGS__ FMT_CONSTEXPR                                       \
+      operator fmt::basic_string_view<char_type>() const {            \
+        /* FMT_STRING only accepts string literals. */                \
+        return fmt::internal::literal_to_view(s);                     \
+      }                                                               \
+    };                                                                \
+    return FMT_COMPILE_STRING();                                      \
   }()
 
 /**

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3544,7 +3544,7 @@ FMT_CONSTEXPR internal::udl_arg<wchar_t> operator"" _a(const wchar_t* s,
 #endif  // FMT_USE_USER_DEFINED_LITERALS
 FMT_END_NAMESPACE
 
-#if FMT_GCC_VERSION >= 900
+#if FMT_GCC_VERSION >= 800
 #  define FMT_STRING_RESULT(s)   ()->fmt::basic_string_view<fmt::remove_cvref_t<decltype(*s)>>
 #else
 #  define FMT_STRING_RESULT(s)

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3544,17 +3544,24 @@ FMT_CONSTEXPR internal::udl_arg<wchar_t> operator"" _a(const wchar_t* s,
 #endif  // FMT_USE_USER_DEFINED_LITERALS
 FMT_END_NAMESPACE
 
-#define FMT_STRING_IMPL(s, ...)                                                    \
-  []() -> fmt::basic_string_view<fmt::remove_cvref_t<decltype(*s)>> {              \
-    /* Use a macro-like name to avoid shadowing warnings. */                       \
-    struct FMT_COMPILE_STRING : fmt::compile_string {                              \
-      __VA_ARGS__ FMT_CONSTEXPR                                                    \
-      operator fmt::basic_string_view<fmt::remove_cvref_t<decltype(*s)>>() const { \
-        /* FMT_STRING only accepts string literals. */                             \
-        return fmt::internal::literal_to_view(s);                                  \
-      }                                                                            \
-    };                                                                             \
-    return FMT_COMPILE_STRING();                                                   \
+#if FMT_GCC_VERSION >= 900
+#  define FMT_STRING_RESULT(s)   ()->fmt::basic_string_view<fmt::remove_cvref_t<decltype(*s)>>
+#else
+#  define FMT_STRING_RESULT(s)
+#endif
+
+#define FMT_STRING_IMPL(s, ...)                              \
+  [] FMT_STRING_RESULT(s) {                                  \
+    /* Use a macro-like name to avoid shadowing warnings. */ \
+    struct FMT_COMPILE_STRING : fmt::compile_string {        \
+      using char_type = fmt::remove_cvref_t<decltype(*s)>;   \
+      __VA_ARGS__ FMT_CONSTEXPR                              \
+      operator fmt::basic_string_view<char_type>() const {   \
+        /* FMT_STRING only accepts string literals. */       \
+        return fmt::internal::literal_to_view(s);            \
+      }                                                      \
+    };                                                       \
+    return FMT_COMPILE_STRING();                             \
   }()
 
 /**

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3544,7 +3544,7 @@ FMT_CONSTEXPR internal::udl_arg<wchar_t> operator"" _a(const wchar_t* s,
 #endif  // FMT_USE_USER_DEFINED_LITERALS
 FMT_END_NAMESPACE
 
-#if FMT_GCC_VERSION >= 800
+#if FMT_GCC_VERSION >= 840
 #  define FMT_STRING_RESULT(s)   ()->fmt::basic_string_view<fmt::remove_cvref_t<decltype(*s)>>
 #else
 #  define FMT_STRING_RESULT(s)

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3544,18 +3544,17 @@ FMT_CONSTEXPR internal::udl_arg<wchar_t> operator"" _a(const wchar_t* s,
 #endif  // FMT_USE_USER_DEFINED_LITERALS
 FMT_END_NAMESPACE
 
-#define FMT_STRING_IMPL(s, ...)                                       \
-  []() -> fmt::basic_string_view<fmt::remove_cvref_t<decltype(*s)>> { \
-    /* Use a macro-like name to avoid shadowing warnings. */          \
-    struct FMT_COMPILE_STRING : fmt::compile_string {                 \
-      using char_type = fmt::remove_cvref_t<decltype(*s)>;            \
-      __VA_ARGS__ FMT_CONSTEXPR                                       \
-      operator fmt::basic_string_view<char_type>() const {            \
-        /* FMT_STRING only accepts string literals. */                \
-        return fmt::internal::literal_to_view(s);                     \
-      }                                                               \
-    };                                                                \
-    return FMT_COMPILE_STRING();                                      \
+#define FMT_STRING_IMPL(s, ...)                                                    \
+  []() -> fmt::basic_string_view<fmt::remove_cvref_t<decltype(*s)>> {              \
+    /* Use a macro-like name to avoid shadowing warnings. */                       \
+    struct FMT_COMPILE_STRING : fmt::compile_string {                              \
+      __VA_ARGS__ FMT_CONSTEXPR                                                    \
+      operator fmt::basic_string_view<fmt::remove_cvref_t<decltype(*s)>>() const { \
+        /* FMT_STRING only accepts string literals. */                             \
+        return fmt::internal::literal_to_view(s);                                  \
+      }                                                                            \
+    };                                                                             \
+    return FMT_COMPILE_STRING();                                                   \
   }()
 
 /**

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2570,3 +2570,13 @@ TEST(FormatTest, FormatUTF8Precision) {
   EXPECT_EQ(result.size(), 5);
   EXPECT_EQ(from_u8str(result), from_u8str(str.substr(0, 5)));
 }
+
+TEST(FormatTest, Issue1455) {
+#if (__cplusplus >= 201703L)
+  if constexpr(true) {
+    EXPECT_EQ("foo", fmt::format(FMT_STRING("{}"), "foo"));
+  } else {
+    EXPECT_EQ("foo", fmt::format(FMT_STRING("{}"), "foo"));
+  }
+#endif
+}


### PR DESCRIPTION
This fixes issue #1455 by making the return type explicit, and adds a C++17-specific test to demonstrate the bug.

This allows usage like:

```
#define LOG(_messsage, ...)                                     \
    do                                                          \
    {                                                           \
        if constexpr(_uses_format_specifiers(_message))         \
        {                                                       \
            LogWithFormat(FMT_STRING(_message), ##__VA_ARGS__)  \
        }                                                       \
        else                                                    \
        {                                                       \
            LogWithPrintf(_message, ##__VA_ARGS__)              \
        }                                                       \
    }                                                           \
    while (false)
```
Where _uses_format_specifiers is a constexpr function that uses some heuristic to decide if a formatting string is fmt-style or printf-style.

We are using this technique to move a large codebase from printf-based logging to fmt-based and hit this same bug with gcc 9.

Edit: Nothing's ever easy! I will check the other compilers on Travis and update.