### PR TITLE
Fixed mingw32/mingw64 build

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -23,7 +23,7 @@
 #endif
 
 #ifdef _WIN32
-#  if defined(FMT_BIG_WIN) || defined(__MINGW32__) || defined(__MINGW64__)
+#  if defined(FMT_BIG_WIN) || defined(NOMINMAX)
 #    include <windows.h>
 #  else
 #    define NOMINMAX

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -23,7 +23,7 @@
 #endif
 
 #ifdef _WIN32
-#  ifdef FMT_BIG_WIN
+#  if defined(FMT_BIG_WIN) || defined(__MINGW32__) || defined(__MINGW64__)
 #    include <windows.h>
 #  else
 #    define NOMINMAX


### PR DESCRIPTION
Fixed mingw32/mingw64 build
```
In file included from C:\projects\gil\sample\CppLogging\modules\CppCommon\modules\fmt\src\format.cc:8:
C:/projects/gil/sample/CppLogging/modules/CppCommon/modules/fmt/include/fmt/format-inl.h:29: error: "NOMINMAX" redefined [-Werror]
 #    define NOMINMAX
 
In file included from C:/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/x86_64-w64-mingw32/bits/c++config.h:508,
                 from C:/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/cassert:43,
                 from C:/projects/gil/sample/CppLogging/modules/CppCommon/modules/fmt/include/fmt/format-inl.h:11,
                 from C:\projects\gil\sample\CppLogging\modules\CppCommon\modules\fmt\src\format.cc:8:
C:/mingw64/lib/gcc/x86_64-w64-mingw32/8.1.0/include/c++/x86_64-w64-mingw32/bits/os_defines.h:45: note: this is the location of the previous definition
 #define NOMINMAX 1
```

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
