### PR TITLE
fix: warning C4100: unreferenced formal parameter

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -368,7 +368,7 @@ template <typename... Args> struct type_list {};
 
 // Returns a reference to the argument at index N from [first, rest...].
 template <int N, typename T, typename... Args>
-constexpr const auto& get(const T& first, const Args&... rest) {
+constexpr const auto& get([[maybe_unused]] const T& first, [[maybe_unused]] const Args&... rest) {
   static_assert(N < 1 + sizeof...(Args), "index is out of bounds");
   if constexpr (N == 0)
     return first;

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -368,7 +368,8 @@ template <typename... Args> struct type_list {};
 
 // Returns a reference to the argument at index N from [first, rest...].
 template <int N, typename T, typename... Args>
-constexpr const auto& get([[maybe_unused]] const T& first, [[maybe_unused]] const Args&... rest) {
+constexpr const auto& get([[maybe_unused]] const T& first,
+                          [[maybe_unused]] const Args&... rest) {
   static_assert(N < 1 + sizeof...(Args), "index is out of bounds");
   if constexpr (N == 0)
     return first;


### PR DESCRIPTION
The code snippet below generates a C4100 warning on MSVC with /W4 option:

```cpp
fmt::format(FMT_COMPILE("{}{}"), 0, "");
```

```
compile.h(371): warning C4100: '<rest_0>': unreferenced formal parameter
compile.h(382): message : see reference to function template instantiation 'const T &fmt::v7::detail::get<0,int,int>(const T &,const int &)' being compiled
    with
    [
        T=int
    ]
compile.h(516): message : see reference to class template instantiation 'fmt::v7::detail::get_type_impl<0,Args>' being compiled
    with
    [
        Args=fmt::v7::detail::type_list<int,int>
    ]
compile.h(516): message : see reference to alias template instantiation 'fmt::v7::detail::get_type<0,fmt::v7::detail::type_list<int,int>>' being compiled
compile.h(541): message : see reference to function template instantiation 'auto fmt::v7::detail::compile_format_string<fmt::v7::detail::type_list<int,int>,0,0,S>(S)' being compiled
    with
    [
        S=main::<lambda_1>::()::FMT_COMPILE_STRING
    ]
compile.h(620): message : see reference to function template instantiation 'auto fmt::v7::detail::compile<int,int,S,0>(S)' being compiled
    with
    [
        S=main::<lambda_1>::()::FMT_COMPILE_STRING
    ]
C:\Users\seokj\Desktop\Project1\Project1\Source.cpp(5): message : see reference to function template instantiation 'std::basic_string<char,std::char_traits<char>,std::allocator<char>> fmt::v7::format<main::<lambda_1>::()::FMT_COMPILE_STRING,int,int,0>(const S &,int &&,int &&)' being compiled
    with
    [
        S=main::<lambda_1>::()::FMT_COMPILE_STRING
    ]
compile.h(371,36): warning C4100: 'first': unreferenced formal parameter
compile.h(382): message : see reference to function template instantiation 'const T &fmt::v7::detail::get<1,int,int>(const T &,const int &)' being compiled
    with
    [
        T=int
    ]
compile.h(516): message : see reference to class template instantiation 'fmt::v7::detail::get_type_impl<1,Args>' being compiled
    with
    [
        Args=fmt::v7::detail::type_list<int,int>
    ]
compile.h(516): message : see reference to alias template instantiation 'fmt::v7::detail::get_type<1,fmt::v7::detail::type_list<int,int>>' being compiled
compile.h(478): message : see reference to function template instantiation 'auto fmt::v7::detail::compile_format_string<Args,2,1,S>(S)' being compiled
    with
    [
        Args=fmt::v7::detail::type_list<int,int>,
        S=main::<lambda_1>::()::FMT_COMPILE_STRING
    ]
compile.h(518): message : see reference to function template instantiation 'auto fmt::v7::detail::parse_tail<Args,2,1,fmt::v7::detail::field<char_type,type,0>,S>(T,S)' being compiled
    with
    [
        Args=fmt::v7::detail::type_list<int,int>,
        S=main::<lambda_1>::()::FMT_COMPILE_STRING,
        T=fmt::v7::detail::field<char_type,type,0>
    ]
```

This PR corrects this warning by adding `[[maybe_unused]]` to parameters in the `get<N>()` function.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
