### PR TITLE
Add check for CompiledFormat to avoid ambiguous call

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -576,7 +576,9 @@ OutputIt format_to(OutputIt out, const CompiledFormat& cf,
 }
 
 template <typename OutputIt, typename CompiledFormat, typename... Args,
-          FMT_ENABLE_IF(internal::is_output_iterator<OutputIt>::value)>
+          FMT_ENABLE_IF(internal::is_output_iterator<OutputIt>::value &&
+                        std::is_base_of<internal::basic_compiled_format,
+                                        CompiledFormat>::value)>
 format_to_n_result<OutputIt> format_to_n(OutputIt out, size_t n,
                                          const CompiledFormat& cf,
                                          const Args&... args) {


### PR DESCRIPTION
Add a check that CompileFormat is derived from basic_compiled_format to avoid compilation error in case if both compile.h and format.h are included.
https://godbolt.org/z/BuhQCh

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.