### PR TITLE
fmt::ptr: Support function pointers

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -314,6 +314,7 @@ Utilities
 .. doxygenfunction:: fmt::ptr(const T *p)
 .. doxygenfunction:: fmt::ptr(const std::unique_ptr<T> &p)
 .. doxygenfunction:: fmt::ptr(const std::shared_ptr<T> &p)
+.. doxygenfunction:: fmt::ptr(T (*fn)(Args...))
 
 .. doxygenfunction:: fmt::to_string(const T &value)
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3739,6 +3739,13 @@ template <typename T> inline const void* ptr(const std::unique_ptr<T>& p) {
 template <typename T> inline const void* ptr(const std::shared_ptr<T>& p) {
   return p.get();
 }
+#if !FMT_MSC_VER
+// MSVC lets function pointers decay to void pointers, so this
+// overload is unnecessary.
+template <typename T, typename... Args> inline const void* ptr(T (*fn)(Args...)) {
+  return detail::bit_cast<const void *>(fn);
+}
+#endif
 
 class bytes {
  private:

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1467,6 +1467,9 @@ TEST(FormatterTest, FormatUCharString) {
   EXPECT_EQ("test", format("{0:s}", ptr));
 }
 
+void function_pointer_test(int, double, std::string) {
+}
+
 TEST(FormatterTest, FormatPointer) {
   check_unknown_types(reinterpret_cast<void*>(0x1234), "p", "pointer");
   EXPECT_EQ("0x0", format("{0}", static_cast<void*>(nullptr)));
@@ -1479,6 +1482,8 @@ TEST(FormatterTest, FormatPointer) {
   EXPECT_EQ(format("{}", fmt::ptr(up.get())), format("{}", fmt::ptr(up)));
   std::shared_ptr<int> sp(new int(1));
   EXPECT_EQ(format("{}", fmt::ptr(sp.get())), format("{}", fmt::ptr(sp)));
+  EXPECT_EQ(format("{}", fmt::detail::bit_cast<const void *>(&function_pointer_test)),
+            format("{}", fmt::ptr(function_pointer_test)));
   EXPECT_EQ("0x0", format("{}", nullptr));
 }
 


### PR DESCRIPTION
Passing a function pointer to fmt::ptr results in:

 In file included from /home/mac/git/fmt/test/gmock/gmock.h:238,
                  from /home/mac/git/fmt/test/format-test.cc:31:
 .../fmt/test/format-test.cc: In member function ‘virtual void FormatterTest_FormatPointer_Test::TestBody()’:
 .../fmt/test/format-test.cc:1486:56: error: no matching function for call to ‘ptr(void (&)(int, double, std::__cxx11::string))’
              format("{}", fmt::ptr(function_pointer_test)));

Let's add an overload to support that usage.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
