### PR TITLE
fix compiler warnings in public header files

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -669,7 +669,7 @@ template <typename T> class buffer {
         size_(sz),
         capacity_(cap) {}
 
-  ~buffer() = default;
+  virtual ~buffer() = default;
 
   /** Sets the buffer data and capacity. */
   void set(T* buf_data, size_t buf_capacity) FMT_NOEXCEPT {

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1609,7 +1609,7 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
     char digits[40];
     format_decimal(digits, abs_value, num_digits);
     basic_memory_buffer<Char> buffer;
-    size += prefix_size;
+    size += static_cast<int>(prefix_size);
     const auto usize = to_unsigned(size);
     buffer.resize(usize);
     basic_string_view<Char> s(&sep, sep_size);
@@ -3493,7 +3493,7 @@ inline std::string to_string(T value) {
   // The buffer should be large enough to store the number including the sign or
   // "false" for bool.
   constexpr int max_size = detail::digits10<T>() + 2;
-  char buffer[max_size > 5 ? max_size : 5];
+  char buffer[max_size > 5 ? static_cast<size_t>(max_size) : 5];
   char* begin = buffer;
   return std::string(begin, detail::write<char>(begin, value));
 }


### PR DESCRIPTION
core.h: buffer had virtual functions but the dtor was not virtual.

format.f: fix two sign conversions warnings

This warnings occurred on clang and gcc with -Wsign-conversion and -Wnon-virtual-dtor.  

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
