### PR TITLE
Move implementation of iterator_buffer::flush() to core.h

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -8,6 +8,7 @@
 #ifndef FMT_CORE_H_
 #define FMT_CORE_H_
 
+#include <algorithm>
 #include <cstdio>  // std::FILE
 #include <cstring>
 #include <functional>
@@ -770,7 +771,10 @@ class iterator_buffer : public Traits, public buffer<T> {
   void grow(size_t) final FMT_OVERRIDE {
     if (this->size() == buffer_size) flush();
   }
-  void flush();
+  void flush() {
+    out_ = std::copy_n(data_, this->limit(this->size()), out_);
+    this->clear();
+  }
 
  public:
   explicit iterator_buffer(OutputIt out, size_t n = buffer_size)

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -566,12 +566,6 @@ void buffer<T>::append(const U* begin, const U* end) {
     begin += count;
   } while (begin != end);
 }
-
-template <typename OutputIt, typename T, typename Traits>
-void iterator_buffer<OutputIt, T, Traits>::flush() {
-  out_ = std::copy_n(data_, this->limit(this->size()), out_);
-  this->clear();
-}
 }  // namespace detail
 
 // The number of characters to store in the basic_memory_buffer object itself


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.


I'm using the `format_to_n` API in core.h like the following to try to guarantee zero allocations or copies:
```
char _buf[128];
char* _out = fmt::format_to_n(_buf, std::size(_buf), "Foo {}", i).out;
size_t _back = std::min((size_t)(_out - _buf), std::size(_buf) - 1);
_buf[_back] = '\0';
```

The implementation of `iterator_buffer::flush()` currently lives in format.h, but is called from core.h - using any API's (in my case, `format_to_n`) that instantiate an `iterator_buffer` specialization that calls `flush()` when only including core.h results in linker errors. This unfortunately means adding the `<algorithm>` include to core.h for `std::copy_n` which is less than ideal.

We're forcing the usage of the "default" specialization of `iterator_buffer` in `vformat_to_n` by providing three template arguments, rather than allowing the `iterator_buffer<T*, T>` specialization that doesn't utilize an intermediate buffer, hence the calls to `flush()`. We only seem to construct an `iterator_buffer` in one place (`vformat_to_n`) which provides three template arguments, so it doesn't seem like we'll ever choose the alternate specializations `iterator_buffer<T*, T>` or `iterator_buffer<Container>`.

Weirdly, I only see these linker errors when compiling my program with optimizations enabled; debug builds are fine... I'm currently compiling on Apple-clang 11.0.3, but I can also test on MSVC 16.7.1 tomorrow. 

_Edit: Some clarifications and example of how I'm using `format_to_n`._
_Edit 2: Additional comments after reading the source code._