### PR TITLE
Suppress redef warning of _CRT_SECURE_NO_WARNINGS if any.

### DIFF
--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -6,7 +6,9 @@
 // For the license information refer to format.h.
 
 #ifdef WIN32
-#  define _CRT_SECURE_NO_WARNINGS
+#  ifndef _CRT_SECURE_NO_WARNINGS
+#    define _CRT_SECURE_NO_WARNINGS
+#  endif
 #endif
 
 #include "fmt/chrono.h"

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -5,10 +5,8 @@
 //
 // For the license information refer to format.h.
 
-#ifdef WIN32
-#  ifndef _CRT_SECURE_NO_WARNINGS
-#    define _CRT_SECURE_NO_WARNINGS
-#  endif
+#ifndef _CRT_SECURE_NO_WARNINGS
+#  define _CRT_SECURE_NO_WARNINGS
 #endif
 
 #include "fmt/chrono.h"


### PR DESCRIPTION
add a pre-check of _CRT_SECURE_NO_WARNINGS before the def

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
