### PR TITLE
Tweaks for EDG based compilers (Intel, nVidia, MCST/Elbrus, etc).

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -73,6 +73,7 @@
 #  if defined(__clang__)
 #    define FMT_FALLTHROUGH [[clang::fallthrough]]
 #  elif FMT_GCC_VERSION >= 700 && !defined(__PGI)
+        && (!defined(__EDG_VERSION__) || __EDG_VERSION__ >= 520)
 #    define FMT_FALLTHROUGH [[gnu::fallthrough]]
 #  else
 #    define FMT_FALLTHROUGH
@@ -127,11 +128,11 @@ FMT_END_NAMESPACE
 #endif
 
 #ifndef FMT_USE_USER_DEFINED_LITERALS
-// For Intel and NVIDIA compilers both they and the system gcc/msc support UDLs.
-#  if (FMT_HAS_FEATURE(cxx_user_literals) || FMT_GCC_VERSION >= 407 ||      \
-       FMT_MSC_VER >= 1900) &&                                              \
-      (!(FMT_ICC_VERSION || FMT_CUDA_VERSION) || FMT_ICC_VERSION >= 1500 || \
-       FMT_CUDA_VERSION >= 700)
+// For EDG based compilers (Intel, NVIDIA, Elbrus, etc)
+// and the system gcc/msc support UDLs.
+#  if (FMT_HAS_FEATURE(cxx_user_literals) || FMT_GCC_VERSION >= 407 ||       \
+       FMT_MSC_VER >= 1900) &&                                               \
+       (!defined(__EDG_VERSION__) || __EDG_VERSION__ >= /* UDL feature */ 480)
 #    define FMT_USE_USER_DEFINED_LITERALS 1
 #  else
 #    define FMT_USE_USER_DEFINED_LITERALS 0
@@ -139,11 +140,11 @@ FMT_END_NAMESPACE
 #endif
 
 #ifndef FMT_USE_UDL_TEMPLATE
-// EDG front end based compilers (icc, nvcc) and GCC < 6.4 do not propertly
+// EDG frontend based compilers (icc, nvcc, etc) and GCC < 6.4 do not propertly
 // support UDL templates and GCC >= 9 warns about them.
-#  if FMT_USE_USER_DEFINED_LITERALS && FMT_ICC_VERSION == 0 && \
-      FMT_CUDA_VERSION == 0 &&                                 \
-      ((FMT_GCC_VERSION >= 604 && __cplusplus >= 201402L) ||   \
+#  if FMT_USE_USER_DEFINED_LITERALS &&                                       \
+      (!defined(__EDG_VERSION__) || __EDG_VERSION__ >= 501) &&               \
+      ((FMT_GCC_VERSION >= 604 && __cplusplus >= 201402L) ||                 \
        FMT_CLANG_VERSION >= 304)
 #    define FMT_USE_UDL_TEMPLATE 1
 #  else


### PR DESCRIPTION
Using the `__EDG_VERSION__` macro for checks related to EDG-based
compilers instead of a macros specific for each of ones.

-----

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
