### PR TITLE
Adding sentinel support to fmt::join().

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -291,6 +291,7 @@ template <> constexpr int num_bits<fallback_uintptr>() {
 // An approximation of iterator_t for pre-C++20 systems.
 template <typename T>
 using iterator_t = decltype(std::begin(std::declval<T&>()));
+template <typename T> using sentinel_t = decltype(std::end(std::declval<T&>()));
 
 // Detect the iterator category of *any* given type in a SFINAE-friendly way.
 // Unfortunately, older implementations of std::iterator_traits are not safe
@@ -3209,19 +3210,21 @@ template <> struct formatter<bytes> {
   detail::dynamic_format_specs<char> specs_;
 };
 
-template <typename It, typename Char> struct arg_join : detail::view {
+template <typename It, typename Sentinel, typename Char>
+struct arg_join : detail::view {
   It begin;
-  It end;
+  Sentinel end;
   basic_string_view<Char> sep;
 
-  arg_join(It b, It e, basic_string_view<Char> s) : begin(b), end(e), sep(s) {}
+  arg_join(It b, Sentinel e, basic_string_view<Char> s)
+      : begin(b), end(e), sep(s) {}
 };
 
-template <typename It, typename Char>
-struct formatter<arg_join<It, Char>, Char>
+template <typename It, typename Sentinel, typename Char>
+struct formatter<arg_join<It, Sentinel, Char>, Char>
     : formatter<typename std::iterator_traits<It>::value_type, Char> {
   template <typename FormatContext>
-  auto format(const arg_join<It, Char>& value, FormatContext& ctx)
+  auto format(const arg_join<It, Sentinel, Char>& value, FormatContext& ctx)
       -> decltype(ctx.out()) {
     using base = formatter<typename std::iterator_traits<It>::value_type, Char>;
     auto it = value.begin;
@@ -3242,13 +3245,13 @@ struct formatter<arg_join<It, Char>, Char>
   Returns an object that formats the iterator range `[begin, end)` with elements
   separated by `sep`.
  */
-template <typename It>
-arg_join<It, char> join(It begin, It end, string_view sep) {
+template <typename It, typename Sentinel>
+arg_join<It, Sentinel, char> join(It begin, Sentinel end, string_view sep) {
   return {begin, end, sep};
 }
 
-template <typename It>
-arg_join<It, wchar_t> join(It begin, It end, wstring_view sep) {
+template <typename It, typename Sentinel>
+arg_join<It, Sentinel, wchar_t> join(It begin, Sentinel end, wstring_view sep) {
   return {begin, end, sep};
 }
 
@@ -3269,14 +3272,15 @@ arg_join<It, wchar_t> join(It begin, It end, wstring_view sep) {
   \endrst
  */
 template <typename Range>
-arg_join<detail::iterator_t<const Range>, char> join(const Range& range,
-                                                     string_view sep) {
+arg_join<detail::iterator_t<const Range>, detail::sentinel_t<const Range>, char>
+join(const Range& range, string_view sep) {
   return join(std::begin(range), std::end(range), sep);
 }
 
 template <typename Range>
-arg_join<detail::iterator_t<const Range>, wchar_t> join(const Range& range,
-                                                        wstring_view sep) {
+arg_join<detail::iterator_t<const Range>, detail::sentinel_t<const Range>,
+         wchar_t>
+join(const Range& range, wstring_view sep) {
   return join(std::begin(range), std::end(range), sep);
 }
 

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -368,13 +368,13 @@ FMT_CONSTEXPR tuple_arg_join<wchar_t, T...> join(const std::tuple<T...>& tuple,
   \endrst
  */
 template <typename T>
-arg_join<detail::iterator_t<const std::initializer_list<T>>, char> join(
+arg_join<const T*, const T*, char> join(
     std::initializer_list<T> list, string_view sep) {
   return join(std::begin(list), std::end(list), sep);
 }
 
 template <typename T>
-arg_join<detail::iterator_t<const std::initializer_list<T>>, wchar_t> join(
+arg_join<const T*, const T*, wchar_t> join(
     std::initializer_list<T> list, wstring_view sep) {
   return join(std::begin(list), std::end(list), sep);
 }

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -261,7 +261,9 @@ struct formatter<RangeT, Char,
                                           FormatContext& ctx) {
     auto out = detail::copy(formatting.prefix, ctx.out());
     size_t i = 0;
-    for (auto it = values.begin(), end = values.end(); it != end; ++it) {
+    auto it = values.begin();
+    auto end = values.end();
+    for (; it != end; ++it) {
       if (i > 0) {
         if (formatting.add_prepostfix_space) *out++ = ' ';
         out = detail::copy(formatting.delimiter, out);
@@ -368,14 +370,14 @@ FMT_CONSTEXPR tuple_arg_join<wchar_t, T...> join(const std::tuple<T...>& tuple,
   \endrst
  */
 template <typename T>
-arg_join<const T*, const T*, char> join(
-    std::initializer_list<T> list, string_view sep) {
+arg_join<const T*, const T*, char> join(std::initializer_list<T> list,
+                                        string_view sep) {
   return join(std::begin(list), std::end(list), sep);
 }
 
 template <typename T>
-arg_join<const T*, const T*, wchar_t> join(
-    std::initializer_list<T> list, wstring_view sep) {
+arg_join<const T*, const T*, wchar_t> join(std::initializer_list<T> list,
+                                           wstring_view sep) {
   return join(std::begin(list), std::end(list), sep);
 }
 

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -139,3 +139,18 @@ TEST(RangesTest, FormatStringLike) {
   EXPECT_EQ("foo", fmt::format("{}", string_like()));
 }
 #endif  // FMT_USE_STRING_VIEW
+
+struct zstring_sentinel {};
+bool operator==(const char* p, zstring_sentinel) { return *p == '\0'; }
+bool operator!=(const char* p, zstring_sentinel) { return *p != '\0'; }
+struct zstring {
+  const char* p;
+  const char* begin() const { return p; }
+  zstring_sentinel end() const { return {}; }
+};
+TEST(RangesTest, JoinSentinel) {
+  zstring hello{"hello"};
+  EXPECT_EQ("{'h', 'e', 'l', 'l', 'o'}", fmt::format("{}", hello));
+  EXPECT_EQ("h_e_l_l_o", fmt::format("{}", fmt::join(hello, "_")));
+}
+

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -153,4 +153,3 @@ TEST(RangesTest, JoinSentinel) {
   EXPECT_EQ("{'h', 'e', 'l', 'l', 'o'}", fmt::format("{}", hello));
   EXPECT_EQ("h_e_l_l_o", fmt::format("{}", fmt::join(hello, "_")));
 }
-


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

This PR adds support to invoke `fmt::join()` on ranges that have a sentinel type that differs from its iterator type. This allows you to use `fmt::join()` on range-v3/C++20 ranges adapters. This shouldn't affect any existing code (whose sentinel is just the same as the iterator type). 