### PR TITLE
FMT_COMPILE tests are temporary switched on even if constexpr_if is n…

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,6 @@ jobs:
       run: |
         ${{matrix.install}}
         cmake -E make_directory ${{runner.workspace}}/build
-      if: always()
 
     - name: Configure
       working-directory: ${{runner.workspace}}/build
@@ -45,14 +44,11 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} ${{matrix.fuzz}} \
               -DCMAKE_CXX_STANDARD=${{matrix.std}} -DFMT_DOC=OFF \
               -DFMT_PEDANTIC=ON -DFMT_WERROR=ON $GITHUB_WORKSPACE
-      if: always()
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --config ${{matrix.build_type}}
-      if: always()
 
     - name: Test
       working-directory: ${{runner.workspace}}/build
       run: ctest -C ${{matrix.build_type}}
-      if: always()

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         cxx: [g++-4.8, g++-8, g++-10, clang++-9]
         build_type: [Debug, Release]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,6 +34,7 @@ jobs:
       run: |
         ${{matrix.install}}
         cmake -E make_directory ${{runner.workspace}}/build
+      if: always()
 
     - name: Configure
       working-directory: ${{runner.workspace}}/build
@@ -44,11 +45,14 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} ${{matrix.fuzz}} \
               -DCMAKE_CXX_STANDARD=${{matrix.std}} -DFMT_DOC=OFF \
               -DFMT_PEDANTIC=ON -DFMT_WERROR=ON $GITHUB_WORKSPACE
+      if: always()
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --config ${{matrix.build_type}}
+      if: always()
 
     - name: Test
       working-directory: ${{runner.workspace}}/build
       run: ctest -C ${{matrix.build_type}}
+      if: always()

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,17 +14,21 @@ jobs:
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build
+      if: always()
 
     - name: Configure
       working-directory: ${{runner.workspace}}/build
       run: |
         cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
               -DFMT_DOC=OFF -DFMT_PEDANTIC=ON -DFMT_WERROR=ON $GITHUB_WORKSPACE
+      if: always()
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --config ${{matrix.build_type}}
+      if: always()
 
     - name: Test
       working-directory: ${{runner.workspace}}/build
       run: ctest -C ${{matrix.build_type}}
+      if: always()

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: macos-10.15
     strategy:
+      fail-fast: false
       matrix:
         build_type: [Debug, Release]
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,21 +14,17 @@ jobs:
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build
-      if: always()
 
     - name: Configure
       working-directory: ${{runner.workspace}}/build
       run: |
         cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
               -DFMT_DOC=OFF -DFMT_PEDANTIC=ON -DFMT_WERROR=ON $GITHUB_WORKSPACE
-      if: always()
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --config ${{matrix.build_type}}
-      if: always()
 
     - name: Test
       working-directory: ${{runner.workspace}}/build
       run: ctest -C ${{matrix.build_type}}
-      if: always()

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,6 +30,7 @@ jobs:
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build
+      if: always()
 
     - name: Configure
       # Use a bash shell for $GITHUB_WORKSPACE.
@@ -40,11 +41,14 @@ jobs:
               -A ${{matrix.platform}} \
               -DCMAKE_CXX_STANDARD=${{matrix.standard}} \
               $GITHUB_WORKSPACE
+      if: always()
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --config ${{matrix.build_type}}
+      if: always()
 
     - name: Test
       working-directory: ${{runner.workspace}}/build
       run: ctest -C ${{matrix.build_type}}
+      if: always()

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ${{matrix.os}}
     strategy:
+      fail-fast: false
       matrix:
         # windows-2016 and windows-2019 have MSVC 2017 and 2019 installed
         # respectively: https://github.com/actions/virtual-environments.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,7 +30,6 @@ jobs:
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build
-      if: always()
 
     - name: Configure
       # Use a bash shell for $GITHUB_WORKSPACE.
@@ -41,14 +40,11 @@ jobs:
               -A ${{matrix.platform}} \
               -DCMAKE_CXX_STANDARD=${{matrix.standard}} \
               $GITHUB_WORKSPACE
-      if: always()
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --config ${{matrix.build_type}}
-      if: always()
 
     - name: Test
       working-directory: ${{runner.workspace}}/build
       run: ctest -C ${{matrix.build_type}}
-      if: always()

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -121,7 +121,7 @@ TEST(CompileTest, EmptyFormatString) {
   EXPECT_EQ(fmt::format(f), "");
 }
 
-#ifdef __cpp_if_constexpr
+//#ifdef __cpp_if_constexpr
 TEST(CompileTest, FormatDefault) {
   EXPECT_EQ("42", fmt::format(FMT_COMPILE("{}"), 42));
   EXPECT_EQ("42", fmt::format(FMT_COMPILE("{}"), 42u));
@@ -177,7 +177,7 @@ TEST(CompileTest, TextAndArg) {
 TEST(CompileTest, Empty) {
   EXPECT_EQ("", fmt::format(FMT_COMPILE("")));
 }
-#endif
+//#endif
 
 #if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
 TEST(CompileTest, CompileFormatStringLiteral) {


### PR DESCRIPTION
I mistakenly tried to compile code with FMT_COMPILE without setting c++ standard to c++17 or upper. And as result, I saw a sexy error output that has to be meditated on to figure out what's happened. And it looks like a library bug at the first glance despite it isn't.

```
<path>/fmt-master/include/fmt/compile.h: In instantiation of ‘constexpr OutputIt fmt::v7::format_to(OutputIt, const S&, const Args& ...) [with OutputIt = char*; S = test_functions::test_bundled(char*)::<lambda()>::FMT_COMPILE_STRING; Args = {int, float, int, char [7], int}; typename std::enable_if<fmt::v7::detail::is_compiled_string<S>::value, int>::type <anonymous> = 0]’:
<path>/test_bundled.cpp:6:58:   required from here
<path>/fmt-master/include/fmt/compile.h:695:53: error: no matching function for call to ‘compile<int, float, int, char [7], int>(test_functions::test_bundled(char*)::<lambda()>::FMT_COMPILE_STRING)’
  695 |   constexpr auto compiled = detail::compile<Args...>(S());
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
<path>/fmt-master/include/fmt/compile.h:611:16: note: candidate: ‘template<class ... Args, class S, typename std::enable_if<fmt::v7::is_compile_string<S>::value, int>::type <anonymous> > constexpr fmt::v7::detail::compiled_format<S, Args ...> fmt::v7::detail::compile(S)’
  611 | constexpr auto compile(S format_str) -> detail::compiled_format<S, Args...> {
      |                ^~~~~~~
<path>/fmt-master/include/fmt/compile.h:611:16: note:   template argument deduction/substitution failed:
In file included from <path>/fmt-master/include/fmt/format.h:45,
                 from <path>/fmt-master/include/fmt/compile.h:14,
                 from <path>/test_bundled.cpp:1:
<path>/fmt-master/include/fmt/core.h:281:64: error: no type named ‘type’ in ‘struct std::enable_if<false, int>’
  281 | #  define FMT_ENABLE_IF(...) enable_if_t<(__VA_ARGS__), int> = 0
      |                                                                ^
<path>/fmt-master/include/fmt/compile.h:610:11: note: in expansion of macro ‘FMT_ENABLE_IF’
  610 |           FMT_ENABLE_IF(is_compile_string<S>::value)>
      |           ^~~~~~~~~~~~~
In file included from <path>/test_bundled.cpp:1:
<path>/fmt-master/include/fmt/compile.h:618:6: note: candidate: ‘template<class ... Args, class Char, long unsigned int N> fmt::v7::detail::compiled_format<const Char*, Args ...> fmt::v7::detail::compile(const Char (&)[N])’
  618 | auto compile(const Char (&format_str)[N])
      |      ^~~~~~~
<path>/fmt-master/include/fmt/compile.h:618:6: note:   template argument deduction/substitution failed:
<path>/fmt-master/include/fmt/compile.h:695:53: note:   mismatched types ‘const Char [N]’ and ‘test_functions::test_bundled(char*)::<lambda()>::FMT_COMPILE_STRING’
  695 |   constexpr auto compiled = detail::compile<Args...>(S());
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```
The compiler is g++9.3, the standard is c++11 (output of c++14 is the same)

The documentation says that FMT_COMPILE "requires C++17 ``constexpr if`` compiler support", but who reads the documentation? And in my case, I didn't use FMT_COMPILE but received someone else's code instead, so I had no idea what of {fmt} features were used and which are their requirements.

```
/**
  \rst
  Converts a string literal *s* into a format string that will be parsed at
  compile time and converted into efficient formatting code. Requires C++17
  ``constexpr if`` compiler support.

  **Example**::

    // Converts 42 into std::string using the most efficient method and no
    // runtime format string processing.
    std::string s = fmt::format(FMT_COMPILE("{}"), 42);
  \endrst
 */
#define FMT_COMPILE(s)
```

I propose to add a better compile-time error explanation. Like the following:

```
<path>/fmt_compile_before.hpp: In instantiation of ‘const char* fmt::v7::detail::report_fmt_compile_error() [with T = void*]’:
<path>/test_before.cpp:6:26:   required from here
<path>/fmt_compile_before.hpp:37:74: error: static assertion failed: FMT_COMPILE requires C++17 `constexpr if` compiler support
   37 | template<class T> const char* report_fmt_compile_error() { static_assert(!std::is_same<T,T>::value, "FMT_COMPILE requires C++17 `constexpr if` compiler support"); return ""; }
      |                                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~
      
```

To reproduce it a trivial code is sufficient:
```
#include "fmt/compile.h"

int main() {
    fmt::format(FMT_COMPILE("{}"), 42);
}
```
https://godbolt.org/z/T8M88b

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
