### PR TITLE
Add C++ standards to CI config (Linux)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         cxx: [g++-4.8, g++-8, g++-10, clang++-9]
+        standard: [11, 14, 17, 20]
         build_type: [Debug, Release]
         include:
           - cxx: clang++-9
@@ -15,6 +16,41 @@ jobs:
             fuzz: -DFMT_FUZZ=ON -DFMT_FUZZ_LINKMAIN=ON
           - cxx: g++-4.8
             install: sudo apt install g++-4.8
+        exclude: # filter some configurations
+          ### gcc 4.8
+          # does not fully support c++14
+          - cxx: g++-4.8
+            standard: 14
+          # does not support c++17
+          - cxx: g++-4.8
+            standard: 17
+          # does not support c++20
+          - cxx: g++-4.8
+            standard: 20
+
+          ### gcc 8
+          # has c++14 as default mode
+          - cxx: g++-8
+            standard: 11
+          # does not fully support c++20
+          - cxx: g++-8
+            standard: 20
+
+          ### gcc 10
+          # has c++14 as default mode
+          - cxx: g++-10
+            standard: 11
+          # does not fully support c++20
+          - cxx: g++-10
+            standard: 20
+
+          ### clang 9
+          # has c++14 as default mode
+          - cxx: clang++-9
+            standard: 11
+          # does not fully support c++20
+          - cxx: clang++-9
+            standard: 20
 
     steps:
     - uses: actions/checkout@v2
@@ -29,8 +65,8 @@ jobs:
       env:
         CXX: ${{matrix.cxx}}
       run: |
-        cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} ${{matrix.fuzz}} \
-              -DFMT_DOC=OFF -DFMT_PEDANTIC=ON -DFMT_WERROR=ON $GITHUB_WORKSPACE
+        cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCMAKE_CXX_STANDARD=${{matrix.standard}} \
+              ${{matrix.fuzz}} -DFMT_DOC=OFF -DFMT_PEDANTIC=ON -DFMT_WERROR=ON $GITHUB_WORKSPACE
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -515,7 +515,7 @@ constexpr parse_specs_result<T, Char> parse_specs(basic_string_view<Char> str,
   auto ctx = basic_format_parse_context<Char>(str, {}, arg_id + 1);
   auto f = formatter<T, Char>();
   auto end = f.parse(ctx);
-  return {f, pos + (end - str.data()) + 1, ctx.next_arg_id()};
+  return {f, pos + static_cast<size_t>(end - str.data()) + 1, ctx.next_arg_id()};
 }
 
 // Compiles a non-empty format string and returns the compiled representation


### PR DESCRIPTION
For Linux workflow, I added several C++ standards with excluding unsupported/excess standard for each presented compiler.
This is related to the issue https://github.com/fmtlib/fmt/issues/1987.
Also, I fixed 1 compile warning (-Werror,-Wsign-conversion) for clang++ with C++17 standard, otherwise, CI build fails.