### PR TITLE
:new: [CI] Test with C++14 in Windows 2019

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,10 @@ jobs:
         build_type: [Debug, Release]
         include:
           - os: windows-2016
+            standard: 11
+          - os: windows-2019
+            standard: 14
+          - os: windows-2016
             platform: Win32
             build_type: Debug
             shared: -DBUILD_SHARED_LIBS=ON
@@ -33,7 +37,9 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: |
         cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} ${{matrix.shared}} \
-              -A ${{matrix.platform}} $GITHUB_WORKSPACE
+              -A ${{matrix.platform}} \
+              -DCMAKE_CXX_STANDARD=${{matrix.standard}} \
+              $GITHUB_WORKSPACE
 
     - name: Build
       working-directory: ${{runner.workspace}}/build


### PR DESCRIPTION
Problem:
- Both Windows builds test C++14

Solution:
- Use C++11 for `windows-2016` builds and C++14 for `windows-2019`
  builds.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
