### PR TITLE
Rename all shadowed types and variables and enable Wshadow when in pedantic mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
       set(PEDANTIC_COMPILE_FLAGS ${PEDANTIC_COMPILE_FLAGS} -Wdouble-promotion
           -Wtrampolines -Wzero-as-null-pointer-constant -Wuseless-cast
-          -Wvector-operation-performance -Wsized-deallocation)
+          -Wvector-operation-performance -Wsized-deallocation -Wshadow)
   endif ()
   if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
       set(PEDANTIC_COMPILE_FLAGS ${PEDANTIC_COMPILE_FLAGS} -Wshift-overflow=2
@@ -130,7 +130,7 @@ endif ()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(PEDANTIC_COMPILE_FLAGS -Wall -Wextra -pedantic -Wconversion -Wundef
-      -Wdeprecated -Wweak-vtables)
+      -Wdeprecated -Wweak-vtables -Wshadow)
   check_cxx_compiler_flag(-Wzero-as-null-pointer-constant HAS_NULLPTR_WARNING)
   if (HAS_NULLPTR_WARNING)
     set(PEDANTIC_COMPILE_FLAGS ${PEDANTIC_COMPILE_FLAGS}

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -175,9 +175,9 @@ class format_string_compiler : public error_handler {
     repl.arg_id = part_.part_kind == part::kind::arg_index
                       ? arg_ref<Char>(part_.val.arg_index)
                       : arg_ref<Char>(part_.val.str);
-    auto part = part::make_replacement(repl);
-    part.arg_id_end = begin;
-    handler_(part);
+    auto replacement_part = part::make_replacement(repl);
+    replacement_part.arg_id_end = begin;
+    handler_(replacement_part);
     return it;
   }
 };
@@ -530,14 +530,14 @@ constexpr auto compile_format_string(S format_str) {
     if constexpr (str[POS + 1] == '{') {
       return parse_tail<Args, POS + 2, ID>(make_text(str, POS, 1), format_str);
     } else if constexpr (str[POS + 1] == '}') {
-      using type = get_type<ID, Args>;
-      return parse_tail<Args, POS + 2, ID + 1>(field<char_type, type, ID>(),
+      using id_type = get_type<ID, Args>;
+      return parse_tail<Args, POS + 2, ID + 1>(field<char_type, id_type, ID>(),
                                                format_str);
     } else if constexpr (str[POS + 1] == ':') {
-      using type = get_type<ID, Args>;
-      constexpr auto result = parse_specs<type>(str, POS + 2, ID);
+      using id_type = get_type<ID, Args>;
+      constexpr auto result = parse_specs<id_type>(str, POS + 2, ID);
       return parse_tail<Args, result.end, result.next_arg_id>(
-          spec_field<char_type, type, ID>{result.fmt}, format_str);
+          spec_field<char_type, id_type, ID>{result.fmt}, format_str);
     } else {
       return unknown_format();
     }

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -363,8 +363,8 @@ struct ostream_params {
   ostream_params() {}
 
   template <typename... T>
-  ostream_params(T... params, int oflag) : ostream_params(params...) {
-    this->oflag = oflag;
+  ostream_params(T... params, int new_oflag) : ostream_params(params...) {
+    oflag = new_oflag;
   }
 
   template <typename... T>

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -108,8 +108,8 @@ TEST(TimeTest, TimePoint) {
 
 #define EXPECT_TIME(spec, time, duration)                 \
   {                                                       \
-    std::locale loc("ja_JP.utf8");                        \
-    EXPECT_EQ(format_tm(time, spec, loc),                 \
+    std::locale jp_loc("ja_JP.utf8");                     \
+    EXPECT_EQ(format_tm(time, spec, jp_loc),              \
               fmt::format(loc, "{:" spec "}", duration)); \
   }
 

--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -83,8 +83,8 @@ template <typename T> struct mock_buffer final : buffer<T> {
 
   void grow(size_t capacity) { this->set(this->data(), do_grow(capacity)); }
 
-  mock_buffer(T* data = nullptr, size_t capacity = 0) {
-    this->set(data, capacity);
+  mock_buffer(T* data = nullptr, size_t buf_capacity = 0) {
+    this->set(data, buf_capacity);
     ON_CALL(*this, do_grow(_)).WillByDefault(Invoke([](size_t capacity) {
       return capacity;
     }));
@@ -224,9 +224,9 @@ struct custom_context {
   };
 
   bool called;
-  fmt::format_parse_context ctx;
+  fmt::format_parse_context parse_ctx;
 
-  fmt::format_parse_context& parse_context() { return ctx; }
+  fmt::format_parse_context& parse_context() { return parse_ctx; }
   void advance_to(const char*) {}
 };
 
@@ -688,9 +688,9 @@ TYPED_TEST(IsStringTest, IsString) {
   EXPECT_TRUE(fmt::detail::is_string<fmt::basic_string_view<TypeParam>>::value);
   EXPECT_TRUE(
       fmt::detail::is_string<derived_from_string_view<TypeParam>>::value);
-  using string_view = fmt::detail::std_string_view<TypeParam>;
-  EXPECT_TRUE(std::is_empty<string_view>::value !=
-              fmt::detail::is_string<string_view>::value);
+  using fmt_string_view = fmt::detail::std_string_view<TypeParam>;
+  EXPECT_TRUE(std::is_empty<fmt_string_view>::value !=
+              fmt::detail::is_string<fmt_string_view>::value);
   EXPECT_TRUE(fmt::detail::is_string<my_ns::my_string<TypeParam>>::value);
   EXPECT_FALSE(fmt::detail::is_string<my_ns::non_string>::value);
 }

--- a/test/locale-test.cc
+++ b/test/locale-test.cc
@@ -131,15 +131,13 @@ template <class charT> struct formatter<std::complex<double>, charT> {
                                           FormatContext& ctx) {
     detail::handle_dynamic_spec<detail::precision_checker>(
         specs_.precision, specs_.precision_ref, ctx);
-    auto format_specs = std::string();
-    if (specs_.precision > 0)
-      format_specs = fmt::format(".{}", specs_.precision);
-    if (specs_.type)
-      format_specs += specs_.type;
+    auto specs = std::string();
+    if (specs_.precision > 0) specs = fmt::format(".{}", specs_.precision);
+    if (specs_.type) specs += specs_.type;
     auto real = fmt::format(ctx.locale().template get<std::locale>(),
-                            "{:" + format_specs + "}", c.real());
+                            "{:" + specs + "}", c.real());
     auto imag = fmt::format(ctx.locale().template get<std::locale>(),
-                            "{:" + format_specs + "}", c.imag());
+                            "{:" + specs + "}", c.imag());
     auto fill_align_width = std::string();
     if (specs_.width > 0)
       fill_align_width = fmt::format(">{}", specs_.width);

--- a/test/ostream-test.cc
+++ b/test/ostream-test.cc
@@ -152,7 +152,7 @@ TEST(OStreamTest, WriteToOStreamMaxSize) {
 
   struct test_buffer final : fmt::detail::buffer<char> {
     explicit test_buffer(size_t size)
-      : fmt::detail::buffer<char>(nullptr, size, size) {}
+        : fmt::detail::buffer<char>(nullptr, size, size) {}
     void grow(size_t) {}
   } buffer(max_size);
 
@@ -165,7 +165,8 @@ TEST(OStreamTest, WriteToOStreamMaxSize) {
   } streambuf;
 
   struct test_ostream : std::ostream {
-    explicit test_ostream(mock_streambuf& buffer) : std::ostream(&buffer) {}
+    explicit test_ostream(mock_streambuf& output_buffer)
+        : std::ostream(&output_buffer) {}
   } os(streambuf);
 
   testing::InSequence sequence;


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
