### PR TITLE
Bump tested CMake version to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,8 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.1...3.18)
 
-# Use newer policies if available, up to most recent tested version of CMake.
-if(${CMAKE_VERSION} VERSION_LESS 3.11)
+# Fallback for using newer policies on CMake <3.12.
+if(${CMAKE_VERSION} VERSION_LESS 3.12)
   cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-else()
-  cmake_policy(VERSION 3.11)
 endif()
 
 # Determine if fmt is built as a subproject (using add_subdirectory)

--- a/test/add-subdirectory-test/CMakeLists.txt
+++ b/test/add-subdirectory-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.1...3.18)
 
 project(fmt-test)
 

--- a/test/compile-error-test/CMakeLists.txt
+++ b/test/compile-error-test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Test if compile errors are produced where necessary.
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.1...3.18)
 
 include(CheckCXXSourceCompiles)
 include(CheckCXXCompilerFlag)

--- a/test/find-package-test/CMakeLists.txt
+++ b/test/find-package-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.1...3.18)
 
 project(fmt-test)
 


### PR DESCRIPTION
Use the version range feature introduced in 3.12. On CMake <3.12 the extra dots are simply interpreted as extra version number separators.  
The fallback for ancient CMake versions is kept.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.