### PR TITLE
use memchr for searching for '%' in printf format string

### DIFF
--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -474,13 +474,8 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
   const Char* end = parse_ctx_.end();
   auto it = start;
   while (it != end) {
-    if (end - it < 32) {
-      // Use a simple linear search instead of memchr for small strings.
-      it = std::find(it, end, '%');
-    } else {
-      if (!detail::find<false, Char>(it, end, '%', it)) {
-        it = end;
-      }
+    if (!detail::find<false, Char>(it, end, '%', it)) {
+      it = end;
     }
     if (it == end) {
       continue;

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -474,8 +474,18 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
   const Char* end = parse_ctx_.end();
   auto it = start;
   while (it != end) {
+    if (end - it < 32) {
+      // Use a simple linear search instead of memchr for small strings.
+      it = std::find(it, end, '%');
+    } else {
+      if (!detail::find<false, Char>(it, end, '%', it)) {
+        it = end;
+      }
+    }
+    if (it == end) {
+      continue;
+    }
     char_type c = *it++;
-    if (c != '%') continue;
     if (it != end && *it == c) {
       out = std::copy(start, it, out);
       start = ++it;

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -475,10 +475,8 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
   auto it = start;
   while (it != end) {
     if (!detail::find<false, Char>(it, end, '%', it)) {
-      it = end;
-    }
-    if (it == end) {
-      continue;
+      it = end;  // detail::find leaves it == nullptr if it doesn't find '%'
+      break;
     }
     char_type c = *it++;
     if (it != end && *it == c) {


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

This is the same change as in the closed pull request https://github.com/fmtlib/fmt/pull/1853 but this time with a simple microbenchmark to argue for it. I hope this isn't considered impolite.

The change starts to be noticeable at a format string length of about 100 characters.

The microbenchmark is the same as in https://github.com/fmtlib/fmt/pull/1982:

```c++
#include <benchmark/benchmark.h>
#include <fmt/printf.h>

void long_argument(benchmark::State& state) {
  std::string long_string(state.range(0), 'A');
  for (auto _ : state) {
    benchmark::DoNotOptimize(fmt::sprintf("%s", long_string));
  };
}
BENCHMARK(long_argument)->Arg(10)->Arg(100)->Arg(1000)->Arg(10000);

void long_format_string(benchmark::State& state) {
  std::string format_string = std::string(state.range(0), 'A') + "%s";
  std::string message = "Hi";
  for (auto _ : state) {
    benchmark::DoNotOptimize(fmt::sprintf(format_string, message));
  };
}
BENCHMARK(long_format_string)->Arg(10)->Arg(100)->Arg(1000)->Arg(10000);

BENCHMARK_MAIN();
```

The microbenchmark numbers:

master (038057eb3ef7ff083eb0c51802c3831473c614d0)
```
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
long_argument/10               36.6 ns         36.6 ns     17808714
long_argument/100               188 ns          188 ns      3716840
long_argument/1000             1284 ns         1284 ns       538288
long_argument/10000           11769 ns        11767 ns        62667
long_format_string/10          39.6 ns         39.6 ns     17552922
long_format_string/100          237 ns          237 ns      2934014
long_format_string/1000        1882 ns         1882 ns       383536
long_format_string/10000      18333 ns        18328 ns        39354
```
branch (e66299973b4f1d580ff1d94bdf920fbb60380ca5)
```
-------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations
-------------------------------------------------------------------
long_argument/10               39.7 ns         39.7 ns     16266435
long_argument/100               191 ns          191 ns      3609438
long_argument/1000             1304 ns         1304 ns       535373
long_argument/10000           11039 ns        11039 ns        62367
long_format_string/10          39.1 ns         39.1 ns     17829580
long_format_string/100          191 ns          191 ns      3675833
long_format_string/1000        1383 ns         1383 ns       493149
long_format_string/10000      12418 ns        12418 ns        55520
```

