### PR TITLE
Try to suppress MVSC warn of narrowing

### DIFF
--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -771,7 +771,10 @@ TEST(FormatterTest, SpaceSign) {
 
 TEST(FormatterTest, SignNotTruncated) {
   wchar_t format_str[] = {L'{', L':',
-                          '+' | static_case<wchar_t>(1 << fmt::detail::num_bits<char>()), L'}', 0};
+                          '+' | static_cast<wchar_t>(
+                            1 << fmt::detail::num_bits<char>() 
+                            & static_cast<typename std::make_unsigned_t<wchar_t> >(-1) ),
+                          L'}', 0};
   EXPECT_THROW(format(format_str, 42), format_error);
 }
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -771,9 +771,7 @@ TEST(FormatterTest, SpaceSign) {
 
 TEST(FormatterTest, SignNotTruncated) {
   wchar_t format_str[] = {L'{', L':',
-                          '+' | static_cast<wchar_t>(
-                            1 << fmt::detail::num_bits<char>() 
-                            & static_cast<typename std::make_unsigned<int>::type >(-1) ),
+                          '+' | static_cast<wchar_t>(1 << fmt::detail::num_bits<char>()),
                           L'}', 0};
   EXPECT_THROW(format(format_str, 42), format_error);
 }

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -771,7 +771,7 @@ TEST(FormatterTest, SpaceSign) {
 
 TEST(FormatterTest, SignNotTruncated) {
   wchar_t format_str[] = {L'{', L':',
-                          '+' | (1 << fmt::detail::num_bits<char>()), L'}', 0};
+                          '+' | static_case<wchar_t>(1 << fmt::detail::num_bits<char>()), L'}', 0};
   EXPECT_THROW(format(format_str, 42), format_error);
 }
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -773,7 +773,7 @@ TEST(FormatterTest, SignNotTruncated) {
   wchar_t format_str[] = {L'{', L':',
                           '+' | static_cast<wchar_t>(
                             1 << fmt::detail::num_bits<char>() 
-                            & static_cast<typename std::make_unsigned_t<wchar_t> >(-1) ),
+                            & static_cast<typename std::make_unsigned<int>::type >(-1) ),
                           L'}', 0};
   EXPECT_THROW(format(format_str, 42), format_error);
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->

Try to suppress MVSC warn of narrowing at

> fmt\test\format-test.cc(774): warning C4838: conversion from 'int' to 'wchar_t' requires a narrowing conversion