### PR TITLE
Remove accidental parenthesis

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1756,7 +1756,7 @@ inline bool divisible_by_power_of_2(uint64_t x, int exp) FMT_NOEXCEPT {
 #ifdef FMT_BUILTIN_CTZLL
   return FMT_BUILTIN_CTZLL(x) >= exp;
 #else
-  return exp < num_bits<uint64_t>()) && x == ((x >> exp) << exp);
+  return exp < num_bits<uint64_t>() && x == ((x >> exp) << exp);
 #endif
 }
 


### PR DESCRIPTION
fails only when FMT_BUILTIN_CTZLL is not defined

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
