### PR TITLE
fix typo which caused the loss of the counting information when using…

### DIFF
--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -206,8 +206,7 @@ template <typename OutputIt, typename Char> class basic_printf_context;
   \endrst
  */
 template <typename OutputIt, typename Char>
-class printf_arg_formatter
-    : public detail::arg_formatter_base<OutputIt, Char> {
+class printf_arg_formatter : public detail::arg_formatter_base<OutputIt, Char> {
  public:
   using iterator = OutputIt;
 
@@ -592,7 +591,7 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
     start = it;
 
     // Format argument.
-    visit_format_arg(ArgFormatter(out, specs, *this), arg);
+    out = visit_format_arg(ArgFormatter(out, specs, *this), arg);
   }
   return std::copy(start, it, out);
 }

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -606,3 +606,23 @@ TEST(PrintfTest, VSPrintfMakeWArgsExample) {
                           {fmt::make_wprintf_args(42, L"something")}));
 #endif
 }
+
+TEST(PrintfTest, PrintfDetermineOutputSize) {
+  using backit = std::back_insert_iterator<std::vector<char>>;
+  using truncated_printf_context =
+      fmt::basic_printf_context<fmt::detail::truncating_iterator<backit>, char>;
+
+  auto v = std::vector<char>{};
+  auto it = std::back_inserter(v);
+
+  const auto format_string = "%s";
+  const auto format_arg = "Hello";
+  const auto expected_size = fmt::sprintf(format_string, format_arg).size();
+
+  EXPECT_EQ((truncated_printf_context(
+                 fmt::detail::truncating_iterator<backit>(it, 0), format_string,
+                 fmt::make_format_args<truncated_printf_context>(format_arg))
+                 .format()
+                 .count()),
+            expected_size);
+}


### PR DESCRIPTION
… a printf context with a truncating_iterator

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
