### PR TITLE
fix #2116 (FMT_COMPILE throws unmatched '{' on ESP32)

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -554,7 +554,7 @@ constexpr auto compile_format_string(S format_str) {
   using char_type = typename S::char_type;
   constexpr basic_string_view<char_type> str = format_str;
   if constexpr (str[POS] == '{') {
-    if (POS + 1 == str.size())
+    if constexpr (POS + 1 == str.size())
       throw format_error("unmatched '{' in format string");
     if constexpr (str[POS + 1] == '{') {
       return parse_tail<Args, POS + 2, ID>(make_text(str, POS, 1), format_str);
@@ -571,7 +571,7 @@ constexpr auto compile_format_string(S format_str) {
       return unknown_format();
     }
   } else if constexpr (str[POS] == '}') {
-    if (POS + 1 == str.size())
+    if constexpr (POS + 1 == str.size())
       throw format_error("unmatched '}' in format string");
     return parse_tail<Args, POS + 2, ID>(make_text(str, POS, 1), format_str);
   } else {


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

-----------

Fixes #2116 (for me, for now!)

Please do note that I am no expert in compile-time metaprogramming, therefore this patch might be "wrong", although it did work out for me.