### PR TITLE
add forgotten template argument to make_format_args which made some u…

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -444,7 +444,8 @@ template <typename Char, typename T, int N> struct spec_field {
   OutputIt format(OutputIt out, const Args&... args) const {
     // This ensures that the argument type is convertile to `const T&`.
     const T& arg = get<N>(args...);
-    const auto& vargs = make_format_args(args...);
+    const auto& vargs =
+        make_format_args<basic_format_context<OutputIt, Char>>(args...);
     basic_format_context<OutputIt, Char> ctx(out, vargs);
     return fmt.format(arg, ctx);
   }

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -151,6 +151,9 @@ TEST(CompileTest, FormatDefault) {
 
 TEST(CompileTest, FormatSpecs) {
   EXPECT_EQ("42", fmt::format(FMT_COMPILE("{:x}"), 0x42));
+  EXPECT_EQ("1.234000:0042:+3.13:str:0x3e8:X",
+            fmt::format(FMT_COMPILE("{:.6f}:{:04}:{:+}:{}:{}:{}"), 1.234, 42,
+                        3.13, "str", (void*)1000, 'X'));
 }
 
 TEST(CompileTest, DynamicWidth) {
@@ -159,18 +162,38 @@ TEST(CompileTest, DynamicWidth) {
 }
 
 TEST(CompileTest, FormatTo) {
-  char buf[8];
-  auto end = fmt::format_to(buf, FMT_COMPILE("{}"), 42);
-  *end = '\0';
-  EXPECT_STREQ("42", buf);
+  {
+    char buf[8];
+    auto end = fmt::format_to(buf, FMT_COMPILE("{}"), 42);
+    *end = '\0';
+    EXPECT_STREQ("42", buf);
+  }
+  {
+    char buf[100];
+    auto end = fmt::format_to(buf, FMT_COMPILE("{:.6f}:{:04}:{:+}:{}:{}:{}"),
+                              1.234, 42, 3.13, "str", (void*)1000, 'X');
+    *end = '\0';
+    EXPECT_STREQ("1.234000:0042:+3.13:str:0x3e8:X", buf);
+  }
 }
 
 TEST(CompileTest, FormatToNWithCompileMacro) {
-  constexpr auto buffer_size = 8;
-  char buffer[buffer_size];
-  auto res = fmt::format_to_n(buffer, buffer_size, FMT_COMPILE("{}"), 42);
-  *res.out = '\0';
-  EXPECT_STREQ("42", buffer);
+  {
+    constexpr auto buffer_size = 8;
+    char buffer[buffer_size];
+    auto res = fmt::format_to_n(buffer, buffer_size, FMT_COMPILE("{}"), 42);
+    *res.out = '\0';
+    EXPECT_STREQ("42", buffer);
+  }
+  {
+    constexpr auto buffer_size = 100;
+    char buffer[buffer_size];
+    auto res = fmt::format_to_n(buffer, buffer_size,
+                                FMT_COMPILE("{:.6f}:{:04}:{:+}:{}:{}:{}"),
+                                1.234, 42, 3.13, "str", (void*)1000, 'X');
+    *res.out = '\0';
+    EXPECT_STREQ("1.234000:0042:+3.13:str:0x3e8:X", buffer);
+  }
 }
 
 TEST(CompileTest, TextAndArg) {

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -153,7 +153,7 @@ TEST(CompileTest, FormatSpecs) {
   EXPECT_EQ("42", fmt::format(FMT_COMPILE("{:x}"), 0x42));
   EXPECT_EQ("1.234000:0042:+3.13:str:0x3e8:X",
             fmt::format(FMT_COMPILE("{:.6f}:{:04}:{:+}:{}:{}:{}"), 1.234, 42,
-                        3.13, "str", (void*)1000, 'X'));
+                        3.13, "str", reinterpret_cast<void*>(1000), 'X'));
 }
 
 TEST(CompileTest, DynamicWidth) {

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -170,8 +170,9 @@ TEST(CompileTest, FormatTo) {
   }
   {
     char buf[100];
-    auto end = fmt::format_to(buf, FMT_COMPILE("{:.6f}:{:04}:{:+}:{}:{}:{}"),
-                              1.234, 42, 3.13, "str", (void*)1000, 'X');
+    auto end =
+        fmt::format_to(buf, FMT_COMPILE("{:.6f}:{:04}:{:+}:{}:{}:{}"), 1.234,
+                       42, 3.13, "str", reinterpret_cast<void*>(1000), 'X');
     *end = '\0';
     EXPECT_STREQ("1.234000:0042:+3.13:str:0x3e8:X", buf);
   }
@@ -188,9 +189,9 @@ TEST(CompileTest, FormatToNWithCompileMacro) {
   {
     constexpr auto buffer_size = 100;
     char buffer[buffer_size];
-    auto res = fmt::format_to_n(buffer, buffer_size,
-                                FMT_COMPILE("{:.6f}:{:04}:{:+}:{}:{}:{}"),
-                                1.234, 42, 3.13, "str", (void*)1000, 'X');
+    auto res = fmt::format_to_n(
+        buffer, buffer_size, FMT_COMPILE("{:.6f}:{:04}:{:+}:{}:{}:{}"), 1.234,
+        42, 3.13, "str", reinterpret_cast<void*>(1000), 'X');
     *res.out = '\0';
     EXPECT_STREQ("1.234000:0042:+3.13:str:0x3e8:X", buffer);
   }


### PR DESCRIPTION
…ses of FMT_COMPILE not work anymore after 54daa0864afb57e9d1, add more elaborate test cases to compile-test as regression tests

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
