### PR TITLE
Fix a conversion warning with Clang10 on Windows

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -566,7 +566,7 @@ template <typename U>
 void buffer<T>::append(const U* begin, const U* end) {
   size_t new_size = size_ + to_unsigned(end - begin);
   reserve(new_size);
-  std::uninitialized_copy(begin, end, make_checked(ptr_, capacity_) + size_);
+  std::uninitialized_copy(begin, end, make_checked(ptr_ + size_, capacity_ - size_));
   size_ = new_size;
 }
 }  // namespace detail


### PR DESCRIPTION
Fixes #1747

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
