### PR TITLE
add default case for core

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1371,6 +1371,8 @@ FMT_CONSTEXPR_DECL FMT_INLINE auto visit_format_arg(
     return vis(arg.value_.pointer);
   case detail::type::custom_type:
     return vis(typename basic_format_arg<Context>::handle(arg.value_.custom));
+  default:
+    break;
   }
   return vis(monostate());
 }


### PR DESCRIPTION
Adding default case for switch statements where the compilation
flag -Wswitch-default is present on the command line.

Signed-off-by: Ryan Sherlock <ryan.m.sherlock@gmail.com>

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
