### PR TITLE
Add cwchar to format.h for std::fputws

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -37,6 +37,7 @@
 #include <cmath>
 #include <cstddef>  // std::byte
 #include <cstdint>
+#include <cwchar>
 #include <limits>
 #include <memory>
 #include <stdexcept>


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

- [x] I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

While trying to build fmtlib with EASTL, I realized that `cwchar` was missing:
```
include/fmt/format.h:3964:7: error: no member named 'fputws' in namespace 'std'; did you mean simply 'fputws'?
  if (std::fputws(buffer.data(), f) == -1)
```