### PR TITLE
Replace direct uses of throw in fmt/compile.h with FMT_THROW.

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -468,7 +468,7 @@ constexpr auto compile_format_string(S format_str) {
   constexpr basic_string_view<char_type> str = format_str;
   if constexpr (str[POS] == '{') {
     if (POS + 1 == str.size())
-      throw format_error("unmatched '{' in format string");
+      FMT_THROW(format_error("unmatched '{' in format string"));
     if constexpr (str[POS + 1] == '{') {
       return parse_tail<Args, POS + 2, ID>(make_text(str, POS, 1), format_str);
     } else if constexpr (str[POS + 1] == '}') {
@@ -484,7 +484,7 @@ constexpr auto compile_format_string(S format_str) {
     }
   } else if constexpr (str[POS] == '}') {
     if (POS + 1 == str.size())
-      throw format_error("unmatched '}' in format string");
+      FMT_THROW(format_error("unmatched '}' in format string"));
     return parse_tail<Args, POS + 2, ID>(make_text(str, POS, 1), format_str);
   } else {
     constexpr auto end = parse_text(str, POS + 1);


### PR DESCRIPTION
The current code fails to compile when exceptions are disabled.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.