### PR TITLE
Fix test on OpenBSD

### DIFF
--- a/test/gtest-extra-test.cc
+++ b/test/gtest-extra-test.cc
@@ -375,9 +375,15 @@ TEST(OutputRedirectTest, DupErrorInCtor) {
   file copy = file::dup(fd);
   FMT_POSIX(close(fd));
   std::unique_ptr<OutputRedirect> redir{nullptr};
+#ifdef __OpenBSD__
+  EXPECT_SYSTEM_ERROR_NOASSERT(
+      redir.reset(new OutputRedirect(f.get())), EBADF,
+      fmt::format("cannot flush stream"));
+#else
   EXPECT_SYSTEM_ERROR_NOASSERT(
       redir.reset(new OutputRedirect(f.get())), EBADF,
       fmt::format("cannot duplicate file descriptor {}", fd));
+#endif
   copy.dup2(fd);  // "undo" close or dtor will fail
 }
 


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

Hello,

I am working on packaging fmt for OpenBSD. During this process I encountered a problem with one of the tests. It appears that for some reason the library is expecting particular error message wording in one of the tests. OpenBSD returns a different error message.

As far as I can tell, this is purely cosmetic (I may be wrong). If there's a better way to resolve this please let me know.

Btw with this change, the entire test suite passes on OpenBSD.

This PR just adds an ifdef to substitute the message when fmt is being built on OpenBSD.