### PR TITLE
Use UDL template for GCC 9.3 and newer

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -135,11 +135,12 @@ FMT_END_NAMESPACE
 #endif
 
 #ifndef FMT_USE_UDL_TEMPLATE
-// EDG front end based compilers (icc, nvcc) and GCC < 6.4 do not propertly
-// support UDL templates and GCC >= 9 warns about them.
+// EDG front end based compilers (icc, nvcc) and GCC < 6.4 do not properly
+// support UDL templates and GCC >= 9 < 9.3 warns about them.
 #  if FMT_USE_USER_DEFINED_LITERALS && FMT_ICC_VERSION == 0 && \
       FMT_CUDA_VERSION == 0 &&                                 \
-      ((FMT_GCC_VERSION >= 604 && FMT_GCC_VERSION <= 900 &&    \
+      ((FMT_GCC_VERSION >= 604 &&                              \
+        (FMT_GCC_VERSION <= 900 || FMT_GCC_VERSION >= 903) &&  \
         __cplusplus >= 201402L) ||                             \
        FMT_CLANG_VERSION >= 304)
 #    define FMT_USE_UDL_TEMPLATE 1


### PR DESCRIPTION
It seems that this was fixed for GCC 9.3 with
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88095

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
