### PR TITLE
Always use FMT_STRING internally where possible [Issue #2002]

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -772,8 +772,10 @@ OutputIt format_duration_value(OutputIt out, Rep val, int) {
 template <typename Char, typename Rep, typename OutputIt,
           FMT_ENABLE_IF(std::is_floating_point<Rep>::value)>
 OutputIt format_duration_value(OutputIt out, Rep val, int precision) {
-  static FMT_CONSTEXPR_DECL const Char pr_f[] = {'{', ':', '.', '{', '}', 'f', '}', 0};
-  if (precision >= 0) return format_to(out, compile_string_to_view(pr_f), val, precision);
+  static FMT_CONSTEXPR_DECL const Char pr_f[] = {'{', ':', '.', '{',
+                                                 '}', 'f', '}', 0};
+  if (precision >= 0)
+    return format_to(out, compile_string_to_view(pr_f), val, precision);
   static FMT_CONSTEXPR_DECL const Char fp_f[] = {'{', ':', 'g', '}', 0};
   return format_to(out, compile_string_to_view(fp_f), val);
 }
@@ -796,9 +798,12 @@ OutputIt format_duration_unit(OutputIt out) {
   if (const char* unit = get_units<Period>())
     return copy_unit(string_view(unit), out, Char());
   static FMT_CONSTEXPR_DECL const Char num_f[] = {'[', '{', '}', ']', 's', 0};
-  if (const_check(Period::den == 1)) return format_to(out, compile_string_to_view(num_f), Period::num);
-  static FMT_CONSTEXPR_DECL const Char num_def_f[] = {'[', '{', '}', '/', '{', '}', ']', 's', 0};
-  return format_to(out, compile_string_to_view(num_def_f), Period::num, Period::den);
+  if (const_check(Period::den == 1))
+    return format_to(out, compile_string_to_view(num_f), Period::num);
+  static FMT_CONSTEXPR_DECL const Char num_def_f[] = {'[', '{', '}', '/', '{',
+                                                      '}', ']', 's', 0};
+  return format_to(out, compile_string_to_view(num_def_f), Period::num,
+                   Period::den);
 }
 
 template <typename FormatContext, typename OutputIt, typename Rep,

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -764,10 +764,10 @@ inline std::chrono::duration<Rep, std::milli> get_milliseconds(
 
 template <typename Char, typename Rep, typename OutputIt>
 OutputIt format_duration_value(OutputIt out, Rep val, int precision) {
-  static constexpr const Char pr_f[] = {'{', ':', '.', '{', '}', 'f', '}', 0};
+  static FMT_CONSTEXPR_DECL const Char pr_f[] = {'{', ':', '.', '{', '}', 'f', '}', 0};
   if (precision >= 0) return format_to(out, FMT_STRING(pr_f), val, precision);
-  static constexpr const Char fp_f[] = {'{', ':', 'g', '}', 0};
-  static constexpr const Char format[] = {'{', '}', 0};
+  static FMT_CONSTEXPR_DECL const Char fp_f[] = {'{', ':', 'g', '}', 0};
+  static FMT_CONSTEXPR_DECL const Char format[] = {'{', '}', 0};
   if(std::is_floating_point<Rep>::value) {
     return format_to(out, FMT_STRING(fp_f), val);  
   } else {
@@ -792,9 +792,9 @@ template <typename Char, typename Period, typename OutputIt>
 OutputIt format_duration_unit(OutputIt out) {
   if (const char* unit = get_units<Period>())
     return copy_unit(string_view(unit), out, Char());
-  static constexpr const Char num_f[] = {'[', '{', '}', ']', 's', 0};
+  static FMT_CONSTEXPR_DECL const Char num_f[] = {'[', '{', '}', ']', 's', 0};
   if (const_check(Period::den == 1)) return format_to(out, FMT_STRING(num_f), Period::num);
-  static constexpr const Char num_def_f[] = {'[', '{', '}', '/', '{', '}', ']', 's', 0};
+  static FMT_CONSTEXPR_DECL const Char num_def_f[] = {'[', '{', '}', '/', '{', '}', ']', 's', 0};
   return format_to(out, FMT_STRING(num_def_f), Period::num, Period::den);
 }
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -763,19 +763,29 @@ inline std::chrono::duration<Rep, std::milli> get_milliseconds(
 }
 
 template <typename Char, typename Rep, typename OutputIt,
-          FMT_ENABLE_IF(std::is_integral<Rep>::value)>
+          FMT_ENABLE_IF(std::is_integral<Rep>::value && std::is_same<Char, char>::value)>
 OutputIt format_duration_value(OutputIt out, Rep val, int) {
-  static FMT_CONSTEXPR_DECL const Char format[] = {'{', '}', 0};
-  return format_to(out, FMT_STRING(format), val);
+  return format_to(out, FMT_STRING("{}"), val);
 }
 
 template <typename Char, typename Rep, typename OutputIt,
-          FMT_ENABLE_IF(std::is_floating_point<Rep>::value)>
+          FMT_ENABLE_IF(std::is_integral<Rep>::value && std::is_same<Char, wchar_t>::value)>
+OutputIt format_duration_value(OutputIt out, Rep val, int) {
+  return format_to(out, FMT_STRING(L"{}"), val);
+}
+
+template <typename Char, typename Rep, typename OutputIt,
+          FMT_ENABLE_IF(std::is_floating_point<Rep>::value && std::is_same<Char, char>::value)>
 OutputIt format_duration_value(OutputIt out, Rep val, int precision) {
-  static FMT_CONSTEXPR_DECL const Char pr_f[] = {'{', ':', '.', '{', '}', 'f', '}', 0};
-  if (precision >= 0) return format_to(out, FMT_STRING(pr_f), val, precision);
-  static FMT_CONSTEXPR_DECL const Char fp_f[] = {'{', ':', 'g', '}', 0};
-  return format_to(out, FMT_STRING(fp_f), val);
+  if (precision >= 0) return format_to(out, FMT_STRING("{:.{}f}"), val, precision);
+  return format_to(out, FMT_STRING("{:g}"), val);
+}
+
+template <typename Char, typename Rep, typename OutputIt,
+          FMT_ENABLE_IF(std::is_floating_point<Rep>::value && std::is_same<Char, wchar_t>::value)>
+OutputIt format_duration_value(OutputIt out, Rep val, int precision) {
+  if (precision >= 0) return format_to(out, FMT_STRING("L{:.{}f}"), val, precision);
+  return format_to(out, FMT_STRING("L{:g}"), val);
 }
 
 template <typename Char, typename OutputIt>
@@ -791,14 +801,22 @@ OutputIt copy_unit(string_view unit, OutputIt out, wchar_t) {
   return std::copy(u.c_str(), u.c_str() + u.size(), out);
 }
 
-template <typename Char, typename Period, typename OutputIt>
+template <typename Char, typename Period, typename OutputIt,
+          FMT_ENABLE_IF(std::is_same<Char, char>::value)>
 OutputIt format_duration_unit(OutputIt out) {
   if (const char* unit = get_units<Period>())
     return copy_unit(string_view(unit), out, Char());
-  static FMT_CONSTEXPR_DECL const Char num_f[] = {'[', '{', '}', ']', 's', 0};
-  if (const_check(Period::den == 1)) return format_to(out, FMT_STRING(num_f), Period::num);
-  static FMT_CONSTEXPR_DECL const Char num_def_f[] = {'[', '{', '}', '/', '{', '}', ']', 's', 0};
-  return format_to(out, FMT_STRING(num_def_f), Period::num, Period::den);
+  if (const_check(Period::den == 1)) return format_to(out, FMT_STRING("[{}]s"), Period::num);
+  return format_to(out, FMT_STRING("[{}/{}]s"), Period::num, Period::den);
+}
+
+template <typename Char, typename Period, typename OutputIt,
+          FMT_ENABLE_IF(std::is_same<Char, wchar_t>::value)>
+OutputIt format_duration_unit(OutputIt out) {
+  if (const char* unit = get_units<Period>())
+    return copy_unit(string_view(unit), out, Char());
+  if (const_check(Period::den == 1)) return format_to(out, FMT_STRING(L"[{}]s"), Period::num);
+  return format_to(out, FMT_STRING(L"[{}/{}]s"), Period::num, Period::den);
 }
 
 template <typename FormatContext, typename OutputIt, typename Rep,

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -762,17 +762,20 @@ inline std::chrono::duration<Rep, std::milli> get_milliseconds(
   return std::chrono::duration<Rep, std::milli>(static_cast<Rep>(ms));
 }
 
-template <typename Char, typename Rep, typename OutputIt>
+template <typename Char, typename Rep, typename OutputIt,
+          FMT_ENABLE_IF(std::is_integral<Rep>::value)>
+OutputIt format_duration_value(OutputIt out, Rep val, int precision) {
+  static FMT_CONSTEXPR_DECL const Char format[] = {'{', '}', 0};
+  return format_to(out, FMT_STRING(format), val);
+}
+
+template <typename Char, typename Rep, typename OutputIt,
+          FMT_ENABLE_IF(std::is_floating_point<Rep>::value)>
 OutputIt format_duration_value(OutputIt out, Rep val, int precision) {
   static FMT_CONSTEXPR_DECL const Char pr_f[] = {'{', ':', '.', '{', '}', 'f', '}', 0};
   if (precision >= 0) return format_to(out, FMT_STRING(pr_f), val, precision);
   static FMT_CONSTEXPR_DECL const Char fp_f[] = {'{', ':', 'g', '}', 0};
-  static FMT_CONSTEXPR_DECL const Char format[] = {'{', '}', 0};
-  if(std::is_floating_point<Rep>::value) {
-    return format_to(out, FMT_STRING(fp_f), val);  
-  } else {
-    return format_to(out, FMT_STRING(format), val);
-  }
+  return format_to(out, FMT_STRING(fp_f), val);
 }
 
 template <typename Char, typename OutputIt>

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -764,7 +764,7 @@ inline std::chrono::duration<Rep, std::milli> get_milliseconds(
 
 template <typename Char, typename Rep, typename OutputIt,
           FMT_ENABLE_IF(std::is_integral<Rep>::value)>
-OutputIt format_duration_value(OutputIt out, Rep val, int precision) {
+OutputIt format_duration_value(OutputIt out, Rep val, int) {
   static FMT_CONSTEXPR_DECL const Char format[] = {'{', '}', 0};
   return format_to(out, FMT_STRING(format), val);
 }

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -578,7 +578,7 @@ inline std::basic_string<Char> vformat(
 */
 template <typename S, typename... Args, typename Char = char_t<S>>
 inline std::basic_string<Char> format(const text_style& ts, const S& format_str,
-                                      const Args&... args) {
+                                      Args&&... args) {
   return vformat(ts, to_string_view(format_str),
                  fmt::make_args_checked<Args...>(format_str, args...));
 }

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -578,7 +578,7 @@ inline std::basic_string<Char> vformat(
 */
 template <typename S, typename... Args, typename Char = char_t<S>>
 inline std::basic_string<Char> format(const text_style& ts, const S& format_str,
-                                      Args&&... args) {
+                                      const Args&... args) {
   return vformat(ts, to_string_view(format_str),
                  fmt::make_args_checked<Args...>(format_str, args...));
 }

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -145,8 +145,8 @@ FMT_FUNC void format_error_code(detail::buffer<char>& out, int error_code,
   error_code_size += detail::to_unsigned(detail::count_digits(abs_value));
   auto it = buffer_appender<char>(out);
   if (message.size() <= inline_buffer_size - error_code_size)
-    format_to(it, "{}{}", message, SEP);
-  format_to(it, "{}{}", ERROR_STR, error_code);
+    format_to(it, FMT_STRING("{}{}"), message, SEP);
+  format_to(it, FMT_STRING("{}{}"), ERROR_STR, error_code);
   assert(out.size() <= inline_buffer_size);
 }
 
@@ -2662,14 +2662,15 @@ template <> struct formatter<detail::bigint> {
     for (auto i = n.bigits_.size(); i > 0; --i) {
       auto value = n.bigits_[i - 1u];
       if (first) {
-        out = format_to(out, "{:x}", value);
+        out = format_to(out, FMT_STRING("{:x}"), value);
         first = false;
         continue;
       }
-      out = format_to(out, "{:08x}", value);
+      out = format_to(out, FMT_STRING("{:08x}"), value);
     }
     if (n.exp_ > 0)
-      out = format_to(out, "p{}", n.exp_ * detail::bigint::bigit_bits);
+      out = format_to(out, FMT_STRING("p{}"),
+                      n.exp_ * detail::bigint::bigit_bits);
     return out;
   }
 };
@@ -2715,8 +2716,8 @@ FMT_FUNC void format_system_error(detail::buffer<char>& out, int error_code,
       int result =
           detail::safe_strerror(error_code, system_message, buf.size());
       if (result == 0) {
-        format_to(detail::buffer_appender<char>(out), "{}: {}", message,
-                  system_message);
+        format_to(detail::buffer_appender<char>(out), FMT_STRING("{}: {}"),
+                  message, system_message);
         return;
       }
       if (result != ERANGE)

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1815,8 +1815,11 @@ TEST(FormatTest, CompileTimeString) {
   EXPECT_EQ("42", fmt::format(FMT_STRING("{}"), 42));
   EXPECT_EQ(L"42", fmt::format(FMT_STRING(L"{}"), 42));
   EXPECT_EQ("foo", fmt::format(FMT_STRING("{}"), string_like()));
+
+#if defined(_MSC_VER) && _MSC_VER <= 1927
   EXPECT_EQ("42", fmt::format(FMT_STRING(static_with_null), 42));
   EXPECT_EQ(L"42", fmt::format(FMT_STRING(static_with_null_wide), 42));
+#endif
 
   (void)with_null;
   (void)no_null;

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -355,22 +355,20 @@ TEST(MemoryBufferTest, ExceptionInDeallocate) {
 }
 
 template <typename Allocator, size_t MaxSize>
-class allocator_max_size: public Allocator {
+class allocator_max_size : public Allocator {
  public:
   using typename Allocator::value_type;
-  size_t max_size() const FMT_NOEXCEPT {
-    return MaxSize;
-  }
+  size_t max_size() const FMT_NOEXCEPT { return MaxSize; }
   value_type* allocate(size_t n) {
     if (n > max_size()) {
       throw std::length_error("size > max_size");
     }
     return std::allocator_traits<Allocator>::allocate(
-      *static_cast<Allocator *>(this), n);
+        *static_cast<Allocator*>(this), n);
   }
   void deallocate(value_type* p, size_t n) {
-    std::allocator_traits<Allocator>::deallocate(
-      *static_cast<Allocator *>(this), p, n);
+    std::allocator_traits<Allocator>::deallocate(*static_cast<Allocator*>(this),
+                                                 p, n);
   }
 };
 
@@ -383,7 +381,7 @@ TEST(MemoryBufferTest, AllocatorMaxSize) {
   try {
     // new_capacity = 128 + 128/2 = 192 > 160
     buffer.resize(160);
-  } catch (const std::exception &) {
+  } catch (const std::exception&) {
     throws_on_resize = true;
   }
   EXPECT_FALSE(throws_on_resize);
@@ -395,7 +393,7 @@ TEST(MemoryBufferTest, AllocatorMaxSizeOverflow) {
   bool throws_on_resize = false;
   try {
     buffer.resize(161);
-  } catch (const std::exception &) {
+  } catch (const std::exception&) {
     throws_on_resize = true;
   }
   EXPECT_TRUE(throws_on_resize);
@@ -1808,7 +1806,8 @@ fmt::string_view to_string_view(string_like) { return "foo"; }
 constexpr char with_null[3] = {'{', '}', '\0'};
 constexpr char no_null[2] = {'{', '}'};
 static FMT_CONSTEXPR_DECL const char static_with_null[3] = {'{', '}', '\0'};
-static FMT_CONSTEXPR_DECL const wchar_t static_with_null_wide[3] = {'{', '}', '\0'};
+static FMT_CONSTEXPR_DECL const wchar_t static_with_null_wide[3] = {'{', '}',
+                                                                    '\0'};
 static FMT_CONSTEXPR_DECL const char static_no_null[2] = {'{', '}'};
 static FMT_CONSTEXPR_DECL const wchar_t static_no_null_wide[2] = {'{', '}'};
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1807,18 +1807,25 @@ fmt::string_view to_string_view(string_like) { return "foo"; }
 
 constexpr char with_null[3] = {'{', '}', '\0'};
 constexpr char no_null[2] = {'{', '}'};
+static FMT_CONSTEXPR_DECL const char static_with_null[3] = {'{', '}', '\0'};
+static FMT_CONSTEXPR_DECL const wchar_t static_with_null_wide[3] = {'{', '}', '\0'};
+static FMT_CONSTEXPR_DECL const char static_no_null[2] = {'{', '}'};
+static FMT_CONSTEXPR_DECL const wchar_t static_no_null_wide[2] = {'{', '}'};
 
 TEST(FormatTest, CompileTimeString) {
-  static FMT_CONSTEXPR_DECL const char static_with_null[3] = {'{', '}', '\0'};
-  static FMT_CONSTEXPR_DECL const wchar_t static_with_null_wide[3] = {'{', '}', '\0'};
-
   EXPECT_EQ("42", fmt::format(FMT_STRING("{}"), 42));
   EXPECT_EQ(L"42", fmt::format(FMT_STRING(L"{}"), 42));
   EXPECT_EQ("foo", fmt::format(FMT_STRING("{}"), string_like()));
 
-#if defined(_MSC_VER) && _MSC_VER <= 1927
+  (void)static_with_null;
+  (void)static_with_null_wide;
+  (void)static_no_null;
+  (void)static_no_null_wide;
+#if !defined(_MSC_VER)
   EXPECT_EQ("42", fmt::format(FMT_STRING(static_with_null), 42));
   EXPECT_EQ(L"42", fmt::format(FMT_STRING(static_with_null_wide), 42));
+  EXPECT_EQ("42", fmt::format(FMT_STRING(static_no_null), 42));
+  EXPECT_EQ(L"42", fmt::format(FMT_STRING(static_no_null_wide), 42));
 #endif
 
   (void)with_null;

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1809,9 +1809,15 @@ constexpr char with_null[3] = {'{', '}', '\0'};
 constexpr char no_null[2] = {'{', '}'};
 
 TEST(FormatTest, CompileTimeString) {
+  static FMT_CONSTEXPR_DECL const char static_with_null[3] = {'{', '}', '\0'};
+  static FMT_CONSTEXPR_DECL const wchar_t static_with_null_wide[3] = {'{', '}', '\0'};
+
   EXPECT_EQ("42", fmt::format(FMT_STRING("{}"), 42));
   EXPECT_EQ(L"42", fmt::format(FMT_STRING(L"{}"), 42));
   EXPECT_EQ("foo", fmt::format(FMT_STRING("{}"), string_like()));
+  EXPECT_EQ("42", fmt::format(FMT_STRING(static_with_null), 42));
+  EXPECT_EQ(L"42", fmt::format(FMT_STRING(static_with_null_wide), 42));
+
   (void)with_null;
   (void)no_null;
 #if __cplusplus >= 201703L


### PR DESCRIPTION
Update a few internal calls to fmt::format to use FMT_STRING, improving compatibility with the FMT_ENFORCE_COMPILE_STRING compile option.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
