### PR TITLE
Make ranges-test available with C++11

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -381,7 +381,7 @@ template <typename T> inline T* make_checked(T* p, size_t) { return p; }
 #endif
 
 template <typename Container, FMT_ENABLE_IF(is_contiguous<Container>::value)>
-#if FMT_CLANG_VERSION
+#if FMT_CLANG_VERSION >= 307
 __attribute__((no_sanitize("undefined")))
 #endif
 inline checked_ptr<typename Container::value_type>
@@ -940,8 +940,8 @@ template <typename T = void> struct FMT_EXTERN_TEMPLATE_API basic_data {
   static const char reset_color[5];
   static const wchar_t wreset_color[5];
   static const char signs[];
-  static constexpr const char left_padding_shifts[] = {31, 31, 0, 1, 0};
-  static constexpr const char right_padding_shifts[] = {0, 31, 0, 1, 0};
+  static constexpr const char left_padding_shifts[5] = {31, 31, 0, 1, 0};
+  static constexpr const char right_padding_shifts[5] = {0, 31, 0, 1, 0};
 
   // DEPRECATED! These are for ABI compatibility.
   static const uint32_t zero_or_powers_of_10_32[];

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -368,7 +368,7 @@ template <typename Char, typename... T> struct tuple_arg_join : detail::view {
   basic_string_view<Char> sep;
 
   tuple_arg_join(const std::tuple<T...>& t, basic_string_view<Char> s)
-      : tuple{t}, sep{s} {}
+      : tuple(t), sep{s} {}
 };
 
 template <typename Char, typename... T>


### PR DESCRIPTION
I noticed here this strange check:
https://github.com/fmtlib/fmt/blob/acef0bb51ade288bf7930d1b74d1338f49f9f900/test/ranges-test.cc#L16-L18
So I decided to do it right - by using `__cpp_if_constexpr` feature macro. But later I realized that since there is no mention in docs that ranges are supported only with C++14 (or C++17 because of `constexpr if`) it's strange to me that test doesn't check C++11, especially when this check is not necessary at all with only few changes in the test.
With this PR `ranges-test` compiles with C++11 on probably most ancient supported compilers - gcc-4.8 and clang-3.5 (couldn't test 3.4).
