### PR TITLE
Fix warning C4018: '<=': signed/unsigned mismatch

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1790,8 +1790,8 @@ bool check_divisibility_and_divide_by_pow5(uint32_t& n) FMT_NOEXCEPT {
 template <int N> uint32_t small_division_by_pow10(uint32_t n) FMT_NOEXCEPT {
   static constexpr struct {
     uint32_t magic_number;
-    int shift_amount;
-    int divisor_times_10;
+    uint32_t shift_amount;
+    uint32_t divisor_times_10;
   } infos[] = {{0xcccd, 19, 100}, {0xa3d8, 22, 1000}};
   constexpr auto info = infos[N - 1];
   FMT_ASSERT(n <= info.divisor_times_10, "n is too large");

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1790,7 +1790,7 @@ bool check_divisibility_and_divide_by_pow5(uint32_t& n) FMT_NOEXCEPT {
 template <int N> uint32_t small_division_by_pow10(uint32_t n) FMT_NOEXCEPT {
   static constexpr struct {
     uint32_t magic_number;
-    uint32_t shift_amount;
+    int shift_amount;
     uint32_t divisor_times_10;
   } infos[] = {{0xcccd, 19, 100}, {0xa3d8, 22, 1000}};
   constexpr auto info = infos[N - 1];


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

```
fmt\include\fmt/format-inl.h(1797): warning C4018: '<=': signed/unsigned mismatch
```