### PR TITLE
Fix fmt::formatted_size() with compiled format (FMT_COMPILE) as argument

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -834,7 +834,10 @@ format_to_n_result<OutputIt> format_to_n(OutputIt out, size_t n, const S&,
   return {it.base(), it.count()};
 }
 
-template <typename CompiledFormat, typename... Args>
+template <typename CompiledFormat, typename... Args,
+          FMT_ENABLE_IF(std::is_base_of<detail::basic_compiled_format,
+                                        CompiledFormat>::value ||
+                        detail::is_compiled_string<CompiledFormat>::value)>
 size_t formatted_size(const CompiledFormat& cf, const Args&... args) {
   return format_to(detail::counting_iterator(), cf, args...).count();
 }

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1861,11 +1861,11 @@ inline auto format_to_n(OutputIt out, size_t n, const S& format_str,
   Returns the number of characters in the output of
   ``format(format_str, args...)``.
  */
-template <typename... Args>
-inline size_t formatted_size(string_view format_str, Args&&... args) {
+template <typename S, typename... Args, typename Char = char_t<S>>
+inline size_t formatted_size(const S& format_str, Args&&... args) {
   const auto& vargs = fmt::make_args_checked<Args...>(format_str, args...);
   detail::counting_buffer<> buf;
-  detail::vformat_to(buf, format_str, vargs);
+  detail::vformat_to(buf, to_string_view(format_str), vargs);
   return buf.count();
 }
 

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -224,6 +224,11 @@ TEST(CompileTest, FormatToNWithCompileMacro) {
   EXPECT_STREQ("2a", buffer);
 }
 
+TEST(CompileTest, FormattedSizeWithCompileMacro) {
+  EXPECT_EQ(2, fmt::formatted_size(FMT_COMPILE("{0}"), 42));
+  EXPECT_EQ(5, fmt::formatted_size(FMT_COMPILE("{0:<4.2f}"), 42.0));
+}
+
 TEST(CompileTest, TextAndArg) {
   EXPECT_EQ(">>>42<<<", fmt::format(FMT_COMPILE(">>>{}<<<"), 42));
   EXPECT_EQ("42!", fmt::format(FMT_COMPILE("{}!"), 42));


### PR DESCRIPTION
Resolves https://github.com/fmtlib/fmt/issues/2141.

All useful info can be found in the issue, including code examples.

One small detail for this PR - `fmt::formatted_size()` in `compile.h` becomes templatized too to eliminate one unclear case - https://godbolt.org/z/Yxnccj. In few words, the implementation of `fmt::formatted_size()` for runtime API (non-compiled format string) changes depending on whether we include `fmt/compile.h` or not. You can see it in assembly for the `formatted_size`, it uses `counting_iterator`, which is used in the overload from `compile.h`:
https://github.com/fmtlib/fmt/blob/835b910e7d758efdfdce9f23df1b190deb3373db/include/fmt/compile.h#L837-L840
but not in the overload from `core.h`:
https://github.com/fmtlib/fmt/blob/835b910e7d758efdfdce9f23df1b190deb3373db/include/fmt/core.h#L1864-L1870

Maybe it's okay, but IMHO in this case, that behavior should be documented, right?