### PR TITLE
Use simplified void_t for all compilers except GCC 4.x

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1379,10 +1379,14 @@ template <typename T> struct formattable : std::false_type {};
 
 namespace detail {
 
+#if FMT_GCC_VERSION && FMT_GCC_VERSION < 500
 // A workaround for gcc 4.8 to make void_t work in a SFINAE context.
 template <typename... Ts> struct void_t_impl { using type = void; };
 template <typename... Ts>
 using void_t = typename detail::void_t_impl<Ts...>::type;
+#else
+template <typename...> using void_t = void;
+#endif
 
 template <typename It, typename T, typename Enable = void>
 struct is_output_iterator : std::false_type {};


### PR DESCRIPTION
Fixes https://github.com/fmtlib/fmt/issues/2149.

This PR moves a special `void_t` workaround for GCC 4.x:
https://github.com/fmtlib/fmt/blob/640acba8509d7458a9c749b243355d223b1cfa25/include/fmt/core.h#L1382-L1385
under the GCC < 5.0 macro check, adding a straightforward `void_t` implementation:
```cpp
template <typename...> using void_t = void;
```
for other compilers.

This solves the problem with GCC 8.x that fails with the current implementation of `void_t`.