### PR TITLE
Add error_reporter_t for customizable error handling when '-fno-exceptions'

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -326,7 +326,7 @@ inline std::tm localtime(std::time_t time) {
   };
   dispatcher lt(time);
   // Too big time values may be unsupported.
-  if (!lt.run()) FMT_THROW(format_error("time_t value out of range"));
+  if (!lt.run()) FMT_ERROR(Error_type::format_error, "time_t value out of range");
   return lt.tm_;
 }
 
@@ -371,7 +371,7 @@ inline std::tm gmtime(std::time_t time) {
   };
   dispatcher gt(time);
   // Too big time values may be unsupported.
-  if (!gt.run()) FMT_THROW(format_error("time_t value out of range"));
+  if (!gt.run()) FMT_ERROR(Error_type::format_error, "time_t value out of range");
   return gt.tm_;
 }
 
@@ -537,7 +537,9 @@ FMT_CONSTEXPR const Char* parse_chrono_format(const Char* begin,
     }
     if (begin != ptr) handler.on_text(begin, ptr);
     ++ptr;  // consume '%'
-    if (ptr == end) FMT_THROW(format_error("invalid format"));
+    if (ptr == end)
+      FMT_ERROR(Error_type::format_error, "invalid format",
+                basic_string_view<Char>(begin, static_cast<std::size_t>(end - begin)));
     c = *ptr++;
     switch (c) {
     case '%':
@@ -628,7 +630,9 @@ FMT_CONSTEXPR const Char* parse_chrono_format(const Char* begin,
       break;
     // Alternative representation:
     case 'E': {
-      if (ptr == end) FMT_THROW(format_error("invalid format"));
+      if (ptr == end)
+        FMT_ERROR(Error_type::format_error, "invalid format", 
+                  basic_string_view<Char>(begin, static_cast<std::size_t>(end - begin)));
       c = *ptr++;
       switch (c) {
       case 'c':
@@ -641,12 +645,15 @@ FMT_CONSTEXPR const Char* parse_chrono_format(const Char* begin,
         handler.on_loc_time(numeric_system::alternative);
         break;
       default:
-        FMT_THROW(format_error("invalid format"));
+        FMT_ERROR(Error_type::format_error, "invalid format", 
+                  basic_string_view<Char>(begin, static_cast<std::size_t>(end - begin)));
       }
       break;
     }
     case 'O':
-      if (ptr == end) FMT_THROW(format_error("invalid format"));
+      if (ptr == end)
+        FMT_ERROR(Error_type::format_error, "invalid format", 
+                  basic_string_view<Char>(begin, static_cast<std::size_t>(end - begin)));
       c = *ptr++;
       switch (c) {
       case 'w':
@@ -668,11 +675,13 @@ FMT_CONSTEXPR const Char* parse_chrono_format(const Char* begin,
         handler.on_second(numeric_system::alternative);
         break;
       default:
-        FMT_THROW(format_error("invalid format"));
+        FMT_ERROR(Error_type::format_error, "invalid format", 
+                  basic_string_view<Char>(begin, static_cast<std::size_t>(end - begin)));
       }
       break;
     default:
-      FMT_THROW(format_error("invalid format"));
+      FMT_ERROR(Error_type::format_error, "invalid format", 
+                basic_string_view<Char>(begin, static_cast<std::size_t>(end - begin)));
     }
     begin = ptr;
   }
@@ -681,7 +690,7 @@ FMT_CONSTEXPR const Char* parse_chrono_format(const Char* begin,
 }
 
 struct chrono_format_checker {
-  FMT_NORETURN void report_no_date() { FMT_THROW(format_error("no date")); }
+  FMT_NORETURN void report_no_date() { FMT_ERROR(Error_type::format_error, "no date"); }
 
   template <typename Char>
   FMT_CONSTEXPR void on_text(const Char*, const Char*) {}
@@ -771,7 +780,7 @@ template <typename To, typename FromRep, typename FromPeriod>
 To fmt_safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from) {
   int ec;
   To to = safe_duration_cast::safe_duration_cast<To>(from, ec);
-  if (ec) FMT_THROW(format_error("cannot format duration"));
+  if (ec) FMT_ERROR(Error_type::format_error, "cannot format duration");
   return to;
 }
 #endif
@@ -1104,7 +1113,7 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
       return arg_ref_type(context.next_arg_id());
     }
 
-    void on_error(const char* msg) { FMT_THROW(format_error(msg)); }
+    void on_error(const char* msg) { FMT_ERROR(Error_type::format_error, msg); }
     FMT_CONSTEXPR void on_fill(basic_string_view<Char> fill) {
       f.specs.fill = fill;
     }

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -244,7 +244,7 @@ class text_style {
       foreground_color = rhs.foreground_color;
     } else if (rhs.set_foreground_color) {
       if (!foreground_color.is_rgb || !rhs.foreground_color.is_rgb)
-        FMT_THROW(format_error("can't OR a terminal color"));
+        FMT_ERROR(Error_type::format_error, "can't OR a terminal color");
       foreground_color.value.rgb_color |= rhs.foreground_color.value.rgb_color;
     }
 
@@ -253,7 +253,7 @@ class text_style {
       background_color = rhs.background_color;
     } else if (rhs.set_background_color) {
       if (!background_color.is_rgb || !rhs.background_color.is_rgb)
-        FMT_THROW(format_error("can't OR a terminal color"));
+        FMT_ERROR(Error_type::format_error, "can't OR a terminal color");
       background_color.value.rgb_color |= rhs.background_color.value.rgb_color;
     }
 
@@ -321,7 +321,7 @@ class text_style {
       foreground_color = rhs.foreground_color;
     } else if (rhs.set_foreground_color) {
       if (!foreground_color.is_rgb || !rhs.foreground_color.is_rgb)
-        FMT_THROW(format_error("can't AND a terminal color"));
+        FMT_ERROR(Error_type::format_error, "can't AND a terminal color");
       foreground_color.value.rgb_color &= rhs.foreground_color.value.rgb_color;
     }
 
@@ -330,7 +330,7 @@ class text_style {
       background_color = rhs.background_color;
     } else if (rhs.set_background_color) {
       if (!background_color.is_rgb || !rhs.background_color.is_rgb)
-        FMT_THROW(format_error("can't AND a terminal color"));
+        FMT_ERROR(Error_type::format_error, "can't AND a terminal color");
       background_color.value.rgb_color &= rhs.background_color.value.rgb_color;
     }
 

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -164,7 +164,7 @@ FMT_FUNC void report_error(format_func func, int error_code,
 inline void fwrite_fully(const void* ptr, size_t size, size_t count,
                          FILE* stream) {
   size_t written = std::fwrite(ptr, size, count, stream);
-  if (written < count) FMT_THROW(system_error(errno, "cannot write to file"));
+  if (written < count) FMT_ERROR(Error_type::system_error, errno, "cannot write to file");
 }
 
 #ifndef FMT_STATIC_THOUSANDS_SEPARATOR
@@ -2627,7 +2627,7 @@ template <> struct formatter<detail::bigint> {
 
 FMT_FUNC detail::utf8_to_utf16::utf8_to_utf16(string_view s) {
   for_each_codepoint(s, [this](uint32_t cp, int error) {
-    if (error != 0) FMT_THROW(std::runtime_error("invalid utf8"));
+    if (error != 0) FMT_ERROR(Error_type::runtime_error, "invalid utf8");
     if (cp <= 0xFFFF) {
       buffer_.push_back(static_cast<wchar_t>(cp));
     } else {
@@ -2663,7 +2663,7 @@ FMT_FUNC void format_system_error(detail::buffer<char>& out, int error_code,
 }
 
 FMT_FUNC void detail::error_handler::on_error(const char* message) {
-  FMT_THROW(format_error(message));
+  FMT_ERROR(Error_type::format_error, message);
 }
 
 FMT_FUNC void report_system_error(int error_code,

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -39,13 +39,13 @@ class printf_precision_handler {
   template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
   int operator()(T value) {
     if (!int_checker<std::numeric_limits<T>::is_signed>::fits_in_int(value))
-      FMT_THROW(format_error("number is too big"));
+      FMT_ERROR(Error_type::format_error, "number is too big");
     return (std::max)(static_cast<int>(value), 0);
   }
 
   template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
   int operator()(T) {
-    FMT_THROW(format_error("precision is not integer"));
+    FMT_ERROR(Error_type::format_error, "precision is not integer");
     return 0;
   }
 };
@@ -167,13 +167,13 @@ template <typename Char> class printf_width_handler {
       width = 0 - width;
     }
     unsigned int_max = max_value<int>();
-    if (width > int_max) FMT_THROW(format_error("number is too big"));
+    if (width > int_max) FMT_ERROR(Error_type::format_error, "number is too big");
     return static_cast<unsigned>(width);
   }
 
   template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
   unsigned operator()(T) {
-    FMT_THROW(format_error("width is not integer"));
+    FMT_ERROR(Error_type::format_error, "width is not integer");
     return 0;
   }
 };
@@ -577,7 +577,9 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
     }
 
     // Parse type.
-    if (it == end) FMT_THROW(format_error("invalid format string"));
+    if (it == end)
+      FMT_ERROR(Error_type::format_error, "invalid format string",
+                basic_string_view<Char>(start, static_cast<std::size_t>(end - start)));
     specs.type = static_cast<char>(*it++);
     if (arg.is_integral()) {
       // Normalize type.


### PR DESCRIPTION
`fmt::error_reporter_t` is a template class that enables user to install their own error report handler.

This is especially useful when the exception is disabled since there is no exception available.

To use `fmt::error_reporter_t`, one would use `FMT_ERROR`, which supersedes `FMT_THROW` in that inside macro `FMT_ERROR`, no exception is created. Instead, an exception is thrown from `fmt::error_reporter_t` only if exception is enabled.

Abstraction of change:

```
// format.h
enum class Error_type {
  format_error,
  system_error,
  runtime_error,
# ifdef _WIN3
  windows_error,
# endif
};

/**
 * Use error_reporter_t as a customization point.
 */

template <Error_type error_type, typename = void> struct error_reporter_t;

template <typename void_type> struct error_reporter_t<Error_type::format_error, void_type> {
    template <typename Char = char>
    FMT_NORETURN void operator () (int line, const char *func, const char *file, const char *msg,
                                   basic_string_view<Char> fmt = basic_string_view<Char>());
};

template <typename void_type> struct error_reporter_t<Error_type::system_error, void_type> {
    template <typename ...Args>
    FMT_NORETURN void operator () (int line, const char *func, const char *file,
                                   int error_code, const char *msg,
                                   const Args&... args);
};

template <typename void_type> struct error_reporter_t<Error_type::runtime_error, void_type> {
    FMT_NORETURN void operator () (int line, const char *func, const char *file, const char *msg);
}; 

# ifdef __GNUC__
#  define FMT_ERROR(error_type, ...)                                          \
    do {                                                                      \
        ::fmt::error_reporter_t<(error_type)> error_reporter;                 \
        error_reporter(__LINE__, __PRETTY_FUNCTION__, __FILE__, __VA_ARGS__); \
    } while (0)
# else
#  define FMT_ERROR(error_type, ...)                                           \
    do {                                                                      \
        ::fmt::error_reporter_t<(error_type)> error_reporter;                 \
        error_reporter(__LINE__, __FUNCTION__, __FILE__, __VA_ARGS__); \
    } while (0)
# endif
```

`fmt::error_reporter_t` also has a partial specialization for `windows_error`:

```
// os.h
template <typename void_type> struct error_reporter_t<Error_type::windows_error, void_type> {
  template <typename... Args>
  FMT_NORETURN void operator () (int line, const char *func, const char *file, 
                                 int error_code, const char *message,
                                 const Args&... args) {
#ifdef FMT_EXCEPTIONS
    static_cast<void>(line);
    static_cast<void>(func);
    static_cast<void>(file);

    throw windows_error(error_code, message, args...);
#else
    report_windows_error(error_code, format(message, args...));
    std::terminate();
#endif
  }
};
```

The rest of the PR simply changes all use of `FMT_THROW` to `FMT_ERROR`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
