### PR TITLE
:art: [ci] Specify the exact version of clang to use

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        cxx: [g++-4.8, g++-8, g++-10, clang++]
+        cxx: [g++-4.8, g++-8, g++-10, clang++-9]
         build_type: [Debug, Release]
         include:
-          - cxx: clang++
+          - cxx: clang++-9
             build_type: Debug
             fuzz: -DFMT_FUZZ=ON -DFMT_FUZZ_LINKMAIN=ON
           - cxx: g++-4.8


### PR DESCRIPTION
Problem:
- The version of clang to use is specified only as `clang++`. This is
  inconsistent with the specifications for gcc and exposed to unexpected
  failure if the default changes.

Solution:
- Specify the exact version of clang to use. I chose `clang++-9` as that
  is the version that `clang++` is currently resolving to.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
