### PR TITLE
Fix std::byte formatting with compile-time API

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2112,8 +2112,14 @@ FMT_CONSTEXPR OutputIt write(OutputIt out, T value) {
 }
 
 template <typename Char, typename OutputIt, typename T,
+#ifdef __cpp_lib_byte
+          FMT_ENABLE_IF(std::is_enum<T>::value &&
+                        !std::is_same<T, Char>::value &&
+                        !std::is_same<T, std::byte>::value)>
+#else
           FMT_ENABLE_IF(std::is_enum<T>::value &&
                         !std::is_same<T, Char>::value)>
+#endif
 FMT_CONSTEXPR OutputIt write(OutputIt out, T value) {
   return write<Char>(
       out, static_cast<typename std::underlying_type<T>::type>(value));
@@ -3562,7 +3568,7 @@ FMT_FORMAT_AS(Char*, const Char*);
 FMT_FORMAT_AS(std::basic_string<Char>, basic_string_view<Char>);
 FMT_FORMAT_AS(std::nullptr_t, const void*);
 FMT_FORMAT_AS(detail::std_string_view<Char>, basic_string_view<Char>);
-#if __cplusplus >= 201703L
+#ifdef __cpp_lib_byte
 FMT_FORMAT_AS(std::byte, unsigned);
 #endif
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2111,12 +2111,14 @@ FMT_CONSTEXPR OutputIt write(OutputIt out, T value) {
   return base_iterator(out, it);
 }
 
+// FMT_ENABLE_IF() condition separated to workaround MSVC bug
 template <
     typename Char, typename OutputIt, typename T,
-    FMT_ENABLE_IF(
+    bool check =
         std::is_enum<T>::value && !std::is_same<T, Char>::value &&
         mapped_type_constant<T, basic_format_context<OutputIt, Char>>::value !=
-            type::custom_type)>
+            type::custom_type,
+    FMT_ENABLE_IF(check)>
 FMT_CONSTEXPR OutputIt write(OutputIt out, T value) {
   return write<Char>(
       out, static_cast<typename std::underlying_type<T>::type>(value));

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2111,15 +2111,12 @@ FMT_CONSTEXPR OutputIt write(OutputIt out, T value) {
   return base_iterator(out, it);
 }
 
-template <typename Char, typename OutputIt, typename T,
-#ifdef __cpp_lib_byte
-          FMT_ENABLE_IF(std::is_enum<T>::value &&
-                        !std::is_same<T, Char>::value &&
-                        !std::is_same<T, std::byte>::value)>
-#else
-          FMT_ENABLE_IF(std::is_enum<T>::value &&
-                        !std::is_same<T, Char>::value)>
-#endif
+template <
+    typename Char, typename OutputIt, typename T,
+    FMT_ENABLE_IF(
+        std::is_enum<T>::value && !std::is_same<T, Char>::value &&
+        mapped_type_constant<T, basic_format_context<OutputIt, Char>>::value !=
+            type::custom_type)>
 FMT_CONSTEXPR OutputIt write(OutputIt out, T value) {
   return write<Char>(
       out, static_cast<typename std::underlying_type<T>::type>(value));

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -133,6 +133,9 @@ TEST(CompileTest, FormatDefault) {
   EXPECT_EQ("foo", fmt::format(FMT_COMPILE("{}"), "foo"));
   EXPECT_EQ("foo", fmt::format(FMT_COMPILE("{}"), std::string("foo")));
   EXPECT_EQ("foo", fmt::format(FMT_COMPILE("{}"), test_formattable()));
+#  ifdef __cpp_lib_byte
+  EXPECT_EQ("42", fmt::format(FMT_COMPILE("{}"), std::byte{42}));
+#  endif
 }
 
 TEST(CompileTest, FormatWideString) {

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1762,7 +1762,7 @@ TEST(FormatTest, JoinArg) {
 #endif
 }
 
-#if __cplusplus >= 201703L
+#ifdef __cpp_lib_byte
 TEST(FormatTest, JoinBytes) {
   std::vector<std::byte> v = {std::byte(1), std::byte(2), std::byte(3)};
   EXPECT_EQ("1, 2, 3", fmt::format("{}", fmt::join(v, ", ")));


### PR DESCRIPTION
Right now formatting of `std::byte` using compile-time API like so:
```cpp
fmt::format(FMT_COMPILE("{}"), std::byte{42})
```
ends up with compilation error, [proof on Compiler Explorer](https://godbolt.org/z/5xqrvr). Because there are 2 `write` functions which satisfy for the passed type `std::byte`:
https://github.com/fmtlib/fmt/blob/5a37e182deee09a873777ff3f8e901d117e5f39b/include/fmt/format.h#L2114-L2120
https://github.com/fmtlib/fmt/blob/5a37e182deee09a873777ff3f8e901d117e5f39b/include/fmt/format.h#L2150-L2162

Also, I found `__cpp_lib_byte` feature macro, so all new checks are based on this macro instead of `__cplusplus >= 201703L` and I changed old checks accordingly.
