### PR TITLE
Add support of most format_specs for formatting at compile-time

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -469,7 +469,7 @@ template <typename Char, typename T, int N> struct spec_field {
   formatter<T, Char> fmt;
 
   template <typename OutputIt, typename... Args>
-  constexpr OutputIt format(OutputIt out, const Args&... args) {
+  constexpr OutputIt format(OutputIt out, const Args&... args) const {
     // This ensures that the argument type is convertile to `const T&`.
     const T& arg = get<N>(args...);
     const auto& vargs =
@@ -488,7 +488,7 @@ template <typename L, typename R> struct concat {
   using char_type = typename L::char_type;
 
   template <typename OutputIt, typename... Args>
-  constexpr OutputIt format(OutputIt out, const Args&... args) {
+  constexpr OutputIt format(OutputIt out, const Args&... args) const {
     out = lhs.format(out, args...);
     return rhs.format(out, args...);
   }
@@ -635,7 +635,7 @@ FMT_DEPRECATED auto compile(const Args&... args)
 template <typename CompiledFormat, typename... Args,
           typename Char = typename CompiledFormat::char_type,
           FMT_ENABLE_IF(detail::is_compiled_format<CompiledFormat>::value)>
-FMT_INLINE std::basic_string<Char> format(CompiledFormat& cf,
+FMT_INLINE std::basic_string<Char> format(const CompiledFormat& cf,
                                           const Args&... args) {
   basic_memory_buffer<Char> buffer;
   cf.format(detail::buffer_appender<Char>(buffer), args...);
@@ -644,7 +644,7 @@ FMT_INLINE std::basic_string<Char> format(CompiledFormat& cf,
 
 template <typename OutputIt, typename CompiledFormat, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_format<CompiledFormat>::value)>
-constexpr OutputIt format_to(OutputIt out, CompiledFormat& cf,
+constexpr OutputIt format_to(OutputIt out, const CompiledFormat& cf,
                              const Args&... args) {
   return cf.format(out, args...);
 }
@@ -674,14 +674,14 @@ FMT_INLINE std::basic_string<typename S::char_type> format(const S&,
       return fmt::to_string(detail::first(args...));
   }
 #endif
-  auto compiled = detail::compile<Args...>(S());
+  constexpr auto compiled = detail::compile<Args...>(S());
   return format(compiled, std::forward<Args>(args)...);
 }
 
 template <typename OutputIt, typename CompiledFormat, typename... Args,
           FMT_ENABLE_IF(std::is_base_of<detail::basic_compiled_format,
                                         CompiledFormat>::value)>
-constexpr OutputIt format_to(OutputIt out, CompiledFormat& cf,
+constexpr OutputIt format_to(OutputIt out, const CompiledFormat& cf,
                              const Args&... args) {
   using char_type = typename CompiledFormat::char_type;
   using context = format_context_t<OutputIt, char_type>;
@@ -692,7 +692,7 @@ constexpr OutputIt format_to(OutputIt out, CompiledFormat& cf,
 template <typename OutputIt, typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
 FMT_CONSTEXPR OutputIt format_to(OutputIt out, const S&, const Args&... args) {
-  auto compiled = detail::compile<Args...>(S());
+  constexpr auto compiled = detail::compile<Args...>(S());
   return format_to(out, compiled, args...);
 }
 
@@ -714,7 +714,7 @@ template <typename OutputIt, typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
 format_to_n_result<OutputIt> format_to_n(OutputIt out, size_t n, const S&,
                                          const Args&... args) {
-  auto compiled = detail::compile<Args...>(S());
+  constexpr auto compiled = detail::compile<Args...>(S());
   auto it = format_to(detail::truncating_iterator<OutputIt>(out, n), compiled,
                       args...);
   return {it.base(), it.count()};

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -466,10 +466,10 @@ struct is_compiled_format<field<Char, T, N>> : std::true_type {};
 // A replacement field that refers to argument N and has format specifiers.
 template <typename Char, typename T, int N> struct spec_field {
   using char_type = Char;
-  mutable formatter<T, Char> fmt;
+  formatter<T, Char> fmt;
 
   template <typename OutputIt, typename... Args>
-  OutputIt format(OutputIt out, const Args&... args) const {
+  constexpr OutputIt format(OutputIt out, const Args&... args) {
     // This ensures that the argument type is convertile to `const T&`.
     const T& arg = get<N>(args...);
     const auto& vargs =
@@ -488,7 +488,7 @@ template <typename L, typename R> struct concat {
   using char_type = typename L::char_type;
 
   template <typename OutputIt, typename... Args>
-  constexpr OutputIt format(OutputIt out, const Args&... args) const {
+  constexpr OutputIt format(OutputIt out, const Args&... args) {
     out = lhs.format(out, args...);
     return rhs.format(out, args...);
   }
@@ -635,7 +635,7 @@ FMT_DEPRECATED auto compile(const Args&... args)
 template <typename CompiledFormat, typename... Args,
           typename Char = typename CompiledFormat::char_type,
           FMT_ENABLE_IF(detail::is_compiled_format<CompiledFormat>::value)>
-FMT_INLINE std::basic_string<Char> format(const CompiledFormat& cf,
+FMT_INLINE std::basic_string<Char> format(CompiledFormat& cf,
                                           const Args&... args) {
   basic_memory_buffer<Char> buffer;
   cf.format(detail::buffer_appender<Char>(buffer), args...);
@@ -644,7 +644,7 @@ FMT_INLINE std::basic_string<Char> format(const CompiledFormat& cf,
 
 template <typename OutputIt, typename CompiledFormat, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_format<CompiledFormat>::value)>
-constexpr OutputIt format_to(OutputIt out, const CompiledFormat& cf,
+constexpr OutputIt format_to(OutputIt out, CompiledFormat& cf,
                              const Args&... args) {
   return cf.format(out, args...);
 }
@@ -674,14 +674,14 @@ FMT_INLINE std::basic_string<typename S::char_type> format(const S&,
       return fmt::to_string(detail::first(args...));
   }
 #endif
-  constexpr auto compiled = detail::compile<Args...>(S());
+  auto compiled = detail::compile<Args...>(S());
   return format(compiled, std::forward<Args>(args)...);
 }
 
 template <typename OutputIt, typename CompiledFormat, typename... Args,
           FMT_ENABLE_IF(std::is_base_of<detail::basic_compiled_format,
                                         CompiledFormat>::value)>
-constexpr OutputIt format_to(OutputIt out, const CompiledFormat& cf,
+constexpr OutputIt format_to(OutputIt out, CompiledFormat& cf,
                              const Args&... args) {
   using char_type = typename CompiledFormat::char_type;
   using context = format_context_t<OutputIt, char_type>;
@@ -692,7 +692,7 @@ constexpr OutputIt format_to(OutputIt out, const CompiledFormat& cf,
 template <typename OutputIt, typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
 FMT_CONSTEXPR OutputIt format_to(OutputIt out, const S&, const Args&... args) {
-  constexpr auto compiled = detail::compile<Args...>(S());
+  auto compiled = detail::compile<Args...>(S());
   return format_to(out, compiled, args...);
 }
 
@@ -714,7 +714,7 @@ template <typename OutputIt, typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
 format_to_n_result<OutputIt> format_to_n(OutputIt out, size_t n, const S&,
                                          const Args&... args) {
-  constexpr auto compiled = detail::compile<Args...>(S());
+  auto compiled = detail::compile<Args...>(S());
   auto it = format_to(detail::truncating_iterator<OutputIt>(out, n), compiled,
                       args...);
   return {it.base(), it.count()};

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -283,7 +283,7 @@ struct monostate {};
 
 namespace detail {
 
-constexpr bool is_constant_evaluated() FMT_DETECTED_NOEXCEPT {
+constexpr bool is_constant_evaluated() FMT_NOEXCEPT {
 #ifdef __cpp_lib_is_constant_evaluated
   return std::is_constant_evaluated();
 #else

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -481,7 +481,7 @@ inline basic_string_view<Char> to_string_view(
 }
 
 template <typename Char>
-inline basic_string_view<Char> to_string_view(basic_string_view<Char> s) {
+constexpr basic_string_view<Char> to_string_view(basic_string_view<Char> s) {
   return s;
 }
 
@@ -938,9 +938,9 @@ struct arg_data<T, Char, NUM_ARGS, 0> {
   T args_[NUM_ARGS != 0 ? NUM_ARGS : +1];
 
   template <typename... U>
-  FMT_INLINE arg_data(const U&... init) : args_{init...} {}
-  FMT_INLINE const T* args() const { return args_; }
-  FMT_INLINE std::nullptr_t named_args() { return nullptr; }
+  FMT_CONSTEXPR arg_data(const U&... init) : args_{init...} {}
+  FMT_CONSTEXPR const T* args() const { return args_; }
+  FMT_CONSTEXPR std::nullptr_t named_args() { return nullptr; }
 };
 
 template <typename Char>
@@ -961,7 +961,7 @@ void init_named_args(named_arg_info<Char>* named_args, int arg_count,
 }
 
 template <typename... Args>
-FMT_INLINE void init_named_args(std::nullptr_t, int, int, const Args&...) {}
+FMT_CONSTEXPR void init_named_args(std::nullptr_t, int, int, const Args&...) {}
 
 template <typename T> struct is_named_arg : std::false_type {};
 
@@ -1073,17 +1073,17 @@ template <typename Context> class value {
 
   constexpr FMT_INLINE value(int val = 0) : int_value(val) {}
   constexpr FMT_INLINE value(unsigned val) : uint_value(val) {}
-  FMT_INLINE value(long long val) : long_long_value(val) {}
-  FMT_INLINE value(unsigned long long val) : ulong_long_value(val) {}
+  constexpr FMT_INLINE value(long long val) : long_long_value(val) {}
+  constexpr FMT_INLINE value(unsigned long long val) : ulong_long_value(val) {}
   FMT_INLINE value(int128_t val) : int128_value(val) {}
   FMT_INLINE value(uint128_t val) : uint128_value(val) {}
   FMT_INLINE value(float val) : float_value(val) {}
   FMT_INLINE value(double val) : double_value(val) {}
   FMT_INLINE value(long double val) : long_double_value(val) {}
-  FMT_INLINE value(bool val) : bool_value(val) {}
-  FMT_INLINE value(char_type val) : char_value(val) {}
-  FMT_INLINE value(const char_type* val) { string.data = val; }
-  FMT_INLINE value(basic_string_view<char_type> val) {
+  constexpr FMT_INLINE value(bool val) : bool_value(val) {}
+  constexpr FMT_INLINE value(char_type val) : char_value(val) {}
+  FMT_CONSTEXPR value(const char_type* val) : string() { string.data = val; }
+  FMT_CONSTEXPR value(basic_string_view<char_type> val) {
     string.data = val.data();
     string.size = val.size();
   }
@@ -1406,7 +1406,7 @@ class locale_ref {
   const void* locale_;  // A type-erased pointer to std::locale.
 
  public:
-  locale_ref() : locale_(nullptr) {}
+  constexpr locale_ref() : locale_(nullptr) {}
   template <typename Locale> explicit locale_ref(const Locale& loc);
 
   explicit operator bool() const FMT_NOEXCEPT { return locale_ != nullptr; }
@@ -1437,7 +1437,7 @@ template <typename T> int check(unformattable) {
       "formatter<T> specialization: https://fmt.dev/latest/api.html#udt");
   return 0;
 }
-template <typename T, typename U> inline const U& check(const U& val) {
+template <typename T, typename U> constexpr const U& check(const U& val) {
   return val;
 }
 
@@ -1446,7 +1446,7 @@ template <typename T, typename U> inline const U& check(const U& val) {
 // another (not recommended).
 template <bool IS_PACKED, typename Context, type, typename T,
           FMT_ENABLE_IF(IS_PACKED)>
-inline value<Context> make_arg(const T& val) {
+constexpr value<Context> make_arg(const T& val) {
   return check<T>(arg_mapper<Context>().map(val));
 }
 
@@ -1480,28 +1480,30 @@ template <typename OutputIt, typename Char> class basic_format_context {
    Constructs a ``basic_format_context`` object. References to the arguments are
    stored in the object so make sure they have appropriate lifetimes.
    */
-  basic_format_context(OutputIt out,
-                       basic_format_args<basic_format_context> ctx_args,
-                       detail::locale_ref loc = detail::locale_ref())
+  constexpr basic_format_context(
+      OutputIt out, basic_format_args<basic_format_context> ctx_args,
+      detail::locale_ref loc = detail::locale_ref())
       : out_(out), args_(ctx_args), loc_(loc) {}
 
-  format_arg arg(int id) const { return args_.get(id); }
-  format_arg arg(basic_string_view<char_type> name) { return args_.get(name); }
+  constexpr format_arg arg(int id) const { return args_.get(id); }
+  FMT_CONSTEXPR format_arg arg(basic_string_view<char_type> name) {
+    return args_.get(name);
+  }
   int arg_id(basic_string_view<char_type> name) { return args_.get_id(name); }
   const basic_format_args<basic_format_context>& args() const { return args_; }
 
-  detail::error_handler error_handler() { return {}; }
+  FMT_CONSTEXPR detail::error_handler error_handler() { return {}; }
   void on_error(const char* message) { error_handler().on_error(message); }
 
   // Returns an iterator to the beginning of the output range.
-  iterator out() { return out_; }
+  FMT_CONSTEXPR iterator out() { return out_; }
 
   // Advances the begin iterator to ``it``.
   void advance_to(iterator it) {
     if (!detail::is_back_insert_iterator<iterator>()) out_ = it;
   }
 
-  detail::locale_ref locale() { return loc_; }
+  FMT_CONSTEXPR detail::locale_ref locale() { return loc_; }
 };
 
 template <typename Char>
@@ -1550,7 +1552,7 @@ class format_arg_store
            : 0);
 
  public:
-  format_arg_store(const Args&... args)
+  FMT_CONSTEXPR format_arg_store(const Args&... args)
       :
 #if FMT_GCC_VERSION && FMT_GCC_VERSION < 409
         basic_format_args<Context>(*this),
@@ -1571,7 +1573,7 @@ class format_arg_store
   \endrst
  */
 template <typename Context = format_context, typename... Args>
-inline format_arg_store<Context, Args...> make_format_args(
+constexpr format_arg_store<Context, Args...> make_format_args(
     const Args&... args) {
   return {args...};
 }
@@ -1644,25 +1646,27 @@ template <typename Context> class basic_format_args {
     const format_arg* args_;
   };
 
-  bool is_packed() const { return (desc_ & detail::is_unpacked_bit) == 0; }
+  constexpr bool is_packed() const {
+    return (desc_ & detail::is_unpacked_bit) == 0;
+  }
   bool has_named_args() const {
     return (desc_ & detail::has_named_args_bit) != 0;
   }
 
-  detail::type type(int index) const {
+  FMT_CONSTEXPR detail::type type(int index) const {
     int shift = index * detail::packed_arg_bits;
     unsigned int mask = (1 << detail::packed_arg_bits) - 1;
     return static_cast<detail::type>((desc_ >> shift) & mask);
   }
 
-  basic_format_args(unsigned long long desc,
-                    const detail::value<Context>* values)
+  constexpr basic_format_args(unsigned long long desc,
+                              const detail::value<Context>* values)
       : desc_(desc), values_(values) {}
-  basic_format_args(unsigned long long desc, const format_arg* args)
+  constexpr basic_format_args(unsigned long long desc, const format_arg* args)
       : desc_(desc), args_(args) {}
 
  public:
-  basic_format_args() : desc_(0) {}
+  constexpr basic_format_args() : desc_(0) {}
 
   /**
    \rst
@@ -1670,7 +1674,7 @@ template <typename Context> class basic_format_args {
    \endrst
    */
   template <typename... Args>
-  FMT_INLINE basic_format_args(const format_arg_store<Context, Args...>& store)
+  constexpr basic_format_args(const format_arg_store<Context, Args...>& store)
       : basic_format_args(store.desc, store.data_.args()) {}
 
   /**
@@ -1679,7 +1683,7 @@ template <typename Context> class basic_format_args {
    `~fmt::dynamic_format_arg_store`.
    \endrst
    */
-  FMT_INLINE basic_format_args(const dynamic_format_arg_store<Context>& store)
+  constexpr basic_format_args(const dynamic_format_arg_store<Context>& store)
       : basic_format_args(store.get_types(), store.data()) {}
 
   /**
@@ -1687,12 +1691,12 @@ template <typename Context> class basic_format_args {
    Constructs a `basic_format_args` object from a dynamic set of arguments.
    \endrst
    */
-  basic_format_args(const format_arg* args, int count)
+  constexpr basic_format_args(const format_arg* args, int count)
       : basic_format_args(detail::is_unpacked_bit | detail::to_unsigned(count),
                           args) {}
 
   /** Returns the argument with the specified id. */
-  format_arg get(int id) const {
+  FMT_CONSTEXPR format_arg get(int id) const {
     format_arg arg;
     if (!is_packed()) {
       if (id < max_size()) arg = args_[id];

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1092,9 +1092,7 @@ template <typename Context> class value {
   constexpr FMT_INLINE value(char_type val) : char_value(val) {}
   FMT_CONSTEXPR value(const char_type* val) {
     string.data = val;
-    if (is_constant_evaluated()) {
-      string.size = {};
-    }
+    if (is_constant_evaluated()) string.size = {};
   }
   FMT_CONSTEXPR value(basic_string_view<char_type> val) {
     string.data = val.data();

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1666,7 +1666,7 @@ template <typename Context> class basic_format_args {
       : desc_(desc), args_(args) {}
 
  public:
-  constexpr basic_format_args() : desc_(0) {}
+  constexpr basic_format_args() : desc_(0), args_(nullptr) {}
 
   /**
    \rst

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -283,6 +283,14 @@ struct monostate {};
 
 namespace detail {
 
+constexpr bool is_constant_evaluated() FMT_DETECTED_NOEXCEPT {
+#ifdef __cpp_lib_is_constant_evaluated
+  return std::is_constant_evaluated();
+#else
+  return false;
+#endif
+}
+
 // A helper function to suppress "conditional expression is constant" warnings.
 template <typename T> constexpr T const_check(T value) { return value; }
 
@@ -1082,7 +1090,12 @@ template <typename Context> class value {
   FMT_INLINE value(long double val) : long_double_value(val) {}
   constexpr FMT_INLINE value(bool val) : bool_value(val) {}
   constexpr FMT_INLINE value(char_type val) : char_value(val) {}
-  FMT_CONSTEXPR value(const char_type* val) : string() { string.data = val; }
+  FMT_CONSTEXPR value(const char_type* val) {
+    string.data = val;
+    if (is_constant_evaluated()) {
+      string.size = {};
+    }
+  }
   FMT_CONSTEXPR value(basic_string_view<char_type> val) {
     string.data = val.data();
     string.size = val.size();

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1070,9 +1070,10 @@ template <typename T> const wchar_t basic_data<T>::wreset_color[] = L"\x1b[0m";
 template <typename T> const char basic_data<T>::signs[] = {0, '-', '+', ' '};
 
 #if __cplusplus < 201703L
-template <typename T> const char basic_data<T>::hex_digits[];
-template <typename T> const char basic_data<T>::left_padding_shifts[];
-template <typename T> const char basic_data<T>::right_padding_shifts[];
+template <typename T> constexpr const char basic_data<T>::hex_digits[];
+template <typename T> constexpr const char basic_data<T>::left_padding_shifts[];
+template <typename T>
+constexpr const char basic_data<T>::right_padding_shifts[];
 #endif
 
 template <typename T> struct bits {

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -248,9 +248,6 @@ const typename basic_data<T>::digit_pair basic_data<T>::digits[] = {
     {'9', '0'}, {'9', '1'}, {'9', '2'}, {'9', '3'}, {'9', '4'}, {'9', '5'},
     {'9', '6'}, {'9', '7'}, {'9', '8'}, {'9', '9'}};
 
-template <typename T>
-const char basic_data<T>::hex_digits[] = "0123456789abcdef";
-
 #define FMT_POWERS_OF_10(factor)                                             \
   factor * 10, (factor)*100, (factor)*1000, (factor)*10000, (factor)*100000, \
       (factor)*1000000, (factor)*10000000, (factor)*100000000,               \
@@ -1071,10 +1068,12 @@ const char basic_data<T>::background_color[] = "\x1b[48;2;";
 template <typename T> const char basic_data<T>::reset_color[] = "\x1b[0m";
 template <typename T> const wchar_t basic_data<T>::wreset_color[] = L"\x1b[0m";
 template <typename T> const char basic_data<T>::signs[] = {0, '-', '+', ' '};
-template <typename T>
-const char basic_data<T>::left_padding_shifts[] = {31, 31, 0, 1, 0};
-template <typename T>
-const char basic_data<T>::right_padding_shifts[] = {0, 31, 0, 1, 0};
+
+#if __cplusplus < 201703L
+template <typename T> const char basic_data<T>::hex_digits[];
+template <typename T> const char basic_data<T>::left_padding_shifts[];
+template <typename T> const char basic_data<T>::right_padding_shifts[];
+#endif
 
 template <typename T> struct bits {
   static FMT_CONSTEXPR_DECL const int value =

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -282,7 +282,7 @@ FMT_END_NAMESPACE
 FMT_BEGIN_NAMESPACE
 namespace detail {
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || FMT_GCC_VERSION >= 1002
 #  define FMT_CONSTEXPR20 constexpr
 #else
 #  define FMT_CONSTEXPR20 inline

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -288,14 +288,6 @@ namespace detail {
 #  define FMT_CONSTEXPR20 inline
 #endif
 
-constexpr bool is_constant_evaluated() FMT_DETECTED_NOEXCEPT {
-#ifdef __cpp_lib_is_constant_evaluated
-  return std::is_constant_evaluated();
-#else
-  return false;
-#endif
-}
-
 // An equivalent of `*reinterpret_cast<Dest*>(&source)` that doesn't have
 // undefined behavior (e.g. due to type aliasing).
 // Example: uint64_t d = bit_cast<uint64_t>(2.718);

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -282,7 +282,8 @@ FMT_END_NAMESPACE
 FMT_BEGIN_NAMESPACE
 namespace detail {
 
-#if __cplusplus >= 202002L || FMT_GCC_VERSION >= 1002
+#if __cplusplus >= 202002L || \
+    (__cplusplus >= 201709L && FMT_GCC_VERSION >= 1002)
 #  define FMT_CONSTEXPR20 constexpr
 #else
 #  define FMT_CONSTEXPR20 inline

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3544,19 +3544,6 @@ struct formatter<T, Char,
                             detail::make_arg<FormatContext>(val));
   }
 
-  template <typename FormatContext>
-  FMT_CONSTEXPR auto format(const T& val, FormatContext& ctx)
-      -> decltype(ctx.out()) {
-    detail::handle_dynamic_spec<detail::width_checker>(specs_.width,
-                                                       specs_.width_ref, ctx);
-    detail::handle_dynamic_spec<detail::precision_checker>(
-        specs_.precision, specs_.precision_ref, ctx);
-    using af = detail::arg_formatter<typename FormatContext::iterator,
-                                     typename FormatContext::char_type>;
-    return visit_format_arg(af(ctx, nullptr, &specs_),
-                            detail::make_arg<FormatContext>(val));
-  }
-
  private:
   detail::dynamic_format_specs<Char> specs_;
 };

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1139,8 +1139,8 @@ inline format_decimal_result<Iterator> format_decimal(Iterator out, UInt value,
 }
 
 template <unsigned BASE_BITS, typename Char, typename UInt>
-FMT_CONSTEXPR20 Char* format_uint(Char* buffer, UInt value, int num_digits,
-                                  bool upper = false) {
+FMT_CONSTEXPR Char* format_uint(Char* buffer, UInt value, int num_digits,
+                                bool upper = false) {
   buffer += num_digits;
   Char* end = buffer;
   do {
@@ -1554,9 +1554,9 @@ FMT_NOINLINE FMT_CONSTEXPR OutputIt fill(OutputIt it, size_t n,
 // width: output display width in (terminal) column positions.
 template <align::type align = align::left, typename OutputIt, typename Char,
           typename F>
-FMT_CONSTEXPR20 OutputIt write_padded(OutputIt out,
-                                      const basic_format_specs<Char>& specs,
-                                      size_t size, size_t width, F&& f) {
+FMT_CONSTEXPR OutputIt write_padded(OutputIt out,
+                                    const basic_format_specs<Char>& specs,
+                                    size_t size, size_t width, F&& f) {
   static_assert(align == align::left || align == align::right, "");
   unsigned spec_width = to_unsigned(specs.width);
   size_t padding = spec_width > width ? spec_width - width : 0;

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -217,6 +217,8 @@ TEST(CompileTimeFormattingTest, Integer) {
   EXPECT_EQ("42", test_format<3>(FMT_COMPILE("{:-}"), 42));
   EXPECT_EQ(" 42", test_format<4>(FMT_COMPILE("{: }"), 42));
 
+  EXPECT_EQ("-0042", test_format<6>(FMT_COMPILE("{:05}"), -42));
+
   EXPECT_EQ("101010", test_format<7>(FMT_COMPILE("{:b}"), 42));
   EXPECT_EQ("0b101010", test_format<9>(FMT_COMPILE("{:#b}"), 42));
   EXPECT_EQ("0B101010", test_format<9>(FMT_COMPILE("{:#B}"), 42));

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -184,7 +184,7 @@ TEST(CompileTest, CompileFormatStringLiteral) {
 }
 #endif
 
-#if __cplusplus >= 202002L
+#if __cplusplus >= 202002L || FMT_GCC_VERSION >= 1002
 template <size_t max_string_length, typename Char = char> struct test_string {
   template <typename T> constexpr bool operator==(const T& rhs) const noexcept {
     return fmt::basic_string_view<Char>(rhs).compare(buffer.data()) == 0;

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -184,7 +184,8 @@ TEST(CompileTest, CompileFormatStringLiteral) {
 }
 #endif
 
-#if __cplusplus >= 202002L || FMT_GCC_VERSION >= 1002
+#if __cplusplus >= 202002L || \
+    (__cplusplus >= 201709L && FMT_GCC_VERSION >= 1002)
 template <size_t max_string_length, typename Char = char> struct test_string {
   template <typename T> constexpr bool operator==(const T& rhs) const noexcept {
     return fmt::basic_string_view<Char>(rhs).compare(buffer.data()) == 0;

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -7,9 +7,6 @@
 
 #include <string>
 #include <type_traits>
-#if __cplusplus >= 202002L
-#  include <string_view>
-#endif
 
 // Check that fmt/compile.h compiles with windows.h included before it.
 #ifdef _WIN32
@@ -188,16 +185,16 @@ TEST(CompileTest, CompileFormatStringLiteral) {
 #endif
 
 #if __cplusplus >= 202002L
-template <size_t max_string_length> struct test_string {
+template <size_t max_string_length, typename Char = char> struct test_string {
   template <typename T> constexpr bool operator==(const T& rhs) const noexcept {
-    return (std::string_view(rhs).compare(buffer.data()) == 0);
+    return fmt::basic_string_view<Char>(rhs).compare(buffer.data()) == 0;
   }
-  std::array<char, max_string_length> buffer{};
+  std::array<Char, max_string_length> buffer{};
 };
 
-template <size_t max_string_length, typename... Args>
+template <size_t max_string_length, typename Char = char, typename... Args>
 consteval auto test_format(auto format, const Args&... args) {
-  test_string<max_string_length> string{};
+  test_string<max_string_length, Char> string{};
   fmt::format_to(string.buffer.data(), format, args...);
   return string;
 }
@@ -205,6 +202,8 @@ consteval auto test_format(auto format, const Args&... args) {
 TEST(CompileTimeFormattingTest, Bool) {
   EXPECT_EQ("true", test_format<5>(FMT_COMPILE("{}"), true));
   EXPECT_EQ("false", test_format<6>(FMT_COMPILE("{}"), false));
+  EXPECT_EQ("true ", test_format<6>(FMT_COMPILE("{:5}"), true));
+  EXPECT_EQ("1", test_format<2>(FMT_COMPILE("{:d}"), true));
 }
 
 TEST(CompileTimeFormattingTest, Integer) {
@@ -213,16 +212,52 @@ TEST(CompileTimeFormattingTest, Integer) {
   EXPECT_EQ("42 42", test_format<6>(FMT_COMPILE("{} {}"), 42, 42));
   EXPECT_EQ("42 42",
             test_format<6>(FMT_COMPILE("{} {}"), uint32_t{42}, uint64_t{42}));
+
+  EXPECT_EQ("+42", test_format<4>(FMT_COMPILE("{:+}"), 42));
+  EXPECT_EQ("42", test_format<3>(FMT_COMPILE("{:-}"), 42));
+  EXPECT_EQ(" 42", test_format<4>(FMT_COMPILE("{: }"), 42));
+
+  EXPECT_EQ("101010", test_format<7>(FMT_COMPILE("{:b}"), 42));
+  EXPECT_EQ("0b101010", test_format<9>(FMT_COMPILE("{:#b}"), 42));
+  EXPECT_EQ("0B101010", test_format<9>(FMT_COMPILE("{:#B}"), 42));
+  EXPECT_EQ("042", test_format<4>(FMT_COMPILE("{:#o}"), 042));
+  EXPECT_EQ("0x4a", test_format<5>(FMT_COMPILE("{:#x}"), 0x4a));
+  EXPECT_EQ("0X4A", test_format<5>(FMT_COMPILE("{:#X}"), 0x4a));
+
+  EXPECT_EQ("   42", test_format<6>(FMT_COMPILE("{:5}"), 42));
+  EXPECT_EQ("   42", test_format<6>(FMT_COMPILE("{:5}"), 42ll));
+  EXPECT_EQ("   42", test_format<6>(FMT_COMPILE("{:5}"), 42ull));
+
+  EXPECT_EQ("42  ", test_format<5>(FMT_COMPILE("{:<4}"), 42));
+  EXPECT_EQ("  42", test_format<5>(FMT_COMPILE("{:>4}"), 42));
+  EXPECT_EQ(" 42 ", test_format<5>(FMT_COMPILE("{:^4}"), 42));
+  EXPECT_EQ("**-42", test_format<6>(FMT_COMPILE("{:*>5}"), -42));
+}
+
+TEST(CompileTimeFormattingTest, Char) {
+  EXPECT_EQ("c", test_format<2>(FMT_COMPILE("{}"), 'c'));
+
+  EXPECT_EQ("c  ", test_format<4>(FMT_COMPILE("{:3}"), 'c'));
+  EXPECT_EQ("99", test_format<3>(FMT_COMPILE("{:d}"), 'c'));
 }
 
 TEST(CompileTimeFormattingTest, String) {
   EXPECT_EQ("42", test_format<3>(FMT_COMPILE("{}"), "42"));
   EXPECT_EQ("The answer is 42",
             test_format<17>(FMT_COMPILE("{} is {}"), "The answer", "42"));
+
+  EXPECT_EQ("abc**", test_format<6>(FMT_COMPILE("{:*<5}"), "abc"));
+  EXPECT_EQ("**🤡**", test_format<9>(FMT_COMPILE("{:*^5}"), "🤡"));
 }
 
 TEST(CompileTimeFormattingTest, Combination) {
   EXPECT_EQ("420, true, answer",
             test_format<18>(FMT_COMPILE("{}, {}, {}"), 420, true, "answer"));
+
+  EXPECT_EQ(" -42", test_format<5>(FMT_COMPILE("{:{}}"), -42, 4));
+}
+
+TEST(CompileTimeFormattingTest, MultiByteFill) {
+  EXPECT_EQ("жж42", test_format<8>(FMT_COMPILE("{:ж>4}"), 42));
 }
 #endif


### PR DESCRIPTION
Extends https://github.com/fmtlib/fmt/pull/2019 by adding support of formatting specs for bool, integer, char and string:

- [fill](https://fmt.dev/latest/syntax.html#grammar-token-fill) `<a character other than '{' or '}'>`, like `{:*>4}`, `{:ж^4}`
- [align](https://fmt.dev/latest/syntax.html#grammar-token-align) `"<" | ">" | "^"`, like `{:^4}`
- [sign](https://fmt.dev/latest/syntax.html#grammar-token-sign) `"+" | "-" | " "`, like `{:+}`
- `"#"`, like `{:#b}`
- `"0"`, like `{:04}`
- [width](https://fmt.dev/latest/syntax.html#grammar-token-width) `integer | "{"  "}"`, like `{:4}`, `{:{}}`
- [int_type](https://fmt.dev/latest/syntax.html#grammar-token-int_type) `"b" | "B" | "d" | "o" | "x" | "X"`, like `{:b}`, `{:x}`, `{:X}`.

I think that bool, integer, char and string formatting should be fully supported at compile-time, of course, if there are no caveats I'm not aware of. Floating-point formatting is not addressed by this PR, so it's still unavailable at compile-time.

Also `test_string` in `compile-test` updated a bit to use not `std::` but `fmt:string_view`, this eliminates unnecessary include there
