### PR TITLE
Use FMT_THROW in fuzzing build mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,7 @@ endif ()
 # Control fuzzing independent of the unit tests.
 if (FMT_FUZZ)
   add_subdirectory(test/fuzzing)
+  target_compile_definitions(fmt PUBLIC FMT_FUZZ)
 endif ()
 
 set(gitignore ${PROJECT_SOURCE_DIR}/.gitignore)

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1151,7 +1151,7 @@ int snprintf_float(T value, int precision, float_specs specs,
   for (;;) {
     auto begin = buf.data() + offset;
     auto capacity = buf.capacity() - offset;
-#ifdef FUZZ_MODE
+#ifdef FMT_FUZZ
     if (precision > 100000)
       throw std::runtime_error(
           "fuzz mode - avoid large allocation inside snprintf");

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1151,7 +1151,7 @@ int snprintf_float(T value, int precision, float_specs specs,
   for (;;) {
     auto begin = buf.data() + offset;
     auto capacity = buf.capacity() - offset;
-#ifdef FMT_FUZZ
+#if FMT_FUZZ
     if (precision > 100000)
       throw std::runtime_error(
           "fuzz mode - avoid large allocation inside snprintf");

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1153,8 +1153,8 @@ int snprintf_float(T value, int precision, float_specs specs,
     auto capacity = buf.capacity() - offset;
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (precision > 100000)
-      throw std::runtime_error(
-          "fuzz mode - avoid large allocation inside snprintf");
+      FMT_THROW(std::runtime_error(
+          "fuzz mode - avoid large allocation inside snprintf"));
 #endif
     // Suppress the warning about a nonliteral format string.
     // Cannot use auto becase of a bug in MinGW (#1532).

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1151,10 +1151,10 @@ int snprintf_float(T value, int precision, float_specs specs,
   for (;;) {
     auto begin = buf.data() + offset;
     auto capacity = buf.capacity() - offset;
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifdef FUZZ_MODE
     if (precision > 100000)
-      FMT_THROW(std::runtime_error(
-          "fuzz mode - avoid large allocation inside snprintf"));
+      throw std::runtime_error(
+          "fuzz mode - avoid large allocation inside snprintf");
 #endif
     // Suppress the warning about a nonliteral format string.
     // Cannot use auto becase of a bug in MinGW (#1532).

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1151,7 +1151,7 @@ int snprintf_float(T value, int precision, float_specs specs,
   for (;;) {
     auto begin = buf.data() + offset;
     auto capacity = buf.capacity() - offset;
-#if FMT_FUZZ
+#ifdef FMT_FUZZ
     if (precision > 100000)
       throw std::runtime_error(
           "fuzz mode - avoid large allocation inside snprintf");

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -699,8 +699,8 @@ class basic_memory_buffer : public internal::buffer<T> {
 
 template <typename T, std::size_t SIZE, typename Allocator>
 void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-  if (size > 1000) FMT_THROW(std::runtime_error("fuzz mode - won't grow that much"));
+#ifdef FUZZ_MODE
+  if (size > 1000) throw std::runtime_error("fuzz mode - won't grow that much");
 #endif
   std::size_t old_capacity = this->capacity();
   std::size_t new_capacity = old_capacity + old_capacity / 2;
@@ -1136,9 +1136,9 @@ template <typename Char> class float_writer {
             *it++ = static_cast<Char>('0');
           return it;
         }
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifdef FUZZ_MODE
         if (num_zeros > 1000)
-          FMT_THROW(std::runtime_error("fuzz mode - avoiding excessive cpu use"));
+          throw std::runtime_error("fuzz mode - avoiding excessive cpu use");
 #endif
         it = std::fill_n(it, num_zeros, static_cast<Char>('0'));
       }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -699,7 +699,7 @@ class basic_memory_buffer : public internal::buffer<T> {
 
 template <typename T, std::size_t SIZE, typename Allocator>
 void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
-#if FMT_FUZZ
+#ifdef FMT_FUZZ
   if (size > 1000) throw std::runtime_error("fuzz mode - won't grow that much");
 #endif
   std::size_t old_capacity = this->capacity();
@@ -1136,7 +1136,7 @@ template <typename Char> class float_writer {
             *it++ = static_cast<Char>('0');
           return it;
         }
-#if FMT_FUZZ
+#ifdef FMT_FUZZ
         if (num_zeros > 1000)
           throw std::runtime_error("fuzz mode - avoiding excessive cpu use");
 #endif

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -699,7 +699,7 @@ class basic_memory_buffer : public internal::buffer<T> {
 
 template <typename T, std::size_t SIZE, typename Allocator>
 void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
-#ifdef FUZZ_MODE
+#ifdef FMT_FUZZ
   if (size > 1000) throw std::runtime_error("fuzz mode - won't grow that much");
 #endif
   std::size_t old_capacity = this->capacity();
@@ -1136,7 +1136,7 @@ template <typename Char> class float_writer {
             *it++ = static_cast<Char>('0');
           return it;
         }
-#ifdef FUZZ_MODE
+#ifdef FMT_FUZZ
         if (num_zeros > 1000)
           throw std::runtime_error("fuzz mode - avoiding excessive cpu use");
 #endif

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -700,7 +700,7 @@ class basic_memory_buffer : public internal::buffer<T> {
 template <typename T, std::size_t SIZE, typename Allocator>
 void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-  if (size > 1000) throw std::runtime_error("fuzz mode - won't grow that much");
+  if (size > 1000) FMT_THROW(std::runtime_error("fuzz mode - won't grow that much"));
 #endif
   std::size_t old_capacity = this->capacity();
   std::size_t new_capacity = old_capacity + old_capacity / 2;
@@ -1138,7 +1138,7 @@ template <typename Char> class float_writer {
         }
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         if (num_zeros > 1000)
-          throw std::runtime_error("fuzz mode - avoiding excessive cpu use");
+          FMT_THROW(std::runtime_error("fuzz mode - avoiding excessive cpu use"));
 #endif
         it = std::fill_n(it, num_zeros, static_cast<Char>('0'));
       }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -699,7 +699,7 @@ class basic_memory_buffer : public internal::buffer<T> {
 
 template <typename T, std::size_t SIZE, typename Allocator>
 void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
-#ifdef FMT_FUZZ
+#if FMT_FUZZ
   if (size > 1000) throw std::runtime_error("fuzz mode - won't grow that much");
 #endif
   std::size_t old_capacity = this->capacity();
@@ -1136,7 +1136,7 @@ template <typename Char> class float_writer {
             *it++ = static_cast<Char>('0');
           return it;
         }
-#ifdef FMT_FUZZ
+#if FMT_FUZZ
         if (num_zeros > 1000)
           throw std::runtime_error("fuzz mode - avoiding excessive cpu use");
 #endif

--- a/src/format.cc
+++ b/src/format.cc
@@ -13,10 +13,10 @@ namespace internal {
 template <typename T>
 int format_float(char* buf, std::size_t size, const char* format, int precision,
                  T value) {
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifdef FUZZ_MODE
   if (precision > 100000)
-    FMT_THROW(std::runtime_error(
-        "fuzz mode - avoid large allocation inside snprintf"));
+    throw std::runtime_error(
+        "fuzz mode - avoid large allocation inside snprintf");
 #endif
   // Suppress the warning about nonliteral format string.
   int (*snprintf_ptr)(char*, size_t, const char*, ...) = FMT_SNPRINTF;

--- a/src/format.cc
+++ b/src/format.cc
@@ -13,7 +13,7 @@ namespace internal {
 template <typename T>
 int format_float(char* buf, std::size_t size, const char* format, int precision,
                  T value) {
-#ifdef FUZZ_MODE
+#ifdef FMT_FUZZ
   if (precision > 100000)
     throw std::runtime_error(
         "fuzz mode - avoid large allocation inside snprintf");

--- a/src/format.cc
+++ b/src/format.cc
@@ -15,8 +15,8 @@ int format_float(char* buf, std::size_t size, const char* format, int precision,
                  T value) {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
   if (precision > 100000)
-    throw std::runtime_error(
-        "fuzz mode - avoid large allocation inside snprintf");
+    FMT_THROW(std::runtime_error(
+        "fuzz mode - avoid large allocation inside snprintf"));
 #endif
   // Suppress the warning about nonliteral format string.
   int (*snprintf_ptr)(char*, size_t, const char*, ...) = FMT_SNPRINTF;

--- a/src/format.cc
+++ b/src/format.cc
@@ -13,7 +13,7 @@ namespace internal {
 template <typename T>
 int format_float(char* buf, std::size_t size, const char* format, int precision,
                  T value) {
-#ifdef FMT_FUZZ
+#if FMT_FUZZ
   if (precision > 100000)
     throw std::runtime_error(
         "fuzz mode - avoid large allocation inside snprintf");

--- a/src/format.cc
+++ b/src/format.cc
@@ -13,7 +13,7 @@ namespace internal {
 template <typename T>
 int format_float(char* buf, std::size_t size, const char* format, int precision,
                  T value) {
-#if FMT_FUZZ
+#ifdef FMT_FUZZ
   if (precision > 100000)
     throw std::runtime_error(
         "fuzz mode - avoid large allocation inside snprintf");

--- a/test/fuzzing/README.md
+++ b/test/fuzzing/README.md
@@ -7,7 +7,7 @@ in fmt. It is a part of the continous fuzzing at
 The source code is modified to make the fuzzing possible without locking up on
 resource exhaustion:
 ```cpp
-#ifdef FMT_FUZZ
+#if FMT_FUZZ
 if(spec.precision>100000) {
   throw std::runtime_error("fuzz mode - avoiding large precision");
 }

--- a/test/fuzzing/README.md
+++ b/test/fuzzing/README.md
@@ -9,7 +9,7 @@ resource exhaustion:
 ```cpp
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 if(spec.precision>100000) {
-  throw std::runtime_error("fuzz mode - avoiding large precision");
+  FMT_THROW(std::runtime_error("fuzz mode - avoiding large precision"));
 }
 #endif
 ```

--- a/test/fuzzing/README.md
+++ b/test/fuzzing/README.md
@@ -7,7 +7,7 @@ in fmt. It is a part of the continous fuzzing at
 The source code is modified to make the fuzzing possible without locking up on
 resource exhaustion:
 ```cpp
-#if FMT_FUZZ
+#ifdef FMT_FUZZ
 if(spec.precision>100000) {
   throw std::runtime_error("fuzz mode - avoiding large precision");
 }

--- a/test/fuzzing/README.md
+++ b/test/fuzzing/README.md
@@ -7,14 +7,19 @@ in fmt. It is a part of the continous fuzzing at
 The source code is modified to make the fuzzing possible without locking up on
 resource exhaustion:
 ```cpp
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifdef FUZZ_MODE
 if(spec.precision>100000) {
-  FMT_THROW(std::runtime_error("fuzz mode - avoiding large precision"));
+  throw std::runtime_error("fuzz mode - avoiding large precision");
 }
 #endif
-```
-This macro is the defacto standard for making fuzzing practically possible, see
-[the libFuzzer documentation](https://llvm.org/docs/LibFuzzer.html#fuzzer-friendly-build-mode).
+``` 
+This macro `FUZZ_MODE` is enabled on OSS-Fuzz builds and makes fuzzing
+practically possible. It is used in fmt code to prevent resource exhaustion in
+fuzzing mode.  
+The macro `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION` is the
+defacto standard for making fuzzing practically possible to disable certain
+fuzzing-unfriendly features (for example, randomness), see [the libFuzzer
+documentation](https://llvm.org/docs/LibFuzzer.html#fuzzer-friendly-build-mode).
 
 ## Running the fuzzers locally
 

--- a/test/fuzzing/README.md
+++ b/test/fuzzing/README.md
@@ -7,13 +7,13 @@ in fmt. It is a part of the continous fuzzing at
 The source code is modified to make the fuzzing possible without locking up on
 resource exhaustion:
 ```cpp
-#ifdef FUZZ_MODE
+#ifdef FMT_FUZZ
 if(spec.precision>100000) {
   throw std::runtime_error("fuzz mode - avoiding large precision");
 }
 #endif
 ``` 
-This macro `FUZZ_MODE` is enabled on OSS-Fuzz builds and makes fuzzing
+This macro `FMT_FUZZ` is enabled on OSS-Fuzz builds and makes fuzzing
 practically possible. It is used in fmt code to prevent resource exhaustion in
 fuzzing mode.  
 The macro `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION` is the


### PR DESCRIPTION
Make code properly build in fuzz mode with clang/gcc when `-fno-exceptions` is specified by using `FMT_THROW` in format files when building with FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION.

Signed-off-by: Asra Ali <asraa@google.com>

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
