### PR TITLE
Correct a typo on syntax.rst (documentation)

### DIFF
--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -444,7 +444,7 @@ Using type-specific formatting::
 
    auto t = tm();
    t.tm_year = 2010 - 1900;
-   t.tm_mon = 6;
+   t.tm_mon = 8;
    t.tm_mday = 4;
    t.tm_hour = 12;
    t.tm_min = 15;

--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -444,7 +444,7 @@ Using type-specific formatting::
 
    auto t = tm();
    t.tm_year = 2010 - 1900;
-   t.tm_mon = 8;
+   t.tm_mon = 7;
    t.tm_mday = 4;
    t.tm_hour = 12;
    t.tm_min = 15;


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

Thank you for this awesome library, I was just reading the documentation until I've noticed this little typo.

tm_mon is supposed to be 8 here.