### PR TITLE
fix wrong order of expected and actual in truncated_printf_context te…

### DIFF
--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -617,12 +617,14 @@ TEST(PrintfTest, PrintfDetermineOutputSize) {
 
   const auto format_string = "%s";
   const auto format_arg = "Hello";
-  const auto expected_size = fmt::sprintf(format_string, format_arg).size();
+  const auto expected_size = 5;
 
-  EXPECT_EQ((truncated_printf_context(
+  EXPECT_EQ(expected_size, fmt::sprintf(format_string, format_arg).size());
+
+  EXPECT_EQ(expected_size,
+            (truncated_printf_context(
                  fmt::detail::truncating_iterator<backit>(it, 0), format_string,
                  fmt::make_format_args<truncated_printf_context>(format_arg))
                  .format()
-                 .count()),
-            expected_size);
+                 .count()));
 }


### PR DESCRIPTION
…st in PrintfDetermineOutputSize, make test of normal sprintf in a separate step

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
