### PR TITLE
Support printing of filtered views

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1097,7 +1097,10 @@ template <typename Context> class value {
                                 Context& ctx) {
     Formatter f;
     parse_ctx.advance_to(f.parse(parse_ctx));
-    ctx.advance_to(f.format(*static_cast<const T*>(arg), ctx));
+    // We cast away any constness in order to print filtered views (ranges)
+    // which cannot be const
+    // This is a private method and we know that won't modify the object
+    ctx.advance_to(f.format(*const_cast<T*>(static_cast<const T*>(arg)), ctx));
   }
 };
 

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -257,7 +257,7 @@ struct formatter<RangeT, Char,
   }
 
   template <typename FormatContext>
-  typename FormatContext::iterator format(const RangeT& values,
+  typename FormatContext::iterator format(RangeT& values,
                                           FormatContext& ctx) {
     auto out = detail::copy(formatting.prefix, ctx.out());
     size_t i = 0;


### PR DESCRIPTION
Filtered views cannot be const and have no const iterators
Note: Transformed views can be const but don't have const iterators either.

The change in ranges.h `formatter<RangeT, Char,
                         enable_if_t<fmt::is_range<RangeT, Char>::value>>::format`
is relatively benign for this reason.

However constness is cast away from the argument to `value<typename
Context>::format_custom_arg` which is in core.h -- seemingly pretty harmless in
a private method without a callback.

It is possibly a bug in gcc-10 that `std::view::tranform` views can be const as the standard only permits `std::ranges::enable_view` to be specialized for cv-_un_qualified objects [https://en.cppreference.com/w/cpp/ranges/view](url)


<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
