### PR TITLE
Fix formatting with compile-time API when format string is empty

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -643,7 +643,7 @@ FMT_INLINE std::basic_string<typename S::char_type> format(const S&,
 #ifdef __cpp_if_constexpr
   if constexpr (std::is_same<typename S::char_type, char>::value) {
     constexpr basic_string_view<typename S::char_type> str = S();
-    if (str.size() == 2 && str[0] == '{' && str[1] == '}')
+    if constexpr (str.size() == 2 && str[0] == '{' && str[1] == '}')
       return fmt::to_string(detail::first(args...));
   }
 #endif

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -173,6 +173,10 @@ TEST(CompileTest, TextAndArg) {
   EXPECT_EQ(">>>42<<<", fmt::format(FMT_COMPILE(">>>{}<<<"), 42));
   EXPECT_EQ("42!", fmt::format(FMT_COMPILE("{}!"), 42));
 }
+
+TEST(CompileTest, Empty) {
+  EXPECT_EQ("", fmt::format(FMT_COMPILE("")));
+}
 #endif
 
 #if __cplusplus >= 202002L


### PR DESCRIPTION
Right now {fmt} cannot be used with empty string format with compile-time API, while it can be used with regular API:

```cpp
fmt::format(""); // ok
fmt::format(FMT_COMPILE("")); // compilation error
```
Proof on [Compiler Explorer](https://godbolt.org/z/6Yj38a)

With this tiny fix, compile-time API also get this useless feature.
Also, a test for `FMT_COMPILE` with an empty string added.