### PR TITLE
Add test for formatting with no args

### DIFF
--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1822,6 +1822,7 @@ static FMT_CONSTEXPR_DECL const char static_no_null[2] = {'{', '}'};
 static FMT_CONSTEXPR_DECL const wchar_t static_no_null_wide[2] = {'{', '}'};
 
 TEST(FormatTest, CompileTimeString) {
+  EXPECT_EQ("42", fmt::format(FMT_STRING("42")));
   EXPECT_EQ("42", fmt::format(FMT_STRING("{}"), 42));
   EXPECT_EQ(L"42", fmt::format(FMT_STRING(L"{}"), 42));
   EXPECT_EQ("foo", fmt::format(FMT_STRING("{}"), string_like()));


### PR DESCRIPTION
Demonstrates a bug reported in https://github.com/fmtlib/fmt/issues/2039.

The code involved here is a bit beyond me & the error message produced is rather inscrutable