### PR TITLE
Make OpenBSD not use fcntl

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -31,7 +31,8 @@
 #endif
 #if (FMT_HAS_INCLUDE(<fcntl.h>) || defined(__APPLE__) || \
      defined(__linux__)) &&                              \
-    (!defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP))
+    (!defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)) && \
+    (!defined(__OpenBSD__))
 #  include <fcntl.h>  // for O_RDONLY
 #  define FMT_USE_FCNTL 1
 #else


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

This is a more elegant workaround to the failing test I encountered the other day. I am still not 100% sure why there's a failure with fcntl, there's possibly a difference in behavior that's non-obvious between other systems and OpenBSD. For now, just opt OpenBSD out of using fcntl.