### PR TITLE
include/fmt/core.h: detail::buffer: declare destructor as virtual, as it already contains virtual methods.

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -669,7 +669,7 @@ template <typename T> class buffer {
         size_(sz),
         capacity_(cap) {}
 
-  ~buffer() = default;
+  virtual ~buffer() = default;
 
   /** Sets the buffer data and capacity. */
   void set(T* buf_data, size_t buf_capacity) FMT_NOEXCEPT {

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -633,7 +633,7 @@ class basic_memory_buffer : public detail::buffer<T> {
       : alloc_(alloc) {
     this->set(store_, SIZE);
   }
-  ~basic_memory_buffer() { deallocate(); }
+  ~basic_memory_buffer() override { deallocate(); }
 
  private:
   // Move data from other to this buffer.


### PR DESCRIPTION

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
