### PR TITLE
:new: [CMake] Enable generation of compile_commands.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ if(${CMAKE_VERSION} VERSION_LESS 3.12)
   cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 endif()
 
+# Enable generation of compile_commands.json if the CMake version is high enough
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.5)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
+
 # Determine if fmt is built as a subproject (using add_subdirectory)
 # or if it is the master project.
 set(MASTER_PROJECT OFF)


### PR DESCRIPTION
Problem:
- `compile_commands.json` is not being generated, which hurts editor
  integration with tooling.

Solution:
- Generate the `compile_commands.json` file with CMake, if the CMake
  version is sufficient.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
