### PR TITLE
Workaround for broken [[deprecated]] in PGI compiler

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -147,8 +147,8 @@
 #  endif
 #endif
 
-// Workaround broken [[deprecated]] in the Intel compiler and NVCC.
-#if defined(__INTEL_COMPILER) || FMT_NVCC
+// Workaround broken [[deprecated]] in the Intel compiler, PGI compiler and NVCC.
+#if defined(__INTEL_COMPILER) || defined(__PGI)  || FMT_NVCC
 #  define FMT_DEPRECATED_ALIAS
 #else
 #  define FMT_DEPRECATED_ALIAS FMT_DEPRECATED

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -147,8 +147,8 @@
 #  endif
 #endif
 
-// Workaround broken [[deprecated]] in the Intel compiler, PGI compiler and NVCC.
-#if defined(__INTEL_COMPILER) || defined(__PGI)  || FMT_NVCC
+// Workaround broken [[deprecated]] in the Intel, PGI and NVCC compiler
+#if defined(__INTEL_COMPILER) || defined(__PGI) || FMT_NVCC
 #  define FMT_DEPRECATED_ALIAS
 #else
 #  define FMT_DEPRECATED_ALIAS FMT_DEPRECATED
@@ -259,7 +259,8 @@ namespace internal {
 // A workaround for gcc 4.8 to make void_t work in a SFINAE context.
 template <typename... Ts> struct void_t_impl { using type = void; };
 
-FMT_NORETURN FMT_API void assert_fail(const char* file, int line, const char* message);
+FMT_NORETURN FMT_API void assert_fail(const char* file, int line,
+                                      const char* message);
 
 #ifndef FMT_ASSERT
 #  ifdef NDEBUG


### PR DESCRIPTION
  - similar to Intel and NVCC, add workaround for PGI compiler

 - I tested this with:

```
kumbhar@bbpv1:~/tmp/fmt/build$ pgc++ --version

pgc++ 19.4-0 LLVM 64-bit target on x86-64 Linux -tp skylake
PGI Compilers and Tools
Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.

kumbhar@bbpv1:~/tmp/fmt/build$ cmake .. -DCMAKE_BUILD_TYPE=Debug
-- CMake version: 3.15.3
-- Version: 6.1.3
-- Build type: Debug
-- CXX_STANDARD: 11
-- Required features: cxx_variadic_templates
CMake Warning (dev) at CMakeLists.txt:35 (set):
  implicitly converting 'STRINGS' to 'STRING' type.
Call Stack (most recent call first):
  CMakeLists.txt:253 (set_doc)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- FMT_PEDANTIC: OFF
-- Configuring done
-- Generating done
-- Build files have been written to: /gpfs/bbp.cscs.ch/home/kumbhar/tmp/fmt/build
```

- Currently two tests are failing:

```
$ make test

88% tests passed, 2 tests failed out of 17

Total Test time (real) =   0.29 sec

The following tests FAILED:
	  7 - format-test (SEGFAULT)
	  8 - format-impl-test (Failed)
Errors while running CTest


$ ctest -V

...
7: /gpfs/bbp.cscs.ch/home/kumbhar/tmp/fmt/test/format-test.cc:1111: Failure
7: Value of: format("{:.494}", 4.9406564584124654E-324)
7:   Actual: "0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
7: Expected: "4.9406564584124654417656879286822137236505980261432476442558568250067550" "727020875186529983636163599237979656469544571773092665671035593979639877" "479601078187812630071319031140452784581716784898210368871863605699873072" "305000638740915356498438731247339727316961514003171538539807412623856559" "117102665855668676818703956031062493194527159149245532930545654440112748" "012970999954193198940908041656332452475714786901472678015935523861155013" "480352649347201937902681071074917033322268447533357208324319361e-324"
7: Which is: "4.9406564584124654417656879286822137236505980261432476442558568250067550727020875186529983636163599237979656469544571773092665671035593979639877479601078187812630071319031140452784581716784898210368871863605699873072305000638740915356498438731247339727316961514003171538539807412623856559117102665855668676818703956031062493194527159149245532930545654440112748012970999954193198940908041656332452475714786901472678015935523861155013480352649347201937902681071074917033322268447533357208324319361e-324"
7: [  FAILED  ] FormatterTest.Precision (1 ms)

8: [ RUN      ] FormatTest.CountCodePoints
8: /gpfs/bbp.cscs.ch/home/kumbhar/tmp/fmt/test/format-impl-test.cc:434: Failure
8: Value of: fmt::internal::count_code_points( fmt::basic_string_view<char8_t>(reinterpret_cast<const char8_t*>("ёжик")))
8:   Actual: 1
8: Expected: 4
8: [  FAILED  ] FormatTest.CountCodePoints (0 ms)
```

I didn't look into details but if there are any suggestions, it will be helpful.