### PR TITLE
Make truncating_iterator an output_iterator

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -477,6 +477,9 @@ class truncating_iterator_default_construct_base<OutputIt, std::false_type> {
   OutputIt out_;
 
   truncating_iterator_default_construct_base() = delete;
+
+  explicit truncating_iterator_default_construct_base(OutputIt out) :
+    out_(std::move(out)) {}
 };
 
 template<typename OutputIt>
@@ -485,6 +488,9 @@ class truncating_iterator_default_construct_base<OutputIt, std::true_type> {
   OutputIt out_;
 
   truncating_iterator_default_construct_base() = default;
+
+  explicit truncating_iterator_default_construct_base(OutputIt out) :
+    out_(std::move(out)) {}
 };
 
 template <typename OutputIt> class truncating_iterator_base

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -465,45 +465,16 @@ class counting_iterator {
   value_type operator*() const { return {}; }
 };
 
-// Used to ensure that truncating_iterator SFINAEs properly on the underlying
-// iterator's default constructibility.
-template <typename OutputIt, typename = typename std::is_default_constructible<
-    OutputIt>::type>
-class truncating_iterator_default_construct_base;
-
-template<typename OutputIt>
-class truncating_iterator_default_construct_base<OutputIt, std::false_type> {
+template <typename OutputIt> class truncating_iterator_base {
  protected:
   OutputIt out_;
-
-  truncating_iterator_default_construct_base() = delete;
-
-  explicit truncating_iterator_default_construct_base(OutputIt out) :
-    out_(std::move(out)) {}
-};
-
-template<typename OutputIt>
-class truncating_iterator_default_construct_base<OutputIt, std::true_type> {
- protected:
-  OutputIt out_;
-
-  truncating_iterator_default_construct_base() : out_() {}
-
-  explicit truncating_iterator_default_construct_base(OutputIt out) :
-    out_(std::move(out)) {}
-};
-
-template <typename OutputIt> class truncating_iterator_base
-    : protected truncating_iterator_default_construct_base<OutputIt> {
- protected:
-  size_t limit_ = 0;
+  size_t limit_;
   size_t count_ = 0;
 
-  truncating_iterator_base() = default;
+  truncating_iterator_base() : out_(), limit_(0) {}
   
   truncating_iterator_base(OutputIt out, size_t limit)
-      : truncating_iterator_default_construct_base<OutputIt>(out),
-        limit_(limit), count_(0) {}
+      : out_(out), limit_(limit) {}
 
  public:
   using iterator_category = std::output_iterator_tag;
@@ -514,7 +485,7 @@ template <typename OutputIt> class truncating_iterator_base
   using _Unchecked_type =
       truncating_iterator_base;  // Mark iterator as checked.
 
-  OutputIt base() const { return this->out_; }
+  OutputIt base() const { return out_; }
   size_t count() const { return count_; }
 };
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -487,7 +487,7 @@ class truncating_iterator_default_construct_base<OutputIt, std::true_type> {
  protected:
   OutputIt out_;
 
-  truncating_iterator_default_construct_base() = default;
+  truncating_iterator_default_construct_base() : out_() {}
 
   explicit truncating_iterator_default_construct_base(OutputIt out) :
     out_(std::move(out)) {}

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -15,6 +15,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <type_traits>
 
 // Check if fmt/format.h compiles with windows.h included before it.
 #ifdef _WIN32
@@ -155,6 +156,16 @@ TEST(IteratorTest, TruncatingIterator) {
   auto prev = it++;
   EXPECT_EQ(prev.base(), p);
   EXPECT_EQ(it.base(), p + 1);
+}
+
+
+TEST(IteratorTest, TruncatingIteratorDefaultConstruct) {
+  static_assert(
+      std::is_default_constructible_v<fmt::detail::truncating_iterator<char*>>);
+  
+  fmt::detail::truncating_iterator<char*> it;
+  EXPECT_EQ(it.base(), nullptr);
+  EXPECT_EQ(it.count(), 0);
 }
 
 TEST(IteratorTest, TruncatingBackInserter) {

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -12,6 +12,7 @@
 #include <climits>
 #include <cmath>
 #include <cstring>
+#include <iterator>
 #include <list>
 #include <memory>
 #include <string>
@@ -167,6 +168,12 @@ TEST(IteratorTest, TruncatingIteratorDefaultConstruct) {
   EXPECT_EQ(it.base(), nullptr);
   EXPECT_EQ(it.count(), 0);
 }
+
+#ifdef __cpp_lib_ranges
+TEST(IteratorTest, TruncatingIteratorOutputIterator) {
+  static_assert(std::output_iterator<fmt::detail::truncating_iterator<char*>>);
+}
+#endif
 
 TEST(IteratorTest, TruncatingBackInserter) {
   std::string buffer;

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -172,7 +172,8 @@ TEST(IteratorTest, TruncatingIteratorDefaultConstruct) {
 
 #ifdef __cpp_lib_ranges
 TEST(IteratorTest, TruncatingIteratorOutputIterator) {
-  static_assert(std::output_iterator<fmt::detail::truncating_iterator<char*>>);
+  static_assert(std::output_iterator<fmt::detail::truncating_iterator<char*>,
+      char>);
 }
 #endif
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -170,6 +170,27 @@ TEST(IteratorTest, TruncatingIteratorDefaultConstruct) {
   EXPECT_EQ(std::size_t{0}, it.count());
 }
 
+TEST(IteratorTest, TruncatingIteratorDeletedDefaultConstruct) {
+  struct non_default_constructible_iterator {
+    using iterator_category = std::output_iterator_tag;
+    using value_type = void;
+    using difference_type = std::ptrdiff_t;
+    using pointer = void;
+    using reference = void;
+
+    non_default_constructible_iterator() = delete;
+    
+    non_default_constructible_iterator& operator++();
+    non_default_constructible_iterator operator++(int);
+    char& operator*() const;
+  };
+
+  static_assert(
+      !std::is_default_constructible<fmt::detail::truncating_iterator<
+          non_default_constructible_iterator>>::value,
+      "");
+}
+
 #ifdef __cpp_lib_ranges
 TEST(IteratorTest, TruncatingIteratorOutputIterator) {
   static_assert(std::output_iterator<fmt::detail::truncating_iterator<char*>,

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -166,8 +166,8 @@ TEST(IteratorTest, TruncatingIteratorDefaultConstruct) {
       "");
   
   fmt::detail::truncating_iterator<char*> it;
-  EXPECT_EQ(it.base(), nullptr);
-  EXPECT_EQ(it.count(), 0);
+  EXPECT_EQ(nullptr, it.base());
+  EXPECT_EQ(0, it.count());
 }
 
 #ifdef __cpp_lib_ranges

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -170,27 +170,6 @@ TEST(IteratorTest, TruncatingIteratorDefaultConstruct) {
   EXPECT_EQ(std::size_t{0}, it.count());
 }
 
-TEST(IteratorTest, TruncatingIteratorDeletedDefaultConstruct) {
-  struct non_default_constructible_iterator {
-    using iterator_category = std::output_iterator_tag;
-    using value_type = void;
-    using difference_type = std::ptrdiff_t;
-    using pointer = void;
-    using reference = void;
-
-    non_default_constructible_iterator() = delete;
-    
-    non_default_constructible_iterator& operator++();
-    non_default_constructible_iterator operator++(int);
-    char& operator*() const;
-  };
-
-  static_assert(
-      !std::is_default_constructible<fmt::detail::truncating_iterator<
-          non_default_constructible_iterator>>::value,
-      "");
-}
-
 #ifdef __cpp_lib_ranges
 TEST(IteratorTest, TruncatingIteratorOutputIterator) {
   static_assert(std::output_iterator<fmt::detail::truncating_iterator<char*>,

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -167,7 +167,7 @@ TEST(IteratorTest, TruncatingIteratorDefaultConstruct) {
   
   fmt::detail::truncating_iterator<char*> it;
   EXPECT_EQ(nullptr, it.base());
-  EXPECT_EQ(0, it.count());
+  EXPECT_EQ(std::size_t{0}, it.count());
 }
 
 #ifdef __cpp_lib_ranges

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -162,7 +162,8 @@ TEST(IteratorTest, TruncatingIterator) {
 
 TEST(IteratorTest, TruncatingIteratorDefaultConstruct) {
   static_assert(
-      std::is_default_constructible_v<fmt::detail::truncating_iterator<char*>>);
+      std::is_default_constructible<fmt::detail::truncating_iterator<char*>>::value,
+      "");
   
   fmt::detail::truncating_iterator<char*> it;
   EXPECT_EQ(it.base(), nullptr);


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

Fixes #2156.