### PR TITLE
Added  #define WIN32_LEAN_AND_MEAN before including windows.h

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -29,7 +29,7 @@
 #    include <windows.h>
 #    undef WIN32_LEAN_AND_MEAN
 #    undef NOMINMAX
-#    else
+#  else
 #    include <windows.h>
 #  endif
 #  include <io.h>

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -23,12 +23,14 @@
 #endif
 
 #ifdef _WIN32
-#  if defined(NOMINMAX)
-#    include <windows.h>
-#  else
+#  if !defined(NOMINMAX) && !defined(WIN32_LEAN_AND_MEAN)
 #    define NOMINMAX
+#    define WIN32_LEAN_AND_MEAN
 #    include <windows.h>
+#    undef WIN32_LEAN_AND_MEAN
 #    undef NOMINMAX
+#    else
+#    include <windows.h>
 #  endif
 #  include <io.h>
 #endif


### PR DESCRIPTION
This prevents winsock2 redefinition warnings (e.g. see issue https://github.com/gabime/spdlog/issues/1589) and minimizes the stuff that windows.h includes.

I also reversed  the `#ifdef`condition to avoid redefinition warnings if either  `NOMINMAX` or `WIN32_LEAN_AND_MEAN` is already defined.