### PR TITLE
add default cases

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2874,6 +2874,8 @@ FMT_CONSTEXPR const Char* parse_align(const Char* begin, const Char* end,
     case '^':
       align = align::center;
       break;
+    default:
+      break;
     }
     if (align != align::none) {
       if (p != begin) {
@@ -2962,6 +2964,8 @@ FMT_CONSTEXPR_DECL FMT_INLINE const Char* parse_format_specs(
   case ' ':
     handler.on_space();
     ++begin;
+    break;
+  default:
     break;
   }
   if (begin == end) return begin;


### PR DESCRIPTION
Adding default case for switch statements where the compilation
flag -Wswitch-default is present on the command line when spdlog
is included in external projects.

Signed-off-by: Ryan Sherlock <ryan.m.sherlock@gmail.com>

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
