### PR TITLE
Simplify CompileTimeFormattingTest tests by reordering arguments of EXPECT_EQ

### DIFF
--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -180,7 +180,6 @@ template <size_t max_string_length> struct test_string {
   template <typename T> constexpr bool operator==(const T& rhs) const noexcept {
     return (std::string_view(rhs).compare(buffer.data()) == 0);
   }
-
   std::array<char, max_string_length> buffer{};
 };
 
@@ -192,51 +191,26 @@ consteval auto test_format(auto format, const Args&... args) {
 }
 
 TEST(CompileTimeFormattingTest, Bool) {
-  {
-    constexpr auto result = test_format<5>(FMT_COMPILE("{}"), true);
-    EXPECT_EQ(result, "true");
-  }
-  {
-    constexpr auto result = test_format<6>(FMT_COMPILE("{}"), false);
-    EXPECT_EQ(result, "false");
-  }
+  EXPECT_EQ("true", test_format<5>(FMT_COMPILE("{}"), true));
+  EXPECT_EQ("false", test_format<6>(FMT_COMPILE("{}"), false));
 }
 
 TEST(CompileTimeFormattingTest, Integer) {
-  {
-    constexpr auto result = test_format<3>(FMT_COMPILE("{}"), 42);
-    EXPECT_EQ(result, "42");
-  }
-  {
-    constexpr auto result = test_format<4>(FMT_COMPILE("{}"), 420);
-    EXPECT_EQ(result, "420");
-  }
-  {
-    constexpr auto result = test_format<6>(FMT_COMPILE("{} {}"), 42, 42);
-    EXPECT_EQ(result, "42 42");
-  }
-  {
-    constexpr auto result =
-        test_format<6>(FMT_COMPILE("{} {}"), uint32_t{42}, uint64_t{42});
-    EXPECT_EQ(result, "42 42");
-  }
+  EXPECT_EQ("42", test_format<3>(FMT_COMPILE("{}"), 42));
+  EXPECT_EQ("420", test_format<4>(FMT_COMPILE("{}"), 420));
+  EXPECT_EQ("42 42", test_format<6>(FMT_COMPILE("{} {}"), 42, 42));
+  EXPECT_EQ("42 42",
+            test_format<6>(FMT_COMPILE("{} {}"), uint32_t{42}, uint64_t{42}));
 }
 
 TEST(CompileTimeFormattingTest, String) {
-  {
-    constexpr auto result = test_format<3>(FMT_COMPILE("{}"), "42");
-    EXPECT_EQ(result, "42");
-  }
-  {
-    constexpr auto result =
-        test_format<17>(FMT_COMPILE("{} is {}"), "The answer", "42");
-    EXPECT_EQ(result, "The answer is 42");
-  }
+  EXPECT_EQ("42", test_format<3>(FMT_COMPILE("{}"), "42"));
+  EXPECT_EQ("The answer is 42",
+            test_format<17>(FMT_COMPILE("{} is {}"), "The answer", "42"));
 }
 
 TEST(CompileTimeFormattingTest, Combination) {
-  constexpr auto result =
-      test_format<18>(FMT_COMPILE("{}, {}, {}"), 420, true, "answer");
-  EXPECT_EQ(result, "420, true, answer");
+  EXPECT_EQ("420, true, answer",
+            test_format<18>(FMT_COMPILE("{}, {}, {}"), 420, true, "answer"));
 }
 #endif


### PR DESCRIPTION
Extends #2019 by simplifying tests. This change was requested there https://github.com/fmtlib/fmt/pull/2019#discussion_r532121123 but I didn't manage to simplify it.

Turns out that the position in `EXPECT_EQ` macro is the key:
```cpp
EXPECT_EQ(test_format<5>(FMT_COMPILE("{}"), true), "true"); // compilation error
EXPECT_EQ("true", test_format<5>(FMT_COMPILE("{}"), true)); // ok
```

In this PR arguments are just swapped, so the result is the first argument. Just like all over the file:
https://github.com/fmtlib/fmt/blob/5a493560f59369e9fa664e8945b8e8a8ec4391b2/test/compile-test.cc#L125-L136