### PR TITLE
Forward arguments to work with views

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -411,8 +411,9 @@ class ostream final : private detail::buffer<char> {
   }
 
   template <typename S, typename... Args>
-  void print(const S& format_str, const Args&... args) {
-    format_to(detail::buffer_appender<char>(*this), format_str, args...);
+  void print(const S& format_str, Args&&... args) {
+    format_to(detail::buffer_appender<char>(*this), format_str,
+              std::forward<Args>(args)...);
   }
 };
 

--- a/test/os-test.cc
+++ b/test/os-test.cc
@@ -295,7 +295,7 @@ TEST(OStreamTest, Move) {
 
 TEST(OStreamTest, Print) {
   fmt::ostream out = fmt::output_file("test-file");
-  out.print("The answer is {}.\n", 42);
+  out.print("The answer is {}.\n", fmt::join(std::initializer_list<int>{42}, ", "));
   out.close();
   file in("test-file", file::RDONLY);
   EXPECT_READ(in, "The answer is 42.\n");


### PR DESCRIPTION
Fix compile error when using `fmt::join(...)` as an argument to `fmt::ostream::print(...)`.
