### PR TITLE
Add C++ standards to the build matrix

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,12 +9,22 @@ jobs:
       matrix:
         cxx: [g++-4.8, g++-8, g++-10, clang++-9]
         build_type: [Debug, Release]
+        standard: [11, 14, 17, 20]
         include:
           - cxx: clang++-9
             build_type: Debug
             fuzz: -DFMT_FUZZ=ON -DFMT_FUZZ_LINKMAIN=ON
           - cxx: g++-4.8
             install: sudo apt install g++-4.8
+        exclude:
+          - cxx: g++-4.8
+            standard: 14
+          - cxx: g++-4.8
+            standard: 17
+          - cxx: g++-4.8
+            standard: 20
+          - cxx: g++-8
+            standard: 20
 
     steps:
     - uses: actions/checkout@v2
@@ -30,7 +40,8 @@ jobs:
         CXX: ${{matrix.cxx}}
       run: |
         cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} ${{matrix.fuzz}} \
-              -DFMT_DOC=OFF -DFMT_PEDANTIC=ON -DFMT_WERROR=ON $GITHUB_WORKSPACE
+              -DFMT_DOC=OFF -DFMT_PEDANTIC=ON -DFMT_WERROR=ON \
+              -DCMAKE_CXX_STANDARD=${{matrix.standard}} $GITHUB_WORKSPACE
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
+        standard: [11, 14, 17, 20]
         build_type: [Debug, Release]
 
     steps:
@@ -19,7 +20,8 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: |
         cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
-              -DFMT_DOC=OFF -DFMT_PEDANTIC=ON -DFMT_WERROR=ON $GITHUB_WORKSPACE
+              -DFMT_DOC=OFF -DFMT_PEDANTIC=ON -DFMT_WERROR=ON \
+              -DCMAKE_CXX_STANDARD=${{matrix.standard}} $GITHUB_WORKSPACE
 
     - name: Build
       working-directory: ${{runner.workspace}}/build


### PR DESCRIPTION
Problem:
- A variety of compilers are tested in CI, but they are all tested on
  the C++11 standard. This prevents CI from catching bugs that exist
  only on a particular version of the C++ standard.

Solution:
- Parameterize CI on C++ standards 11, 14, 17, and 20.

This also includes fixes for compiler warnings discovered along the way. I've included a detailed writeup of each compilation error and the fix in the commit notes for each fix.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
