### PR TITLE
Make dynamic_format_arg_store reusable and add reserve()

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1586,7 +1586,7 @@ class dynamic_format_arg_store
   */
   void reserve(size_t new_cap, size_t new_cap_named) {
     FMT_ASSERT(new_cap >= new_cap_named,
-               "Set of argument includes set of named arguments");
+               "Set of arguments includes set of named arguments");
     data_.reserve(new_cap);
     named_info_.reserve(new_cap_named);
   }

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1572,6 +1572,24 @@ class dynamic_format_arg_store
       emplace_arg(fmt::arg(arg_name, arg.value));
     }
   }
+
+  /** Erase all elements from the store */
+  void clear() {
+    data_.clear();
+    named_info_.clear();
+    dynamic_args_ = internal::dynamic_arg_list();
+  }
+
+  /**
+    Reserves space to store at least *new_cap* arguments including
+    *new_cap_named* named arguments.
+  */
+  void reserve(size_t new_cap, size_t new_cap_named) {
+    FMT_ASSERT(new_cap >= new_cap_named,
+               "Set of argument includes set of named arguments");
+    data_.reserve(new_cap);
+    named_info_.reserve(new_cap_named);
+  }
 };
 
 /**

--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -512,6 +512,32 @@ TEST(FormatDynArgsTest, NamedCustomFormat) {
   EXPECT_EQ("cust=0 and cust=1 and cust=3", result);
 }
 
+TEST(FormatDynArgsTest, Clear) {
+  fmt::dynamic_format_arg_store<fmt::format_context> store;
+  store.push_back(42);
+
+  std::string result = fmt::vformat("{}", store);
+  EXPECT_EQ("42", result);
+
+  store.push_back(43);
+  result = fmt::vformat("{} and {}", store);
+  EXPECT_EQ("42 and 43", result);
+
+  store.clear();
+  store.push_back(44);
+  result = fmt::vformat("{}", store);
+  EXPECT_EQ("44", result);
+}
+
+TEST(FormatDynArgsTest, Reserve) {
+  fmt::dynamic_format_arg_store<fmt::format_context> store;
+  store.reserve(2, 1);
+  store.push_back(1.5f);
+  store.push_back(fmt::arg("a1", 42));
+  std::string result = fmt::vformat("{a1} and {}", store);
+  EXPECT_EQ("42 and 1.5", result);
+}
+
 struct copy_throwable {
   copy_throwable() {}
   copy_throwable(const copy_throwable&) { throw "deal with it"; }


### PR DESCRIPTION
Implementation of #1674.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
