### PR TITLE
Add print overload accepting locale to locale.h

### DIFF
--- a/include/fmt/locale.h
+++ b/include/fmt/locale.h
@@ -52,11 +52,24 @@ inline OutputIt vformat_to(
 
 template <typename OutputIt, typename S, typename... Args,
           bool enable = detail::is_output_iterator<OutputIt, char_t<S>>::value>
-inline auto format_to(OutputIt out, const std::locale& loc,
-                      const S& format_str, Args&&... args) ->
+inline auto format_to(OutputIt out, const std::locale& loc, const S& format_str,
+                      Args&&... args) ->
     typename std::enable_if<enable, OutputIt>::type {
   const auto& vargs = fmt::make_args_checked<Args...>(format_str, args...);
   return vformat_to(out, loc, to_string_view(format_str), vargs);
+}
+
+template <typename S, typename... Args, typename Char = char_t<S>>
+inline void print(std::FILE* f, const std::locale& loc, const S& format_str,
+                  Args&&... args) {
+  const auto str = fmt::format(loc, format_str, std::forward<Args>(args)...);
+
+  static FMT_CONSTEXPR_DECL const Char print_fmt_str[] = {'{', '}', 0};
+  fmt::print(f, FMT_STRING(print_fmt_str), str);
+}
+template <typename S, typename... Args, typename Char = char_t<S>>
+inline void print(const std::locale& loc, const S& format_str, Args&&... args) {
+  print(stdout, loc, format_str, std::forward<Args>(args)...);
 }
 
 FMT_END_NAMESPACE

--- a/test/locale-test.cc
+++ b/test/locale-test.cc
@@ -10,6 +10,7 @@
 #include <complex>
 
 #include "gmock.h"
+#include "gtest-extra.h"
 
 using fmt::detail::max_value;
 
@@ -139,8 +140,7 @@ template <class charT> struct formatter<std::complex<double>, charT> {
     auto imag = fmt::format(ctx.locale().template get<std::locale>(),
                             "{:" + specs + "}", c.imag());
     auto fill_align_width = std::string();
-    if (specs_.width > 0)
-      fill_align_width = fmt::format(">{}", specs_.width);
+    if (specs_.width > 0) fill_align_width = fmt::format(">{}", specs_.width);
     return format_to(
         ctx.out(), "{:" + fill_align_width + "}",
         fmt::format(c.real() != 0 ? "({0}+{1}i)" : "{1}i", real, imag));
@@ -155,4 +155,14 @@ TEST(FormatTest, Complex) {
   EXPECT_EQ(fmt::format("{:8}", std::complex<double>(1, 2)), "  (1+2i)");
 }
 
+TEST(FormatTest, Print) {
+  std::locale special_grouping_loc(std::locale(), new special_grouping<char>());
+  EXPECT_WRITE(stdout, fmt::print(std::locale(), "{:L}", 12345678), "12345678");
+  EXPECT_WRITE(stdout, fmt::print(special_grouping_loc, "{:L}", 12345678),
+               "1,23,45,678");
+  EXPECT_WRITE(stdout, fmt::print(special_grouping_loc, "{:L}", 12345),
+               "12,345");
+  EXPECT_WRITE(stderr, fmt::print(stderr, special_grouping_loc, "{:L}", 12345),
+               "12,345");
+}
 #endif  // FMT_STATIC_THOUSANDS_SEPARATOR

--- a/test/locale-test.cc
+++ b/test/locale-test.cc
@@ -164,5 +164,10 @@ TEST(FormatTest, Print) {
                "12,345");
   EXPECT_WRITE(stderr, fmt::print(stderr, special_grouping_loc, "{:L}", 12345),
                "12,345");
+
+  // The wide string overload is expected to compile, but fail to execute.
+  if (fmt::detail::const_check(false))
+    EXPECT_WRITE(stdout, fmt::print(std::locale(), L"{:L}", 12345678),
+                 "12345678");
 }
 #endif  // FMT_STATIC_THOUSANDS_SEPARATOR


### PR DESCRIPTION
Nothing complicated, just fills a coverage gap in the API by providing fmt::print overloads in locale.h. Feel free to reject if this feature is undesired.