### PR TITLE
"Use" `fwrite` result (workaround for `warn_unused_result`)

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -155,7 +155,9 @@ FMT_FUNC void report_error(format_func func, int error_code,
   memory_buffer full_message;
   func(full_message, error_code, message);
   // Don't use fwrite_fully because the latter may throw.
-  (void)std::fwrite(full_message.data(), full_message.size(), 1, stderr);
+  if (std::fwrite(full_message.data(), full_message.size(), 1, stderr)) {
+      ;
+  }
   std::fputc('\n', stderr);
 }
 


### PR DESCRIPTION
Fixes #2185 