### PR TITLE
Update date formatting example to use threadsafe localtime

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -408,7 +408,7 @@ formatting::
 
   std::time_t t = std::time(nullptr);
   // Prints "The date is 2016-04-29." (with the current date)
-  fmt::print("The date is {:%Y-%m-%d}.", *std::localtime(&t));
+  fmt::print("The date is {:%Y-%m-%d}.", fmt::localtime(t));
 
 The format string syntax is described in the documentation of
 `strftime <http://en.cppreference.com/w/cpp/chrono/c/strftime>`_.


### PR DESCRIPTION
As a bonus, this hints the user to the existence of `fmt::localtime()`/`fmt::gmtime()`.

----

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
