### PR TITLE
Eliminate shadowed variable warnings on intel

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2703,17 +2703,17 @@ FMT_CONSTEXPR_DECL FMT_INLINE void parse_format_string(
     return;
   }
   struct writer {
-    FMT_CONSTEXPR void operator()(const Char* begin, const Char* end) {
-      if (begin == end) return;
+    FMT_CONSTEXPR void operator()(const Char* pbegin, const Char* pend) {
+      if (pbegin == pend) return;
       for (;;) {
         const Char* p = nullptr;
-        if (!find<IS_CONSTEXPR>(begin, end, '}', p))
-          return handler_.on_text(begin, end);
+        if (!find<IS_CONSTEXPR>(pbegin, pend, '}', p))
+          return handler_.on_text(pbegin, pend);
         ++p;
-        if (p == end || *p != '}')
+        if (p == pend || *p != '}')
           return handler_.on_error("unmatched '}' in format string");
-        handler_.on_text(begin, p);
-        begin = p + 1;
+        handler_.on_text(pbegin, p);
+        pbegin = p + 1;
       }
     }
     Handler& handler_;


### PR DESCRIPTION
The intel-19 compiler warns about hidden variables:
```
/s/dev/nightly/libraries/ioss/src/fmt/format.h(2689): warning #1599: declaration hides variable "begin" (declared at line 2668)
      FMT_CONSTEXPR void operator()(const Char* begin, const Char* end) {
                                                ^
          detected during:
            instantiation of "Context::iterator fmt::v7::vformat_to<ArgFormatter,Char,Context>(ArgFormatter::iterator, fmt::v7::basic_string_view<Char>, fmt::v7::basic_format_args<Context>, fmt::v7::detail::locale_ref) [with ArgFormatter=fmt::v7::detail::arg_formatter<fmt::v7::detail::buffer_appender<char>, char>, Char=char, Context=fmt::v7::format_context]" at line 3492
            instantiation of "fmt::v7::detail::buffer_appender<Char> fmt::v7::detail::vformat_to(fmt::v7::detail::buffer<Char> &, fmt::v7::basic_string_view<Char>, fmt::v7::basic_format_args<fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<fmt::v7::type_identity_t<Char>>, fmt::v7::type_identity_t<Char>>>) [with Char=char]" at line 1413 of "/s/dev/nightly/libraries/ioss/src/fmt/format-inl.h"

/s/dev/nightly/libraries/ioss/src/fmt/format.h(2689): warning #1599: declaration hides variable "end" (declared at line 2669)
      FMT_CONSTEXPR void operator()(const Char* begin, const Char* end) {
                                                                   ^
          detected during:
            instantiation of "Context::iterator fmt::v7::vformat_to<ArgFormatter,Char,Context>(ArgFormatter::iterator, fmt::v7::basic_string_view<Char>, fmt::v7::basic_format_args<Context>, fmt::v7::detail::locale_ref) [with ArgFormatter=fmt::v7::detail::arg_formatter<fmt::v7::detail::buffer_appender<char>, char>, Char=char, Context=fmt::v7::format_context]" at line 3492
            instantiation of "fmt::v7::detail::buffer_appender<Char> fmt::v7::detail::vformat_to(fmt::v7::detail::buffer<Char> &, fmt::v7::basic_string_view<Char>, fmt::v7::basic_format_args<fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<fmt::v7::type_identity_t<Char>>, fmt::v7::type_identity_t<Char>>>) [with Char=char]" at line 1413 of "/s/dev/nightly/libraries/ioss/src/fmt/format-inl.h"
```
Rename the second set of variables to `pbegin` and `pend` to eliminate warning.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
