### PR TITLE
Disable fallthrough attributes for the Intel compilers on Linux and MacOS

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -70,9 +70,9 @@
 #endif
 
 #if __cplusplus == 201103L || __cplusplus == 201402L
-#  if defined(__clang__)
+#  if defined(__clang__) && !defined(__INTEL_COMPILER)
 #    define FMT_FALLTHROUGH [[clang::fallthrough]]
-#  elif FMT_GCC_VERSION >= 700 && !defined(__PGI) && \
+#  elif FMT_GCC_VERSION >= 700 && !defined(__PGI) && !defined(__INTEL_COMPILER) && \
       (!defined(__EDG_VERSION__) || __EDG_VERSION__ >= 520)
 #    define FMT_FALLTHROUGH [[gnu::fallthrough]]
 #  else

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -70,9 +70,11 @@
 #endif
 
 #if __cplusplus == 201103L || __cplusplus == 201402L
-#  if defined(__clang__) && !defined(__INTEL_COMPILER)
+#  if defined(__INTEL_COMPILER) || defined(__PGI)
+#    define FMT_FALLTHROUGH
+#  elif defined(__clang__)
 #    define FMT_FALLTHROUGH [[clang::fallthrough]]
-#  elif FMT_GCC_VERSION >= 700 && !defined(__PGI) && !defined(__INTEL_COMPILER) && \
+#  elif FMT_GCC_VERSION >= 700 && \
       (!defined(__EDG_VERSION__) || __EDG_VERSION__ >= 520)
 #    define FMT_FALLTHROUGH [[gnu::fallthrough]]
 #  else


### PR DESCRIPTION
On MacOS and Linux the Intel compilers may be identified as the host compilers (Clang or GNU) but do not support the corresponding compiler specific fallthrough attributes. This pull request adds conditions to the preprocessor tests to skip using those in those cases.


I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
