### PR TITLE
Add missing detail namespace

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -287,7 +287,7 @@ struct formatter<TupleT, Char, enable_if_t<fmt::is_tuple_like<TupleT>::value>> {
   // C++11 generic lambda for format()
   template <typename FormatContext> struct format_each {
     template <typename T> void operator()(const T& v) {
-      if (i > 0) out = write_delimiter(out);
+      if (i > 0) out = detail::write_delimiter(out);
       out = detail::write_range_entry<Char>(out, v);
       ++i;
     }


### PR DESCRIPTION
This is a minor fix for an issue I discovered in one of my own projects that for some reason I cannot seem to reproduce it in ranges-test.cc. I'm not sure *why* exactly this isn't having any troubles internally, but it does definitely appear to be invalid syntax.