### PR TITLE
Fix Mingw support

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -50,7 +50,7 @@
 #ifdef FMT_SYSTEM
 #  define FMT_POSIX_CALL(call) FMT_SYSTEM(call)
 #else
-#  define FMT_SYSTEM(call) call
+#  define FMT_SYSTEM(call) ::call
 #  ifdef _WIN32
 // Fix warnings about deprecated symbols.
 #    define FMT_POSIX_CALL(call) ::_##call

--- a/src/os.cc
+++ b/src/os.cc
@@ -289,7 +289,11 @@ void file::pipe(file& read_end, file& write_end) {
 
 buffered_file file::fdopen(const char* mode) {
   // Don't retry as fdopen doesn't return EINTR.
+  #if defined(__MINGW32__) && defined(_POSIX_)
+  FILE* f = ::fdopen(fd_, mode);
+  #else
   FILE* f = FMT_POSIX_CALL(fdopen(fd_, mode));
+  #endif
   if (!f)
     FMT_THROW(
         system_error(errno, "cannot associate stream with file descriptor"));


### PR DESCRIPTION
If the ``_POSIX_`` flag is set, _fdopen will not be defined by
Mingw headers, which is addressed by this PR.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
