### PR TITLE
Add format_to_n overload that accepts FMT_COMPILE (from #1767)

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -654,6 +654,16 @@ format_to_n_result<OutputIt> format_to_n(OutputIt out, size_t n,
   return {it.base(), it.count()};
 }
 
+template <typename OutputIt, typename S, typename... Args,
+          FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
+format_to_n_result<OutputIt> format_to_n(OutputIt out, size_t n, const S&,
+                                         const Args&... args) {
+  constexpr auto compiled = detail::compile<Args...>(S());
+  auto it = format_to(detail::truncating_iterator<OutputIt>(out, n), compiled,
+                      args...);
+  return {it.base(), it.count()};
+}
+
 template <typename CompiledFormat, typename... Args>
 size_t formatted_size(const CompiledFormat& cf, const Args&... args) {
   return format_to(detail::counting_iterator(), cf, args...).count();

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -160,6 +160,14 @@ TEST(CompileTest, FormatTo) {
   EXPECT_STREQ("42", buf);
 }
 
+TEST(CompileTest, FormatToNWithCompileMacro) {
+  constexpr auto buffer_size = 8;
+  char buffer[buffer_size];
+  auto res = fmt::format_to_n(buffer, buffer_size, FMT_COMPILE("{}"), 42);
+  *res.out = '\0';
+  EXPECT_STREQ("42", buffer);
+}
+
 TEST(CompileTest, TextAndArg) {
   EXPECT_EQ(">>>42<<<", fmt::format(FMT_COMPILE(">>>{}<<<"), 42));
 }


### PR DESCRIPTION
Extends https://github.com/fmtlib/fmt/pull/1767 by adding requested test.