### PR TITLE
Suppress gcc warning on privates-only class

### DIFF
--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -85,6 +85,8 @@ template <typename T, typename Char> class is_streamable {
   using result = decltype(test<T>(0));
 
  public:
+  is_streamable() = default;
+
   static const bool value = result::value;
 };
 


### PR DESCRIPTION
Since gcc 9 it warns about is_streamable to have only private methods.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
