### PR TITLE
Disabled __attribute__((deprecated)) usage for LCC

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -152,7 +152,7 @@
 #  if FMT_HAS_CPP14_ATTRIBUTE(deprecated) || FMT_MSC_VER >= 1900
 #    define FMT_DEPRECATED [[deprecated]]
 #  else
-#    if defined(__GNUC__) || defined(__clang__)
+#    if (defined(__GNUC__) && !defined(__LCC__)) || defined(__clang__)
 #      define FMT_DEPRECATED __attribute__((deprecated))
 #    elif FMT_MSC_VER
 #      define FMT_DEPRECATED __declspec(deprecated)


### PR DESCRIPTION
This fixes compilation error when compiling with `lcc`.

From Google:
> LCC is a compiler for Elbrus (E2K) CPU. (...) The LCC tries to mimic GCC by user interface (both supported options and GCC-specific features)

 but it fails in this case: it doesn't support `__attribute__((deprecated))` for type declarations.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
