### PR TITLE
Add reference to lhelper package manager in usage

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -173,6 +173,16 @@ The fmt port in vcpkg is kept up to date by Microsoft team members and community
 contributors. If the version is out of date, please `create an issue or pull
 request <https://github.com/Microsoft/vcpkg>`__ on the vcpkg repository.
 
+LHelper
+=======
+
+You can download and install fmt using `lhelper <https://github.com/franko/lhelper>`__ dependency manager::
+
+  lhelper activate <some-environment>
+  lhelper install fmt
+
+All the recipes for lhelper are kept in the `lhelper's recipe <https://github.com/franko/lhelper-recipes>`__ repository.
+
 Android NDK
 ===========
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -176,12 +176,14 @@ request <https://github.com/Microsoft/vcpkg>`__ on the vcpkg repository.
 LHelper
 =======
 
-You can download and install fmt using `lhelper <https://github.com/franko/lhelper>`__ dependency manager::
+You can download and install fmt using
+`lhelper <https://github.com/franko/lhelper>`__ dependency manager::
 
   lhelper activate <some-environment>
   lhelper install fmt
 
-All the recipes for lhelper are kept in the `lhelper's recipe <https://github.com/franko/lhelper-recipes>`__ repository.
+All the recipes for lhelper are kept in the
+`lhelper's recipe <https://github.com/franko/lhelper-recipes>`__ repository.
 
 Android NDK
 ===========


### PR DESCRIPTION
Hello,

I am the author of lhelper. I am now using the fmt library is one of my project and I quickly create a recipe to download and install fmt using lhelper.

I know that lhelper is not widely used but it works quite well for C and C++ projects. It works well on Linux and on Windows where it requires the MSYS2 system. It targets the gcc and clang compilers and works well with CMake, Meson and autoconf based build systems.
