### PR TITLE
Print error message in FMT_THROW when exception is disabled

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -123,8 +123,7 @@ FMT_END_NAMESPACE
 #  else
 #    define FMT_THROW(x)       \
       do {                     \
-        static_cast<void>(x);  \
-        FMT_ASSERT(false, ""); \
+        FMT_ASSERT(false, (x).what()); \
       } while (false)
 #  endif
 #endif


### PR DESCRIPTION
Currently, if exception is disabled, an error in `fmt` will result a termination via `FMT_ASSERT`, but there is no error message printed on `stderr`, so it can be a little bit confusing for the user on why the program failed.

This PR modifies `FMT_THROW` to pass `exception.what()` to `FMT_ASSERT` as the error message.

Although it doesn't provide more information which part of format string caused the error, it is better than printing no error message at all.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
