### PR TITLE
Fix compilation for systems without fcntl.h

### DIFF
--- a/src/os.cc
+++ b/src/os.cc
@@ -62,7 +62,7 @@ using RWResult = int;
 inline unsigned convert_rwcount(std::size_t count) {
   return count <= UINT_MAX ? static_cast<unsigned>(count) : UINT_MAX;
 }
-#else
+#elif FMT_USE_FCNTL
 // Return type of read and write functions.
 using RWResult = ssize_t;
 


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
