### PR TITLE
Adding convenience append(range)

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -728,6 +728,7 @@ template <typename T> class buffer {
 
   /** Appends data to the end of the buffer. */
   template <typename U> void append(const U* begin, const U* end);
+  template <typename ContiguousRange> void append(const ContiguousRange&);
 
   template <typename I> T& operator[](I index) { return ptr_[index]; }
   template <typename I> const T& operator[](I index) const {

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -728,7 +728,6 @@ template <typename T> class buffer {
 
   /** Appends data to the end of the buffer. */
   template <typename U> void append(const U* begin, const U* end);
-  template <typename ContiguousRange> void append(const ContiguousRange&);
 
   template <typename I> T& operator[](I index) { return ptr_[index]; }
   template <typename I> const T& operator[](I index) const {

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -566,6 +566,12 @@ void buffer<T>::append(const U* begin, const U* end) {
   } while (begin != end);
 }
 
+template <typename T>
+template <typename ContiguousRange>
+void buffer<T>::append(const ContiguousRange& range) {
+  append(range.data(), range.data() + range.size());
+}
+
 template <typename OutputIt, typename T, typename Traits>
 void iterator_buffer<OutputIt, T, Traits>::flush() {
   out_ = std::copy_n(data_, this->limit(this->size()), out_);

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -566,12 +566,6 @@ void buffer<T>::append(const U* begin, const U* end) {
   } while (begin != end);
 }
 
-template <typename T>
-template <typename ContiguousRange>
-void buffer<T>::append(const ContiguousRange& range) {
-  append(range.data(), range.data() + range.size());
-}
-
 template <typename OutputIt, typename T, typename Traits>
 void iterator_buffer<OutputIt, T, Traits>::flush() {
   out_ = std::copy_n(data_, this->limit(this->size()), out_);
@@ -691,6 +685,13 @@ class basic_memory_buffer : public detail::buffer<T> {
 
   /** Increases the buffer capacity to *new_capacity*. */
   void reserve(size_t new_capacity) { this->try_reserve(new_capacity); }
+
+  // Directly append data into the buffer
+  using detail::buffer<T>::append;
+  template <typename ContiguousRange>
+  void append(const ContiguousRange& range) {
+    append(range.data(), range.data() + range.size());
+  }
 };
 
 template <typename T, size_t SIZE, typename Allocator>

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -236,7 +236,7 @@ TEST(MemoryBufferTest, MoveCtorInlineBuffer) {
   std::allocator<char> alloc;
   basic_memory_buffer<char, 5, TestAllocator> buffer((TestAllocator(&alloc)));
   const char test[] = "test";
-  buffer.append(test, test + 4);
+  buffer.append(string_view(test, 4));
   check_move_buffer("test", buffer);
   // Adding one more character fills the inline buffer, but doesn't cause
   // dynamic allocation.


### PR DESCRIPTION
Just a convenience overload of append() that can be invoked with contiguous ranges (notably `string_view`s). 