### PR TITLE
Don't include <cassert>. (#2148)

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -147,7 +147,7 @@ FMT_FUNC void format_error_code(detail::buffer<char>& out, int error_code,
   if (message.size() <= inline_buffer_size - error_code_size)
     format_to(it, FMT_STRING("{}{}"), message, SEP);
   format_to(it, FMT_STRING("{}{}"), ERROR_STR, error_code);
-  FMT_ASSERT(out.size() <= inline_buffer_size, "must not require dynamic alloc");
+  FMT_ASSERT(out.size() <= inline_buffer_size, "");
 }
 
 FMT_FUNC void report_error(format_func func, int error_code,
@@ -1218,7 +1218,7 @@ struct accumulator {
     if (lower < n) ++upper;
   }
   void operator>>=(int shift) {
-    FMT_ASSERT(shift == 32, "only 32-bit shift is supported");
+    FMT_ASSERT(shift == 32, "");
     (void)shift;
     lower = (upper << 32) | (lower >> 32);
     upper >>= 32;
@@ -1323,7 +1323,7 @@ class bigint {
   int num_bigits() const { return static_cast<int>(bigits_.size()) + exp_; }
 
   FMT_NOINLINE bigint& operator<<=(int shift) {
-    FMT_ASSERT(shift >= 0, "shift must be non-negative");
+    FMT_ASSERT(shift >= 0, "");
     exp_ += shift / bigit_bits;
     shift %= bigit_bits;
     if (shift == 0) return *this;
@@ -1385,7 +1385,7 @@ class bigint {
 
   // Assigns pow(10, exp) to this bigint.
   void assign_pow10(int exp) {
-    FMT_ASSERT(exp >= 0, "exponent must be non-negative");
+    FMT_ASSERT(exp >= 0, "");
     if (exp == 0) return assign(1);
     // Find the top bit.
     int bitmask = 1;
@@ -2556,11 +2556,11 @@ int snprintf_float(T value, int precision, float_specs specs,
       --exp_pos;
     } while (*exp_pos != 'e');
     char sign = exp_pos[1];
-    FMT_ASSERT(sign == '+' || sign == '-', "expect valid sign character");
+    FMT_ASSERT(sign == '+' || sign == '-', "");
     int exp = 0;
     auto p = exp_pos + 2;  // Skip 'e' and sign.
     do {
-      FMT_ASSERT(is_digit(*p), "expect digit");
+      FMT_ASSERT(is_digit(*p), "");
       exp = exp * 10 + (*p++ - '0');
     } while (p != end);
     if (sign == '-') exp = -exp;

--- a/test/test-assert.h
+++ b/test/test-assert.h
@@ -22,8 +22,24 @@ class assertion_failure : public std::logic_error {
 
 void assertion_failure::avoid_weak_vtable() {}
 
+inline void throw_assertion_failure (const char *message)
+{
+#  if FMT_GCC_VERSION >= 600
+     // Avoid warnings when FMT_ASSERT is used in a destructor.
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wterminate"
+#  endif
+
+  throw assertion_failure(message);
+
+#  if FMT_GCC_VERSION >= 600
+#    pragma GCC diagnostic pop
+#  endif
+}
+
+
 #define FMT_ASSERT(condition, message) \
-  if (!(condition)) throw assertion_failure(message);
+  if (!(condition)) throw_assertion_failure(message);
 
 // Expects an assertion failure.
 #define EXPECT_ASSERT(stmt, message) \

--- a/test/test-assert.h
+++ b/test/test-assert.h
@@ -24,11 +24,9 @@ void assertion_failure::avoid_weak_vtable() {}
 
 // We use a separate function (rather than throw directly from FMT_ASSERT) to
 // avoid GCC's -Wterminate warning when FMT_ASSERT is used in a destructor.
-inline void throw_assertion_failure (const char *message)
-{
+inline void throw_assertion_failure(const char* message) {
   throw assertion_failure(message);
 }
-
 
 #define FMT_ASSERT(condition, message) \
   if (!(condition)) throw_assertion_failure(message);

--- a/test/test-assert.h
+++ b/test/test-assert.h
@@ -24,7 +24,7 @@ void assertion_failure::avoid_weak_vtable() {}
 
 inline void throw_assertion_failure (const char *message)
 {
-#  if FMT_GCC_VERSION >= 600
+#  if defined(__GNUC__) && __GNUC__ >= 6
      // Avoid warnings when FMT_ASSERT is used in a destructor.
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wterminate"
@@ -32,7 +32,7 @@ inline void throw_assertion_failure (const char *message)
 
   throw assertion_failure(message);
 
-#  if FMT_GCC_VERSION >= 600
+#  if defined(__GNUC__) && __GNUC__ >= 6
 #    pragma GCC diagnostic pop
 #  endif
 }

--- a/test/test-assert.h
+++ b/test/test-assert.h
@@ -22,19 +22,11 @@ class assertion_failure : public std::logic_error {
 
 void assertion_failure::avoid_weak_vtable() {}
 
+// We use a separate function (rather than throw directly from FMT_ASSERT) to
+// avoid GCC's -Wterminate warning when FMT_ASSERT is used in a destructor.
 inline void throw_assertion_failure (const char *message)
 {
-#  if defined(__GNUC__) && __GNUC__ >= 6
-     // Avoid warnings when FMT_ASSERT is used in a destructor.
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wterminate"
-#  endif
-
   throw assertion_failure(message);
-
-#  if defined(__GNUC__) && __GNUC__ >= 6
-#    pragma GCC diagnostic pop
-#  endif
 }
 
 


### PR DESCRIPTION
This commit replaces use of the assert() macro in format-inl.h with
FMT_ASSERT(). This allows us to drop the cassert include.

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

Note that the change to ``FMT_ASSERT`` in test-assert.h is to avoid the following warning:
```
In file included from /home/jscott/src/fmt/test/format-impl-test.cc:10:
/home/jscott/src/fmt/include/fmt/format-inl.h: In destructor ‘fmt::v7::detail::bigint::~bigint()’:
/home/jscott/src/fmt/test/test-assert.h:26:52: warning: throw will always call terminate() [-Wterminate]
   26 |   if (!(condition)) throw assertion_failure(message);
      |                                                    ^
/home/jscott/src/fmt/include/fmt/format-inl.h:1300:15: note: in expansion of macro ‘FMT_ASSERT’
 1300 |   ~bigint() { FMT_ASSERT(bigits_.capacity() <= bigits_capacity, ""); }
      |               ^~~~~~~~~~
/home/jscott/src/fmt/test/test-assert.h:26:52: note: in C++11 destructors default to noexcept
   26 |   if (!(condition)) throw assertion_failure(message);
      |                                                    ^
/home/jscott/src/fmt/include/fmt/format-inl.h:1300:15: note: in expansion of macro ‘FMT_ASSERT’
 1300 |   ~bigint() { FMT_ASSERT(bigits_.capacity() <= bigits_capacity, ""); }
      |               ^~~~~~~~~~
```
Actually it seems that just moving the ``throw`` into a separate function (even inline) is enough to squelch the warning, with GCC 9.3 at least. In the end I went with this more explicit version.