### PR TITLE
Improve FMT_ALWAYS_INLINE

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -870,8 +870,10 @@ template <> int count_digits<4>(detail::fallback_uintptr n);
 
 #if FMT_GCC_VERSION || FMT_CLANG_VERSION
 #  define FMT_ALWAYS_INLINE inline __attribute__((always_inline))
+#elif FMT_MSC_VER
+#  define FMT_ALWAYS_INLINE __forceinline
 #else
-#  define FMT_ALWAYS_INLINE
+#  define FMT_ALWAYS_INLINE inline
 #endif
 
 #ifdef FMT_BUILTIN_CLZ


### PR DESCRIPTION
1. `FMT_ALWAYS_INLINE` should imply `inline`; otherwise, there might be  linkage problems
2. Add specialization for MSVC (`__forceinline`)

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
