### PR TITLE
Add formatters for chrono::time_point<system_clock>

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -351,6 +351,11 @@ inline std::tm localtime(std::time_t time) {
   return lt.tm_;
 }
 
+inline std::tm localtime(
+    std::chrono::time_point<std::chrono::system_clock> time_point) {
+  return localtime(std::chrono::system_clock::to_time_t(time_point));
+}
+
 // Thread-safe replacement for std::gmtime
 inline std::tm gmtime(std::time_t time) {
   struct dispatcher {
@@ -387,6 +392,11 @@ inline std::tm gmtime(std::time_t time) {
   return gt.tm_;
 }
 
+inline std::tm gmtime(
+    std::chrono::time_point<std::chrono::system_clock> time_point) {
+  return gmtime(std::chrono::system_clock::to_time_t(time_point));
+}
+
 namespace detail {
 inline size_t strftime(char* str, size_t count, const char* format,
                        const std::tm* time) {
@@ -398,6 +408,17 @@ inline size_t strftime(wchar_t* str, size_t count, const wchar_t* format,
   return std::wcsftime(str, count, format, time);
 }
 }  // namespace detail
+
+template <typename Char>
+struct formatter<std::chrono::time_point<std::chrono::system_clock>, Char>
+    : formatter<std::tm, Char> {
+  template <typename FormatContext>
+  auto format(std::chrono::time_point<std::chrono::system_clock> val,
+              FormatContext& ctx) -> decltype(ctx.out()) {
+    std::tm time = localtime(val);
+    return formatter<std::tm, Char>::format(time, ctx);
+  }
+};
 
 template <typename Char> struct formatter<std::tm, Char> {
   template <typename ParseContext>

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -95,6 +95,28 @@ TEST(TimeTest, GMTime) {
   EXPECT_TRUE(EqualTime(tm, fmt::gmtime(t)));
 }
 
+TEST(TimeTest, TimePoint) {
+  setenv("TZ", "EST+5", 1);
+  tzset();
+  std::chrono::system_clock::time_point point(std::chrono::seconds(1598412345));
+  EXPECT_EQ("It is 2020-08-25 22:25:45.",
+            fmt::format("It is {:%Y-%m-%d %H:%M:%S}.", point));
+}
+
+TEST(TimeTest, LocalTimeWithTimePoint) {
+  setenv("TZ", "EST+5", 1);
+  tzset();
+  std::chrono::system_clock::time_point point(std::chrono::seconds(1598412345));
+  EXPECT_EQ("It is 2020-08-25 22:25:45.",
+            fmt::format("It is {:%Y-%m-%d %H:%M:%S}.", fmt::localtime(point)));
+}
+
+TEST(TimeTest, GMTimeWithTimePoint) {
+  std::chrono::system_clock::time_point point(std::chrono::seconds(1598412345));
+  EXPECT_EQ("It is 2020-08-26 03:25:45 UTC.",
+            fmt::format("It is {:%Y-%m-%d %H:%M:%S} UTC.", fmt::gmtime(point)));
+}
+
 #define EXPECT_TIME(spec, time, duration)                 \
   {                                                       \
     std::locale loc("ja_JP.utf8");                        \

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -95,32 +95,15 @@ TEST(TimeTest, GMTime) {
   EXPECT_TRUE(EqualTime(tm, fmt::gmtime(t)));
 }
 
-#ifdef WIN32
-#  define ENV(key, val) _putenv_s(key, val)
-#else
-#  define ENV(key, val) setenv(key, val, 1)
-#endif
-
 TEST(TimeTest, TimePoint) {
-  ENV("TZ", "EST+5");
-  tzset();
-  std::chrono::system_clock::time_point point(std::chrono::seconds(1598412345));
-  EXPECT_EQ("It is 2020-08-25 22:25:45.",
-            fmt::format("It is {:%Y-%m-%d %H:%M:%S}.", point));
-}
+  std::chrono::system_clock::time_point point = std::chrono::system_clock::now();
 
-TEST(TimeTest, LocalTimeWithTimePoint) {
-  ENV("TZ", "EST+5");
-  tzset();
-  std::chrono::system_clock::time_point point(std::chrono::seconds(1598412345));
-  EXPECT_EQ("It is 2020-08-25 22:25:45.",
-            fmt::format("It is {:%Y-%m-%d %H:%M:%S}.", fmt::localtime(point)));
-}
+  std::time_t t = std::chrono::system_clock::to_time_t(point);
+  std::tm tm = *std::localtime(&t);
+  char strftime_output[256];
+  std::strftime(strftime_output, sizeof(strftime_output), "It is %Y-%m-%d %H:%M:%S", &tm);
 
-TEST(TimeTest, GMTimeWithTimePoint) {
-  std::chrono::system_clock::time_point point(std::chrono::seconds(1598412345));
-  EXPECT_EQ("It is 2020-08-26 03:25:45 UTC.",
-            fmt::format("It is {:%Y-%m-%d %H:%M:%S} UTC.", fmt::gmtime(point)));
+  EXPECT_EQ(strftime_output, fmt::format("It is {:%Y-%m-%d %H:%M:%S}", point));
 }
 
 #define EXPECT_TIME(spec, time, duration)                 \

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -95,8 +95,14 @@ TEST(TimeTest, GMTime) {
   EXPECT_TRUE(EqualTime(tm, fmt::gmtime(t)));
 }
 
+#ifdef WIN32
+#  define ENV(key, val) _putenv_s(key, val)
+#else
+#  define ENV(key, val) setenv(key, val, 1)
+#endif
+
 TEST(TimeTest, TimePoint) {
-  setenv("TZ", "EST+5", 1);
+  ENV("TZ", "EST+5");
   tzset();
   std::chrono::system_clock::time_point point(std::chrono::seconds(1598412345));
   EXPECT_EQ("It is 2020-08-25 22:25:45.",
@@ -104,7 +110,7 @@ TEST(TimeTest, TimePoint) {
 }
 
 TEST(TimeTest, LocalTimeWithTimePoint) {
-  setenv("TZ", "EST+5", 1);
+  ENV("TZ", "EST+5");
   tzset();
   std::chrono::system_clock::time_point point(std::chrono::seconds(1598412345));
   EXPECT_EQ("It is 2020-08-25 22:25:45.",


### PR DESCRIPTION
Fixes #1819

Makes dates a little easier to format:

```c++
auto the_time = std::chrono::system_clock::now();
fmt::print("{}", the_time); // the_time is converted using fmt::localtime, which then uses the normal tm formatter
fmt::print("UTC {}", fmt::gmtime(the_time)); // prints UTC time using a new overload on gmtime/localtime
```

I wanted to test localtime so I did that using setenv/tzset, though I'm not sure if that's the best way.

C++20 does include a [formatter for sys_time](https://en.cppreference.com/w/cpp/chrono/system_clock/formatter) -- in #985 it was discussed that printing a time_point was not in the standard library, but it seems with time (hah) it has now been added.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
