### PR TITLE
Support custom FMT_INC_DIR in pkgconfig and cmake configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,8 +197,7 @@ endif ()
 target_compile_features(fmt INTERFACE ${FMT_REQUIRED_FEATURES})
 
 target_include_directories(fmt PUBLIC
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 
 set(FMT_DEBUG_POSTFIX d CACHE STRING "Debug library postfix.")
 
@@ -232,8 +231,7 @@ target_compile_definitions(fmt-header-only INTERFACE FMT_HEADER_ONLY=1)
 target_compile_features(fmt-header-only INTERFACE ${FMT_REQUIRED_FEATURES})
 
 target_include_directories(fmt-header-only INTERFACE
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>)
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 
 # Install targets.
 if (FMT_INSTALL)
@@ -247,11 +245,6 @@ if (FMT_INSTALL)
   set(pkgconfig ${PROJECT_BINARY_DIR}/fmt.pc)
   set(targets_export_name fmt-targets)
 
-  set (INSTALL_TARGETS fmt)
-  if (TARGET fmt-header-only)
-    set(INSTALL_TARGETS ${INSTALL_TARGETS} fmt-header-only)
-  endif ()
-
   set_verbose(FMT_LIB_DIR ${CMAKE_INSTALL_LIBDIR} CACHE STRING
               "Installation directory for libraries, a relative path "
               "that will be joined to ${CMAKE_INSTALL_PREFIX}, or an arbitrary absolute path.")
@@ -264,14 +257,22 @@ if (FMT_INSTALL)
               "Installation directory for pkgconfig (.pc) files, a relative path "
               "that will be joined to ${CMAKE_INSTALL_PREFIX}, or an arbitrary absolute path.")
 
+  get_filename_component(FMT_INC_DIR_PARENT "${FMT_INC_DIR}" DIRECTORY)
+
+  set(INSTALL_TARGETS fmt fmt-header-only)
+  target_include_directories(fmt PUBLIC
+    $<INSTALL_INTERFACE:${FMT_INC_DIR_PARENT}>)
+  target_include_directories(fmt-header-only INTERFACE
+    $<INSTALL_INTERFACE:${FMT_INC_DIR_PARENT}>)
+
   # Generate the version, config and target files into the build directory.
   write_basic_package_version_file(
     ${version_config}
     VERSION ${FMT_VERSION}
     COMPATIBILITY AnyNewerVersion)
 
-  join_paths(libdir_for_pc_file "\${exec_prefix}" "${CMAKE_INSTALL_LIBDIR}")
-  join_paths(includedir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+  join_paths(libdir_for_pc_file "\${exec_prefix}" "${FMT_LIB_DIR}")
+  join_paths(includedir_for_pc_file "\${prefix}" "${FMT_INC_DIR_PARENT}")
 
   configure_file(
     "${PROJECT_SOURCE_DIR}/support/cmake/fmt.pc.in"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ if (FMT_INSTALL)
               "Installation directory for libraries, a relative path "
               "that will be joined to ${CMAKE_INSTALL_PREFIX}, or an arbitrary absolute path.")
 
-  set_verbose(FMT_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR}/fmt CACHE STRING
+  set_verbose(FMT_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE STRING
               "Installation directory for include files, a relative path "
               "that will be joined to ${CMAKE_INSTALL_PREFIX}, or an arbitrary absolute path.")
 
@@ -257,13 +257,11 @@ if (FMT_INSTALL)
               "Installation directory for pkgconfig (.pc) files, a relative path "
               "that will be joined to ${CMAKE_INSTALL_PREFIX}, or an arbitrary absolute path.")
 
-  get_filename_component(FMT_INC_DIR_PARENT "${FMT_INC_DIR}" DIRECTORY)
-
   set(INSTALL_TARGETS fmt fmt-header-only)
   target_include_directories(fmt PUBLIC
-    $<INSTALL_INTERFACE:${FMT_INC_DIR_PARENT}>)
+    $<INSTALL_INTERFACE:${FMT_INC_DIR}>)
   target_include_directories(fmt-header-only INTERFACE
-    $<INSTALL_INTERFACE:${FMT_INC_DIR_PARENT}>)
+    $<INSTALL_INTERFACE:${FMT_INC_DIR}>)
 
   # Generate the version, config and target files into the build directory.
   write_basic_package_version_file(
@@ -272,7 +270,7 @@ if (FMT_INSTALL)
     COMPATIBILITY AnyNewerVersion)
 
   join_paths(libdir_for_pc_file "\${exec_prefix}" "${FMT_LIB_DIR}")
-  join_paths(includedir_for_pc_file "\${prefix}" "${FMT_INC_DIR_PARENT}")
+  join_paths(includedir_for_pc_file "\${prefix}" "${FMT_INC_DIR}")
 
   configure_file(
     "${PROJECT_SOURCE_DIR}/support/cmake/fmt.pc.in"
@@ -302,7 +300,7 @@ if (FMT_INSTALL)
 
   install(FILES $<TARGET_PDB_FILE:${INSTALL_TARGETS}>
           DESTINATION ${FMT_LIB_DIR} OPTIONAL)
-  install(FILES ${FMT_HEADERS} DESTINATION ${FMT_INC_DIR})
+  install(FILES ${FMT_HEADERS} DESTINATION "${FMT_INC_DIR}/fmt")
   install(FILES "${pkgconfig}" DESTINATION "${FMT_PKGCONFIG_DIR}")
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ if (MASTER_PROJECT AND NOT CMAKE_BUILD_TYPE)
               "CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel.")
 endif ()
 
+include(GNUInstallDirs)
+set_verbose(FMT_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE STRING
+            "Installation directory for include files, a relative path "
+            "that will be joined to ${CMAKE_INSTALL_PREFIX}, or an arbitrary absolute path.")
+
 option(FMT_PEDANTIC "Enable extra warnings and expensive tests." OFF)
 option(FMT_WERROR "Halt the compilation with an error on compiler warnings."
        OFF)
@@ -197,7 +202,8 @@ endif ()
 target_compile_features(fmt INTERFACE ${FMT_REQUIRED_FEATURES})
 
 target_include_directories(fmt PUBLIC
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${FMT_INC_DIR}>)
 
 set(FMT_DEBUG_POSTFIX d CACHE STRING "Debug library postfix.")
 
@@ -231,11 +237,11 @@ target_compile_definitions(fmt-header-only INTERFACE FMT_HEADER_ONLY=1)
 target_compile_features(fmt-header-only INTERFACE ${FMT_REQUIRED_FEATURES})
 
 target_include_directories(fmt-header-only INTERFACE
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${FMT_INC_DIR}>)
 
 # Install targets.
 if (FMT_INSTALL)
-  include(GNUInstallDirs)
   include(CMakePackageConfigHelpers)
   set_verbose(FMT_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/fmt CACHE STRING
               "Installation directory for cmake files, a relative path "
@@ -249,19 +255,9 @@ if (FMT_INSTALL)
               "Installation directory for libraries, a relative path "
               "that will be joined to ${CMAKE_INSTALL_PREFIX}, or an arbitrary absolute path.")
 
-  set_verbose(FMT_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE STRING
-              "Installation directory for include files, a relative path "
-              "that will be joined to ${CMAKE_INSTALL_PREFIX}, or an arbitrary absolute path.")
-
   set_verbose(FMT_PKGCONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/pkgconfig CACHE PATH
               "Installation directory for pkgconfig (.pc) files, a relative path "
               "that will be joined to ${CMAKE_INSTALL_PREFIX}, or an arbitrary absolute path.")
-
-  set(INSTALL_TARGETS fmt fmt-header-only)
-  target_include_directories(fmt PUBLIC
-    $<INSTALL_INTERFACE:${FMT_INC_DIR}>)
-  target_include_directories(fmt-header-only INTERFACE
-    $<INSTALL_INTERFACE:${FMT_INC_DIR}>)
 
   # Generate the version, config and target files into the build directory.
   write_basic_package_version_file(
@@ -280,6 +276,8 @@ if (FMT_INSTALL)
     ${PROJECT_SOURCE_DIR}/support/cmake/fmt-config.cmake.in
     ${project_config}
     INSTALL_DESTINATION ${FMT_CMAKE_DIR})
+
+  set(INSTALL_TARGETS fmt fmt-header-only)
   # Use a namespace because CMake provides better diagnostics for namespaced
   # imported targets.
   export(TARGETS ${INSTALL_TARGETS} NAMESPACE fmt::


### PR DESCRIPTION
When `CMAKE_INSTALL_INCLUDEDIR` or `FMT_INC_DIR` override the header installation directory, they should be used instead of `${CMAKE_INSTALL_PREFIX}/include` in `fmt-targets.cmake` and `fmt.pc`.