### PR TITLE
:bug: Implicit sign conversion warning in clang in c++17 and 20 modes

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -515,7 +515,8 @@ constexpr parse_specs_result<T, Char> parse_specs(basic_string_view<Char> str,
   auto ctx = basic_format_parse_context<Char>(str, {}, arg_id + 1);
   auto f = formatter<T, Char>();
   auto end = f.parse(ctx);
-  return {f, pos + (end - str.data()) + 1, ctx.next_arg_id()};
+  return {f, pos + fmt::detail::to_unsigned(end - str.data()) + 1,
+          ctx.next_arg_id()};
 }
 
 // Compiles a non-empty format string and returns the compiled representation


### PR DESCRIPTION
Problem:
- On Apple clang version 11.0.3 (clang-1103.0.32.62) in C++17 and C++20
  mode, clang 11.0.0 in C++17 and C++20 mode, and clang 9.0.1 in C++17
  mode, the following error is generated:

    In file included from test/compile-test.cc:16:
    include/fmt/compile.h:518:25: error: implicit conversion changes signedness: 'long' to 'unsigned long' [-Werror,-Wsign-conversion]
      return {f, pos + (end - str.data()) + 1, ctx.next_arg_id()};
                     ~  ~~~~^~~~~~~~~~~~
    include/fmt/compile.h:538:31: note: in instantiation of function template specialization
          'fmt::v7::detail::parse_specs<int, char>' requested here
          constexpr auto result = parse_specs<id_type>(str, POS + 2, ID);
                                  ^
    include/fmt/compile.h:569:17: note: in instantiation of function template specialization
          'fmt::v7::detail::compile_format_string<fmt::v7::detail::type_list<int>, 0, 0, FMT_COMPILE_STRING>' requested here
            detail::compile_format_string<detail::type_list<Args...>, 0, 0>(
                    ^
    include/fmt/compile.h:648:37: note: in instantiation of function template specialization
          'fmt::v7::detail::compile<int, FMT_COMPILE_STRING, 0>' requested here
      constexpr auto compiled = detail::compile<Args...>(S());
                                        ^
    test/compile-test.cc:140:24: note: in instantiation of function template specialization
          'fmt::v7::format<FMT_COMPILE_STRING, int, 0>' requested here
      EXPECT_EQ("42", fmt::format(FMT_COMPILE("{:x}"), 0x42));
                           ^
    In file included from test/compile-test.cc:16:
    include/fmt/compile.h:518:25: error: implicit conversion changes signedness: 'long' to 'unsigned long' [-Werror,-Wsign-conversion]
      return {f, pos + (end - str.data()) + 1, ctx.next_arg_id()};
                     ~  ~~~~^~~~~~~~~~~~
    include/fmt/compile.h:538:31: note: in instantiation of function template specialization
          'fmt::v7::detail::parse_specs<char [4], char>' requested here
          constexpr auto result = parse_specs<id_type>(str, POS + 2, ID);
                                  ^
    include/fmt/compile.h:494:27: note: in instantiation of function template specialization
          'fmt::v7::detail::compile_format_string<fmt::v7::detail::type_list<int, int, char const (&)[4], int>, 5, 2, FMT_COMPILE_STRING>'
          requested here
        constexpr auto tail = compile_format_string<Args, POS, ID>(format_str);
                              ^
    include/fmt/compile.h:539:14: note: in instantiation of function template specialization
          'fmt::v7::detail::parse_tail<fmt::v7::detail::type_list<int, int, char const (&)[4], int>, 5, 2, fmt::v7::detail::spec_field<char, int, 0>, FMT_COMPILE_STRING>' requested here
          return parse_tail<Args, result.end, result.next_arg_id>(
                 ^
    include/fmt/compile.h:569:17: note: in instantiation of function template specialization
          'fmt::v7::detail::compile_format_string<fmt::v7::detail::type_list<int, int, char const (&)[4], int>, 0, 0, FMT_COMPILE_STRING>'
          requested here
            detail::compile_format_string<detail::type_list<Args...>, 0, 0>(
                    ^
    include/fmt/compile.h:648:37: note: in instantiation of function template specialization
          'fmt::v7::detail::compile<int, int, char const (&)[4], int, FMT_COMPILE_STRING, 0>' requested here
      constexpr auto compiled = detail::compile<Args...>(S());
                                        ^
    test/compile-test.cc:145:18: note: in instantiation of function template specialization
          'fmt::v7::format<FMT_COMPILE_STRING, int, int, char const (&)[4], int, 0>' requested here
                fmt::format(FMT_COMPILE("{:{}}{:{}}"), 42, 4, "foo", 5));
                     ^
    2 errors generated.

Solution:
- Explicitly cast the result of the subtraction to the (unsigned) outer
  type.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
