### PR TITLE
Fix 1917

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -2468,6 +2468,15 @@ int format_float(T value, int precision, float_specs specs, buffer<char>& buf) {
   } else {
     exp -= cached_exp10;
     buf.try_resize(to_unsigned(handler.size));
+    if ((specs.format == detail::float_format::exp) && (buf.size() > precision)) {
+      if (exp < 0) {
+        exp += (buf.size() - precision);
+      }
+      else {
+        exp -= (buf.size() - precision);
+      }
+      buf.try_resize(to_unsigned(precision));
+    }
   }
   if (!fixed && !specs.showpoint) {
     // Remove trailing zeros.

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -958,6 +958,10 @@ TEST(FormatterTest, Precision) {
   EXPECT_EQ("1019666400", format("{}", 1019666432.0f));
   EXPECT_EQ("1e+01", format("{:.0e}", 9.5));
 
+  EXPECT_EQ("1.0e-02", format("{:.1e}", 1e-2));
+  EXPECT_EQ("1.0e-12", format("{:.1e}", 1e-12));
+  EXPECT_EQ("1.0e+12", format("{:.1e}", 1e12));
+
   EXPECT_THROW_MSG(format("{0:.2}", reinterpret_cast<void*>(0xcafe)),
                    format_error,
                    "precision not allowed for this argument type");


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
This is my first time contributing.

Fix fmtlib/fmt#1917

Problem:
format("{:.1e}", 1e-12)
Actual: 1.00e-12
Expected: 1.0e-12

Solution:
Added EXPECT expressions for the situation described in fmtlib/fmt#1917.
Added an if expression for the individual case.
