### PR TITLE
Fix unresolved reference error

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1765,7 +1765,7 @@ std::basic_string<Char> vformat(
     basic_string_view<Char> format_str,
     basic_format_args<buffer_context<type_identity_t<Char>>> args);
 
-std::string vformat(string_view format_str, format_args args);
+FMT_API std::string vformat(string_view format_str, format_args args);
 
 template <typename Char>
 typename buffer_context<Char>::iterator vformat_to(


### PR DESCRIPTION
I'm using {fmt} in not header-only mode. After upgrade to 7.0.0 build is broken due to unresolved reference.
```
error LNK2001: unresolved external symbol "class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl fmt::v6::detail::vformat(class fmt::v6::basic_string_view<char>,struct fmt::v6::format_args)"
```


I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
