### PR TITLE
Fix join for specific types (#1981)

### DIFF
--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -11,6 +11,7 @@
 #include <cfloat>
 #include <climits>
 #include <cmath>
+#include <cstddef>
 #include <cstring>
 #include <list>
 #include <memory>
@@ -1759,6 +1760,20 @@ TEST(FormatTest, JoinArg) {
   EXPECT_EQ("(1, 2, 3)", format("({})", join(v1, ", ")));
   EXPECT_EQ("(+01.20, +03.40)", format("({:+06.2f})", join(v2, ", ")));
 #endif
+}
+
+TEST(FormatTest, JoinByte) {
+  using fmt::join;
+#if __cplusplus >= 201703L
+  using byte = std::byte;
+#else
+  enum class byte : unsigned char {};
+#endif
+
+  std::vector<byte> v = {static_cast<byte>(0x1), static_cast<byte>(0x2)};
+
+  EXPECT_EQ("(1, 2)", format("({})", join(v, ", ")));
+  EXPECT_EQ("(0x1, 0x2)", format("({0:#x})", join(v, ", ")));
 }
 
 template <typename T> std::string str(const T& value) {

--- a/test/ostream-test.cc
+++ b/test/ostream-test.cc
@@ -188,6 +188,11 @@ TEST(OStreamTest, Join) {
   EXPECT_EQ("1, 2, 3", fmt::format("{}", fmt::join(v, v + 3, ", ")));
 }
 
+TEST(OStreamTest, JoinCustom) {
+  auto strs = std::vector<TestString>{TestString("foo"), TestString("bar")};
+  EXPECT_EQ("foo, bar", fmt::format("{}", fmt::join(strs, ", ")));
+}
+
 #if FMT_USE_CONSTEXPR
 TEST(OStreamTest, ConstexprString) {
   EXPECT_EQ("42", format(FMT_STRING("{}"), std::string("42")));


### PR DESCRIPTION
Try to apply the same rules for iterator value type (join) as for
regular types.

Try to convert iterator value type to a formattable one.
For instance if the join operation refers to an enum class iterator
(such as std::byte) then try to use the enum class underlying type.

Also try to use a fallback formatter if available.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
