### PR TITLE
remove dependency to windows.h

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -23,14 +23,15 @@
 #endif
 
 #ifdef _WIN32
-#include <io.h>
+#  include <io.h>
 FMT_BEGIN_NAMESPACE
-    extern "C" {
-        int __stdcall WriteConsoleW(void* hConsoleOutput, const void* lpBuffer, uint32_t nNumberOfCharsToWrite, uint32_t* lpNumberOfCharsWritten, void* lpReserved);
-    }
+extern "C" {
+int __stdcall WriteConsoleW(void* hConsoleOutput, const void* lpBuffer,
+                            uint32_t nNumberOfCharsToWrite,
+                            uint32_t* lpNumberOfCharsWritten, void* lpReserved);
+}
 FMT_END_NAMESPACE
 #endif
-
 
 // Dummy implementations of strerror_r and strerror_s called if corresponding
 // system functions are not available.
@@ -2895,9 +2896,8 @@ FMT_FUNC void vprint(std::FILE* f, string_view format_str, format_args args) {
   if (_isatty(fd)) {
     detail::utf8_to_utf16 u16(string_view(buffer.data(), buffer.size()));
     auto written = uint32_t();
-    if (!WriteConsoleW(reinterpret_cast<void*>(_get_osfhandle(fd)),
-                       u16.c_str(), static_cast<uint32_t>(u16.size()), &written,
-                       nullptr)) {
+    if (!WriteConsoleW(reinterpret_cast<void*>(_get_osfhandle(fd)), u16.c_str(),
+                       static_cast<uint32_t>(u16.size()), &written, nullptr)) {
       FMT_THROW(format_error("failed to write to console"));
     }
     return;

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -23,16 +23,15 @@
 #endif
 
 #ifdef _WIN32
-#  if defined(FMT_BIG_WIN) || defined(NOMINMAX)
-#    include <windows.h>
-#  else
-#    define NOMINMAX
-#    define WIN32_LEAN_AND_MEAN
-#    include <windows.h>
-#    undef WIN32_LEAN_AND_MEAN
-#    undef NOMINMAX
-#  endif
 #  include <io.h>
+FMT_BEGIN_NAMESPACE
+  using DWORD = uint32_t;
+  using HANDLE = void*;
+
+  extern "C" {
+    int __stdcall WriteConsoleW(void* hConsoleOutput, const void* lpBuffer, uint32_t nNumberOfCharsToWrite, uint32_t* lpNumberOfCharsWritten, void* lpReserved);
+  }
+FMT_END_NAMESPACE
 #endif
 
 // Dummy implementations of strerror_r and strerror_s called if corresponding

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -23,16 +23,14 @@
 #endif
 
 #ifdef _WIN32
-#  include <io.h>
+#include <io.h>
 FMT_BEGIN_NAMESPACE
-  using DWORD = uint32_t;
-  using HANDLE = void*;
-
-  extern "C" {
-    int __stdcall WriteConsoleW(void* hConsoleOutput, const void* lpBuffer, uint32_t nNumberOfCharsToWrite, uint32_t* lpNumberOfCharsWritten, void* lpReserved);
-  }
+    extern "C" {
+        int __stdcall WriteConsoleW(void* hConsoleOutput, const void* lpBuffer, uint32_t nNumberOfCharsToWrite, uint32_t* lpNumberOfCharsWritten, void* lpReserved);
+    }
 FMT_END_NAMESPACE
 #endif
+
 
 // Dummy implementations of strerror_r and strerror_s called if corresponding
 // system functions are not available.
@@ -2896,9 +2894,9 @@ FMT_FUNC void vprint(std::FILE* f, string_view format_str, format_args args) {
   auto fd = _fileno(f);
   if (_isatty(fd)) {
     detail::utf8_to_utf16 u16(string_view(buffer.data(), buffer.size()));
-    auto written = DWORD();
-    if (!WriteConsoleW(reinterpret_cast<HANDLE>(_get_osfhandle(fd)),
-                       u16.c_str(), static_cast<DWORD>(u16.size()), &written,
+    auto written = uint32_t();
+    if (!WriteConsoleW(reinterpret_cast<void*>(_get_osfhandle(fd)),
+                       u16.c_str(), static_cast<uint32_t>(u16.size()), &written,
                        nullptr)) {
       FMT_THROW(format_error("failed to write to console"));
     }

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -25,11 +25,20 @@
 #ifdef _WIN32
 #  include <io.h>
 FMT_BEGIN_NAMESPACE
+namespace details {
+
+#  if !defined(__LP64__)
+using DWORD = unsigned long;
+#  else
+using DWORD = unsigned int;
+#  endif
+// WriteConsoleW should not become visible in global namespace
 extern "C" {
 int __stdcall WriteConsoleW(void* hConsoleOutput, const void* lpBuffer,
-                            uint32_t nNumberOfCharsToWrite,
-                            uint32_t* lpNumberOfCharsWritten, void* lpReserved);
+                            DWORD nNumberOfCharsToWrite,
+                            DWORD* lpNumberOfCharsWritten, void* lpReserved);
 }
+}  // namespace details
 FMT_END_NAMESPACE
 #endif
 
@@ -2895,9 +2904,10 @@ FMT_FUNC void vprint(std::FILE* f, string_view format_str, format_args args) {
   auto fd = _fileno(f);
   if (_isatty(fd)) {
     detail::utf8_to_utf16 u16(string_view(buffer.data(), buffer.size()));
-    auto written = uint32_t();
-    if (!WriteConsoleW(reinterpret_cast<void*>(_get_osfhandle(fd)), u16.c_str(),
-                       static_cast<uint32_t>(u16.size()), &written, nullptr)) {
+    auto written = details::DWORD();
+    if (!details::WriteConsoleW(
+            reinterpret_cast<void*>(_get_osfhandle(fd)), u16.c_str(),
+            static_cast<details::DWORD>(u16.size()), &written, nullptr)) {
       FMT_THROW(format_error("failed to write to console"));
     }
     return;


### PR DESCRIPTION
Because windows.h is full of macros (not just min and max) it is best to not include this header.
In format-inl.h we need not really much from it...
