### PR TITLE
Fixing buffer_appender's ++ slicing.

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -845,11 +845,23 @@ template <typename T = char> class counting_buffer : public buffer<T> {
 // It is used to reduce symbol sizes for the common case.
 template <typename T>
 class buffer_appender : public std::back_insert_iterator<buffer<T>> {
+  using base = std::back_insert_iterator<buffer<T>>;
  public:
   explicit buffer_appender(buffer<T>& buf)
-      : std::back_insert_iterator<buffer<T>>(buf) {}
-  buffer_appender(std::back_insert_iterator<buffer<T>> it)
-      : std::back_insert_iterator<buffer<T>>(it) {}
+      : base(buf) {}
+  buffer_appender(base it)
+      : base(it) {}
+
+  buffer_appender& operator++() {
+    base::operator++();
+    return *this;
+  }
+
+  buffer_appender operator++(int) {
+    buffer_appender tmp = *this;
+    ++*this;
+    return tmp;
+  }
 };
 
 // Maps an output iterator into a buffer.

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2474,6 +2474,7 @@ TEST(FormatTest, FormatUTF8Precision) {
   EXPECT_EQ(from_u8str(result), from_u8str(str.substr(0, 5)));
 }
 
+#ifdef __cpp_decltype_auto
 struct lazy_optional {
   bool engaged;
   std::string value;
@@ -2499,3 +2500,5 @@ TEST(FormatTest, BackInsertSlicing) {
   EXPECT_EQ(fmt::format("{}", lazy_optional{false, ""}), "None()");
   EXPECT_EQ(fmt::format("{}", lazy_optional{true, "X"}), "Some(X)");
 }
+#endif
+

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2485,9 +2485,9 @@ template <> struct formatter<check_back_appender> {
 
   template <typename Context>
   auto format(check_back_appender, Context& ctx) -> decltype(ctx.out()) {
-    // needs to satisfy weakly_incrementable
     auto out = ctx.out();
-    static_assert(std::is_same<decltype(++out), decltype(out)&>::value);
+    static_assert(std::is_same<decltype(++out), decltype(out)&>::value,
+                  "needs to satisfy weakly_incrementable");
     *out = 'y';
     return ++out;
   }
@@ -2497,4 +2497,3 @@ FMT_END_NAMESPACE
 TEST(FormatTest, BackInsertSlicing) {
   EXPECT_EQ(fmt::format("{}", check_back_appender{}), "y");
 }
-

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2481,7 +2481,12 @@ struct lazy_optional {
 };
 
 FMT_BEGIN_NAMESPACE
-template <> struct formatter<lazy_optional> : formatter<std::string_view> {
+template <> struct formatter<lazy_optional> {
+  template <typename ParseContext>
+  auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+    return ctx.begin();
+  }
+
   template <typename Context>
   auto format(const lazy_optional& opt, Context& ctx) {
     if (opt.engaged) {


### PR DESCRIPTION
`buffer_appender`'s pre- and post-fix increment operators slice down to `back_inserter`, which means it actually breaks the iterator requirements (which would be actually checked in C++20, it is not `weakly_incrementable`) and also breaks any code that assumes that `++it` and `it` have the same type (as illustrated in the test case, a reduced form of how we format our optional type, which no longer compiles).