### PR TITLE
Fix fallback to runtime API from compile-time API

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -22,10 +22,6 @@
 #  endif
 #endif
 
-#ifndef FMT_ENABLE_FALLBACK_TO_RUNTIME_API
-#  define FMT_ENABLE_FALLBACK_TO_RUNTIME_API 1
-#endif
-
 FMT_BEGIN_NAMESPACE
 namespace detail {
 
@@ -708,12 +704,6 @@ constexpr auto compile(S format_str) {
     constexpr auto result =
         detail::compile_format_string<detail::type_list<Args...>, 0, 0>(
             format_str);
-#  if !FMT_ENABLE_FALLBACK_TO_RUNTIME_API
-    static_assert(!std::is_same<remove_cvref_t<decltype(result)>,
-                                detail::unknown_format>(),
-                  "format string is invalid for compile-time API, "
-                  "and fallback to runtime API is disabled");
-#  endif
     return result;
   }
 }

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -844,25 +844,9 @@ template <typename OutputIt, typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
 format_to_n_result<OutputIt> format_to_n(OutputIt out, size_t n, const S&,
                                          Args&&... args) {
-  constexpr auto compiled = detail::compile<Args...>(S());
-#ifdef __cpp_if_constexpr
-  if constexpr (std::is_same<remove_cvref_t<decltype(compiled)>,
-                             detail::unknown_format>()) {
-    auto it =
-        format_to(detail::truncating_iterator<OutputIt>(out, n),
-                  static_cast<basic_string_view<typename S::char_type>>(S()),
-                  std::forward<Args>(args)...);
-    return {it.base(), it.count()};
-  } else {
-    auto it = format_to(detail::truncating_iterator<OutputIt>(out, n), compiled,
-                        std::forward<Args>(args)...);
-    return {it.base(), it.count()};
-  }
-#else
-  auto it = format_to(detail::truncating_iterator<OutputIt>(out, n), compiled,
+  auto it = format_to(detail::truncating_iterator<OutputIt>(out, n), S(),
                       std::forward<Args>(args)...);
   return {it.base(), it.count()};
-#endif
 }
 
 template <typename CompiledFormat, typename... Args>

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -22,6 +22,10 @@
 #  endif
 #endif
 
+#ifndef FMT_ENABLE_FALLBACK_TO_RUNTIME_API
+#  define FMT_ENABLE_FALLBACK_TO_RUNTIME_API 1
+#endif
+
 FMT_BEGIN_NAMESPACE
 namespace detail {
 
@@ -704,12 +708,13 @@ constexpr auto compile(S format_str) {
     constexpr auto result =
         detail::compile_format_string<detail::type_list<Args...>, 0, 0>(
             format_str);
-    if constexpr (std::is_same<remove_cvref_t<decltype(result)>,
-                               detail::unknown_format>()) {
-      return detail::compiled_format<S, Args...>(to_string_view(format_str));
-    } else {
-      return result;
-    }
+#  if !FMT_ENABLE_FALLBACK_TO_RUNTIME_API
+    static_assert(!std::is_same<remove_cvref_t<decltype(result)>,
+                                detail::unknown_format>(),
+                  "format string is invalid for compile-time API, "
+                  "and fallback to runtime API is disabled");
+#  endif
+    return result;
   }
 }
 #else
@@ -789,7 +794,17 @@ FMT_INLINE std::basic_string<typename S::char_type> format(const S&,
   }
 #endif
   constexpr auto compiled = detail::compile<Args...>(S());
+#ifdef __cpp_if_constexpr
+  if constexpr (std::is_same<remove_cvref_t<decltype(compiled)>,
+                             detail::unknown_format>()) {
+    return format(static_cast<basic_string_view<typename S::char_type>>(S()),
+                  std::forward<Args>(args)...);
+  } else {
+    return format(compiled, std::forward<Args>(args)...);
+  }
+#else
   return format(compiled, std::forward<Args>(args)...);
+#endif
 }
 
 template <typename OutputIt, typename CompiledFormat, typename... Args,
@@ -805,9 +820,20 @@ constexpr OutputIt format_to(OutputIt out, const CompiledFormat& cf,
 
 template <typename OutputIt, typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
-FMT_CONSTEXPR OutputIt format_to(OutputIt out, const S&, const Args&... args) {
+FMT_CONSTEXPR OutputIt format_to(OutputIt out, const S&, Args&&... args) {
   constexpr auto compiled = detail::compile<Args...>(S());
-  return format_to(out, compiled, args...);
+#ifdef __cpp_if_constexpr
+  if constexpr (std::is_same<remove_cvref_t<decltype(compiled)>,
+                             detail::unknown_format>()) {
+    return format_to(out,
+                     static_cast<basic_string_view<typename S::char_type>>(S()),
+                     std::forward<Args>(args)...);
+  } else {
+    return format_to(out, compiled, std::forward<Args>(args)...);
+  }
+#else
+  return format_to(out, compiled, std::forward<Args>(args)...);
+#endif
 }
 
 template <typename OutputIt, typename CompiledFormat, typename... Args>
@@ -827,11 +853,26 @@ auto format_to_n(OutputIt out, size_t n, const CompiledFormat& cf,
 template <typename OutputIt, typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
 format_to_n_result<OutputIt> format_to_n(OutputIt out, size_t n, const S&,
-                                         const Args&... args) {
+                                         Args&&... args) {
   constexpr auto compiled = detail::compile<Args...>(S());
+#ifdef __cpp_if_constexpr
+  if constexpr (std::is_same<remove_cvref_t<decltype(compiled)>,
+                             detail::unknown_format>()) {
+    auto it =
+        format_to(detail::truncating_iterator<OutputIt>(out, n),
+                  static_cast<basic_string_view<typename S::char_type>>(S()),
+                  std::forward<Args>(args)...);
+    return {it.base(), it.count()};
+  } else {
+    auto it = format_to(detail::truncating_iterator<OutputIt>(out, n), compiled,
+                        std::forward<Args>(args)...);
+    return {it.base(), it.count()};
+  }
+#else
   auto it = format_to(detail::truncating_iterator<OutputIt>(out, n), compiled,
-                      args...);
+                      std::forward<Args>(args)...);
   return {it.base(), it.count()};
+#endif
 }
 
 template <typename CompiledFormat, typename... Args>

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -229,7 +229,6 @@ TEST(CompileTest, TextAndArg) {
   EXPECT_EQ("42!", fmt::format(FMT_COMPILE("{}!"), 42));
 }
 
-#  if FMT_ENABLE_FALLBACK_TO_RUNTIME_API
 TEST(CompileTest, UnknownFormatFallback) {
   EXPECT_EQ(" 42 ",
             fmt::format(FMT_COMPILE("{name:^4}"), fmt::arg("name", 42)));
@@ -246,7 +245,6 @@ TEST(CompileTest, UnknownFormatFallback) {
   EXPECT_EQ(buffer + 4, result.out);
   EXPECT_EQ(" 42 ", fmt::string_view(buffer, 4));
 }
-#  endif
 
 TEST(CompileTest, Empty) { EXPECT_EQ("", fmt::format(FMT_COMPILE(""))); }
 #endif

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -229,6 +229,25 @@ TEST(CompileTest, TextAndArg) {
   EXPECT_EQ("42!", fmt::format(FMT_COMPILE("{}!"), 42));
 }
 
+#  if FMT_ENABLE_FALLBACK_TO_RUNTIME_API
+TEST(CompileTest, UnknownFormatFallback) {
+  EXPECT_EQ(" 42 ",
+            fmt::format(FMT_COMPILE("{name:^4}"), fmt::arg("name", 42)));
+
+  std::vector<char> v;
+  fmt::format_to(std::back_inserter(v), FMT_COMPILE("{name:^4}"),
+                 fmt::arg("name", 42));
+  EXPECT_EQ(" 42 ", fmt::string_view(v.data(), v.size()));
+
+  char buffer[4];
+  auto result = fmt::format_to_n(buffer, 4, FMT_COMPILE("{name:^4}"),
+                                 fmt::arg("name", 42));
+  EXPECT_EQ(4u, result.size);
+  EXPECT_EQ(buffer + 4, result.out);
+  EXPECT_EQ(" 42 ", fmt::string_view(buffer, 4));
+}
+#  endif
+
 TEST(CompileTest, Empty) { EXPECT_EQ("", fmt::format(FMT_COMPILE(""))); }
 #endif
 

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -239,9 +239,9 @@ TEST(CompileTest, UnknownFormatFallback) {
   EXPECT_EQ(" 42 ", fmt::string_view(v.data(), v.size()));
 
   char buffer[4];
-  auto result = fmt::format_to_n(buffer, 4, FMT_COMPILE("{name:^4}"),
+  auto result = fmt::format_to_n(buffer, 4, FMT_COMPILE("{name:^5}"),
                                  fmt::arg("name", 42));
-  EXPECT_EQ(4u, result.size);
+  EXPECT_EQ(5u, result.size);
   EXPECT_EQ(buffer + 4, result.out);
   EXPECT_EQ(" 42 ", fmt::string_view(buffer, 4));
 }


### PR DESCRIPTION
Right now, when {fmt} fails to prepare compiled format for format string (using `FMT_COMPILE` or `_cf`) it also fails to report about that clearly. Here is an example - https://godbolt.org/z/G1ETdc.

There [were](https://github.com/fmtlib/fmt/pull/2061) some attempts to make the error a bit clearer, but as it [turned out](https://github.com/fmtlib/fmt/pull/2061#issuecomment-743775046) {fmt} should fall back to the runtime API in those cases. This PR adds that fallback.

Some points for the PR:
* test added
* there is a bit of code duplication introduced, because I decided that this code is clearer:
  ```cpp
  #ifdef __cpp_if_constexpr
    if constexpr (std::is_same<remove_cvref_t<decltype(compiled)>,
                               detail::unknown_format>()) {
      return format(static_cast<basic_string_view<typename S::char_type>>(S()),
                    std::forward<Args>(args)...);
    } else {
      return format(compiled, std::forward<Args>(args)...);
    }
  #else
    return format(compiled, std::forward<Args>(args)...);
  #endif
  ```
  then this one:
  ```cpp
  #ifdef __cpp_if_constexpr
    if constexpr (std::is_same<remove_cvref_t<decltype(compiled)>,
                               detail::unknown_format>()) {
      return format(static_cast<basic_string_view<typename S::char_type>>(S()),
                    std::forward<Args>(args)...);
    } else {
  #endif
      return format(compiled, std::forward<Args>(args)...);
  #ifdef __cpp_if_constexpr
    }
  #endif
  ```