### PR TITLE
Allow disabling floating point support

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1095,23 +1095,11 @@ FMT_CONSTEXPR auto visit_format_arg(Visitor&& vis,
   case internal::type::char_type:
     return vis(arg.value_.char_value);
   case internal::type::float_type:
-#if FMT_USE_FLOAT
     return vis(arg.value_.float_value);
-#else
-    break;
-#endif
   case internal::type::double_type:
-#if FMT_USE_DOUBLE
     return vis(arg.value_.double_value);
-#else
-    break;
-#endif
   case internal::type::long_double_type:
-#if FMT_USE_LONG_DOUBLE
     return vis(arg.value_.long_double_value);
-#else
-    break;
-#endif
   case internal::type::cstring_type:
     return vis(arg.value_.string.data);
   case internal::type::string_type:

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -296,6 +296,18 @@ struct int128_t {};
 struct uint128_t {};
 #endif
 
+#ifndef FMT_USE_FLOAT
+#  define FMT_USE_FLOAT 1
+#endif
+
+#ifndef FMT_USE_DOUBLE
+#  define FMT_USE_DOUBLE 1
+#endif
+
+#ifndef FMT_USE_LONG_DOUBLE
+#  define FMT_USE_LONG_DOUBLE 1
+#endif
+
 // Casts a nonnegative integer to unsigned.
 template <typename Int>
 FMT_CONSTEXPR typename std::make_unsigned<Int>::type to_unsigned(Int value) {
@@ -1083,11 +1095,23 @@ FMT_CONSTEXPR auto visit_format_arg(Visitor&& vis,
   case internal::type::char_type:
     return vis(arg.value_.char_value);
   case internal::type::float_type:
+#if FMT_USE_FLOAT
     return vis(arg.value_.float_value);
+#else
+    break;
+#endif
   case internal::type::double_type:
+#if FMT_USE_DOUBLE
     return vis(arg.value_.double_value);
+#else
+    break;
+#endif
   case internal::type::long_double_type:
+#if FMT_USE_LONG_DOUBLE
     return vis(arg.value_.long_double_value);
+#else
+    break;
+#endif
   case internal::type::cstring_type:
     return vis(arg.value_.string.data);
   case internal::type::string_type:

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2939,22 +2939,25 @@ struct formatter<T, Char,
           &specs_, internal::char_specs_checker<decltype(eh)>(specs_.type, eh));
       break;
     case internal::type::float_type:
-      if (internal::const_check(FMT_USE_FLOAT))
+      if (internal::const_check(FMT_USE_FLOAT)) {
         internal::parse_float_type_spec(specs_, eh);
-      else
+      } else {
         FMT_ASSERT(false, "float support disabled");
+      }
       break;
     case internal::type::double_type:
-      if (internal::const_check(FMT_USE_DOUBLE))
+      if (internal::const_check(FMT_USE_DOUBLE)) {
         internal::parse_float_type_spec(specs_, eh);
-      else
+      } else {
         FMT_ASSERT(false, "double support disabled");
+      }
       break;
     case internal::type::long_double_type:
-      if (internal::const_check(FMT_USE_LONG_DOUBLE))
+      if (internal::const_check(FMT_USE_LONG_DOUBLE)) {
         internal::parse_float_type_spec(specs_, eh);
-      else
+      } else {
         FMT_ASSERT(false, "long double support disabled");
+      }
       break;
     case internal::type::cstring_type:
       internal::handle_cstring_type_spec(


### PR DESCRIPTION
Add FMT_USE_FLOAT, FMT_USE_DOUBLE and FMT_USE_LONG_DOUBLE to allow a
user of the library to configure the float types they want to allow.
This is specially useful in embedded environements where code size is
important.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
