### PR TITLE
6.2.1 to string fix

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,10 +1,11 @@
 6.2.1 - TBD
 -----------
 
-* Fix ostream support in sprintf
+* Fixed ostream support in ``sprintf``
   (`#1631 <https://github.com/fmtlib/fmt/issues/1631>`_).
 
-* Fix inconsistent type detection
+* Fixed type detection when using implicit conversion to ``string_view`` and
+  ostream ``operator<<`` inconsistently
   (`#1662 <https://github.com/fmtlib/fmt/issues/1662>`_).
 
 6.2.0 - 2020-04-05

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,5 +1,5 @@
-6.2.1 - TBD
------------
+6.2.1 - 2020-05-09
+------------------
 
 * Fixed ostream support in ``sprintf``
   (`#1631 <https://github.com/fmtlib/fmt/issues/1631>`_).

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,3 +1,12 @@
+6.2.1 - TBD
+-----------
+
+* Fix ostream support in sprintf
+  (`#1631 <https://github.com/fmtlib/fmt/issues/1631>`_).
+
+* Fix inconsistent type detection
+  (`#1662 <https://github.com/fmtlib/fmt/issues/1662>`_).
+
 6.2.0 - 2020-04-05
 ------------------
 

--- a/doc/build.py
+++ b/doc/build.py
@@ -6,7 +6,7 @@ import errno, os, shutil, sys, tempfile
 from subprocess import check_call, check_output, CalledProcessError, Popen, PIPE
 from distutils.version import LooseVersion
 
-versions = ['1.0.0', '1.1.0', '2.0.0', '3.0.2', '4.0.0', '4.1.0', '5.0.0', '5.1.0', '5.2.0', '5.2.1', '5.3.0', '6.0.0', '6.1.0', '6.1.1', '6.1.2', '6.2.0']
+versions = ['1.0.0', '1.1.0', '2.0.0', '3.0.2', '4.0.0', '4.1.0', '5.0.0', '5.1.0', '5.2.0', '5.2.1', '5.3.0', '6.0.0', '6.1.0', '6.1.1', '6.1.2', '6.2.0', '6.2.1']
 
 def pip_install(package, commit=None, **kwargs):
   "Install package using pip."

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1208,13 +1208,16 @@ FMT_CONSTEXPR basic_format_arg<Context> make_arg(const T& value) {
   return arg;
 }
 
-template <bool IS_PACKED, typename Context, typename T,
+// The type template parameter is there to avoid an ODR violation when using
+// a fallback formatter in one translation unit and an implicit conversion in
+// another (not recommended).
+template <bool IS_PACKED, typename Context, type, typename T,
           FMT_ENABLE_IF(IS_PACKED)>
 inline value<Context> make_arg(const T& val) {
   return arg_mapper<Context>().map(val);
 }
 
-template <bool IS_PACKED, typename Context, typename T,
+template <bool IS_PACKED, typename Context, type, typename T,
           FMT_ENABLE_IF(!IS_PACKED)>
 inline basic_format_arg<Context> make_arg(const T& value) {
   return make_arg<Context>(value);
@@ -1348,7 +1351,9 @@ class format_arg_store
 #if FMT_GCC_VERSION && FMT_GCC_VERSION < 409
         basic_format_args<Context>(*this),
 #endif
-        data_{internal::make_arg<is_packed, Context>(args)...} {
+        data_{internal::make_arg<
+            is_packed, Context,
+            internal::mapped_type_constant<Args, Context>::value>(args)...} {
   }
 };
 

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -18,7 +18,7 @@
 #include <vector>
 
 // The fmt library version in the form major * 10000 + minor * 100 + patch.
-#define FMT_VERSION 60200
+#define FMT_VERSION 60201
 
 #ifdef __has_feature
 #  define FMT_HAS_FEATURE(x) __has_feature(x)

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -830,7 +830,8 @@ template <typename Char> struct string_value {
 template <typename Context> struct custom_value {
   using parse_context = basic_format_parse_context<typename Context::char_type>;
   const void* value;
-  void (*format)(const void* arg, parse_context& parse_ctx, Context& ctx);
+  void (*format)(const void* arg,
+                 typename Context::parse_context_type& parse_ctx, Context& ctx);
 };
 
 // A formatting argument value.
@@ -890,9 +891,9 @@ template <typename Context> class value {
  private:
   // Formats an argument of a custom type, such as a user-defined class.
   template <typename T, typename Formatter>
-  static void format_custom_arg(
-      const void* arg, basic_format_parse_context<char_type>& parse_ctx,
-      Context& ctx) {
+  static void format_custom_arg(const void* arg,
+                                typename Context::parse_context_type& parse_ctx,
+                                Context& ctx) {
     Formatter f;
     parse_ctx.advance_to(f.parse(parse_ctx));
     ctx.advance_to(f.format(*static_cast<const T*>(arg), ctx));
@@ -1061,7 +1062,7 @@ template <typename Context> class basic_format_arg {
    public:
     explicit handle(internal::custom_value<Context> custom) : custom_(custom) {}
 
-    void format(basic_format_parse_context<char_type>& parse_ctx,
+    void format(typename Context::parse_context_type& parse_ctx,
                 Context& ctx) const {
       custom_.format(custom_.value, parse_ctx, ctx);
     }
@@ -1272,6 +1273,7 @@ template <typename OutputIt, typename Char> class basic_format_context {
  public:
   using iterator = OutputIt;
   using format_arg = basic_format_arg<basic_format_context>;
+  using parse_context_type = basic_format_parse_context<Char>;
   template <typename T> using formatter_type = formatter<T, char_type>;
 
   basic_format_context(const basic_format_context&) = delete;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3336,14 +3336,14 @@ arg_join<internal::iterator_t<const Range>, wchar_t> join(const Range& range,
   \endrst
  */
 template <typename T> inline std::string to_string(const T& value) {
-  return format("{}", value);
+  return fmt::format("{}", value);
 }
 
 /**
   Converts *value* to ``std::wstring`` using the default format for type *T*.
  */
 template <typename T> inline std::wstring to_wstring(const T& value) {
-  return format(L"{}", value);
+  return fmt::format(L"{}", value);
 }
 
 template <typename Char, std::size_t SIZE>

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -189,6 +189,10 @@ using internal::printf;  // For printing into memory_buffer.
 
 template <typename Range> class printf_arg_formatter;
 
+template <typename Char>
+class basic_printf_parse_context : public basic_format_parse_context<Char> {
+  using basic_format_parse_context<Char>::basic_format_parse_context;
+};
 template <typename OutputIt, typename Char> class basic_printf_context;
 
 /**
@@ -324,6 +328,7 @@ template <typename OutputIt, typename Char> class basic_printf_context {
   using char_type = Char;
   using iterator = OutputIt;
   using format_arg = basic_format_arg<basic_printf_context>;
+  using parse_context_type = basic_printf_parse_context<Char>;
   template <typename T> using formatter_type = printf_formatter<T>;
 
  private:
@@ -331,7 +336,7 @@ template <typename OutputIt, typename Char> class basic_printf_context {
 
   OutputIt out_;
   basic_format_args<basic_printf_context> args_;
-  basic_format_parse_context<Char> parse_ctx_;
+  parse_context_type parse_ctx_;
 
   static void parse_flags(format_specs& specs, const Char*& it,
                           const Char* end);
@@ -362,7 +367,7 @@ template <typename OutputIt, typename Char> class basic_printf_context {
 
   format_arg arg(int id) const { return args_.get(id); }
 
-  basic_format_parse_context<Char>& parse_context() { return parse_ctx_; }
+  parse_context_type& parse_context() { return parse_ctx_; }
 
   FMT_CONSTEXPR void on_error(const char* message) {
     parse_ctx_.on_error(message);

--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -210,7 +210,8 @@ TEST(ArgTest, FormatArgs) {
 }
 
 struct custom_context {
-  typedef char char_type;
+  using char_type = char;
+  using parse_context_type = fmt::format_parse_context;
 
   template <typename T> struct formatter_type {
     template <typename ParseContext>

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2259,8 +2259,9 @@ struct test_parse_context {
 };
 
 struct test_context {
-  typedef char char_type;
-  typedef fmt::basic_format_arg<test_context> format_arg;
+  using char_type = char;
+  using format_arg = fmt::basic_format_arg<test_context>;
+  using parse_context_type = fmt::format_parse_context;
 
   template <typename T> struct formatter_type {
     typedef fmt::formatter<T, char_type> type;

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -502,9 +502,7 @@ TEST(PrintfTest, PrintfError) {
 TEST(PrintfTest, WideString) { EXPECT_EQ(L"abc", fmt::sprintf(L"%s", L"abc")); }
 
 TEST(PrintfTest, PrintfCustom) {
-  // The test is disabled for now because it requires decoupling
-  // fallback_formatter::format from format_context.
-  //EXPECT_EQ("abc", test_sprintf("%s", TestString("abc")));
+  EXPECT_EQ("abc", test_sprintf("%s", TestString("abc")));
 }
 
 TEST(PrintfTest, OStream) {


### PR DESCRIPTION
PR after that question: https://stackoverflow.com/q/62423981/19905

This only applies cleanly to tags/6.2.1. I can't find a stable branch (or equivalent) in fmt, and github doesn't seem to allow creating PRs for tags, so applying for master branch. If there is a better way for me to submit this commit https://github.com/ashutosh108/fmt/commit/e8b47c3efb17609659645c0dfdab949cb5ecdc00 for tags/6.2.1, please let me know.

I can't create working PR for the most current version as it seems to be in the process of re-working, with to_string() apparently failing for user-defined classes (after commit https://github.com/fmtlib/fmt/commit/7431165f38bc608c8367f5511ad670e1afa9aefa ) and I can't fix that.
By the way, this PR contains a test for to_string()-ing user-defined class so this kind of regressions should be caught in the future.

P.S. I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.