### PR TITLE
:bug: Cannot call non-constexpr function in constexpr context

### DIFF
--- a/test/std-format-test.cc
+++ b/test/std-format-test.cc
@@ -103,13 +103,17 @@ template <> struct std::formatter<S> {
 
   // Parses a width argument id in the format { <digit> }.
   constexpr auto parse(format_parse_context& ctx) {
+    constexpr auto is_ascii_digit = [](const char c) {
+      return c >= '0' && c <= '9';
+    };
+
     auto iter = ctx.begin();
     // auto get_char = [&]() { return iter != ctx.end() ? *iter : 0; };
     auto get_char = [&]() { return iter != ctx.end() ? *iter : '\0'; };
     if (get_char() != '{') return iter;
     ++iter;
     char c = get_char();
-    if (!isdigit(c) || (++iter, get_char()) != '}')
+    if (!is_ascii_digit(c) || (++iter, get_char()) != '}')
       throw format_error("invalid format");
     width_arg_id = fmt::detail::to_unsigned(c - '0');
     ctx.check_arg_id(width_arg_id);


### PR DESCRIPTION
Problem:
- gcc-8 gives the following error when compiling this function on all
  standards:
```
    test/std-format-test.cc: In member function 'constexpr auto std::formatter<S>::parse(std::format_parse_context&)':
    test/std-format-test.cc:112:17: error: call to non-'constexpr' function 'int isdigit(int)'
        if (!isdigit(c) || (++iter, get_char()) != '}')
         ~~~~~~~^~~
```

Solution:
- Write a `constexpr` version of `isdigit` for use in this function.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
