### PR TITLE
Don't install sphinx cache files

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -9,4 +9,5 @@ add_custom_target(doc
   SOURCES api.rst syntax.rst usage.rst build.py conf.py _templates/layout.html)
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html/
-        DESTINATION share/doc/fmt OPTIONAL)
+        DESTINATION share/doc/fmt OPTIONAL
+        PATTERN ".doctrees" EXCLUDE)


### PR DESCRIPTION
When building documentation sphinx creates cached files in the .doctrees
directory and aren't required for viewing documentation only for
building. As added benefit this makes fmt reprodcubile as the cached
files are different when the build environment is varied.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
