### PR TITLE
Don't use 128 bit integers with clang-cl

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -298,7 +298,7 @@ template <typename T> struct std_string_view {};
 
 #ifdef FMT_USE_INT128
 // Do nothing.
-#elif defined(__SIZEOF_INT128__) && !FMT_NVCC
+#elif defined(__SIZEOF_INT128__) && !FMT_NVCC && !(FMT_CLANG_VERSION && FMT_MSC_VER)
 #  define FMT_USE_INT128 1
 using int128_t = __int128_t;
 using uint128_t = __uint128_t;


### PR DESCRIPTION
clang-cl currently has a long-standing bug that using 128 bit integers generates references to symbols that are provided neither by its own nor by the Microsoft runtime: https://bugs.llvm.org/show_bug.cgi?id=25305

Visual Studio (2017, I was unable to test 2019) also does not satisfy the conditions to use 128 bit integers in {fmt}, so this effectively causes Clang to match its behavior when targetting the Microsoft ABI. The condition could therefore be simplified to just checking FMT_MSC_VER, but also checking for Clang expresses the intent better as it does advertise its support for 128 bit integers while Visual Studio does not (at the very least not in the way tested here).

This fixes the linker error described in #1798.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
