### PR TITLE
Fix implicit signedness conversion warning

### DIFF
--- a/test/std-format-test.cc
+++ b/test/std-format-test.cc
@@ -111,7 +111,7 @@ template <> struct std::formatter<S> {
     char c = get_char();
     if (!isdigit(c) || (++iter, get_char()) != '}')
       throw format_error("invalid format");
-    width_arg_id = c - '0';
+    width_arg_id = fmt::detail::to_unsigned(c - '0');
     ctx.check_arg_id(width_arg_id);
     return ++iter;
   }


### PR DESCRIPTION
Problem:
- On Apple clang 11.0.3 (clang-1103.0.32.62), pedantic mode compilation
  generates the following error:

    test/std-format-test.cc:114:22: error: implicit conversion changes
          signedness: 'int' to 'size_t' (aka 'unsigned long')
          [-Werror,-Wsign-conversion]
        width_arg_id = c - '0';
                     ~ ~~^~~~~

Solution:
- Use a `to_unsigned` to make the conversion explicit. This is
  guaranteed to be safe due to the check before the ASCII-to-int
  conversion.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
