### PR TITLE
Fix format_to(memory_buffer, text_style) overload

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -618,6 +618,16 @@ inline auto format_to(OutputIt out, const text_style& ts, const S& format_str,
                     fmt::make_args_checked<Args...>(format_str, args...));
 }
 
+template <typename S, typename... Args, size_t SIZE = inline_buffer_size,
+          typename Char = enable_if_t<detail::is_string<S>::value, char_t<S>>>
+inline typename buffer_context<Char>::iterator format_to(
+    basic_memory_buffer<Char, SIZE>& buf, const text_style& ts,
+    const S& format_str, Args&&... args) {
+  const auto& vargs = fmt::make_args_checked<Args...>(format_str, args...);
+  detail::vformat_to(buf, ts, to_string_view(format_str), vargs);
+  return detail::buffer_appender<Char>(buf);
+}
+
 FMT_END_NAMESPACE
 
 #endif  // FMT_COLOR_H_

--- a/test/color-test.cc
+++ b/test/color-test.cc
@@ -97,3 +97,12 @@ TEST(ColorsTest, FormatToOutAcceptsTextStyle) {
   EXPECT_EQ(fmt::to_string(out),
             "\x1b[38;2;255;020;030mrgb(255,20,30)123\x1b[0m");
 }
+
+TEST(ColorsTest, FormatToBufAcceptsTextStyle) {
+  fmt::text_style ts = fg(fmt::rgb(255, 20, 30));
+  fmt::memory_buffer buf;
+  fmt::format_to(buf, ts, "rgb(255,20,30){}{}{}", 1, 2, 3);
+
+  EXPECT_EQ(std::string(buf.data(), buf.size()),
+            "\x1b[38;2;255;020;030mrgb(255,20,30)123\x1b[0m");
+}


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

Fixes #2069 

This pull request fixes the `fmt::format_to` overload in <fmt/color.h> when formatting to memory buffers by adding an overload of `format_to` that accepts a buffer.
