### PR TITLE
Fix string_view detection with libstdc++ (#1850)

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -847,10 +847,11 @@ template <typename T = char> class counting_buffer : public buffer<T> {
 template <typename T>
 class buffer_appender : public std::back_insert_iterator<buffer<T>> {
   using base = std::back_insert_iterator<buffer<T>>;
- 
  public:
-  explicit buffer_appender(buffer<T>& buf) : base(buf) {}
-  buffer_appender(base it) : base(it) {}
+  explicit buffer_appender(buffer<T>& buf) 
+      : base(buf) {}
+  buffer_appender(base it) 
+      : base(it) {}
 
   buffer_appender& operator++() {
     base::operator++();

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -227,11 +227,11 @@
 
 // libc++ supports string_view in pre-c++17.
 #if (FMT_HAS_INCLUDE(<string_view>) &&                       \
-     (__cplusplus > 201402L || defined(_LIBCPP_VERSION))) || \
+     (__cplusplus > 201402L && defined(_LIBCPP_VERSION))) || \
     (defined(_MSVC_LANG) && _MSVC_LANG > 201402L && _MSC_VER >= 1910)
 #  include <string_view>
 #  define FMT_USE_STRING_VIEW
-// libstdc++ supports experimental/string_view in c++14
+// libstdc++ supports experimental/string_view in c++14.
 #elif FMT_HAS_INCLUDE("experimental/string_view") && __cplusplus >= 201402L
 #  include <experimental/string_view>
 #  define FMT_USE_EXPERIMENTAL_STRING_VIEW
@@ -847,7 +847,7 @@ template <typename T = char> class counting_buffer : public buffer<T> {
 template <typename T>
 class buffer_appender : public std::back_insert_iterator<buffer<T>> {
   using base = std::back_insert_iterator<buffer<T>>;
-
+ 
  public:
   explicit buffer_appender(buffer<T>& buf) : base(buf) {}
   buffer_appender(base it) : base(it) {}

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -231,6 +231,7 @@
     (defined(_MSVC_LANG) && _MSVC_LANG > 201402L && _MSC_VER >= 1910)
 #  include <string_view>
 #  define FMT_USE_STRING_VIEW
+// libstdc++ supports experimental/string_view in c++14
 #elif FMT_HAS_INCLUDE("experimental/string_view") && __cplusplus >= 201402L
 #  include <experimental/string_view>
 #  define FMT_USE_EXPERIMENTAL_STRING_VIEW
@@ -846,11 +847,10 @@ template <typename T = char> class counting_buffer : public buffer<T> {
 template <typename T>
 class buffer_appender : public std::back_insert_iterator<buffer<T>> {
   using base = std::back_insert_iterator<buffer<T>>;
+
  public:
-  explicit buffer_appender(buffer<T>& buf)
-      : base(buf) {}
-  buffer_appender(base it)
-      : base(it) {}
+  explicit buffer_appender(buffer<T>& buf) : base(buf) {}
+  buffer_appender(base it) : base(it) {}
 
   buffer_appender& operator++() {
     base::operator++();


### PR DESCRIPTION
Fixes #1850 

Simple fix to correct finding `experimental/string_view` when the `std` library is `libstdc++` and C++ version is < C++17.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
