### PR TITLE
Make implicit capture explicit for C++20

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -172,7 +172,7 @@ FMT_END_NAMESPACE
 #  define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
 #endif
 
-#if (__cplusplus >= 201703L)
+#if (__cplusplus > 201703L)
 #  define FMT_CAPTURE_OF_THIS , this
 #else
 #  define FMT_CAPTURE_OF_THIS

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -172,6 +172,12 @@ FMT_END_NAMESPACE
 #  define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
 #endif
 
+#if (__cplusplus >= 201703L)
+#  define FMT_CAPTURE_OF_THIS , this
+#else
+#  define FMT_CAPTURE_OF_THIS
+#endif
+
 // Some compilers masquerade as both MSVC and GCC-likes or otherwise support
 // __builtin_clz and __builtin_clzll, so only define FMT_BUILTIN_CLZ using the
 // MSVC intrinsics if the clz and clzll builtins are not available.
@@ -1467,10 +1473,10 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
 
   void on_dec() {
     auto num_digits = count_digits(abs_value);
-    out =
-        write_int(out, num_digits, get_prefix(), specs, [=, this](iterator it) {
-          return format_decimal<Char>(it, abs_value, num_digits);
-        });
+    out = write_int(out, num_digits, get_prefix(), specs,
+                    [= FMT_CAPTURE_OF_THIS](iterator it) {
+                      return format_decimal<Char>(it, abs_value, num_digits);
+                    });
   }
 
   void on_hex() {
@@ -1479,11 +1485,11 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
       prefix[prefix_size++] = specs.type;
     }
     int num_digits = count_digits<4>(abs_value);
-    out =
-        write_int(out, num_digits, get_prefix(), specs, [=, this](iterator it) {
-          return format_uint<4, Char>(it, abs_value, num_digits,
-                                      specs.type != 'x');
-        });
+    out = write_int(out, num_digits, get_prefix(), specs,
+                    [= FMT_CAPTURE_OF_THIS](iterator it) {
+                      return format_uint<4, Char>(it, abs_value, num_digits,
+                                                  specs.type != 'x');
+                    });
   }
 
   void on_bin() {
@@ -1492,10 +1498,10 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
       prefix[prefix_size++] = static_cast<char>(specs.type);
     }
     int num_digits = count_digits<1>(abs_value);
-    out =
-        write_int(out, num_digits, get_prefix(), specs, [=, this](iterator it) {
-          return format_uint<1, Char>(it, abs_value, num_digits);
-        });
+    out = write_int(out, num_digits, get_prefix(), specs,
+                    [= FMT_CAPTURE_OF_THIS](iterator it) {
+                      return format_uint<1, Char>(it, abs_value, num_digits);
+                    });
   }
 
   void on_oct() {
@@ -1505,10 +1511,10 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
       // is not greater than the number of digits.
       prefix[prefix_size++] = '0';
     }
-    out =
-        write_int(out, num_digits, get_prefix(), specs, [=, this](iterator it) {
-          return format_uint<3, Char>(it, abs_value, num_digits);
-        });
+    out = write_int(out, num_digits, get_prefix(), specs,
+                    [= FMT_CAPTURE_OF_THIS](iterator it) {
+                      return format_uint<3, Char>(it, abs_value, num_digits);
+                    });
   }
 
   enum { sep_size = 1 };

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -173,9 +173,9 @@ FMT_END_NAMESPACE
 #endif
 
 #if (__cplusplus > 201703L)
-#  define FMT_CAPTURE_OF_THIS , this
+#  define FMT_CAPTURE_THIS , this
 #else
-#  define FMT_CAPTURE_OF_THIS
+#  define FMT_CAPTURE_THIS
 #endif
 
 // Some compilers masquerade as both MSVC and GCC-likes or otherwise support
@@ -1474,7 +1474,7 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
   void on_dec() {
     auto num_digits = count_digits(abs_value);
     out = write_int(out, num_digits, get_prefix(), specs,
-                    [= FMT_CAPTURE_OF_THIS](iterator it) {
+                    [= FMT_CAPTURE_THIS](iterator it) {
                       return format_decimal<Char>(it, abs_value, num_digits);
                     });
   }
@@ -1486,7 +1486,7 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
     }
     int num_digits = count_digits<4>(abs_value);
     out = write_int(out, num_digits, get_prefix(), specs,
-                    [= FMT_CAPTURE_OF_THIS](iterator it) {
+                    [= FMT_CAPTURE_THIS](iterator it) {
                       return format_uint<4, Char>(it, abs_value, num_digits,
                                                   specs.type != 'x');
                     });
@@ -1499,7 +1499,7 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
     }
     int num_digits = count_digits<1>(abs_value);
     out = write_int(out, num_digits, get_prefix(), specs,
-                    [= FMT_CAPTURE_OF_THIS](iterator it) {
+                    [= FMT_CAPTURE_THIS](iterator it) {
                       return format_uint<1, Char>(it, abs_value, num_digits);
                     });
   }
@@ -1512,7 +1512,7 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
       prefix[prefix_size++] = '0';
     }
     out = write_int(out, num_digits, get_prefix(), specs,
-                    [= FMT_CAPTURE_OF_THIS](iterator it) {
+                    [= FMT_CAPTURE_THIS](iterator it) {
                       return format_uint<3, Char>(it, abs_value, num_digits);
                     });
   }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1467,9 +1467,10 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
 
   void on_dec() {
     auto num_digits = count_digits(abs_value);
-    out = write_int(out, num_digits, get_prefix(), specs, [=](iterator it) {
-      return format_decimal<Char>(it, abs_value, num_digits);
-    });
+    out =
+        write_int(out, num_digits, get_prefix(), specs, [=, this](iterator it) {
+          return format_decimal<Char>(it, abs_value, num_digits);
+        });
   }
 
   void on_hex() {
@@ -1478,9 +1479,11 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
       prefix[prefix_size++] = specs.type;
     }
     int num_digits = count_digits<4>(abs_value);
-    out = write_int(out, num_digits, get_prefix(), specs, [=](iterator it) {
-      return format_uint<4, Char>(it, abs_value, num_digits, specs.type != 'x');
-    });
+    out =
+        write_int(out, num_digits, get_prefix(), specs, [=, this](iterator it) {
+          return format_uint<4, Char>(it, abs_value, num_digits,
+                                      specs.type != 'x');
+        });
   }
 
   void on_bin() {
@@ -1489,9 +1492,10 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
       prefix[prefix_size++] = static_cast<char>(specs.type);
     }
     int num_digits = count_digits<1>(abs_value);
-    out = write_int(out, num_digits, get_prefix(), specs, [=](iterator it) {
-      return format_uint<1, Char>(it, abs_value, num_digits);
-    });
+    out =
+        write_int(out, num_digits, get_prefix(), specs, [=, this](iterator it) {
+          return format_uint<1, Char>(it, abs_value, num_digits);
+        });
   }
 
   void on_oct() {
@@ -1501,9 +1505,10 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
       // is not greater than the number of digits.
       prefix[prefix_size++] = '0';
     }
-    out = write_int(out, num_digits, get_prefix(), specs, [=](iterator it) {
-      return format_uint<3, Char>(it, abs_value, num_digits);
-    });
+    out =
+        write_int(out, num_digits, get_prefix(), specs, [=, this](iterator it) {
+          return format_uint<3, Char>(it, abs_value, num_digits);
+        });
   }
 
   enum { sep_size = 1 };

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -172,12 +172,6 @@ FMT_END_NAMESPACE
 #  define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
 #endif
 
-#if (__cplusplus > 201703L)
-#  define FMT_CAPTURE_THIS , this
-#else
-#  define FMT_CAPTURE_THIS
-#endif
-
 // Some compilers masquerade as both MSVC and GCC-likes or otherwise support
 // __builtin_clz and __builtin_clzll, so only define FMT_BUILTIN_CLZ using the
 // MSVC intrinsics if the clz and clzll builtins are not available.
@@ -1474,7 +1468,7 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
   void on_dec() {
     auto num_digits = count_digits(abs_value);
     out = write_int(out, num_digits, get_prefix(), specs,
-                    [= FMT_CAPTURE_THIS](iterator it) {
+                    [this, num_digits](iterator it) {
                       return format_decimal<Char>(it, abs_value, num_digits);
                     });
   }
@@ -1486,7 +1480,7 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
     }
     int num_digits = count_digits<4>(abs_value);
     out = write_int(out, num_digits, get_prefix(), specs,
-                    [= FMT_CAPTURE_THIS](iterator it) {
+                    [this, num_digits](iterator it) {
                       return format_uint<4, Char>(it, abs_value, num_digits,
                                                   specs.type != 'x');
                     });
@@ -1499,7 +1493,7 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
     }
     int num_digits = count_digits<1>(abs_value);
     out = write_int(out, num_digits, get_prefix(), specs,
-                    [= FMT_CAPTURE_THIS](iterator it) {
+                    [this, num_digits](iterator it) {
                       return format_uint<1, Char>(it, abs_value, num_digits);
                     });
   }
@@ -1512,7 +1506,7 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
       prefix[prefix_size++] = '0';
     }
     out = write_int(out, num_digits, get_prefix(), specs,
-                    [= FMT_CAPTURE_THIS](iterator it) {
+                    [this, num_digits](iterator it) {
                       return format_uint<3, Char>(it, abs_value, num_digits);
                     });
   }


### PR DESCRIPTION
- Implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20, therefore this change.
- fixes #1668

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
