### PR TITLE
Remove allocating containers from on_num

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -392,6 +392,13 @@ template <typename Char> class basic_string_view {
   constexpr iterator begin() const { return data_; }
   constexpr iterator end() const { return data_ + size_; }
 
+  constexpr iterator cbegin() const { return data_; }
+  constexpr iterator cend() const { return data_ + size_; }
+
+  constexpr bool empty() const { return size_ == 0; };
+
+  constexpr Char back() const { return data_[size_ - 1]; }
+
   constexpr const Char& operator[](size_t pos) const { return data_[pos]; }
 
   FMT_CONSTEXPR void remove_prefix(size_t n) {


### PR DESCRIPTION
Use std::string_view and std::array containers when
FMT_STATIC_THOUSANDS_SEPARATOR is defined.

This will help in the case for embedded system where even using
containers that can potentially allocate results in malloc/free and
new/delete being linked into the binary. In many embedded cases dynamic
library allocation is prohibited and even the cost of linking in these
libraries costs too high of a cost in flash size.

Resolves #1762

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
