### PR TITLE
Fix possible infinite recursion in FMT_ASSERT

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -49,7 +49,7 @@ FMT_BEGIN_NAMESPACE
 namespace detail {
 
 FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
-  print(stderr, "{}:{}: assertion failed: {}", file, line, message);
+  std::fprintf(stderr, "%s:%d: assertion failed: %s", file, line, message);
   // Chosen instead of std::abort to satisfy Clang in CUDA mode during device
   // code pass.
   std::terminate();

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -49,6 +49,8 @@ FMT_BEGIN_NAMESPACE
 namespace detail {
 
 FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
+  // Use unchecked std::fprintf to avoid triggering another assertion when
+  // writing to stderr fails
   std::fprintf(stderr, "%s:%d: assertion failed: %s", file, line, message);
   // Chosen instead of std::abort to satisfy Clang in CUDA mode during device
   // code pass.


### PR DESCRIPTION
With exceptions disabled and assertions enabled FMT_ASSERT can lead to infinite recursion until stack overflows.

**Reason**
When a fmt assertion is triggered it tries to print a
message via *assert_fail* before terminating. For printing it uses
fmt::print to stderr that, when stderr output is limited leads again
to an assertion that tries to print a message (and so on).

**Reproduce**
Easiest way to reproduce is to close stderr to cause the recursion and to also close stdout to trigger an assertion condition.
Compile the following code with *FMT_EXCEPTIONS=0*:

```c++
#include "fmt/format.h"

int main() {
    std::fclose(stdout);
    std::fclose(stderr);
    fmt::print("foo");
    return 0;
}
```

Resulting stacktrace:
```
...
#35474 0x000055d68c17609f in fmt::v6::vprint (f=0x7fc5892db680 <_IO_2_1_stderr_>, format_str=..., args=...) at ../fmt/include/fmt/format-inl.h:1412
#35475 0x000055d68c17b09c in fmt::v6::print<char [28], char const*&, int&, char const*&, char> (f=0x7fc5892db680 <_IO_2_1_stderr_>, format_str=...) at ../fmt/include/fmt/core.h:1857
#35476 0x000055d68c174bf2 in fmt::v6::detail::assert_fail (file=0x55d68c1912b8 "../fmt/include/fmt/format-inl.h", line=177, message=0x55d68c191371 "") at ../fmt/include/fmt/format-inl.h:52
#35477 0x000055d68c174ff4 in fmt::v6::detail::fwrite_fully (ptr=0x7ffe387b8210, size=1, count=55, stream=0x7fc5892db680 <_IO_2_1_stderr_>) at ../fmt/include/fmt/format-inl.h:177
#35478 0x000055d68c17609f in fmt::v6::vprint (f=0x7fc5892db680 <_IO_2_1_stderr_>, format_str=..., args=...) at ../fmt/include/fmt/format-inl.h:1412
#35479 0x000055d68c17b09c in fmt::v6::print<char [28], char const*&, int&, char const*&, char> (f=0x7fc5892db680 <_IO_2_1_stderr_>, format_str=...) at ../fmt/include/fmt/core.h:1857
#35480 0x000055d68c174bf2 in fmt::v6::detail::assert_fail (file=0x55d68c1912b8 "../fmt/include/fmt/format-inl.h", line=177, message=0x55d68c191371 "") at ../fmt/include/fmt/format-inl.h:52
#35481 0x000055d68c174ff4 in fmt::v6::detail::fwrite_fully (ptr=0x7ffe387b85c0, size=1, count=55, stream=0x7fc5892db680 <_IO_2_1_stderr_>) at ../fmt/include/fmt/format-inl.h:177
#35482 0x000055d68c17609f in fmt::v6::vprint (f=0x7fc5892db680 <_IO_2_1_stderr_>, format_str=..., args=...) at ../fmt/include/fmt/format-inl.h:1412
#35483 0x000055d68c17b09c in fmt::v6::print<char [28], char const*&, int&, char const*&, char> (f=0x7fc5892db680 <_IO_2_1_stderr_>, format_str=...) at ../fmt/include/fmt/core.h:1857
#35484 0x000055d68c174bf2 in fmt::v6::detail::assert_fail (file=0x55d68c1912b8 "../fmt/include/fmt/format-inl.h", line=177, message=0x55d68c191371 "") at ../fmt/include/fmt/format-inl.h:52
#35485 0x000055d68c174ff4 in fmt::v6::detail::fwrite_fully (ptr=0x7ffe387b8970, size=1, count=55, stream=0x7fc5892db680 <_IO_2_1_stderr_>) at ../fmt/include/fmt/format-inl.h:177
#35486 0x000055d68c17609f in fmt::v6::vprint (f=0x7fc5892db680 <_IO_2_1_stderr_>, format_str=..., args=...) at ../fmt/include/fmt/format-inl.h:1412
#35487 0x000055d68c17b09c in fmt::v6::print<char [28], char const*&, int&, char const*&, char> (f=0x7fc5892db680 <_IO_2_1_stderr_>, format_str=...) at ../fmt/include/fmt/core.h:1857
#35488 0x000055d68c174bf2 in fmt::v6::detail::assert_fail (file=0x55d68c1912b8 "../fmt/include/fmt/format-inl.h", line=177, message=0x55d68c191371 "") at ../fmt/include/fmt/format-inl.h:52
#35489 0x000055d68c174ff4 in fmt::v6::detail::fwrite_fully (ptr=0x7ffe387b8d20, size=1, count=3, stream=0x7fc5892db760 <_IO_2_1_stdout_>) at ../fmt/include/fmt/format-inl.h:177
#35490 0x000055d68c17609f in fmt::v6::vprint (f=0x7fc5892db760 <_IO_2_1_stdout_>, format_str=..., args=...) at ../fmt/include/fmt/format-inl.h:1412
#35491 0x000055d68c176131 in fmt::v6::vprint (format_str=..., args=...) at ../fmt/include/fmt/format-inl.h:1427
#35492 0x000055d68c174a61 in fmt::v6::print<char [4], , char>(char const (&) [4]) (format_str=...) at ../fmt/include/fmt/core.h:1876
#35493 0x000055d68c1749a3 in main () at ../main.cc:8
```

Proposed fix is to not rely on std::print for assertion message output but to directly use (unchecked) output via std::fprintf.
This results in the expected stacktrace with abort:

```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007f483226e801 in __GI_abort () at abort.c:79
#2  0x00007f48328d1257 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00007f48328dc606 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f48328dc671 in std::terminate() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x0000562cb8e61c4b in fmt::v6::detail::assert_fail (file=0x562cb8e7dc58 "../fmt/include/fmt/format-inl.h", line=177, message=0x562cb8e7dd11 "") at ../fmt/include/fmt/format-inl.h:55
#6  0x0000562cb8e62048 in fmt::v6::detail::fwrite_fully (ptr=0x7fffc5ac1260, size=1, count=3, stream=0x7f483261a760 <_IO_2_1_stdout_>) at ../fmt/include/fmt/format-inl.h:177
#7  0x0000562cb8e630f3 in fmt::v6::vprint (f=0x7f483261a760 <_IO_2_1_stdout_>, format_str=..., args=...) at ../fmt/include/fmt/format-inl.h:1412
#8  0x0000562cb8e63185 in fmt::v6::vprint (format_str=..., args=...) at ../fmt/include/fmt/format-inl.h:1427
#9  0x0000562cb8e61ab1 in fmt::v6::print<char [4], , char>(char const (&) [4]) (format_str=...) at ../fmt/include/fmt/core.h:1876
#10 0x0000562cb8e619f3 in main () at ../main.cc:7
```


I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
