### PR TITLE
Printf get container

### DIFF
--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -330,40 +330,6 @@ template <typename T> struct printf_formatter {
   }
 };
 
-namespace detail {
-template <typename, typename = void>
-struct has_container_append : std::false_type {};
-
-template <typename OutputIt>
-struct has_container_append<
-    OutputIt,
-    void_t<decltype(
-        get_container(std::declval<OutputIt>())
-            .append(std::declval<
-                        const typename OutputIt::container_type::value_type*>(),
-                    std::declval<const typename OutputIt::container_type::
-                                     value_type*>()))>> : std::true_type {};
-
-template <typename OutputIt>
-enable_if_t<has_container_append<OutputIt>::value, OutputIt>
-container_aware_copy(const typename OutputIt::container_type::value_type* first,
-                     const typename OutputIt::container_type::value_type* last,
-                     OutputIt out) {
-  detail::get_container(out).append(first, last);
-  return out;
-}
-
-static_assert(has_container_append<buffer_appender<char>>::value,
-              "has_container_append doesn't work");
-
-template <typename OutputIt, typename Char>
-enable_if_t<!has_container_append<OutputIt>::value, OutputIt>
-container_aware_copy(const Char* first, const Char* last, OutputIt out) {
-  return std::copy(first, last, out);
-}
-
-}  // namespace detail
-
 /**
  This template formats data and writes the output through an output iterator.
  */
@@ -514,11 +480,11 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
     }
     char_type c = *it++;
     if (it != end && *it == c) {
-      out = container_aware_copy(start, it, out);
+      out = detail::write(out, basic_string_view<Char>(start, it - start));
       start = ++it;
       continue;
     }
-    out = container_aware_copy(start, it - 1, out);
+    out = detail::write(out, basic_string_view<Char>(start, it - 1 - start));
 
     format_specs specs;
     specs.align = align::right;
@@ -630,7 +596,7 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
     // Format argument.
     out = visit_format_arg(ArgFormatter(out, specs, *this), arg);
   }
-  return container_aware_copy(start, it, out);
+  return detail::write(out, basic_string_view<Char>(start, it - start));
 }
 
 template <typename Char>

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -480,11 +480,13 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
     }
     char_type c = *it++;
     if (it != end && *it == c) {
-      out = detail::write(out, basic_string_view<Char>(start, it - start));
+      out = detail::write(
+          out, basic_string_view<Char>(start, detail::to_unsigned(it - start)));
       start = ++it;
       continue;
     }
-    out = detail::write(out, basic_string_view<Char>(start, it - 1 - start));
+    out = detail::write(out, basic_string_view<Char>(
+                                 start, detail::to_unsigned(it - 1 - start)));
 
     format_specs specs;
     specs.align = align::right;
@@ -596,7 +598,8 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
     // Format argument.
     out = visit_format_arg(ArgFormatter(out, specs, *this), arg);
   }
-  return detail::write(out, basic_string_view<Char>(start, it - start));
+  return detail::write(
+      out, basic_string_view<Char>(start, detail::to_unsigned(it - start)));
 }
 
 template <typename Char>

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -617,7 +617,9 @@ TEST(PrintfTest, PrintfDetermineOutputSize) {
 
   const auto format_string = "%s";
   const auto format_arg = "Hello";
-  const auto expected_size = fmt::sprintf(format_string, format_arg).size();
+  const auto expected_size = 5;
+
+  EXPECT_EQ(expected_size, fmt::sprintf(format_string, format_arg).size());
 
   EXPECT_EQ(expected_size,
             (truncated_printf_context(
@@ -625,20 +627,4 @@ TEST(PrintfTest, PrintfDetermineOutputSize) {
                  fmt::make_format_args<truncated_printf_context>(format_arg))
                  .format()
                  .count()));
-}
-
-TEST(PrintfTest, PrintfAppendToBuffer) {
-  using backit = std::back_insert_iterator<fmt::basic_memory_buffer<char>>;
-  using context = fmt::basic_printf_context<backit, char>;
-
-  const auto format_string = "%s";
-  const char* format_arg = "Hello";
-  fmt::basic_memory_buffer<char> buffer;
-  context(std::back_inserter(buffer), format_string,
-          fmt::make_format_args<context>(format_arg))
-      .format();
-
-  std::string result(std::begin(buffer), std::end(buffer));
-
-  EXPECT_EQ(std::string("Hello"), result);
 }

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -617,14 +617,12 @@ TEST(PrintfTest, PrintfDetermineOutputSize) {
 
   const auto format_string = "%s";
   const auto format_arg = "Hello";
-  const auto expected_size = 5;
+  const auto expected_size = fmt::sprintf(format_string, format_arg).size();
 
-  EXPECT_EQ(expected_size, fmt::sprintf(format_string, format_arg).size());
-
-  EXPECT_EQ(expected_size,
-            (truncated_printf_context(
+  EXPECT_EQ((truncated_printf_context(
                  fmt::detail::truncating_iterator<backit>(it, 0), format_string,
                  fmt::make_format_args<truncated_printf_context>(format_arg))
                  .format()
-                 .count()));
+                 .count()),
+            expected_size);
 }

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -619,10 +619,26 @@ TEST(PrintfTest, PrintfDetermineOutputSize) {
   const auto format_arg = "Hello";
   const auto expected_size = fmt::sprintf(format_string, format_arg).size();
 
-  EXPECT_EQ((truncated_printf_context(
+  EXPECT_EQ(expected_size,
+            (truncated_printf_context(
                  fmt::detail::truncating_iterator<backit>(it, 0), format_string,
                  fmt::make_format_args<truncated_printf_context>(format_arg))
                  .format()
-                 .count()),
-            expected_size);
+                 .count()));
+}
+
+TEST(PrintfTest, PrintfAppendToBuffer) {
+  using backit = std::back_insert_iterator<fmt::basic_memory_buffer<char>>;
+  using context = fmt::basic_printf_context<backit, char>;
+
+  const auto format_string = "%s";
+  const char* format_arg = "Hello";
+  fmt::basic_memory_buffer<char> buffer;
+  context(std::back_inserter(buffer), format_string,
+          fmt::make_format_args<context>(format_arg))
+      .format();
+
+  std::string result(std::begin(buffer), std::end(buffer));
+
+  EXPECT_EQ(std::string("Hello"), result);
 }


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

This affects the performance of fmt::sprintf in the case where the format string is at least on the order of 100 characters long.

The benchmark:

```c++
#include <benchmark/benchmark.h>
#include <fmt/printf.h>

void long_printf_format_string(benchmark::State& state) {
  std::string format_string = std::string(state.range(0), 'A') + "%s";
  std::string message = "Hi";
  for (auto _ : state) {
    benchmark::DoNotOptimize(fmt::sprintf(format_string, message));
  };
}
BENCHMARK(long_printf_format_string)->Arg(10)->Arg(100)->Arg(1000)->Arg(10000);

void long_fmt_format_string(benchmark::State& state) {
  std::string format_string = std::string(state.range(0), 'A') + "{}";
  std::string message = "Hi";
  for (auto _ : state) {
    benchmark::DoNotOptimize(fmt::format(format_string, message));
  };
}
BENCHMARK(long_fmt_format_string)->Arg(10)->Arg(100)->Arg(1000)->Arg(10000);
```

The benchmark numbers change as follows:

master (60dc273513449dc959fc8212464058c54c7c36bb)
```
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
long_printf_format_string/10          39.9 ns         39.9 ns     17364987
long_printf_format_string/100          188 ns          188 ns      3697522
long_printf_format_string/1000        1402 ns         1402 ns       494033
long_printf_format_string/10000      12409 ns        12409 ns        55024
long_fmt_format_string/10             28.0 ns         28.0 ns     24726944
long_fmt_format_string/100            88.2 ns         88.2 ns      7890169
long_fmt_format_string/1000            333 ns          333 ns      2119728
long_fmt_format_string/10000           873 ns          873 ns       779553
```
branch (104b3de77b637f94334dcfd726abe3d38c3d13c)
```
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
long_printf_format_string/10          36.7 ns         36.7 ns     17982978
long_printf_format_string/100         95.8 ns         95.8 ns      7214487
long_printf_format_string/1000         337 ns          337 ns      2075802
long_printf_format_string/10000        763 ns          763 ns       910155
long_fmt_format_string/10             28.0 ns         28.0 ns     24945565
long_fmt_format_string/100            86.6 ns         86.6 ns      7932910
long_fmt_format_string/1000            330 ns          330 ns      2093427
long_fmt_format_string/10000           838 ns          838 ns       807894
```
