### PR TITLE
Fix empty debug postfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ set(FMT_DEBUG_POSTFIX d CACHE STRING "Debug library postfix.")
 
 set_target_properties(fmt PROPERTIES
   VERSION ${FMT_VERSION} SOVERSION ${CPACK_PACKAGE_VERSION_MAJOR}
-  DEBUG_POSTFIX ${FMT_DEBUG_POSTFIX})
+  DEBUG_POSTFIX "${FMT_DEBUG_POSTFIX}")
 
 # Set FMT_LIB_NAME for pkg-config fmt.pc.
 get_target_property(FMT_LIB_NAME fmt OUTPUT_NAME)


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

Passing an empty string to FMT_DEBUG_POSTFIX leads to the following error:

```
CMake Error at CMakeLists.txt:179 (set_target_properties):
  set_target_properties called with incorrect number of arguments.
```
This PR fixes this.