### PR TITLE
visual studio 2019 gives error C2049 

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -180,7 +180,7 @@
 
 #ifndef FMT_BEGIN_NAMESPACE
 #  if FMT_HAS_FEATURE(cxx_inline_namespaces) || FMT_GCC_VERSION >= 404 || \
-      FMT_MSC_VER >= 1900
+      (FMT_MSC_VER >= 1900 && !_MANAGED)
 #    define FMT_INLINE_NAMESPACE inline namespace
 #    define FMT_END_NAMESPACE \
       }                       \


### PR DESCRIPTION
visual studio 2019 gives error C2049 ('fmt::v7': non-inline namespace cannot be reopened as inline) when compiling fmt with /clr)

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
