### PR TITLE
Allocator::max_size support in basic_memory_buffer

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -742,9 +742,11 @@ void basic_memory_buffer<T, SIZE, Allocator>::grow(size_t size) {
 #ifdef FMT_FUZZ
   if (size > 5000) throw std::runtime_error("fuzz mode - won't grow that much");
 #endif
+  const size_t max_size = std::allocator_traits<Allocator>::max_size(alloc_);
   size_t old_capacity = this->capacity();
   size_t new_capacity = old_capacity + old_capacity / 2;
   if (size > new_capacity) new_capacity = size;
+  else if (new_capacity > max_size) new_capacity = (std::max)(size, max_size);
   T* old_data = this->data();
   T* new_data =
       std::allocator_traits<Allocator>::allocate(alloc_, new_capacity);


### PR DESCRIPTION
The allocator may have a limit on the size of the allocated memory.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
