### PR TITLE
Use gcc-10.2 instead of gcc-10.1 on CI, also fix one problem

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,28 +4,35 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         cxx: [g++-4.8, g++-8, g++-10, clang++-9]
         build_type: [Debug, Release]
         std: [11]
+        os: [ubuntu-18.04]
         include:
           - cxx: g++-4.8
             install: sudo apt install g++-4.8
+            os: ubuntu-18.04
           - cxx: g++-8
             std: 14
+            os: ubuntu-18.04
           - cxx: g++-10
             std: 17
+            os: ubuntu-18.04
           - cxx: g++-10
             std: 20
             cxxflags: -DFMT_COMPILE_TIME_CHECKS=1
+            os: ubuntu-20.04
           - cxx: clang++-9
             std: 11
+            os: ubuntu-18.04
           - cxx: clang++-9
             build_type: Debug
             fuzz: -DFMT_FUZZ=ON -DFMT_FUZZ_LINKMAIN=ON
             std: 17
+            os: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1674,7 +1674,7 @@ template <typename OutputIt, typename Char, typename UInt> struct int_writer {
     return string_view(prefix, prefix_size);
   }
 
-  void write_dec() {
+  FMT_CONSTEXPR void write_dec() {
     auto num_digits = count_digits(abs_value);
     out = write_int(
         out, num_digits, get_prefix(), specs, [this, num_digits](iterator it) {


### PR DESCRIPTION
Somehow I missed that `ubuntu-18.04` image on CI has GCC-10._**1**_ installed, so CI is unable to build compile-time formatting tests because they require GCC-10._**2**_+. 

https://github.com/fmtlib/fmt/blob/9c418bc468baf434a848010bff74663e1f820e79/include/fmt/format.h#L286-L287
https://github.com/fmtlib/fmt/blob/9c418bc468baf434a848010bff74663e1f820e79/test/compile-test.cc#L190-L191

So I just switched the Ubuntu image to `ubuntu-20.04` for the `g++-10` compiler with C++20 standard. The `CompileTimeFormattingTest` tests do run now, it's checked by failing CI build with [false commit](https://github.com/alexezeder/fmt/commit/7568ddc94cb11957ea1cf64dc0e2841692998f3e) on [CI](https://github.com/fmtlib/fmt/runs/1754041007?check_suite_focus=true).

Also, this PR fixes the problem that was not detected on CI because of the wrong GCC-10 minor version.