### PR TITLE
Trying to clear ambiguous compile time claims

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -114,9 +114,12 @@ string checks, wide string, output iterator and user-defined type support.
 Compile-time Format String Checks
 ---------------------------------
 
-Compile-time checks are supported for built-in and string types as well as
-user-defined types with ``constexpr`` ``parse`` functions in their ``formatter``
-specializations.
+Compile-time checks are enabled when using ``FMT_STRING``. It supports built-in
+and string types as well as user-defined types with ``constexpr`` ``parse``
+functions in their ``formatter`` specializations.
+
+When the compiler supports UDL templates extensions, using the litteral string
+``""_format()`` will also enable compile-time checks.
 
 .. doxygendefine:: FMT_STRING
 
@@ -389,9 +392,10 @@ The format string syntax is described in the documentation of
 Format string compilation
 =========================
 
-``fmt/compile.h`` provides format string compilation support. Format strings
-are parsed at compile time and converted into efficient formatting code. This
-supports arguments of built-in and string types as well as user-defined types
+``fmt/compile.h`` provides format string compilation support when using
+``FMT_COMPILE``. Format strings are parsed, checked and converted
+into efficient formatting code at compile-time.
+This supports arguments of built-in and string types as well as user-defined types
 with ``constexpr`` ``parse`` functions in their ``formatter`` specializations.
 Format string compilation can generate more binary code compared to the default
 API and is only recommended in places where formatting is a performance

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -114,12 +114,9 @@ string checks, wide string, output iterator and user-defined type support.
 Compile-time Format String Checks
 ---------------------------------
 
-Compile-time checks are enabled when using ``FMT_STRING``. It supports built-in
+Compile-time checks are enabled when using ``FMT_STRING``. They support built-in
 and string types as well as user-defined types with ``constexpr`` ``parse``
 functions in their ``formatter`` specializations.
-
-When the compiler supports UDL templates extensions, using the litteral string
-``""_format()`` will also enable compile-time checks.
 
 .. doxygendefine:: FMT_STRING
 


### PR DESCRIPTION
Documentation was a bit misleading. Many people quickly assume that fmt does compile time checks by default, while it requires the use of `FMT_STRING`. It was also unclear that `FMT_COMPILE` does the same checks.

See initial discussion here: https://github.com/fmtlib/fmt/issues/1772

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
