### PR TITLE
nested replacement fields may omit arg_id

### DIFF
--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -79,8 +79,8 @@ The general form of a *standard format specifier* is:
    fill: <a character other than '{' or '}'>
    align: "<" | ">" | "^"
    sign: "+" | "-" | " "
-   width: `integer` | "{" `arg_id` "}"
-   precision: `integer` | "{" `arg_id` "}"
+   width: `integer` | "{" [`arg_id`] "}"
+   precision: `integer` | "{" [`arg_id`] "}"
    type: `int_type` | "a" | "A" | "c" | "e" | "E" | "f" | "F" | "g" | "G" | "L" | "p" | "s"
    int_type: "b" | "B" | "d" | "o" | "x" | "X"
 


### PR DESCRIPTION
syntax.html already has examples like `fmt::format("{:.{}f}", 3.14, 1)` using this, 
and https://en.cppreference.com/w/cpp/utility/format/formatter#width_and_precision shows that this is the case for the C++20 std::format

The Format Specification Mini-Language grammar seems to be the only one not showing this; update it to match.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

Closes fmtlib/fmtlib.github.io#10