### PR TITLE
Fix finding string_view on libstdc++ <= c++14 (#1850)

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -227,10 +227,11 @@
 
 // libc++ supports string_view in pre-c++17.
 #if (FMT_HAS_INCLUDE(<string_view>) &&                       \
-     (__cplusplus > 201402L || defined(_LIBCPP_VERSION))) || \
+     (__cplusplus > 201703L || (__cplusplus > 201402L && defined(_LIBCPP_VERSION)))) || \
     (defined(_MSVC_LANG) && _MSVC_LANG > 201402L && _MSC_VER >= 1910)
 #  include <string_view>
 #  define FMT_USE_STRING_VIEW
+// libstdc++ supports experimental/string_view in c++14
 #elif FMT_HAS_INCLUDE("experimental/string_view") && __cplusplus >= 201402L
 #  include <experimental/string_view>
 #  define FMT_USE_EXPERIMENTAL_STRING_VIEW

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -227,7 +227,7 @@
 
 // libc++ supports string_view in pre-c++17.
 #if (FMT_HAS_INCLUDE(<string_view>) &&                       \
-     (__cplusplus > 201703L || (__cplusplus > 201402L && defined(_LIBCPP_VERSION)))) || \
+     (__cplusplus >= 201703L || (__cplusplus > 201402L && defined(_LIBCPP_VERSION)))) || \
     (defined(_MSVC_LANG) && _MSVC_LANG > 201402L && _MSC_VER >= 1910)
 #  include <string_view>
 #  define FMT_USE_STRING_VIEW


### PR DESCRIPTION
Fixes #1850

Simple fix to correct finding experimental/string_view when the std library is libstdc++ and C++ version is < C++17.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
