### PR TITLE
Fix some warnings

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -849,6 +849,10 @@ inline int count_digits(uint32_t n) {
 #endif
 
 template <typename Char> FMT_API std::string grouping_impl(locale_ref loc);
+#ifndef FMT_HEADER_ONLY
+extern template FMT_API std::string grouping_impl<char>(locale_ref loc);
+extern template FMT_API std::string grouping_impl<wchar_t>(locale_ref loc);
+#endif
 template <typename Char> inline std::string grouping(locale_ref loc) {
   return grouping_impl<char>(loc);
 }
@@ -857,6 +861,10 @@ template <> inline std::string grouping<wchar_t>(locale_ref loc) {
 }
 
 template <typename Char> FMT_API Char thousands_sep_impl(locale_ref loc);
+#ifndef FMT_HEADER_ONLY
+extern template FMT_API char thousands_sep_impl<char>(locale_ref loc);
+extern template FMT_API wchar_t thousands_sep_impl<wchar_t>(locale_ref loc);
+#endif
 template <typename Char> inline Char thousands_sep(locale_ref loc) {
   return Char(thousands_sep_impl<char>(loc));
 }
@@ -865,6 +873,10 @@ template <> inline wchar_t thousands_sep(locale_ref loc) {
 }
 
 template <typename Char> FMT_API Char decimal_point_impl(locale_ref loc);
+#ifndef FMT_HEADER_ONLY
+extern template FMT_API char decimal_point_impl(locale_ref loc);
+extern template FMT_API wchar_t decimal_point_impl(locale_ref loc);
+#endif
 template <typename Char> inline Char decimal_point(locale_ref loc) {
   return Char(decimal_point_impl<char>(loc));
 }
@@ -1205,10 +1217,30 @@ template <typename Char> class float_writer {
 template <typename T>
 int format_float(T value, int precision, float_specs specs, buffer<char>& buf);
 
+#ifndef FMT_HEADER_ONLY
+extern template
+int format_float<double>(double value, int precision, float_specs specs,
+                         buffer<char>& buf);
+extern template
+int format_float<long double>(long double value, int precision,
+                              float_specs specs, buffer<char>& buf);
+#endif
+
 // Formats a floating-point number with snprintf.
 template <typename T>
 int snprintf_float(T value, int precision, float_specs specs,
                    buffer<char>& buf);
+
+#ifndef FMT_HEADER_ONLY
+int snprintf_float(float value, int precision, float_specs specs,
+                   buffer<char>& buf) = delete;
+extern template
+int snprintf_float<double>(double value, int precision, float_specs specs,
+                           buffer<char>& buf);
+extern template
+int snprintf_float<long double>(long double value, int precision,
+                                float_specs specs, buffer<char>& buf);
+#endif
 
 template <typename T> T promote_float(T value) { return value; }
 inline double promote_float(float value) { return static_cast<double>(value); }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1034,12 +1034,12 @@ template <typename Char> struct fill_t {
 // We cannot use enum classes as bit fields because of a gcc bug
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61414.
 namespace align {
-enum type { none, left, right, center, numeric };
+enum type : uint8_t { none, left, right, center, numeric };
 }
 using align_t = align::type;
 
 namespace sign {
-enum type { none, minus, plus, space };
+enum type : uint8_t { none, minus, plus, space };
 }
 using sign_t = sign::type;
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -849,10 +849,6 @@ inline int count_digits(uint32_t n) {
 #endif
 
 template <typename Char> FMT_API std::string grouping_impl(locale_ref loc);
-#ifndef FMT_HEADER_ONLY
-extern template FMT_API std::string grouping_impl<char>(locale_ref loc);
-extern template FMT_API std::string grouping_impl<wchar_t>(locale_ref loc);
-#endif
 template <typename Char> inline std::string grouping(locale_ref loc) {
   return grouping_impl<char>(loc);
 }
@@ -861,10 +857,6 @@ template <> inline std::string grouping<wchar_t>(locale_ref loc) {
 }
 
 template <typename Char> FMT_API Char thousands_sep_impl(locale_ref loc);
-#ifndef FMT_HEADER_ONLY
-extern template FMT_API char thousands_sep_impl<char>(locale_ref loc);
-extern template FMT_API wchar_t thousands_sep_impl<wchar_t>(locale_ref loc);
-#endif
 template <typename Char> inline Char thousands_sep(locale_ref loc) {
   return Char(thousands_sep_impl<char>(loc));
 }
@@ -873,10 +865,6 @@ template <> inline wchar_t thousands_sep(locale_ref loc) {
 }
 
 template <typename Char> FMT_API Char decimal_point_impl(locale_ref loc);
-#ifndef FMT_HEADER_ONLY
-extern template FMT_API char decimal_point_impl(locale_ref loc);
-extern template FMT_API wchar_t decimal_point_impl(locale_ref loc);
-#endif
 template <typename Char> inline Char decimal_point(locale_ref loc) {
   return Char(decimal_point_impl<char>(loc));
 }
@@ -1217,30 +1205,10 @@ template <typename Char> class float_writer {
 template <typename T>
 int format_float(T value, int precision, float_specs specs, buffer<char>& buf);
 
-#ifndef FMT_HEADER_ONLY
-extern template
-int format_float<double>(double value, int precision, float_specs specs,
-                         buffer<char>& buf);
-extern template
-int format_float<long double>(long double value, int precision,
-                              float_specs specs, buffer<char>& buf);
-#endif
-
 // Formats a floating-point number with snprintf.
 template <typename T>
 int snprintf_float(T value, int precision, float_specs specs,
                    buffer<char>& buf);
-
-#ifndef FMT_HEADER_ONLY
-int snprintf_float(float value, int precision, float_specs specs,
-                   buffer<char>& buf) = delete;
-extern template
-int snprintf_float<double>(double value, int precision, float_specs specs,
-                           buffer<char>& buf);
-extern template
-int snprintf_float<long double>(long double value, int precision,
-                                float_specs specs, buffer<char>& buf);
-#endif
 
 template <typename T> T promote_float(T value) { return value; }
 inline double promote_float(float value) { return static_cast<double>(value); }
@@ -3369,6 +3337,28 @@ typename buffer_context<Char>::iterator internal::vformat_to(
 #ifndef FMT_HEADER_ONLY
 extern template format_context::iterator internal::vformat_to(
     internal::buffer<char>&, string_view, basic_format_args<format_context>);
+namespace internal {
+extern template FMT_API std::string grouping_impl<char>(locale_ref loc);
+extern template FMT_API std::string grouping_impl<wchar_t>(locale_ref loc);
+extern template FMT_API char thousands_sep_impl<char>(locale_ref loc);
+extern template FMT_API wchar_t thousands_sep_impl<wchar_t>(locale_ref loc);
+extern template FMT_API char decimal_point_impl(locale_ref loc);
+extern template FMT_API wchar_t decimal_point_impl(locale_ref loc);
+extern template
+int format_float<double>(double value, int precision, float_specs specs,
+                         buffer<char>& buf);
+extern template
+int format_float<long double>(long double value, int precision,
+                              float_specs specs, buffer<char>& buf);
+int snprintf_float(float value, int precision, float_specs specs,
+                   buffer<char>& buf) = delete;
+extern template
+int snprintf_float<double>(double value, int precision, float_specs specs,
+                           buffer<char>& buf);
+extern template
+int snprintf_float<long double>(long double value, int precision,
+                                float_specs specs, buffer<char>& buf);
+}
 #endif
 
 template <typename S, typename Char = char_t<S>,

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -507,7 +507,7 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
       auto str_end = str + specs.precision;
       auto nul = std::find(str, str_end, Char());
       arg = internal::make_arg<basic_printf_context>(basic_string_view<Char>(
-          str, nul != str_end ? nul - str : specs.precision));
+          str, internal::to_unsigned(nul != str_end ? nul - str : specs.precision)));
     }
     if (specs.alt && visit_format_arg(internal::is_zero_int(), arg))
       specs.alt = false;


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

This fixes a few warnings I was seeing compiling with clang:
- `-Wsigned-enum-bitfield` from using standard enums in a bitfield, fixed by giving them an unsigned underlying type.
- `-Wundefined-func-template` from templates without definitions, fixed by adding `extern template` declarations.
- `-Wsign-conversion` from constructing a `string_view` with an `int` size, fixed with `internal::to_unsigned`.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

