### PR TITLE
Fix detail::write with fallback formatter

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1841,13 +1841,26 @@ OutputIt write(OutputIt out, const void* value) {
   return write_ptr<Char>(out, to_uintptr(value), nullptr);
 }
 
-template <typename Char, typename OutputIt, typename T>
+template <typename Char, typename OutputIt, typename T,
+          FMT_ENABLE_IF(
+              has_formatter<T, basic_format_context<OutputIt, Char>>::value)>
 auto write(OutputIt out, const T& value) -> typename std::enable_if<
     mapped_type_constant<T, basic_format_context<OutputIt, Char>>::value ==
         type::custom_type,
     OutputIt>::type {
   basic_format_context<OutputIt, Char> ctx(out, {}, {});
   return formatter<T>().format(value, ctx);
+}
+
+template <typename Char, typename OutputIt, typename T,
+          FMT_ENABLE_IF(has_fallback_formatter<
+                        T, basic_format_context<OutputIt, Char>>::value)>
+auto write(OutputIt out, const T& value) -> typename std::enable_if<
+    mapped_type_constant<T, basic_format_context<OutputIt, Char>>::value ==
+        type::custom_type,
+    OutputIt>::type {
+  basic_format_context<OutputIt, Char> ctx(out, {}, {});
+  return fallback_formatter<T>().format(value, ctx);
 }
 
 // An argument visitor that formats the argument and writes it via the output

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1842,25 +1842,17 @@ OutputIt write(OutputIt out, const void* value) {
 }
 
 template <typename Char, typename OutputIt, typename T,
-          FMT_ENABLE_IF(
-              has_formatter<T, basic_format_context<OutputIt, Char>>::value)>
-auto write(OutputIt out, const T& value) -> typename std::enable_if<
-    mapped_type_constant<T, basic_format_context<OutputIt, Char>>::value ==
-        type::custom_type,
-    OutputIt>::type {
-  basic_format_context<OutputIt, Char> ctx(out, {}, {});
-  return formatter<T>().format(value, ctx);
-}
-
-template <typename Char, typename OutputIt, typename T,
-          FMT_ENABLE_IF(has_fallback_formatter<
-                        T, basic_format_context<OutputIt, Char>>::value)>
-auto write(OutputIt out, const T& value) -> typename std::enable_if<
-    mapped_type_constant<T, basic_format_context<OutputIt, Char>>::value ==
-        type::custom_type,
-    OutputIt>::type {
-  basic_format_context<OutputIt, Char> ctx(out, {}, {});
-  return fallback_formatter<T>().format(value, ctx);
+          typename Context = basic_format_context<OutputIt, Char>>
+auto write(OutputIt out, const T& value) ->
+    typename std::enable_if<mapped_type_constant<T, Context>::value ==
+                                type::custom_type,
+                            OutputIt>::type {
+  using formatter_type =
+      conditional_t<has_formatter<T, Context>::value,
+                    typename Context::template formatter_type<T>,
+                    fallback_formatter<T, Char>>;
+  Context ctx(out, {}, {});
+  return formatter_type().format(value, ctx);
 }
 
 // An argument visitor that formats the argument and writes it via the output

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1841,17 +1841,17 @@ OutputIt write(OutputIt out, const void* value) {
   return write_ptr<Char>(out, to_uintptr(value), nullptr);
 }
 
-template <typename Char, typename OutputIt, typename T,
-          typename Context = basic_format_context<OutputIt, Char>>
-auto write(OutputIt out, const T& value) ->
-    typename std::enable_if<mapped_type_constant<T, Context>::value ==
-                                type::custom_type,
-                            OutputIt>::type {
+template <typename Char, typename OutputIt, typename T>
+auto write(OutputIt out, const T& value) -> typename std::enable_if<
+    mapped_type_constant<T, basic_format_context<OutputIt, Char>>::value ==
+        type::custom_type,
+    OutputIt>::type {
+  using context_type = basic_format_context<OutputIt, Char>;
   using formatter_type =
-      conditional_t<has_formatter<T, Context>::value,
-                    typename Context::template formatter_type<T>,
+      conditional_t<has_formatter<T, context_type>::value,
+                    typename context_type::template formatter_type<T>,
                     fallback_formatter<T, Char>>;
-  Context ctx(out, {}, {});
+  context_type ctx(out, {}, {});
   return formatter_type().format(value, ctx);
 }
 

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -23,7 +23,6 @@
 #endif
 
 #include "fmt/compile.h"
-#include "fmt/ostream.h"
 #include "gmock.h"
 #include "gtest-extra.h"
 #include "mock-allocator.h"
@@ -170,15 +169,4 @@ TEST(CompileTest, TextAndArg) {
   EXPECT_EQ(">>>42<<<", fmt::format(FMT_COMPILE(">>>{}<<<"), 42));
   EXPECT_EQ("42!", fmt::format(FMT_COMPILE("{}!"), 42));
 }
-
-struct ostream_operator_test {};
-
-std::ostream& operator<<(std::ostream& os, ostream_operator_test) {
-  return os << "42";
-}
-
-TEST(CompileTest, WithOstreamOperator) {
-  EXPECT_EQ("42", fmt::format(FMT_COMPILE("{}"), ostream_operator_test()));
-}
-
 #endif

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -23,6 +23,7 @@
 #endif
 
 #include "fmt/compile.h"
+#include "fmt/ostream.h"
 #include "gmock.h"
 #include "gtest-extra.h"
 #include "mock-allocator.h"
@@ -169,4 +170,15 @@ TEST(CompileTest, TextAndArg) {
   EXPECT_EQ(">>>42<<<", fmt::format(FMT_COMPILE(">>>{}<<<"), 42));
   EXPECT_EQ("42!", fmt::format(FMT_COMPILE("{}!"), 42));
 }
+
+struct ostream_operator_test {};
+
+std::ostream& operator<<(std::ostream& os, ostream_operator_test) {
+  return os << "42";
+}
+
+TEST(CompileTest, WithOstreamOperator) {
+  EXPECT_EQ("42", fmt::format(FMT_COMPILE("{}"), ostream_operator_test()));
+}
+
 #endif

--- a/test/ostream-test.cc
+++ b/test/ostream-test.cc
@@ -319,3 +319,7 @@ TEST(OStreamTest, CopyFmt) {
 TEST(OStreamTest, CompileTimeString) {
   EXPECT_EQ("42", fmt::format(FMT_STRING("{}"), 42));
 }
+
+TEST(OStreamTest, ToString) {
+  EXPECT_EQ("ABC", fmt::to_string(fmt_test::ABC()));
+}


### PR DESCRIPTION
Recently I was trying to use both `FMT_COMPILE()` and struct with ostream operator, but with no luck. After first look on issues and pull requests I found one issue that describes the same problem, here it is - https://github.com/fmtlib/fmt/issues/1815. 

I'm not sure that this solution is clean enough, but I am open to change whatever you want.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
