### PR TITLE
:wrench: Silence useless cast warnings

### DIFF
--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -105,7 +105,7 @@ struct uint32_pair {
 TEST(UtilTest, BitCast) {
   auto s = fmt::detail::bit_cast<uint32_pair>(uint64_t{42});
   EXPECT_EQ(fmt::detail::bit_cast<uint64_t>(s), 42ull);
-  s = fmt::detail::bit_cast<uint32_pair>(uint64_t(~0ull));
+  s = fmt::detail::bit_cast<uint32_pair>(~uint64_t{0});
   EXPECT_EQ(fmt::detail::bit_cast<uint64_t>(s), ~0ull);
 }
 


### PR DESCRIPTION
Problem:
- gcc-10 is generating the following warning at all standards:

    test/format-test.cc: In member function 'virtual void UtilTest_BitCast_Test::TestBody()':
    test/format-test.cc:108:42: error: useless cast to type 'uint64_t' {aka 'long long unsigned int'} [-Werror=useless-cast]
      108 |   s = fmt::detail::bit_cast<uint32_pair>(uint64_t(~0ull));
          |                                          ^~~~~~~~~~~~~~~
- gcc-8 is generating the following warning at all standards:
    test/format-test.cc: In member function 'virtual void UtilTest_BitCast_Test::TestBody()':
    test/format-test.cc:108:56: error: useless cast to type 'uint64_t' {aka 'long long unsigned int'} [-Werror=useless-cast]
       s = fmt::detail::bit_cast<uint32_pair>(uint64_t(~0ull));
                                                        ^
Solution:
- Cast 0 to a 64 unsigned bit int and then invert.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
