### PR TITLE
Add speech synthesis support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        cxx: [g++-4.8, g++-8, g++-10, clang++-9]
+        cxx: [g++-4.8, g++-10, clang++-9]
         build_type: [Debug, Release]
         std: [11]
         os: [ubuntu-18.04]
@@ -17,6 +17,7 @@ jobs:
             os: ubuntu-18.04
           - cxx: g++-8
             std: 14
+            install: sudo apt install g++-8
             os: ubuntu-18.04
           - cxx: g++-10
             std: 17

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -200,6 +200,11 @@ FMT_API void report_windows_error(int error_code,
                                   string_view message) FMT_NOEXCEPT;
 #endif  // _WIN32
 
+template <typename S, typename... Args, typename Char = char_t<S>>
+void say(const S& format_str, Args&&... args) {
+  std::system(format("say \"{}\"", format(format_str, args...)).c_str());
+}
+
 // A buffered file.
 class buffered_file {
  private:


### PR DESCRIPTION
Add speech synthesis support to {fmt}.

For example:

```c++
#include <fmt/os.h>

int main() {
  fmt::say(
    R"SHANTY(
    There [[emph +]] once was a pen that [[emph +]] put to [[emph +]] paper,
    It [[emph -]] was [[emph +]] gonna be written [[emph +]] sooner or later,
    Ctrl-S went down, the proposal sent out,
    Vote [[emph +]] down my committee vote [[emph +]] down.

    [[emph +]] Soon, may the Unicode come,
    So [[emph +]] we can write aleph and [[emph +]] xĭ and [[emph +]] từng,
    One day when '23 is done,
    We'll take our bom and go.)SHANTY");
}
```
Output:


https://user-images.githubusercontent.com/576385/113313097-c9623f00-92bf-11eb-8903-f7acaa7c982f.mov



