### PR TITLE
Add CE6 support

### DIFF
--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -30,7 +30,9 @@
 #include <string.h>
 
 #include <cctype>
-#include <cerrno>
+#if !defined(UNDER_CE)
+# include <cerrno>
+#endif
 #include <climits>
 #include <cmath>
 #include <cstdarg>
@@ -98,7 +100,11 @@ namespace {
 inline int fmt_snprintf(char *buffer, size_t size, const char *format, ...) {
   va_list args;
   va_start(args, format);
+# if !defined(UNDER_CE)
   int result = vsnprintf_s(buffer, size, _TRUNCATE, format, args);
+# else
+  int result = _vsnprintf_s(buffer, size, _TRUNCATE, format, args);
+# endif
   va_end(args);
   return result;
 }
@@ -108,7 +114,11 @@ inline int fmt_snprintf(char *buffer, size_t size, const char *format, ...) {
 #if defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
 # define FMT_SWPRINTF snwprintf
 #else
-# define FMT_SWPRINTF swprintf
+# if defined(UNDER_CE)
+#  define FMT_SWPRINTF swprintf_s
+# else
+#  define FMT_SWPRINTF swprintf
+#endif
 #endif // defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
 
 const char RESET_COLOR[] = "\x1b[0m";
@@ -137,11 +147,13 @@ int safe_strerror(
     // A noop assignment operator to avoid bogus warnings.
     void operator=(const StrError &) {}
 
+#if !defined(UNDER_CE)
     // Handle the result of XSI-compliant version of strerror_r.
     int handle(int result) {
       // glibc versions before 2.13 return result in errno.
       return result == -1 ? errno : result;
     }
+#endif
 
     // Handle the result of GNU-specific version of strerror_r.
     int handle(char *message) {
@@ -171,9 +183,13 @@ int safe_strerror(
 
     // Fallback to strerror if strerror_r and strerror_s are not available.
     int fallback(internal::Null<>) {
+#if !defined(UNDER_CE)
       errno = 0;
       buffer_ = strerror(error_code_);
       return errno;
+#else
+	  return 0;
+#endif
     }
 
 #ifdef __clang__

--- a/fmt/format.cc
+++ b/fmt/format.cc
@@ -188,7 +188,7 @@ int safe_strerror(
       buffer_ = strerror(error_code_);
       return errno;
 #else
-	  return 0;
+      return 0;
 #endif
     }
 

--- a/fmt/format.h
+++ b/fmt/format.h
@@ -370,7 +370,7 @@ typedef __int64          intmax_t;
 // otherwise support __builtin_clz and __builtin_clzll, so
 // only define FMT_BUILTIN_CLZ using the MSVC intrinsics
 // if the clz and clzll builtins are not available.
-#if FMT_MSC_VER && !defined(FMT_BUILTIN_CLZLL) && !defined(_MANAGED)
+#if FMT_MSC_VER && !defined(FMT_BUILTIN_CLZLL) && !defined(_MANAGED) && !defined(UNDER_CE)
 # include <intrin.h>  // _BitScanReverse, _BitScanReverse64
 
 namespace fmt {
@@ -3149,7 +3149,7 @@ void BasicWriter<Char>::write_int(T value, Spec spec) {
   case 'n': {
     unsigned num_digits = internal::count_digits(abs_value);
     fmt::StringRef sep = "";
-#ifndef __ANDROID__
+#if !defined(__ANDROID__) && !defined(UNDER_CE)
     sep = internal::thousands_sep(std::localeconv());
 #endif
     unsigned size = static_cast<unsigned>(


### PR DESCRIPTION
I was able to compile 4.x branch for CE6 and run a demo exmple
`fmt::print("Hello, {}!", "world");`
with the changes in this PR.
I'm not sure if the workaround for the lack of `errno` and `<cerrno>` are ok.
CE6 doesn't implement `errno`, `<cerrno>` and `strerror()` and so I return 0.

It's really useful if someone can review this PR and give impressions.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
