### PR TITLE
Add color format_to overloads

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -463,16 +463,16 @@ template <> inline void reset_color<wchar_t>(FILE* stream) FMT_NOEXCEPT {
 }
 
 template <typename Char>
-inline void reset_color(basic_memory_buffer<Char>& buffer) FMT_NOEXCEPT {
+inline void reset_color(buffer<Char>& buffer) FMT_NOEXCEPT {
   const char* begin = data::reset_color;
   const char* end = begin + sizeof(data::reset_color) - 1;
   buffer.append(begin, end);
 }
 
 template <typename Char>
-void vformat_to(basic_memory_buffer<Char>& buf, const text_style& ts,
+void vformat_to(buffer<Char>& buf, const text_style& ts,
                 basic_string_view<Char> format_str,
-                basic_format_args<buffer_context<Char>> args) {
+                basic_format_args<buffer_context<type_identity_t<Char>>> args) {
   bool has_style = false;
   if (ts.has_emphasis()) {
     has_style = true;
@@ -561,6 +561,49 @@ inline std::basic_string<Char> format(const text_style& ts, const S& format_str,
                                       const Args&... args) {
   return vformat(ts, to_string_view(format_str),
                  fmt::make_args_checked<Args...>(format_str, args...));
+}
+
+/** Formats a string with the given text_style and writes the output to ``out``.
+ */
+template <typename OutputIt, typename S, typename Char = char_t<S>,
+          FMT_ENABLE_IF(detail::is_output_iterator<OutputIt>::value)>
+OutputIt vformat_to(
+    OutputIt out, const text_style& ts, const S& format_str,
+    basic_format_args<buffer_context<type_identity_t<Char>>> args) {
+  decltype(detail::get_buffer<Char>(out)) buf(detail::get_buffer_init(out));
+  detail::vformat_to(buf, ts, to_string_view(format_str), args);
+  return detail::get_iterator(buf);
+}
+
+/**
+ \rst
+ Formats arguments with the given text_style, writes the result to the output
+ iterator ``out`` and returns the iterator past the end of the output range.
+
+ **Example**::
+
+   std::vector<char> out;
+   fmt::format_to(std::back_inserter(out),
+                  fmt::emphasis::bold | fg(fmt::color::red), "{}", 42);
+   \endrst
+ */
+template <typename OutputIt, typename S, typename... Args,
+          FMT_ENABLE_IF(detail::is_output_iterator<OutputIt>::value&&
+                            detail::is_string<S>::value)>
+inline OutputIt format_to(OutputIt out, const text_style& ts,
+                          const S& format_str, Args&&... args) {
+  return vformat_to(out, ts, to_string_view(format_str),
+                    fmt::make_args_checked<Args...>(format_str, args...));
+}
+
+template <typename S, typename... Args, size_t SIZE = inline_buffer_size,
+          typename Char = enable_if_t<detail::is_string<S>::value, char_t<S>>>
+inline typename buffer_context<Char>::iterator format_to(
+    basic_memory_buffer<Char, SIZE>& buf, const text_style& ts,
+    const S& format_str, Args&&... args) {
+  detail::vformat_to(buf, ts, to_string_view(format_str),
+                     fmt::make_args_checked<Args...>(format_str, args...));
+  return detail::buffer_appender<Char>(buf);
 }
 
 FMT_END_NAMESPACE

--- a/test/color-test.cc
+++ b/test/color-test.cc
@@ -7,6 +7,10 @@
 
 #include "fmt/color.h"
 
+#include <iterator>
+#include <string>
+#include <utility>
+
 #include "gtest-extra.h"
 
 TEST(ColorsTest, ColorsPrint) {
@@ -83,4 +87,22 @@ TEST(ColorsTest, Format) {
             "\x1b[105mtbmagenta\x1b[0m");
   EXPECT_EQ(fmt::format(fg(fmt::terminal_color::red), "{}", "foo"),
             "\x1b[31mfoo\x1b[0m");
+}
+
+TEST(ColorsTest, FormatToOutAcceptsTextStyle) {
+  fmt::text_style const ts = fg(fmt::rgb(255, 20, 30));
+  std::string out;
+  fmt::format_to(std::back_inserter(out), ts, "rgb(255,20,30){}{}{}", 1, 2, 3);
+
+  EXPECT_EQ(fmt::to_string(out),
+            "\x1b[38;2;255;020;030mrgb(255,20,30)123\x1b[0m");
+}
+
+TEST(ColorsTest, FormatToAcceptsTextStyle) {
+  fmt::text_style const ts = fg(fmt::rgb(255, 20, 30));
+  fmt::basic_memory_buffer<char> out;
+  fmt::format_to(out, ts, "rgb(255,20,30){}{}{}", 1, 2, 3);
+
+  EXPECT_EQ(fmt::to_string(out),
+            "\x1b[38;2;255;020;030mrgb(255,20,30)123\x1b[0m");
 }

--- a/test/gtest-extra.h
+++ b/test/gtest-extra.h
@@ -145,7 +145,13 @@ std::string read(fmt::file& f, size_t count);
               read(file, fmt::string_view(expected_content).size()))
 
 #else
-#  define EXPECT_WRITE(file, statement, expected_output) SUCCEED()
+#  define EXPECT_WRITE(file, statement, expected_output) \
+    do {                                                 \
+      (void)(file);                                      \
+      (void)(statement);                                 \
+      (void)(expected_output);                           \
+      SUCCEED();                                         \
+    } while (false)
 #endif  // FMT_USE_FCNTL
 
 template <typename Mock> struct ScopedMock : testing::StrictMock<Mock> {


### PR DESCRIPTION
* Fix variable size basic_memory_buffer colorization
* Rewrite the color unit tests to test the same colors against multiple backends
* Ref #1842
* Ref #1593

---

- Compile time formatted strings are not supported (yet)
- The underlying buffer type the colorization is working on was changed to `detail::buffer` to also accept `iterator_buffer`, and non default internal size memory buffers. Size limited buffers are not supported (and also not accepted by the public API). This is why `format_to_n` is not added as part of this change. Additionally since a colorized string is not an atomic unit per character anymore (because it can't be split in the middle of the ansi color code effectively) it doesnt make sence to add support for `format_to_n` anyway.

---

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
