### PR TITLE
build: Fix installation paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 
 include(cxx14)
 include(CheckCXXCompilerFlag)
+include(JoinPaths)
 
 list(FIND CMAKE_CXX_COMPILE_FEATURES "cxx_variadic_templates" index)
 if (${index} GREATER -1)
@@ -235,8 +236,8 @@ if (FMT_INSTALL)
   include(GNUInstallDirs)
   include(CMakePackageConfigHelpers)
   set_verbose(FMT_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/fmt CACHE STRING
-              "Installation directory for cmake files, relative to "
-              "${CMAKE_INSTALL_PREFIX}.")
+              "Installation directory for cmake files, a relative path "
+              "that will be joined to ${CMAKE_INSTALL_PREFIX}, or an arbitrary absolute path.")
   set(version_config ${PROJECT_BINARY_DIR}/fmt-config-version.cmake)
   set(project_config ${PROJECT_BINARY_DIR}/fmt-config.cmake)
   set(pkgconfig ${PROJECT_BINARY_DIR}/fmt.pc)
@@ -248,22 +249,26 @@ if (FMT_INSTALL)
   endif ()
 
   set_verbose(FMT_LIB_DIR ${CMAKE_INSTALL_LIBDIR} CACHE STRING
-              "Installation directory for libraries, relative to "
-              "${CMAKE_INSTALL_PREFIX}.")
+              "Installation directory for libraries, a relative path "
+              "that will be joined to ${CMAKE_INSTALL_PREFIX}, or an arbitrary absolute path.")
 
   set_verbose(FMT_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR}/fmt CACHE STRING
-              "Installation directory for include files, relative to "
-              "${CMAKE_INSTALL_PREFIX}.")
+              "Installation directory for include files, a relative path "
+              "that will be joined to ${CMAKE_INSTALL_PREFIX}, or an arbitrary absolute path.")
 
   set_verbose(FMT_PKGCONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/pkgconfig CACHE PATH
-              "Installation directory for pkgconfig (.pc) files, relative to "
-              "${CMAKE_INSTALL_PREFIX}.")
+              "Installation directory for pkgconfig (.pc) files, a relative path "
+              "that will be joined to ${CMAKE_INSTALL_PREFIX}, or an arbitrary absolute path.")
 
   # Generate the version, config and target files into the build directory.
   write_basic_package_version_file(
     ${version_config}
     VERSION ${FMT_VERSION}
     COMPATIBILITY AnyNewerVersion)
+
+  join_paths(libdir_for_pc_file "\${exec_prefix}" "${CMAKE_INSTALL_LIBDIR}")
+  join_paths(includedir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+
   configure_file(
     "${PROJECT_SOURCE_DIR}/support/cmake/fmt.pc.in"
     "${pkgconfig}"

--- a/support/cmake/JoinPaths.cmake
+++ b/support/cmake/JoinPaths.cmake
@@ -1,0 +1,26 @@
+# This module provides function for joining paths
+# known from from most languages
+#
+# Original license:
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Explicit permission given to distribute this module under
+# the terms of the project as described in /LICENSE.rst.
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()

--- a/support/cmake/fmt.pc.in
+++ b/support/cmake/fmt.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
 
 Name: fmt
 Description: A modern formatting library


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->
    
It is not generally true that `CMAKE_INSTALL_<dir>` variables are relative paths:
    
https://github.com/jtojnar/cmake-snips#concatenating-paths-when-building-pkg-config-files

This lead to `includedir=/nix/store/9axh4pacy7l4s7ii9j0ij54nmdslj7yy-fmt-6.2.0-dev//nix/store/9axh4pacy7l4s7ii9j0ij54nmdslj7yy-fmt-6.2.0-dev/include`.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
