### PR TITLE
nvcc compiler should be EDG-based, but fails test

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -145,7 +145,7 @@ FMT_END_NAMESPACE
       (!defined(__EDG_VERSION__) || __EDG_VERSION__ >= 501) && \
       ((FMT_GCC_VERSION >= 604 && __cplusplus >= 201402L) ||   \
        FMT_CLANG_VERSION >= 304) &&                            \
-      !defined(__PGI)
+      !defined(__PGI) && !defined(__NVCC__)
 #    define FMT_USE_UDL_TEMPLATE 1
 #  else
 #    define FMT_USE_UDL_TEMPLATE 0


### PR DESCRIPTION
Our nvcc compilers (10.1.243 and 9.2.X) do not define the correct value for `FMT_USE_UDL_TEMPLATE` and then end up with an error later on in the build.  Explicitly search for `__NVCC__` symbol not being defined.   Might want to instead use `FMT_NVCC` or some other check, but the raw `__EDG_VERSION__` check is not working correctly for nvcc.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
