### PR TITLE
Exclude std::abort from compilation when compiling CUDA with Clang

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -48,10 +48,9 @@ namespace internal {
 
 FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
   print(stderr, "{}:{}: assertion failed: {}", file, line, message);
-#if defined(__clang__) && defined(__CUDA__) && defined(__CUDA_ARCH__)
+  // Chosen instead of std::abort to satisfy Clang in CUDA mode during device
+  // code pass.
   std::terminate();
-#else
-  std::abort();
 #endif
 }
 

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -15,6 +15,7 @@
 #include <cstdarg>
 #include <cstring>  // for std::memmove
 #include <cwchar>
+#include <exception>
 
 #include "format.h"
 #if !defined(FMT_STATIC_THOUSANDS_SEPARATOR)
@@ -47,7 +48,11 @@ namespace internal {
 
 FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
   print(stderr, "{}:{}: assertion failed: {}", file, line, message);
+#if defined(__clang__) && defined(__CUDA__) && defined(__CUDA_ARCH__)
+  std::terminate();
+#else
   std::abort();
+#endif
 }
 
 #ifndef _MSC_VER

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -51,7 +51,6 @@ FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
   // Chosen instead of std::abort to satisfy Clang in CUDA mode during device
   // code pass.
   std::terminate();
-#endif
 }
 
 #ifndef _MSC_VER


### PR DESCRIPTION
Excludes ```std::abort``` for device code only. Fixes #1659.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
