### PR TITLE
Ignore /doc/node_modules directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ bin/
 /CMakeScripts
 /doc/doxyxml
 /doc/html
+/doc/node_modules
 virtualenv
 /Testing
 /install_manifest.txt


### PR DESCRIPTION
I'd really appreciate /doc/node_modules being ignored, as it's cluttering up a CMake super-build... Thanks.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
