### PR TITLE
Add UDL as replacement for FMT_COMPILE

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -13,6 +13,12 @@
 
 #include "format.h"
 
+#if !defined(FMT_USE_NONTYPE_TEMPLATE_PARAMETERS) &&   \
+    defined(__cpp_nontype_template_parameter_class) && \
+    (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 903)
+#  define FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
+#endif
+
 FMT_BEGIN_NAMESPACE
 namespace detail {
 
@@ -37,9 +43,8 @@ struct is_compiled_string : std::is_base_of<compiled_string, S> {};
  */
 #define FMT_COMPILE(s) FMT_STRING_IMPL(s, fmt::detail::compiled_string)
 
-#if defined(__cpp_nontype_template_parameter_class) && \
-    (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 903)
-template <typename Char, std::size_t N> struct fixed_string {
+#ifdef FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
+template <typename Char, size_t N> struct fixed_string {
   constexpr fixed_string(const Char (&str)[N + 1]) {
     copy_str<Char, const Char*, Char*>(static_cast<const Char*>(str), str + N,
                                        data);
@@ -47,10 +52,10 @@ template <typename Char, std::size_t N> struct fixed_string {
   Char data[N]{};
 };
 
-template <typename Char, std::size_t N>
+template <typename Char, size_t N>
 fixed_string(const Char (&str)[N]) -> fixed_string<Char, N - 1>;
 
-template <typename Char, std::size_t N, fixed_string<Char, N> Str>
+template <typename Char, size_t N, fixed_string<Char, N> Str>
 struct udl_compiled_string : compiled_string {
   using char_type = Char;
   constexpr operator basic_string_view<char_type>() const {
@@ -720,8 +725,7 @@ size_t formatted_size(const CompiledFormat& cf, const Args&... args) {
   return format_to(detail::counting_iterator(), cf, args...).count();
 }
 
-#if defined(__cpp_nontype_template_parameter_class) && \
-    (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 903)
+#ifdef FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
 inline namespace literals {
 template <detail::fixed_string Str>
 constexpr detail::udl_compiled_string<remove_cvref_t<decltype(Str.data[0])>,

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -55,9 +55,6 @@ template <typename Char, size_t N> struct fixed_string {
   Char data[N]{};
 };
 
-template <typename Char, size_t N>
-fixed_string(const Char (&str)[N]) -> fixed_string<Char, N>;
-
 template <typename Char, size_t N, fixed_string<Char, N> Str>
 struct udl_compiled_string : compiled_string {
   using char_type = Char;

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -13,10 +13,13 @@
 
 #include "format.h"
 
-#if !defined(FMT_USE_NONTYPE_TEMPLATE_PARAMETERS) &&   \
-    defined(__cpp_nontype_template_parameter_class) && \
-    (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 903)
-#  define FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
+#ifndef FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
+#  if defined(__cpp_nontype_template_parameter_class) && \
+      (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 903)
+#    define FMT_USE_NONTYPE_TEMPLATE_PARAMETERS 1
+#  else
+#    define FMT_USE_NONTYPE_TEMPLATE_PARAMETERS 0
+#  endif
 #endif
 
 FMT_BEGIN_NAMESPACE
@@ -43,7 +46,7 @@ struct is_compiled_string : std::is_base_of<compiled_string, S> {};
  */
 #define FMT_COMPILE(s) FMT_STRING_IMPL(s, fmt::detail::compiled_string)
 
-#ifdef FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
+#if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
 template <typename Char, size_t N> struct fixed_string {
   constexpr fixed_string(const Char (&str)[N]) {
     copy_str<Char, const Char*, Char*>(static_cast<const Char*>(str), str + N,
@@ -725,7 +728,7 @@ size_t formatted_size(const CompiledFormat& cf, const Args&... args) {
   return format_to(detail::counting_iterator(), cf, args...).count();
 }
 
-#ifdef FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
+#if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
 inline namespace literals {
 template <detail::fixed_string Str>
 constexpr detail::udl_compiled_string<remove_cvref_t<decltype(Str.data[0])>,

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -45,7 +45,7 @@ struct is_compiled_string : std::is_base_of<compiled_string, S> {};
 
 #ifdef FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
 template <typename Char, size_t N> struct fixed_string {
-  constexpr fixed_string(const Char (&str)[N + 1]) {
+  constexpr fixed_string(const Char (&str)[N]) {
     copy_str<Char, const Char*, Char*>(static_cast<const Char*>(str), str + N,
                                        data);
   }
@@ -53,13 +53,13 @@ template <typename Char, size_t N> struct fixed_string {
 };
 
 template <typename Char, size_t N>
-fixed_string(const Char (&str)[N]) -> fixed_string<Char, N - 1>;
+fixed_string(const Char (&str)[N]) -> fixed_string<Char, N>;
 
 template <typename Char, size_t N, fixed_string<Char, N> Str>
 struct udl_compiled_string : compiled_string {
   using char_type = Char;
   constexpr operator basic_string_view<char_type>() const {
-    return {Str.data, N};
+    return {Str.data, N - 1};
   }
 };
 #endif

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -182,6 +182,7 @@ TEST(CompileTest, Empty) {
 #ifdef FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
 TEST(CompileTest, CompileFormatStringLiteral) {
   using namespace fmt::literals;
+  EXPECT_EQ("", fmt::format(""_cf));
   EXPECT_EQ("42", fmt::format("{}"_cf, 42));
 }
 #endif

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -179,8 +179,7 @@ TEST(CompileTest, Empty) {
 }
 #endif
 
-#if defined(__cpp_nontype_template_parameter_class) && \
-    (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 903)
+#ifdef FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
 TEST(CompileTest, CompileFormatStringLiteral) {
   using namespace fmt::literals;
   EXPECT_EQ("42", fmt::format("{}"_cf, 42));

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -179,7 +179,7 @@ TEST(CompileTest, Empty) {
 }
 #endif
 
-#ifdef FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
+#if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
 TEST(CompileTest, CompileFormatStringLiteral) {
   using namespace fmt::literals;
   EXPECT_EQ("", fmt::format(""_cf));

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -179,6 +179,14 @@ TEST(CompileTest, Empty) {
 }
 #endif
 
+#if defined(__cpp_nontype_template_parameter_class) && \
+    (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 903)
+TEST(CompileTest, CompileFormatStringLiteral) {
+  using namespace fmt::literals;
+  EXPECT_EQ("42", fmt::format("{}"_cf, 42));
+}
+#endif
+
 #if __cplusplus >= 202002L
 template <size_t max_string_length> struct test_string {
   template <typename T> constexpr bool operator==(const T& rhs) const noexcept {


### PR DESCRIPTION
Right now {fmt} has a special macro to invoke compile-time API functions - `FMT_COMPILE`. This macro can be replaced with UDL for modern compilers that support C++20. The chosen name in this PR for this feature is `_cf`.

```cpp
fmt::format(FMT_COMPILE("{}"), 42); // 🙁 not modern
fmt::format("{}"_cf, 42); // 🙂 modern as hell
```

Note that only GCC 9.3+ support that. Clang (trunk) is also able to compile this code, but it doesn't have `__cpp_nontype_template_parameter_class` defined, I hope it'll be fixed in Clang 12 release.
Proof on [Compiler Explorer](https://godbolt.org/z/boTTr9)

`constexpr` is used instead of `consteval` (even though it would make more sense) to lower GCC version.

Also, I should note that this PR is based on my own ideas and the following comments: https://github.com/fmtlib/fmt/issues/1874#issuecomment-716097084, https://github.com/fmtlib/fmt/issues/613#issuecomment-491906397.