### PR TITLE
Add format_to_n overload that accepts FMT_COMPILE

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -654,6 +654,16 @@ format_to_n_result<OutputIt> format_to_n(OutputIt out, size_t n,
   return {it.base(), it.count()};
 }
 
+template <typename OutputIt, typename S, typename... Args,
+          FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
+format_to_n_result<OutputIt> format_to_n(OutputIt out, size_t n, const S&,
+                                         const Args&... args) {
+  constexpr auto compiled = detail::compile<Args...>(S());
+  auto it = format_to(detail::truncating_iterator<OutputIt>(out, n), compiled,
+                      args...);
+  return {it.base(), it.count()};
+}
+
 template <typename CompiledFormat, typename... Args>
 size_t formatted_size(const CompiledFormat& cf, const Args&... args) {
   return format_to(detail::counting_iterator(), cf, args...).count();


### PR DESCRIPTION
Resolves #1764 

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
