### PR TITLE
Do not pass empty format_str to UDT formatters

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -94,7 +94,7 @@ template <typename Char> struct part_counter {
     return ++num_parts, 0;
   }
 
-  FMT_CONSTEXPR void on_replacement_field(int, const Char*) {}
+  FMT_CONSTEXPR void on_replacement_field(int, const Char*, const Char*) {}
 
   FMT_CONSTEXPR const Char* on_format_specs(int, const Char* begin,
                                             const Char* end) {
@@ -160,7 +160,7 @@ class format_string_compiler : public error_handler {
     return 0;
   }
 
-  FMT_CONSTEXPR void on_replacement_field(int, const Char* ptr) {
+  FMT_CONSTEXPR void on_replacement_field(int, const Char* ptr, const Char*) {
     part_.arg_id_end = ptr;
     handler_(part_);
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,6 +108,7 @@ add_fmt_test(printf-test)
 add_fmt_test(custom-formatter-test)
 add_fmt_test(ranges-test)
 add_fmt_test(scan-test)
+add_fmt_test(user-defined-type-test)
 
 if (NOT MSVC_BUILD_STATIC)
   add_fmt_executable(posix-mock-test

--- a/test/format
+++ b/test/format
@@ -600,7 +600,7 @@ struct format_handler : detail::error_handler {
   int on_arg_id(unsigned id) { return parse_ctx.check_arg_id(id), id; }
   int on_arg_id(fmt::basic_string_view<Char>) { return 0; }
 
-  void on_replacement_field(int id, const Char* p) {
+  void on_replacement_field(int id, const Char* p, const Char*) {
     auto arg = context.arg(id);
     parse_ctx.advance_to(parse_ctx.begin() + (p  - &*parse_ctx.begin()));
     custom_formatter<Context> f(parse_ctx, context);

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2246,7 +2246,7 @@ struct test_format_string_handler {
 
   template <typename T> FMT_CONSTEXPR int on_arg_id(T) { return 0; }
 
-  FMT_CONSTEXPR void on_replacement_field(int, const char*) {}
+  FMT_CONSTEXPR void on_replacement_field(int, const char*, const char*) {}
 
   FMT_CONSTEXPR const char* on_format_specs(int, const char* begin,
                                             const char*) {

--- a/test/scan.h
+++ b/test/scan.h
@@ -177,7 +177,7 @@ struct scan_handler : error_handler {
   }
   int on_arg_id(string_view) { return on_error("invalid format"), 0; }
 
-  void on_replacement_field(int, const char*) {
+  void on_replacement_field(int, const char*, const char*) {
     auto it = scan_ctx_.begin(), end = scan_ctx_.end();
     switch (arg_.type) {
     case scan_type::int_type:

--- a/test/user-defined-type-test.cc
+++ b/test/user-defined-type-test.cc
@@ -1,0 +1,43 @@
+#ifndef _CRT_SECURE_NO_WARNINGS
+#  define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include <algorithm>
+
+#include "fmt/format.h"
+#include "gtest-extra.h"
+
+enum struct color { red, green, blue };
+
+template <> struct fmt::formatter<color> {
+  constexpr auto parse(format_parse_context& ctx) {
+    auto it = ctx.begin();
+    if (it == ctx.end()) throw fmt::format_error("incomplete format string");
+    if (*it != '}') throw fmt::format_error("unknown format specs");
+    return it;
+  }
+  template <typename FormatContext> auto format(color c, FormatContext& ctx) {
+    static const char red_s[] = "red", green_s[] = "green", blue_s[] = "blue";
+    const char *begin_p, *end_p;
+    switch (c) {
+    case color::red:
+      begin_p = std::begin(red_s);
+      end_p = std::end(red_s);
+      break;
+    case color::green:
+      begin_p = std::begin(green_s);
+      end_p = std::end(green_s);
+      break;
+    case color::blue:
+      begin_p = std::begin(blue_s);
+      end_p = std::end(blue_s);
+      break;
+    }
+    return std::copy(begin_p, end_p - 1, ctx.out());
+  }
+};
+
+TEST(UserDefinedTypeTest, Format) {
+  EXPECT_EQ("red green blue",
+            fmt::format("{} {} {}", color::red, color::green, color::blue));
+}


### PR DESCRIPTION
Basically changed `format.h:1837` to actually pass the format string instead of `{}`.

For consistency I did a `grep -r. -nFwe on_replacement_field` and added an additional `const Char*` to every function with that name.  All the ones except `format_handler::on_replacement_field` does not appear to be used in any way by any code however.  Should those functions be touched?