### PR TITLE
detail::write in one more place relevant to printf with long argument…

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -638,6 +638,7 @@ void iterator_buffer<OutputIt, T, Traits>::flush() {
   out_ = copy_str<T>(data_, data_ + this->limit(this->size()), out_);
   this->clear();
 }
+
 }  // namespace detail
 
 // The number of characters to store in the basic_memory_buffer object itself
@@ -1518,6 +1519,34 @@ FMT_NOINLINE OutputIt fill(OutputIt it, size_t n, const fill_t<Char>& fill) {
   return it;
 }
 
+template <typename Char, typename OutputIt>
+OutputIt write(OutputIt out, monostate) {
+  FMT_ASSERT(false, "");
+  return out;
+}
+
+template <typename Char, typename OutputIt,
+          FMT_ENABLE_IF(!std::is_same<Char, char>::value)>
+OutputIt write(OutputIt out, string_view value) {
+  auto it = reserve(out, value.size());
+  it = copy_str<Char>(value.begin(), value.end(), it);
+  return base_iterator(out, it);
+}
+
+template <typename Char, typename OutputIt>
+OutputIt write(OutputIt out, basic_string_view<Char> value) {
+  auto it = reserve(out, value.size());
+  it = copy_str<Char>(value.begin(), value.end(), it);
+  return base_iterator(out, it);
+}
+
+template <typename Char>
+buffer_appender<Char> write(buffer_appender<Char> out,
+                            basic_string_view<Char> value) {
+  get_container(out).append(value.begin(), value.end());
+  return out;
+}
+
 // Writes the output of f, padded according to format specifications in specs.
 // size: output size in code units.
 // width: output display width in (terminal) column positions.
@@ -1607,7 +1636,7 @@ OutputIt write(OutputIt out, basic_string_view<StrChar> s,
                    : 0;
   using iterator = remove_reference_t<decltype(reserve(out, 0))>;
   return write_padded(out, specs, size, width, [=](iterator it) {
-    return copy_str<Char>(data, data + size, it);
+    return detail::write<Char>(it, basic_string_view<StrChar>(data, size));
   });
 }
 
@@ -2033,34 +2062,6 @@ OutputIt write_ptr(OutputIt out, UIntPtr value,
 template <typename T> struct is_integral : std::is_integral<T> {};
 template <> struct is_integral<int128_t> : std::true_type {};
 template <> struct is_integral<uint128_t> : std::true_type {};
-
-template <typename Char, typename OutputIt>
-OutputIt write(OutputIt out, monostate) {
-  FMT_ASSERT(false, "");
-  return out;
-}
-
-template <typename Char, typename OutputIt,
-          FMT_ENABLE_IF(!std::is_same<Char, char>::value)>
-OutputIt write(OutputIt out, string_view value) {
-  auto it = reserve(out, value.size());
-  it = copy_str<Char>(value.begin(), value.end(), it);
-  return base_iterator(out, it);
-}
-
-template <typename Char, typename OutputIt>
-OutputIt write(OutputIt out, basic_string_view<Char> value) {
-  auto it = reserve(out, value.size());
-  it = copy_str<Char>(value.begin(), value.end(), it);
-  return base_iterator(out, it);
-}
-
-template <typename Char>
-buffer_appender<Char> write(buffer_appender<Char> out,
-                            basic_string_view<Char> value) {
-  get_container(out).append(value.begin(), value.end());
-  return out;
-}
 
 template <typename Char, typename OutputIt, typename T,
           FMT_ENABLE_IF(is_integral<T>::value &&

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2063,13 +2063,6 @@ OutputIt write(OutputIt out, basic_string_view<Char> value) {
   return base_iterator(out, it);
 }
 
-template <typename Char>
-buffer_appender<Char> write(buffer_appender<Char> out,
-                            basic_string_view<Char> value) {
-  get_container(out).append(value.begin(), value.end());
-  return out;
-}
-
 template <typename Char, typename OutputIt, typename T,
           FMT_ENABLE_IF(is_integral<T>::value &&
                         !std::is_same<T, bool>::value &&

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -638,7 +638,6 @@ void iterator_buffer<OutputIt, T, Traits>::flush() {
   out_ = copy_str<T>(data_, data_ + this->limit(this->size()), out_);
   this->clear();
 }
-
 }  // namespace detail
 
 // The number of characters to store in the basic_memory_buffer object itself


### PR DESCRIPTION
…s, requires moving the definition of detail::write up in the file

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

The benchmark just looks at the scaling for a long string argument:
```C++

#include <benchmark/benchmark.h>
#include <fmt/printf.h

void long_printf_format_arg(benchmark::State& state) {
  std::string format_string = "%s";
  std::string message = std::string(state.range(0), 'A');
  for (auto _ : state) {
    benchmark::DoNotOptimize(fmt::sprintf(format_string, message));
  };
}
BENCHMARK(long_printf_format_arg)->Arg(10)->Arg(100)->Arg(1000)->Arg(10000);

void long_fmt_format_arg(benchmark::State& state) {
  std::string format_string = "{}";
  std::string message = std::string(state.range(0), 'A');
  for (auto _ : state) {
    benchmark::DoNotOptimize(fmt::format(format_string, message));
  };
}
BENCHMARK(long_fmt_format_arg)->Arg(10)->Arg(100)->Arg(1000)->Arg(10000);

BENCHMARK_MAIN();
```
Timings on main (986fa00406c4ce6e2b60639ca85d36cfc58eb43c):
```
-----------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations
-----------------------------------------------------------------------
long_printf_format_arg/10          38.9 ns         38.9 ns     17873649
long_printf_format_arg/100          192 ns          192 ns      3640240
long_printf_format_arg/1000        1297 ns         1297 ns       526502
long_printf_format_arg/10000      11060 ns        11059 ns        62581
long_fmt_format_arg/10             15.7 ns         15.7 ns     44365010
long_fmt_format_arg/100            75.3 ns         75.3 ns      9133969
long_fmt_format_arg/1000            121 ns          121 ns      5455920
long_fmt_format_arg/10000           275 ns          275 ns      2542404
```

Timings on the branch (6684314ccd2b48b32f5884b):
```
-----------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations
-----------------------------------------------------------------------
long_printf_format_arg/10          37.0 ns         37.0 ns     18809721
long_printf_format_arg/100         94.1 ns         94.1 ns      7307423
long_printf_format_arg/1000         250 ns          250 ns      2756264
long_printf_format_arg/10000        443 ns          443 ns      1569507
long_fmt_format_arg/10             15.8 ns         15.8 ns     43821209
long_fmt_format_arg/100            75.8 ns         75.8 ns      9125515
long_fmt_format_arg/1000            118 ns          118 ns      5865348
long_fmt_format_arg/10000           294 ns          294 ns      2473629
```

