### PR TITLE
Update build.gradle for latest AGP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ gradle/
 gradlew*
 local.properties
 build/
+support/.cxx
 
 bin/
 /_CPack_Packages

--- a/support/build.gradle
+++ b/support/build.gradle
@@ -117,4 +117,16 @@ assemble.doLast
     // Remove empty directory
     delete "${rootDir}/libs/debug/obj"
     delete "${rootDir}/libs/release/obj"
+
+    // Copy AAR files. Notice that the aar is named after the folder of this script.
+    copy {
+        from "build/outputs/aar/support-release.aar"
+        into "${rootDir}/libs"
+        rename "support-release.aar", "fmt-release.aar"
+    }
+    copy {
+        from "build/outputs/aar/support-debug.aar"
+        into "${rootDir}/libs"
+        rename "support-debug.aar", "fmt-debug.aar"
+    }
 }

--- a/support/build.gradle
+++ b/support/build.gradle
@@ -1,3 +1,4 @@
+import java.nio.file.Paths
 
 // General gradle arguments for root project
 buildscript {    
@@ -7,24 +8,25 @@ buildscript {
     }
     dependencies {
         //
-        // https://developer.android.com/studio/releases/gradle-plugin
+        // https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
         //
-        // Notice that 3.3.0 here is the version of [Android Gradle Plugin]
-        // Accroding to URL above you will need Gradle 5.0 or higher
+        // Notice that 4.0.0 here is the version of [Android Gradle Plugin]
+        // Accroding to URL above you will need Gradle 6.1 or higher
         //
-        // If you are using Android Studio, and it is using Gradle's lower 
-        // version, Use the plugin version 3.1.3 ~ 3.2.0 for Gradle 4.4 ~ 4.10
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath "com.android.tools.build:gradle:4.1.1"
     }
 }
 repositories {
     google()
     jcenter()
 }
-    
-// Output: Shared library (.so) for Android 
-apply plugin: 'com.android.library'
 
+// Project's root where CMakeLists.txt exists: rootDir/support/.cxx -> rootDir
+def rootDir = Paths.get(project.buildDir.getParent()).getParent()
+println("rootDir: ${rootDir}")
+
+// Output: Shared library (.so) for Android 
+apply plugin: "com.android.library"
 android {
     compileSdkVersion 25    // Android 7.0
 
@@ -41,13 +43,13 @@ android {
             include  "arm64-v8a", "armeabi-v7a", "x86_64"
         }
     }
+    ndkVersion "21.3.6528147" // ANDROID_NDK_HOME is deprecated. Be explicit
 
     defaultConfig {
         minSdkVersion 21    // Android 5.0+
         targetSdkVersion 25 // Follow Compile SDK
-        versionCode 21      // Follow release count
-        versionName "5.3.0" // Follow Official version
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        versionCode 34      // Follow release count
+        versionName "7.1.2" // Follow Official version
         
         externalNativeBuild {
             cmake {
@@ -56,9 +58,9 @@ android {
                 arguments "-DFMT_TEST=false"            // Skip test
                 arguments "-DFMT_DOC=false"             // Skip document
                 cppFlags  "-std=c++17"
+                targets   "fmt"
             }
         }
-        println("Gradle CMake Plugin: ")
         println(externalNativeBuild.cmake.cppFlags)
         println(externalNativeBuild.cmake.arguments)
     }
@@ -69,16 +71,27 @@ android {
     //    neighbor of the top level cmake
     externalNativeBuild {
         cmake {
-            path "../CMakeLists.txt"
+            version "3.10.0+"
+            path "${rootDir}/CMakeLists.txt"
             // buildStagingDirectory "./build"  // Custom path for cmake output
         }
-        //println(cmake.path)
     }
     
     sourceSets{
         // Android Manifest for Gradle
         main {
-            manifest.srcFile 'AndroidManifest.xml'
+            manifest.srcFile "AndroidManifest.xml"
+        }
+    }
+
+    // https://developer.android.com/studio/build/native-dependencies#build_system_configuration
+    buildFeatures {
+        prefab true
+        prefabPublishing true
+    }
+    prefab {
+        fmt {
+            headers "${rootDir}/include"
         }
     }
 }
@@ -88,20 +101,20 @@ assemble.doLast
     // Instead of `ninja install`, Gradle will deploy the files.
     // We are doing this since FMT is dependent to the ANDROID_STL after build
     copy {
-        from 'build/intermediates/cmake'
-        into '../libs'
+        from "build/intermediates/cmake"
+        into "${rootDir}/libs"
     }
     // Copy debug binaries
     copy {
-        from '../libs/debug/obj'
-        into '../libs/debug'
+        from "${rootDir}/libs/debug/obj"
+        into "${rootDir}/libs/debug"
     }
     // Copy Release binaries
     copy {
-        from '../libs/release/obj'
-        into '../libs/release'
+        from "${rootDir}/libs/release/obj"
+        into "${rootDir}/libs/release"
     }
     // Remove empty directory
-    delete '../libs/debug/obj'
-    delete '../libs/release/obj'
+    delete "${rootDir}/libs/debug/obj"
+    delete "${rootDir}/libs/release/obj"
 }


### PR DESCRIPTION
### Changes

[Last month(2020/10), there was Android Studio 4.1 release](https://android-developers.googleblog.com/2020/10/android-studio-41.html), this PR targets that. 

#### Tool Requirement

Adjust for the IDE (Android Studio)

* Gradle 5.x -> 6.6.1
* Android Gradle Plugin 3.x -> 4.1.1
* Android NDK `21.3.6528147`

NDK version is not mandatory. Users can comment the line, and use their own.

#### Usage

The build step is not changed.

```bash
pushd support # this folder has build.gradle
    gradle assemble
popd

tree -L 2 ./libs
```

#### Note

ignore `.cxx` which was `externalNativeBuild` in old Android Gradle Plugin versions

`build.gradle` file now uses variable `rootDir` instead of using the relative path to make ease of understanding.

```console
user:host$ pushd support/
~/dev/fmt/support ~/dev/fmt
user:host$ gradle assemble

> Configure project :
rootDir: /Users/user/dev/fmt
[-std=c++17]
[-DANDROID_STL=c++_shared, -DBUILD_SHARED_LIBS=true, -DFMT_TEST=false, -DFMT_DOC=false]

> Task...
```

After the install, the `libs/` folder will contain `.so` for each architecture and `.aar` files

```console
user:host$ tree $(pwd)/../libs
/Users/user/dev/fmt/support/../libs
├── debug
│   ├── arm64-v8a
│   ├── armeabi-v7a
│   └── x86_64
│       ├── libc++_shared.so
│       └── libfmtd.so
├── fmt-debug.aar
├── fmt-release.aar
└── release
    ├── arm64-v8a
    ├── armeabi-v7a
    └── x86_64
```

With the AGP 4.1, the aar include files in `include/fmt/*.h`.
```console
user:host$ unzip ./fmt-debug.aar -d .
Archive:  ./fmt-debug.aar
  inflating: ./R.txt                 
  inflating: ./AndroidManifest.xml   
  inflating: ./classes.jar           
   creating: ./jni/
...
  creating: ./prefab/modules/fmt/include/
   creating: ./prefab/modules/fmt/include/fmt/
  inflating: ./prefab/modules/fmt/include/fmt/chrono.h  
  inflating: ./prefab/modules/fmt/include/fmt/color.h  
...
  inflating: ./prefab/modules/fmt/include/fmt/ranges.h  
   creating: ./prefab/modules/fmt/libs/
   creating: ./prefab/modules/fmt/libs/android.arm64-v8a/
  inflating: ./prefab/modules/fmt/libs/android.arm64-v8a/abi.json  
  inflating: ./prefab/modules/fmt/libs/android.arm64-v8a/libfmtd.so  
...
```
### Related Issues

#### Previous Work

#1039 (update for Gradle 5.2)

### License Agreement

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
