### PR TITLE
Workaround a GCC 7,8,9 warning about unused but set parameter

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -557,9 +557,10 @@ template <typename Char> struct runtime_named_field {
   basic_string_view<Char> name;
 
   template <typename OutputIt, typename T>
-  constexpr static bool try_format_argument(OutputIt& out,
-                                            basic_string_view<Char> arg_name,
-                                            const T& arg) {
+  constexpr static bool try_format_argument(
+      OutputIt& out,
+      // [[maybe_unused]] due to unused-but-set-parameter warning in GCC 7,8,9
+      [[maybe_unused]] basic_string_view<Char> arg_name, const T& arg) {
     if constexpr (is_named_arg<typename std::remove_cv<T>::type>::value) {
       if (arg_name == arg.name) {
         out = write<Char>(out, arg.value);


### PR DESCRIPTION
Resolves https://github.com/fmtlib/fmt/issues/2170.

I checked this fix on GitHub Actions for GCC 6-10 for warning from issue:
| | GCC 6 | GCC 7 | GCC 8 | GCC 9 | GCC 10 |
|-|-|-|-|-|-|
|before| [no warning](https://github.com/alexezeder/fmt/runs/2100340626?check_suite_focus=true#step:4:1) | [warning presented](https://github.com/alexezeder/fmt/runs/2100340632?check_suite_focus=true#step:4:1) | [warning presented](https://github.com/alexezeder/fmt/runs/2100340641?check_suite_focus=true#step:4:1) | [warning presented](https://github.com/alexezeder/fmt/runs/2100340646?check_suite_focus=true#step:4:1) | [no warning](https://github.com/alexezeder/fmt/runs/2100340651?check_suite_focus=true#step:4:1) |
|after | [no warning](https://github.com/alexezeder/fmt/runs/2100353102?check_suite_focus=true#step:4:1) | [no warning](https://github.com/alexezeder/fmt/runs/2100353120?check_suite_focus=true#step:4:1) | [no warning](https://github.com/alexezeder/fmt/runs/2100353135?check_suite_focus=true#step:4:1) | [no warning](https://github.com/alexezeder/fmt/runs/2100353159?check_suite_focus=true#step:4:1) | [no warning](https://github.com/alexezeder/fmt/runs/2100353181?check_suite_focus=true#step:4:1) |

