### PR TITLE
Add full support of format string parsing in compile-time API

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1090,7 +1090,7 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
 
     template <typename Id> FMT_CONSTEXPR arg_ref_type make_arg_ref(Id arg_id) {
       context.check_arg_id(arg_id);
-      return arg_ref_type(arg_id);
+      return arg_ref_type(arg_id, true);
     }
 
     FMT_CONSTEXPR arg_ref_type make_arg_ref(basic_string_view<Char> arg_id) {
@@ -1099,7 +1099,7 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
     }
 
     FMT_CONSTEXPR arg_ref_type make_arg_ref(detail::auto_id) {
-      return arg_ref_type(context.next_arg_id());
+      return arg_ref_type(context.next_arg_id(), false);
     }
 
     void on_error(const char* msg) { FMT_THROW(format_error(msg)); }

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -649,14 +649,11 @@ template <typename CompiledString> constexpr auto get_parts_array() {
   return result;
 }
 
-template <typename CompiledString>
-constexpr static auto compiled_parts = get_parts_array<CompiledString>();
-
 template <typename Args, typename CompiledString, size_t part_index>
 constexpr auto make_compiled_part() {
   using char_type = typename CompiledString::char_type;
 
-  constexpr format_part part = compiled_parts<CompiledString>[part_index];
+  constexpr auto part = get_parts_array<CompiledString>()[part_index];
   if constexpr (part.part_kind == decltype(part)::kind::arg_index_auto ||
                 part.part_kind == decltype(part)::kind::arg_index_manual) {
     using id_type = get_type<part.val.arg_index, Args>;
@@ -695,7 +692,7 @@ constexpr auto make_compiled_part() {
 // Prepares a compiled representation for non-empty format string
 template <typename Args, typename CompiledString, size_t part_index>
 constexpr auto make_compiled_parts() {
-  if constexpr (part_index == compiled_parts<CompiledString>.size() - 1) {
+  if constexpr (part_index == get_parts_array<CompiledString>().size() - 1) {
     return make_compiled_part<Args, CompiledString, part_index>();
   } else {
     return make_concat(

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2177,12 +2177,16 @@ struct test_format_specs_handler {
 
   FMT_CONSTEXPR void on_width(int w) { width = w; }
   FMT_CONSTEXPR void on_dynamic_width(fmt::detail::auto_id) {}
-  FMT_CONSTEXPR void on_dynamic_width(int index) { width_ref = index; }
+  FMT_CONSTEXPR void on_dynamic_width(int index) {
+    width_ref = fmt::detail::arg_ref<char>(index, true);
+  }
   FMT_CONSTEXPR void on_dynamic_width(string_view) {}
 
   FMT_CONSTEXPR void on_precision(int p) { precision = p; }
   FMT_CONSTEXPR void on_dynamic_precision(fmt::detail::auto_id) {}
-  FMT_CONSTEXPR void on_dynamic_precision(int index) { precision_ref = index; }
+  FMT_CONSTEXPR void on_dynamic_precision(int index) {
+    precision_ref = fmt::detail::arg_ref<char>(index, true);
+  }
   FMT_CONSTEXPR void on_dynamic_precision(string_view) {}
 
   FMT_CONSTEXPR void end_precision() {}


### PR DESCRIPTION
Some time ago, I wrote that I would try to add support of named arguments in compile-time API [here](https://github.com/fmtlib/fmt/issues/2078#issuecomment-753662719). This took some time... especially when I realize that I can replace most of the functions written by me with functions that already exist in {fmt}.

Some points for the changes:

- [works with C++17](https://github.com/alexezeder/fmt/actions/runs/509533441) as [it did before](https://github.com/alexezeder/fmt/actions/runs/506035706), I tried to make additional implementation for C++20 with non-type template parameters to eliminate unnecessary template instantiations, but I ended up recreating every used type to make them structural and facing with [this fancy problem](https://godbolt.org/z/7hrzGb) I was not even thinking about, so there is no additional C++20 implementation for now (and maybe forever)
- custom (for compile-time API's `FMT_COMPILE` and `_cf`) parsing functions (`compile_format_string()` + `parse_tail()`) replaced with the usage of `format_string_compiler`, this gives full support of format string parsing, it's already written and tested code, and that's nice
- one-step algorithm with recursion of `compile_format_string()` + `parse_tail()` functions replaced by two-steps algorithm (kinda):
  - first step is to prepare an array of `format_part` using `format_string_compiler`
  - second step is to create the same compiled format object as it was before (with recursion of `concat<L, R>`)
- manual indexing with `{0}` and automatic indexing with `{name}` usage works exactly as it works in runtime API (thanks to `format_string_compiler`)
- named replacement fields are compiled into their own `compiled_format` types (`runtime_named_field` and `runtime_named_spec_field`), but these types just hold name or name+specs to be able to use `write()` function or to create `formatter` for specified specs
- single `*index` argument kind divided into `index_auto` and `index_manual` to have meta info about how the argument was created, maybe it's not the best solution, but this meta info needed for proper `spec_field` creation
- tests added

I was afraid of making compilation time significantly longer by using the current approach, so I made a very straightforward test by compiling `compile-test.cc` with the same tests (`master` version of this file) several times, here are average times (mean ± σ, big thanks to [hyperfine](https://github.com/sharkdp/hyperfine)):
Compiler | master | this PR
------------ | --------- | --------------
clang++-11 | 2.831 s ±  0.016 s | 2.894 s ±  0.019 s
clang++-11 `-g` | 3.373 s ±  0.026 s | 3.425 s ±  0.022 s
clang++-11 `-O3 -DNDEBUG` | 10.632 s ±  0.016 s | 10.601 s ±  0.042 s
g++-10 | 4.728 s ±  0.024 s | 4.819 s ±  0.023 s
g++-10 `-g` | 5.299 s ±  0.024 s | 5.403 s ±  0.032 s
g++-10 `-O3 -DNDEBUG` | 11.787 s ±  0.028 s | 11.978 s ±  0.033 s

So, there is some compilation time increase (in most cases), but I'm not sure how bad it is.