### PR TITLE
Fix char8_t with FMT_COMPILE()

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -639,7 +639,7 @@ FMT_INLINE std::basic_string<typename S::char_type> format(const S&,
                                                            Args&&... args) {
   constexpr basic_string_view<typename S::char_type> str = S();
   if (str.size() == 2 && str[0] == '{' && str[1] == '}')
-    return fmt::to_string(detail::first(args...));
+    return fmt::to_string<typename S::char_type>(detail::first(args...));
   constexpr auto compiled = detail::compile<Args...>(S());
   return format(compiled, std::forward<Args>(args)...);
 }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3481,21 +3481,23 @@ arg_join<detail::iterator_t<Range>, detail::sentinel_t<Range>, wchar_t> join(
     std::string answer = fmt::to_string(42);
   \endrst
  */
-template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
-inline std::string to_string(const T& value) {
-  std::string result;
-  detail::write<char>(std::back_inserter(result), value);
+template <typename Char = char, typename T,
+          FMT_ENABLE_IF(!std::is_integral<T>::value)>
+inline std::basic_string<Char> to_string(const T& value) {
+  std::basic_string<Char> result;
+  detail::write<Char>(std::back_inserter(result), value);
   return result;
 }
 
-template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
-inline std::string to_string(T value) {
+template <typename Char = char, typename T,
+          FMT_ENABLE_IF(std::is_integral<T>::value)>
+inline std::basic_string<Char> to_string(T value) {
   // The buffer should be large enough to store the number including the sign or
   // "false" for bool.
   constexpr int max_size = detail::digits10<T>() + 2;
-  char buffer[max_size > 5 ? max_size : 5];
-  char* begin = buffer;
-  return std::string(begin, detail::write<char>(begin, value));
+  Char buffer[max_size > 5 ? max_size : 5];
+  Char* begin = buffer;
+  return std::basic_string<Char>(begin, detail::write<Char>(begin, value));
 }
 
 /**

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -177,4 +177,11 @@ TEST(CompileTest, TextAndArg) {
   EXPECT_EQ(">>>42<<<", fmt::format(FMT_COMPILE(">>>{}<<<"), 42));
   EXPECT_EQ("42!", fmt::format(FMT_COMPILE("{}!"), 42));
 }
+
+#  ifdef __cpp_char8_t
+TEST(CompileTest, Char8T) {
+  EXPECT_EQ(u8"42", fmt::format(FMT_COMPILE(u8"{}"), 42));
+  EXPECT_EQ(u8">>>42<<<", fmt::format(FMT_COMPILE(u8">>>{}<<<"), u8"42"));
+}
+#  endif
 #endif

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1936,6 +1936,14 @@ FMT_END_NAMESPACE
 
 TEST(FormatTest, ToString) {
   EXPECT_EQ("42", fmt::to_string(42));
+  EXPECT_EQ(L"42", fmt::to_string<wchar_t>(42));
+#ifdef __cpp_char8_t
+  EXPECT_EQ(u8"42", fmt::to_string<char8_t>(42));
+#else
+  EXPECT_EQ(u8"42", fmt::to_string<char>(42));
+#endif
+  EXPECT_EQ(u"42", fmt::to_string<char16_t>(42));
+  EXPECT_EQ(U"42", fmt::to_string<char32_t>(42));
   EXPECT_EQ("0x1234", fmt::to_string(reinterpret_cast<void*>(0x1234)));
   EXPECT_EQ("foo", fmt::to_string(adl_test::fmt::detail::foo()));
 }


### PR DESCRIPTION
Resolves https://github.com/fmtlib/fmt/issues/1813

Signature of to_string was changed a bit.
