### PR TITLE
Add a disable wchar support option

### DIFF
--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -249,6 +249,7 @@ int CharTraits<char>::format_float(
       FMT_SNPRINTF(buffer, size, format, width, precision, value);
 }
 
+#ifdef FMT_HAS_WCHAR_T
 template <typename T>
 int CharTraits<wchar_t>::format_float(
     wchar_t *buffer, std::size_t size, const wchar_t *format,
@@ -262,6 +263,7 @@ int CharTraits<wchar_t>::format_float(
       FMT_SWPRINTF(buffer, size, format, width, value) :
       FMT_SWPRINTF(buffer, size, format, width, precision, value);
 }
+#endif
 
 template <typename T>
 const char BasicData<T>::DIGITS[] =

--- a/fmt/printf.cc
+++ b/fmt/printf.cc
@@ -25,7 +25,9 @@ FMT_FUNC int fprintf(std::FILE *f, CStringRef format, ArgList args) {
 #ifndef FMT_HEADER_ONLY
 
 template void PrintfFormatter<char>::format(CStringRef format);
+#ifdef FMT_HAS_WCHAR_T
 template void PrintfFormatter<wchar_t>::format(WCStringRef format);
+#endif
 
 #endif  // FMT_HEADER_ONLY
 

--- a/fmt/printf.h
+++ b/fmt/printf.h
@@ -524,10 +524,12 @@ inline void printf(Writer &w, CStringRef format, ArgList args) {
 }
 FMT_VARIADIC(void, printf, Writer &, CStringRef)
 
+#ifdef FMT_HAS_WCHAR_T
 inline void printf(WWriter &w, WCStringRef format, ArgList args) {
   PrintfFormatter<wchar_t>(args, w).format(format);
 }
 FMT_VARIADIC(void, printf, WWriter &, WCStringRef)
+#endif
 
 /**
   \rst


### PR DESCRIPTION
On MCUs with a static libstdc++ disabling wchar in the standard library can
safe a lot of space. This change tries to autodetect the wchar_t support
on gcc systems. But also allows disabling wchar with a compiler flag.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
