### PR TITLE
Fix fmt::localtime formatting not working in wide-char string contexts

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -413,7 +413,8 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock>, Char>
 };
 
 template <typename Char> struct formatter<std::tm, Char> {
-  FMT_CONSTEXPR auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+  template <typename ParseContext>
+  FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
     auto it = ctx.begin();
     if (it != ctx.end() && *it == ':') ++it;
     auto end = it;


### PR DESCRIPTION
Issue was caused by incorrectly using an explicit type for `parse_context` parameter instead of a templated type, which meant that the `parse` function would only work in regular string contexts.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.