### PR TITLE
Fixing VS2019 warning C4127: conditional expression is constant

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -396,7 +396,7 @@ template <typename Char> class basic_string_view {
   FMT_CONSTEXPR
 #endif
   FMT_INLINE basic_string_view(const Char* s) : data_(s) {
-    if (std::is_same<Char, char>::value && !detail::is_constant_evaluated())
+    if (detail::const_check(std::is_same<Char, char>::value && !detail::is_constant_evaluated()))
       size_ = std::strlen(reinterpret_cast<const char*>(s));
     else
       size_ = std::char_traits<Char>::length(s);


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
