### PR TITLE
Remove sizeof from unused variable silencer

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -115,7 +115,7 @@ FMT_END_NAMESPACE
 #  else
 #    define FMT_THROW(x)              \
       do {                            \
-        static_cast<void>(sizeof(x)); \
+        static_cast<void>(x); \
         FMT_ASSERT(false, "");        \
       } while (false)
 #  endif


### PR DESCRIPTION
Using sizeof causes some compilers to complain:
'operand of sizeof is not a type, variable, or dereferenced pointer'

static_cast itself should be enough to silence unused variable warning
