### PR TITLE
Create separate dllexport marking points for clang and msvc.

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -223,8 +223,19 @@
 #ifndef FMT_EXTERN_TEMPLATE_API
 #  define FMT_EXTERN_TEMPLATE_API
 #endif
-#ifndef FMT_INSTANTIATION_DECL_API
-#  define FMT_INSTANTIATION_DECL_API FMT_API
+#ifndef FMT_INSTANTIATION_DECL_API // clang marks dllexport at extern template.
+#  ifndef _MSC_VER
+#    define FMT_INSTANTIATION_DECL_API FMT_API
+#  else
+#    define FMT_INSTANTIATION_DECL_API
+#  endif
+#endif
+#ifndef FMT_INSTANTIATION_DEF_API // msvc marks dllexport at the definition itself.
+#  ifndef _MSC_VER
+#    define FMT_INSTANTIATION_DEF_API
+#  else
+#    define FMT_INSTANTIATION_DEF_API FMT_API
+# endif
 #endif
 
 #ifndef FMT_HEADER_ONLY

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -995,7 +995,9 @@ FMT_INLINE uint16_t bsr2log10(int bsr) {
   return data[bsr];
 }
 
+#ifndef FMT_EXPORTED
 FMT_EXTERN template struct FMT_INSTANTIATION_DECL_API basic_data<void>;
+#endif
 
 // This is a struct rather than an alias to avoid shadowing warnings in gcc.
 struct data : basic_data<> {};

--- a/src/format.cc
+++ b/src/format.cc
@@ -57,7 +57,7 @@ vformat_to(buffer<char>&, string_view,
 
 // Clang doesn't allow dllexport on template instantiation definitions:
 // https://reviews.llvm.org/D61118.
-template struct detail::basic_data<void>;
+template struct FMT_INSTANTIATION_DEF_API detail::basic_data<void>;
 
 // Workaround a bug in MSVC2013 that prevents instantiation of format_float.
 int (*instantiate_format_float)(double, int, detail::float_specs,


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
This should fix https://github.com/fmtlib/fmt/issues/2228

The issue is caused by changes in clang below.

[MinGW] Fix dllexport of explicit template instantiation
by mstorsjo on Apr 25 2019
https://reviews.llvm.org/D61118

Have to keep seperated `dllexport` marking points, until `msvc` follows `GNU` and `LLVM`'s policy or vice versa.
