### PR TITLE
Support char*_t in fmt::join

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3753,14 +3753,9 @@ struct formatter<arg_join<It, Sentinel, Char>, Char> {
   Returns an object that formats the iterator range `[begin, end)` with elements
   separated by `sep`.
  */
-template <typename It, typename Sentinel>
-arg_join<It, Sentinel, char> join(It begin, Sentinel end, string_view sep) {
-  return {begin, end, sep};
-}
-
-template <typename It, typename Sentinel>
-arg_join<It, Sentinel, wchar_t> join(It begin, Sentinel end, wstring_view sep) {
-  return {begin, end, sep};
+template <typename It, typename Sentinel, typename S>
+arg_join<It, Sentinel, char_t<S>> join(It begin, Sentinel end, const S& sep) {
+  return {begin, end, to_string_view(sep)};
 }
 
 /**
@@ -3779,15 +3774,9 @@ arg_join<It, Sentinel, wchar_t> join(It begin, Sentinel end, wstring_view sep) {
     // Output: "01, 02, 03"
   \endrst
  */
-template <typename Range>
-arg_join<detail::iterator_t<Range>, detail::sentinel_t<Range>, char> join(
-    Range&& range, string_view sep) {
-  return join(std::begin(range), std::end(range), sep);
-}
-
-template <typename Range>
-arg_join<detail::iterator_t<Range>, detail::sentinel_t<Range>, wchar_t> join(
-    Range&& range, wstring_view sep) {
+template <typename Range, typename S>
+arg_join<detail::iterator_t<Range>, detail::sentinel_t<Range>, char_t<S>> join(
+    Range&& range, const S& sep) {
   return join(std::begin(range), std::end(range), sep);
 }
 

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -427,16 +427,10 @@ struct formatter<tuple_arg_join<Char, T...>, Char> {
     // Output: "1, a"
   \endrst
  */
-template <typename... T>
-FMT_CONSTEXPR tuple_arg_join<char, T...> join(const std::tuple<T...>& tuple,
-                                              string_view sep) {
-  return {tuple, sep};
-}
-
-template <typename... T>
-FMT_CONSTEXPR tuple_arg_join<wchar_t, T...> join(const std::tuple<T...>& tuple,
-                                                 wstring_view sep) {
-  return {tuple, sep};
+template <typename... T, typename S>
+FMT_CONSTEXPR tuple_arg_join<char_t<S>, T...> join(const std::tuple<T...>& tuple,
+                                                   const S& sep) {
+  return {tuple, to_string_view(sep)};
 }
 
 /**
@@ -450,15 +444,9 @@ FMT_CONSTEXPR tuple_arg_join<wchar_t, T...> join(const std::tuple<T...>& tuple,
     // Output: "1, 2, 3"
   \endrst
  */
-template <typename T>
-arg_join<const T*, const T*, char> join(std::initializer_list<T> list,
-                                        string_view sep) {
-  return join(std::begin(list), std::end(list), sep);
-}
-
-template <typename T>
-arg_join<const T*, const T*, wchar_t> join(std::initializer_list<T> list,
-                                           wstring_view sep) {
+template <typename T, typename S>
+arg_join<const T*, const T*, char_t<S>> join(std::initializer_list<T> list,
+                                             const S& sep) {
   return join(std::begin(list), std::end(list), sep);
 }
 


### PR DESCRIPTION
Makes fmt::join templated on the string argument so you can use unicode strings with it.