### PR TITLE
Fix usage of override for clang

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -99,7 +99,7 @@
 #endif
 
 #ifndef FMT_OVERRIDE
-#  if FMT_HAS_FEATURE(cxx_override) || \
+#  if FMT_HAS_FEATURE(cxx_override_control) || \
       (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1900
 #    define FMT_OVERRIDE override
 #  else


### PR DESCRIPTION
It seems fmt is checking cxx_override which seems to be a [CMake related term](https://cmake.org/cmake/help/latest/manual/cmake-compile-features.7.html). At least for clang it's  [cxx_override_control](https://clang.llvm.org/docs/LanguageExtensions.html#c-11-override-control).
In clangs current trunk fmt is reported as having no override keyword. This change silences the warning in clangs trunk as expected.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
