### PR TITLE
fix warnings (-Wconversion, -Wsign-conversion, -Wshadow)

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -669,7 +669,7 @@ template <typename T> class buffer {
         size_(sz),
         capacity_(cap) {}
 
-  ~buffer() = default;
+  virtual ~buffer() = default;
 
   /** Sets the buffer data and capacity. */
   void set(T* buf_data, size_t buf_capacity) FMT_NOEXCEPT {

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -669,7 +669,7 @@ template <typename T> class buffer {
         size_(sz),
         capacity_(cap) {}
 
-  virtual ~buffer() = default;
+  ~buffer() = default;
 
   /** Sets the buffer data and capacity. */
   void set(T* buf_data, size_t buf_capacity) FMT_NOEXCEPT {

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -800,10 +800,10 @@ template <typename T = void> struct FMT_EXTERN_TEMPLATE_API basic_data {
 // This is a function instead of an array to workaround a bug in GCC10 (#1810).
 FMT_INLINE uint16_t bsr2log10(int bsr) {
   constexpr uint16_t data[] = {
-    1,  1,  1,  2,  2,  2,  3,  3,  3,  4,  4,  4,  4,  5,  5,  5,
-    6,  6,  6,  7,  7,  7,  7,  8,  8,  8,  9,  9,  9,  10, 10, 10,
-    10, 11, 11, 11, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 15, 15,
-    15, 16, 16, 16, 16, 17, 17, 17, 18, 18, 18, 19, 19, 19, 19, 20};
+      1,  1,  1,  2,  2,  2,  3,  3,  3,  4,  4,  4,  4,  5,  5,  5,
+      6,  6,  6,  7,  7,  7,  7,  8,  8,  8,  9,  9,  9,  10, 10, 10,
+      10, 11, 11, 11, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 15, 15,
+      15, 16, 16, 16, 16, 17, 17, 17, 18, 18, 18, 19, 19, 19, 19, 20};
   return data[bsr];
 }
 
@@ -1632,9 +1632,9 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
     }
     if (prefix_size != 0) p[-1] = static_cast<Char>('-');
     auto data = buffer.data();
-    out = write_padded<align::right>(out, specs, usize, usize, [=](iterator it) {
-      return copy_str<Char>(data, data + size, it);
-    });
+    out = write_padded<align::right>(
+        out, specs, usize, usize,
+        [=](iterator it) { return copy_str<Char>(data, data + size, it); });
   }
 
   void on_chr() { *out++ = static_cast<Char>(abs_value); }
@@ -3482,7 +3482,7 @@ inline std::string to_string(T value) {
   // The buffer should be large enough to store the number including the sign or
   // "false" for bool.
   constexpr int max_size = detail::digits10<T>() + 2;
-  char buffer[static_cast<size_t>(max_size > 5 ? max_size : 5)];
+  char buffer[detail::to_unsigned(max_size > 5 ? max_size : 5)];
   char* begin = buffer;
   return std::string(begin, detail::write<char>(begin, value));
 }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1609,7 +1609,7 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
     char digits[40];
     format_decimal(digits, abs_value, num_digits);
     basic_memory_buffer<Char> buffer;
-    size += prefix_size;
+    size += static_cast<int>(prefix_size);
     const auto usize = to_unsigned(size);
     buffer.resize(usize);
     basic_string_view<Char> s(&sep, sep_size);
@@ -3482,7 +3482,7 @@ inline std::string to_string(T value) {
   // The buffer should be large enough to store the number including the sign or
   // "false" for bool.
   constexpr int max_size = detail::digits10<T>() + 2;
-  char buffer[max_size > 5 ? max_size : 5];
+  char buffer[static_cast<size_t>(max_size > 5 ? max_size : 5)];
   char* begin = buffer;
   return std::string(begin, detail::write<char>(begin, value));
 }

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -361,8 +361,8 @@ struct ostream_params {
   ostream_params() {}
 
   template <typename... T>
-  ostream_params(T... params, int oflag) : ostream_params(params...) {
-    this->oflag = oflag;
+  ostream_params(T... params, int _oflag) : ostream_params(params...) {
+    this->oflag = _oflag;
   }
 
   template <typename... T>

--- a/src/os.cc
+++ b/src/os.cc
@@ -72,6 +72,8 @@ inline std::size_t convert_rwcount(std::size_t count) { return count; }
 
 FMT_BEGIN_NAMESPACE
 
+inline int get_windows_error() { return static_cast<int>(GetLastError()); }
+
 #ifdef _WIN32
 detail::utf16_to_utf8::utf16_to_utf8(wstring_view s) {
   if (int error_code = convert(s)) {
@@ -92,11 +94,11 @@ int detail::utf16_to_utf8::convert(wstring_view s) {
 
   int length = WideCharToMultiByte(CP_UTF8, 0, s.data(), s_size, nullptr, 0,
                                    nullptr, nullptr);
-  if (length == 0) return static_cast<int>(GetLastError());
+  if (length == 0) return get_windows_error();
   buffer_.resize(static_cast<size_t>(length + 1));
   length = WideCharToMultiByte(CP_UTF8, 0, s.data(), s_size, &buffer_[0],
                                length, nullptr, nullptr);
-  if (length == 0) return static_cast<int>(GetLastError());
+  if (length == 0) return get_windows_error();
   buffer_[length] = 0;
   return 0;
 }
@@ -119,12 +121,14 @@ void detail::format_windows_error(detail::buffer<char>& out, int error_code,
       wchar_t* system_message = &buf[0];
       int result = static_cast<int>(FormatMessageW(
           FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
-          static_cast<DWORD>(error_code), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), system_message,
+          static_cast<DWORD>(error_code),
+          MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), system_message,
           static_cast<uint32_t>(buf.size()), nullptr));
       if (result != 0) {
         utf16_to_utf8 utf8_message;
         if (utf8_message.convert(system_message) == ERROR_SUCCESS) {
-          format_to(buffer_appender<char>(out), "{}: {}", message, utf8_message);
+          format_to(buffer_appender<char>(out), "{}: {}", message,
+                    utf8_message);
           return;
         }
         break;
@@ -212,10 +216,11 @@ long long file::size() const {
   if (size_lower == INVALID_FILE_SIZE) {
     DWORD error = GetLastError();
     if (error != NO_ERROR)
-      FMT_THROW(windows_error(static_cast<int>(GetLastError()), "cannot get file size"));
+      FMT_THROW(windows_error(get_windows_error(), "cannot get file size"));
   }
   unsigned long long long_size = size_upper;
-  return static_cast<long long int>((long_size << sizeof(DWORD) * CHAR_BIT) | size_lower);
+  return static_cast<long long>((long_size << sizeof(DWORD) * CHAR_BIT) |
+                                size_lower);
 #  else
   using Stat = struct stat;
   Stat file_stat = Stat();
@@ -288,12 +293,12 @@ void file::pipe(file& read_end, file& write_end) {
 }
 
 buffered_file file::fdopen(const char* mode) {
-  // Don't retry as fdopen doesn't return EINTR.
-  #if defined(__MINGW32__) && defined(_POSIX_)
+// Don't retry as fdopen doesn't return EINTR.
+#  if defined(__MINGW32__) && defined(_POSIX_)
   FILE* f = ::fdopen(fd_, mode);
-  #else
+#  else
   FILE* f = FMT_POSIX_CALL(fdopen(fd_, mode));
-  #endif
+#  endif
   if (!f)
     FMT_THROW(
         system_error(errno, "cannot associate stream with file descriptor"));
@@ -306,7 +311,7 @@ long getpagesize() {
 #  ifdef _WIN32
   SYSTEM_INFO si;
   GetSystemInfo(&si);
-  return static_cast<long int>(si.dwPageSize);
+  return static_cast<long>(si.dwPageSize);
 #  else
   long size = FMT_POSIX_CALL(sysconf(_SC_PAGESIZE));
   if (size < 0) FMT_THROW(system_error(errno, "cannot get memory page size"));


### PR DESCRIPTION
fixes:
-Wconversion, -Wsign-conversion, -Wshadow, -Wnon-virtual-dtor

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

Hi, thanks for the great library!

I noticed a few compiler warnings when using the above flags. I've fixed the warnings that I was getting, however I wasn't really sure what to name the [oflag](https://github.com/fmtlib/fmt/blob/f9f02df719329ef7449c2b9e356f99d2f960cf3e/include/fmt/os.h#L364) so i just prefixed it with an underscore. Let me know if you'd prefer something else, or to remove it
