### PR TITLE
Fix build failure when not using fcntl with -Werror

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -31,8 +31,7 @@
 #endif
 #if (FMT_HAS_INCLUDE(<fcntl.h>) || defined(__APPLE__) || \
      defined(__linux__)) &&                              \
-    (!defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)) && \
-    (!defined(__OpenBSD__))
+    (!defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP))
 #  include <fcntl.h>  // for O_RDONLY
 #  define FMT_USE_FCNTL 1
 #else

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -31,7 +31,8 @@
 #endif
 #if (FMT_HAS_INCLUDE(<fcntl.h>) || defined(__APPLE__) || \
      defined(__linux__)) &&                              \
-    (!defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP))
+    (!defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)) && \
+    (!defined(__OpenBSD__))
 #  include <fcntl.h>  // for O_RDONLY
 #  define FMT_USE_FCNTL 1
 #else

--- a/test/gtest-extra-test.cc
+++ b/test/gtest-extra-test.cc
@@ -22,16 +22,6 @@
 
 namespace {
 
-#if FMT_USE_FCNTL
-// This is used to suppress coverity warnings about untrusted values.
-std::string sanitize(const std::string& s) {
-  std::string result;
-  for (std::string::const_iterator i = s.begin(), end = s.end(); i != end; ++i)
-    result.push_back(static_cast<char>(*i & 0xff));
-  return result;
-}
-#endif
-
 // Tests that assertion macros evaluate their arguments exactly once.
 class SingleEvaluationTest : public ::testing::Test {
  protected:
@@ -390,8 +380,8 @@ TEST(OutputRedirectTest, RestoreAndRead) {
   std::fprintf(file.get(), "[[[");
   OutputRedirect redir(file.get());
   std::fprintf(file.get(), "censored");
-  EXPECT_EQ("censored", sanitize(redir.restore_and_read()));
-  EXPECT_EQ("", sanitize(redir.restore_and_read()));
+  EXPECT_EQ("censored", redir.restore_and_read());
+  EXPECT_EQ("", redir.restore_and_read());
   std::fprintf(file.get(), "]]]");
   file = buffered_file();
   EXPECT_READ(read_end, "[[[]]]");

--- a/test/gtest-extra-test.cc
+++ b/test/gtest-extra-test.cc
@@ -22,6 +22,7 @@
 
 namespace {
 
+#if FMT_USE_FCNTL
 // This is used to suppress coverity warnings about untrusted values.
 std::string sanitize(const std::string& s) {
   std::string result;
@@ -29,6 +30,7 @@ std::string sanitize(const std::string& s) {
     result.push_back(static_cast<char>(*i & 0xff));
   return result;
 }
+#endif
 
 // Tests that assertion macros evaluate their arguments exactly once.
 class SingleEvaluationTest : public ::testing::Test {

--- a/test/posix-mock-test.cc
+++ b/test/posix-mock-test.cc
@@ -194,12 +194,12 @@ int(test::fileno)(FILE* stream) {
 #  define EXPECT_EQ_POSIX(expected, actual)
 #endif
 
+#if FMT_USE_FCNTL
 static void write_file(fmt::cstring_view filename, fmt::string_view content) {
   fmt::buffered_file f(filename, "w");
   f.print("{}", content);
 }
 
-#if FMT_USE_FCNTL
 using fmt::file;
 
 TEST(UtilTest, GetPageSize) {


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

If not using fcntl, but building with -Werror enabled, there's a couple functions in the tests that aren't ifdef guarded and don't actually get called. This results in the tests failing to build (log attached) due to unused function warnings.

This PR just adds them to an ifdef guard so the tests build correctly.

[blows_up.txt](https://github.com/fmtlib/fmt/files/5503811/blows_up.txt)
