### PR TITLE
fix gcc warning of missing override

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -388,7 +388,7 @@ class ostream final : private detail::buffer<char> {
     clear();
   }
 
-  void grow(size_t) final;
+  void grow(size_t) override final;
 
   ostream(cstring_view path, const detail::ostream_params& params)
       : file_(path, params.oflag) {


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
