### PR TITLE
Bugfix with ostream move constructors in os.h

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -395,6 +395,7 @@ class ostream : private detail::buffer<char> {
 
  public:
   ostream(ostream&& other) : file_(std::move(other.file_)) {
+    set(other.data(), other.capacity());
     other.set(nullptr, 0);
   }
   ~ostream() {


### PR DESCRIPTION
<!--Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

A pull request as requested in #1844  

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
