### PR TITLE
Fix MSVC workaround with FMT_ENFORCE_COMPILE_STRING

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -770,8 +770,8 @@ template <typename Char, typename Rep, typename OutputIt,
 OutputIt format_duration_value(OutputIt out, Rep val, int) {
   static FMT_CONSTEXPR_DECL const Char format[] = {'{', '}', 0};
 
-// Workaround a compiler error in MSVC <= 16.8.2
-#if FMT_MSC_VER && FMT_MSC_VER <= 1928
+// Note(12/3/2020): Workaround an as-of-yet unfixed compiler error in MSVC.
+#if FMT_MSC_VER
   return vformat_to(out, to_string_view(format),
                     make_format_args<buffer_context<Char>>(val));
 #else
@@ -821,7 +821,7 @@ OutputIt format_duration_unit(OutputIt out) {
     return copy_unit(string_view(unit), out, Char());
   static FMT_CONSTEXPR_DECL const Char num_f[] = {'[', '{', '}', ']', 's', 0};
   if (const_check(Period::den == 1)) {
-#if FMT_MSC_VER && FMT_MSC_VER <= 1928
+#if FMT_MSC_VER
     return vformat_to(out, to_string_view(num_f),
                       make_format_args<buffer_context<Char>>(Period::num));
 #else
@@ -830,7 +830,7 @@ OutputIt format_duration_unit(OutputIt out) {
   }
   static FMT_CONSTEXPR_DECL const Char num_def_f[] = {'[', '{', '}', '/', '{',
                                                       '}', ']', 's', 0};
-#if FMT_MSC_VER && FMT_MSC_VER <= 1928
+#if FMT_MSC_VER
   return vformat_to(
       out, to_string_view(num_def_f),
       make_format_args<buffer_context<Char>>(Period::num, Period::den));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -106,6 +106,10 @@ add_fmt_test(printf-test)
 add_fmt_test(ranges-test)
 add_fmt_test(scan-test)
 
+
+add_fmt_test(enforce-compiletime-test)
+target_compile_definitions(enforce-compiletime-test PRIVATE "-DFMT_ENFORCE_COMPILE_STRING")
+
 if (NOT DEFINED MSVC_STATIC_RUNTIME AND MSVC)
   foreach (flag_var
 			 CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE

--- a/test/enforce-compiletime-test.cc
+++ b/test/enforce-compiletime-test.cc
@@ -1,0 +1,29 @@
+// Formatting library for C++ - formatting library tests
+//
+// Copyright (c) 2012 - present, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+
+#ifdef WIN32
+#  define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include "fmt/chrono.h"
+#include "fmt/format.h"
+
+#include "gmock.h"
+#include "gtest-extra.h"
+
+#ifndef FMT_STATIC_THOUSANDS_SEPARATOR
+
+TEST(ChronoTest, FormatDefault) {
+  EXPECT_EQ("42s", fmt::format(FMT_STRING("{}"), std::chrono::seconds(42)));
+}
+
+TEST(ChronoTest, FormatWide) {
+  EXPECT_EQ(L"42s", fmt::format(FMT_STRING(L"{}"), std::chrono::seconds(42)));
+}
+
+#endif  // FMT_STATIC_THOUSANDS_SEPARATOR


### PR DESCRIPTION
Per comments in https://github.com/fmtlib/fmt/pull/2038, This is just the proper fix for a previous attempt at working around this compile error. Though Microsoft reported that a related error had been resolved (https://developercommunity.visualstudio.com/content/problem/1256077/internal-compiler-failure-with-macro-defining-lamb.html) in the latest build of MSVC, the more complex case is still a problem, which I've reported here: https://developercommunity.visualstudio.com/content/problem/1277597/internal-compiler-c0001-error-on-complex-nested-la.html

