### PR TITLE
Correct the locale format specifier in api.rst

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -125,7 +125,7 @@ Compatibility
 Locale
 ------
 
-All formatting is locale-independent by default. Use the ``'n'`` format
+All formatting is locale-independent by default. Use the ``'L'`` format
 specifier to insert the appropriate number separator characters from the
 locale::
 


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
