### PR TITLE
Fix: fmt::ostream cannot be moved while holding buffered data #2197

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -396,8 +396,10 @@ class ostream final : private detail::buffer<char> {
   ostream(ostream&& other)
       : detail::buffer<char>(other.data(), other.size(), other.capacity()),
         file_(std::move(other.file_)) {
+    other.clear();
     other.set(nullptr, 0);
   }
+
   ~ostream() {
     flush();
     delete[] data();

--- a/test/os-test.cc
+++ b/test/os-test.cc
@@ -293,6 +293,19 @@ TEST(OStreamTest, Move) {
   moved.print("hello");
 }
 
+TEST(OStreamTest, MoveWhileHoldingData) {
+  {
+    fmt::ostream out = fmt::output_file("test-file");
+    out.print("Hello, ");
+    fmt::ostream moved(std::move(out));
+    moved.print("world!\n");
+  }
+  {
+    file in("test-file", file::RDONLY);
+    EXPECT_READ(in, "Hello, world!\n");
+  }
+}
+
 TEST(OStreamTest, Print) {
   fmt::ostream out = fmt::output_file("test-file");
   out.print("The answer is {}.\n", fmt::join(std::initializer_list<int>{42}, ", "));


### PR DESCRIPTION
#2197 