### PR TITLE
Add full support of format string parsing in compile-time API

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1157,27 +1157,30 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
   }
 
   template <typename FormatContext>
-  auto format(const duration& d, FormatContext& ctx) -> decltype(ctx.out()) {
+  auto format(const duration& d, FormatContext& ctx) const
+      -> decltype(ctx.out()) {
+    auto specs_copy = specs;
+    auto precision_copy = precision;
     auto begin = format_str.begin(), end = format_str.end();
     // As a possible future optimization, we could avoid extra copying if width
     // is not specified.
     basic_memory_buffer<Char> buf;
     auto out = std::back_inserter(buf);
-    detail::handle_dynamic_spec<detail::width_checker>(specs.width, width_ref,
-                                                       ctx);
-    detail::handle_dynamic_spec<detail::precision_checker>(precision,
+    detail::handle_dynamic_spec<detail::width_checker>(specs_copy.width,
+                                                       width_ref, ctx);
+    detail::handle_dynamic_spec<detail::precision_checker>(precision_copy,
                                                            precision_ref, ctx);
     if (begin == end || *begin == '}') {
-      out = detail::format_duration_value<Char>(out, d.count(), precision);
+      out = detail::format_duration_value<Char>(out, d.count(), precision_copy);
       detail::format_duration_unit<Char, Period>(out);
     } else {
       detail::chrono_formatter<FormatContext, decltype(out), Rep, Period> f(
           ctx, out, d);
-      f.precision = precision;
+      f.precision = precision_copy;
       parse_chrono_format(begin, end, f);
     }
     return detail::write(
-        ctx.out(), basic_string_view<Char>(buf.data(), buf.size()), specs);
+        ctx.out(), basic_string_view<Char>(buf.data(), buf.size()), specs_copy);
   }
 };
 

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -454,9 +454,14 @@ template <typename Char, typename T, int N> struct field {
 
   template <typename OutputIt, typename... Args>
   constexpr OutputIt format(OutputIt out, const Args&... args) const {
-    // This ensures that the argument type is convertile to `const T&`.
-    const T& arg = get<N>(args...);
-    return write<Char>(out, arg);
+    if constexpr (is_named_arg<typename std::remove_cv<T>::type>::value) {
+      decltype(T::value) arg = get<N>(args...).value;
+      return write<Char>(out, arg);
+    } else {
+      // This ensures that the argument type is convertile to `const T&`.
+      const T& arg = get<N>(args...);
+      return write<Char>(out, arg);
+    }
   }
 };
 
@@ -775,8 +780,15 @@ FMT_INLINE std::basic_string<typename S::char_type> format(const S&,
 #ifdef __cpp_if_constexpr
   if constexpr (std::is_same<typename S::char_type, char>::value) {
     constexpr basic_string_view<typename S::char_type> str = S();
-    if constexpr (str.size() == 2 && str[0] == '{' && str[1] == '}')
-      return fmt::to_string(detail::first(args...));
+    if constexpr (str.size() == 2 && str[0] == '{' && str[1] == '}') {
+      auto first = detail::first(args...);
+      if constexpr (detail::is_named_arg<typename std::remove_cv<
+                        decltype(first)>::type>::value) {
+        return fmt::to_string(first.value);
+      } else {
+        return fmt::to_string(first);
+      }
+    }
   }
 #endif
   constexpr auto compiled = detail::compile<Args...>(S());

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -455,7 +455,7 @@ template <typename Char, typename T, int N> struct field {
   template <typename OutputIt, typename... Args>
   constexpr OutputIt format(OutputIt out, const Args&... args) const {
     if constexpr (is_named_arg<typename std::remove_cv<T>::type>::value) {
-      decltype(T::value) arg = get<N>(args...).value;
+      const auto& arg = get<N>(args...).value;
       return write<Char>(out, arg);
     } else {
       // This ensures that the argument type is convertile to `const T&`.
@@ -778,9 +778,9 @@ FMT_INLINE std::basic_string<typename S::char_type> format(const S&,
   if constexpr (std::is_same<typename S::char_type, char>::value) {
     constexpr basic_string_view<typename S::char_type> str = S();
     if constexpr (str.size() == 2 && str[0] == '{' && str[1] == '}') {
-      auto first = detail::first(args...);
-      if constexpr (detail::is_named_arg<typename std::remove_cv<
-                        decltype(first)>::type>::value) {
+      const auto& first = detail::first(args...);
+      if constexpr (detail::is_named_arg<
+                        remove_cvref_t<decltype(first)>>::value) {
         return fmt::to_string(first.value);
       } else {
         return fmt::to_string(first);

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -589,7 +589,7 @@ template <typename Char> struct arg_id_handler {
   constexpr void on_error(const char* message) { throw format_error(message); }
 
   constexpr int on_arg_id() {
-    throw format_error("handler cannot be used for empty arg_id");
+    FMT_ASSERT(false, "handler cannot be used with automatic indexing");
     return 0;
   }
 

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -668,11 +668,8 @@ constexpr auto compile_format_string(S format_str) {
               format_str);
         }
       } else if constexpr (arg_id_result.arg_id.kind == arg_id_kind::name) {
-        static_assert(
-            ID != manual_indexing_id,
-            "cannot switch from manual to automatic argument indexing");
         if constexpr (c == '}') {
-          return parse_tail<Args, arg_id_end_pos + 1, ID + 1>(
+          return parse_tail<Args, arg_id_end_pos + 1, ID>(
               runtime_named_field<char_type>{arg_id_result.arg_id.val.name},
               format_str);
         } else if constexpr (c == ':') {

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -262,18 +262,14 @@ TEST(CompileTest, Named) {
   EXPECT_EQ("foobar",
             fmt::format(FMT_COMPILE("{a0}{a1}"), fmt::arg("a0", "foo"),
                         fmt::arg("a1", "bar")));
-  EXPECT_EQ("foobar",
-            fmt::format(/*FMT_COMPILE(*/ "{}{a1}" /*)*/, fmt::arg("a0", "foo"),
-                        fmt::arg("a1", "bar")));
-  EXPECT_EQ("foofoo",
-            fmt::format(/*FMT_COMPILE(*/ "{a0}{}" /*)*/, fmt::arg("a0", "foo"),
-                        fmt::arg("a1", "bar")));
-  EXPECT_EQ("foobar",
-            fmt::format(/*FMT_COMPILE(*/ "{a0}{1}" /*)*/, fmt::arg("a0", "foo"),
-                        fmt::arg("a1", "bar")));
-  EXPECT_EQ("foobar",
-            fmt::format(/*FMT_COMPILE(*/ "{0}{a1}" /*)*/, fmt::arg("a0", "foo"),
-                        fmt::arg("a1", "bar")));
+  EXPECT_EQ("foobar", fmt::format(FMT_COMPILE("{}{a1}"), fmt::arg("a0", "foo"),
+                                  fmt::arg("a1", "bar")));
+  EXPECT_EQ("foofoo", fmt::format(FMT_COMPILE("{a0}{}"), fmt::arg("a0", "foo"),
+                                  fmt::arg("a1", "bar")));
+  EXPECT_EQ("foobar", fmt::format(FMT_COMPILE("{0}{a1}"), fmt::arg("a0", "foo"),
+                                  fmt::arg("a1", "bar")));
+  EXPECT_EQ("foobar", fmt::format(FMT_COMPILE("{a0}{1}"), fmt::arg("a0", "foo"),
+                                  fmt::arg("a1", "bar")));
 
   EXPECT_EQ("foobar",
             fmt::format(FMT_COMPILE("{}{a1}"), "foo", fmt::arg("a1", "bar")));

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -139,13 +139,136 @@ TEST(CompileTest, FormatWideString) {
   EXPECT_EQ(L"42", fmt::format(FMT_COMPILE(L"{}"), 42));
 }
 
+struct test_custom_formattable {};
+
+FMT_BEGIN_NAMESPACE
+template <> struct formatter<test_custom_formattable> {
+  enum class output_type { two, four } type{output_type::two};
+
+  FMT_CONSTEXPR auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+    auto it = ctx.begin(), end = ctx.end();
+    while (it != end && *it != '}') {
+      ++it;
+    }
+    auto spec = string_view(ctx.begin(), static_cast<size_t>(it - ctx.begin()));
+    auto tag = string_view("custom");
+    if (spec.size() == tag.size()) {
+      bool is_same = true;
+      for (size_t index = 0; index < spec.size(); ++index) {
+        if (spec[index] != tag[index]) {
+          is_same = false;
+          break;
+        }
+      }
+      type = is_same ? output_type::four : output_type::two;
+    } else {
+      type = output_type::two;
+    }
+    return it;
+  }
+
+  template <typename FormatContext>
+  auto format(const test_custom_formattable&, FormatContext& ctx) const
+      -> decltype(ctx.out()) {
+    return format_to(ctx.out(), type == output_type::two ? "{:>2}" : "{:>4}",
+                     42);
+  }
+};
+FMT_END_NAMESPACE
+
 TEST(CompileTest, FormatSpecs) {
   EXPECT_EQ("42", fmt::format(FMT_COMPILE("{:x}"), 0x42));
+  EXPECT_EQ("42", fmt::format(FMT_COMPILE("{}"), test_custom_formattable()));
+  EXPECT_EQ("  42",
+            fmt::format(FMT_COMPILE("{:custom}"), test_custom_formattable()));
 }
 
-TEST(CompileTest, DynamicWidth) {
+struct test_dynamic_formattable {};
+
+FMT_BEGIN_NAMESPACE
+template <> struct formatter<test_dynamic_formattable> {
+  size_t amount = 0;
+  detail::arg_ref<char> width_refs[3];
+
+  FMT_CONSTEXPR auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+    amount = static_cast<size_t>(*ctx.begin() - '0');
+    if (amount >= 1) {
+      width_refs[0] = detail::arg_ref<char>(ctx.next_arg_id());
+    }
+    if (amount >= 2) {
+      width_refs[1] = detail::arg_ref<char>(ctx.next_arg_id());
+    }
+    if (amount >= 3) {
+      width_refs[2] = detail::arg_ref<char>(ctx.next_arg_id());
+    }
+    return ctx.begin() + 1;
+  }
+
+  template <typename FormatContext>
+  auto format(const test_dynamic_formattable&, FormatContext& ctx) const
+      -> decltype(ctx.out()) {
+    int widths[3]{};
+    for (size_t i = 0; i < amount; ++i) {
+      detail::handle_dynamic_spec<detail::width_checker>(widths[i],
+                                                         width_refs[i], ctx);
+    }
+    if (amount == 1) {
+      return format_to(ctx.out(), "{:{}}", 41, widths[0]);
+    } else if (amount == 2) {
+      return format_to(ctx.out(), "{:{}}{:{}}", 41, widths[0], 42, widths[1]);
+    } else if (amount == 3) {
+      return format_to(ctx.out(), "{:{}}{:{}}{:{}}", 41, widths[0], 42,
+                       widths[1], 43, widths[2]);
+    } else {
+      throw format_error("formatting error");
+    }
+  }
+};
+FMT_END_NAMESPACE
+
+TEST(CompileTest, DynamicFormatSpecs) {
   EXPECT_EQ("  42foo  ",
             fmt::format(FMT_COMPILE("{:{}}{:{}}"), 42, 4, "foo", 5));
+  EXPECT_EQ("  41",
+            fmt::format(FMT_COMPILE("{:1}"), test_dynamic_formattable(), 4));
+  EXPECT_EQ(" 41   42",
+            fmt::format(FMT_COMPILE("{:2}"), test_dynamic_formattable(), 3, 5));
+  EXPECT_EQ("   41 42  43", fmt::format(FMT_COMPILE("{:3}"),
+                                        test_dynamic_formattable(), 5, 3, 4));
+}
+
+TEST(CompileTest, ManualOrdering) {
+  EXPECT_EQ("42", fmt::format(FMT_COMPILE("{0}"), 42));
+  EXPECT_EQ(" -42", fmt::format(FMT_COMPILE("{0:4}"), -42));
+  EXPECT_EQ("41 43", fmt::format(FMT_COMPILE("{0} {1}"), 41, 43));
+  EXPECT_EQ("41 43", fmt::format(FMT_COMPILE("{1} {0}"), 43, 41));
+  EXPECT_EQ("41 43", fmt::format(FMT_COMPILE("{0} {2}"), 41, 42, 43));
+  EXPECT_EQ("  41   43", fmt::format(FMT_COMPILE("{1:{2}} {0:4}"), 43, 41, 4));
+  EXPECT_EQ("42   42",
+            fmt::format(FMT_COMPILE("{1} {0:custom}"),
+                        test_custom_formattable(), test_custom_formattable()));
+  EXPECT_EQ(
+      "true 42 42 foo 0x1234 foo",
+      fmt::format(FMT_COMPILE("{0} {1} {2} {3} {4} {5}"), true, 42, 42.0f,
+                  "foo", reinterpret_cast<void*>(0x1234), test_formattable()));
+  EXPECT_EQ(L"42", fmt::format(FMT_COMPILE(L"{0}"), 42));
+}
+
+TEST(CompileTest, Named) {
+  EXPECT_EQ("41 43", fmt::format(FMT_COMPILE("{name1} {name2}"),
+                                 fmt::arg("name1", 41), fmt::arg("name2", 43)));
+  EXPECT_EQ("41 43",
+            fmt::format(FMT_COMPILE("{} {name2}"), 41, fmt::arg("name2", 43)));
+  EXPECT_EQ("41 43",
+            fmt::format(FMT_COMPILE("{name1} {}"), fmt::arg("name1", 41), 43));
+  EXPECT_EQ("41 43",
+            fmt::format(FMT_COMPILE("{name1} {name2}"), fmt::arg("name1", 41),
+                        fmt::arg("name2", 43), fmt::arg("name3", 42)));
+  EXPECT_EQ("41 43", fmt::format(FMT_COMPILE("{name2} {name1}"),
+                                 fmt::arg("name1", 43), fmt::arg("name2", 41)));
+
+  EXPECT_THROW(fmt::format(FMT_COMPILE("{invalid}"), fmt::arg("valid", 42)),
+               fmt::format_error);
 }
 
 TEST(CompileTest, FormatTo) {
@@ -174,9 +297,7 @@ TEST(CompileTest, TextAndArg) {
   EXPECT_EQ("42!", fmt::format(FMT_COMPILE("{}!"), 42));
 }
 
-TEST(CompileTest, Empty) {
-  EXPECT_EQ("", fmt::format(FMT_COMPILE("")));
-}
+TEST(CompileTest, Empty) { EXPECT_EQ("", fmt::format(FMT_COMPILE(""))); }
 #endif
 
 #if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -255,17 +255,34 @@ TEST(CompileTest, ManualOrdering) {
 }
 
 TEST(CompileTest, Named) {
-  EXPECT_EQ("41 43", fmt::format(FMT_COMPILE("{name1} {name2}"),
-                                 fmt::arg("name1", 41), fmt::arg("name2", 43)));
-  EXPECT_EQ("41 43",
-            fmt::format(FMT_COMPILE("{} {name2}"), 41, fmt::arg("name2", 43)));
-  EXPECT_EQ("41 43",
-            fmt::format(FMT_COMPILE("{name1} {}"), fmt::arg("name1", 41), 43));
-  EXPECT_EQ("41 43",
-            fmt::format(FMT_COMPILE("{name1} {name2}"), fmt::arg("name1", 41),
-                        fmt::arg("name2", 43), fmt::arg("name3", 42)));
-  EXPECT_EQ("41 43", fmt::format(FMT_COMPILE("{name2} {name1}"),
-                                 fmt::arg("name1", 43), fmt::arg("name2", 41)));
+  EXPECT_EQ("42", fmt::format(FMT_COMPILE("{}"), fmt::arg("arg", 42)));
+  EXPECT_EQ("41 43", fmt::format(FMT_COMPILE("{} {}"), fmt::arg("arg", 41),
+                                 fmt::arg("arg", 43)));
+
+  EXPECT_EQ("foobar",
+            fmt::format(FMT_COMPILE("{a0}{a1}"), fmt::arg("a0", "foo"),
+                        fmt::arg("a1", "bar")));
+  EXPECT_EQ("foobar",
+            fmt::format(/*FMT_COMPILE(*/ "{}{a1}" /*)*/, fmt::arg("a0", "foo"),
+                        fmt::arg("a1", "bar")));
+  EXPECT_EQ("foofoo",
+            fmt::format(/*FMT_COMPILE(*/ "{a0}{}" /*)*/, fmt::arg("a0", "foo"),
+                        fmt::arg("a1", "bar")));
+  EXPECT_EQ("foobar",
+            fmt::format(/*FMT_COMPILE(*/ "{a0}{1}" /*)*/, fmt::arg("a0", "foo"),
+                        fmt::arg("a1", "bar")));
+  EXPECT_EQ("foobar",
+            fmt::format(/*FMT_COMPILE(*/ "{0}{a1}" /*)*/, fmt::arg("a0", "foo"),
+                        fmt::arg("a1", "bar")));
+
+  EXPECT_EQ("foobar",
+            fmt::format(FMT_COMPILE("{}{a1}"), "foo", fmt::arg("a1", "bar")));
+  EXPECT_EQ("foobar",
+            fmt::format(FMT_COMPILE("{a0}{a1}"), fmt::arg("a1", "bar"),
+                        fmt::arg("a2", "baz"), fmt::arg("a0", "foo")));
+  EXPECT_EQ(" bar foo ",
+            fmt::format(FMT_COMPILE(" {foo} {bar} "), fmt::arg("foo", "bar"),
+                        fmt::arg("bar", "foo")));
 
   EXPECT_THROW(fmt::format(FMT_COMPILE("{invalid}"), fmt::arg("valid", 42)),
                fmt::format_error);


### PR DESCRIPTION
Compile-time API functionality extended to support manual ordering and named arguments. Unlike my first attempt to do this in https://github.com/fmtlib/fmt/pull/2111, where I tried to use a format part array, here I'm just reusing that recursion of functions `compile_format_string()` and `parse_tail()`.

Some points for the changes:
* works with C++17 as it did before
* unlike https://github.com/fmtlib/fmt/pull/2111, this PR fully supports custom parsing in formatters
* manual indexing with `{0}` and automatic indexing with `{name}` work exactly as they work in the runtime API
* a switch of the argument indexing between automatic to manual or manual to automatic is detected at compile-time, and `static_assert`s fail with corresponding messages
* usage of named arguments with specs is unsupported because these arguments cannot provide type information unless their names are available at compile-time (I wrote about that with more details [here](https://github.com/fmtlib/fmt/issues/2078#issuecomment-769167144)), in case if named argument is used with specs in format string then `unknown_format()` is returned from string compilation procedure, thus we fallback to the runtime API for this string (but this fallback is currently broken)
* tests added