### PR TITLE
Support compiling {fmt} as named module

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -289,6 +289,8 @@ inline null<> gmtime_r(...) { return null<>(); }
 inline null<> gmtime_s(...) { return null<>(); }
 }  // namespace detail
 
+FMT_MODULE_EXPORT_BEGIN
+
 /**
   Converts given time since epoch as ``std::time_t`` value into calendar time,
   expressed in local time. Unlike ``std::localtime``, this function is
@@ -380,6 +382,8 @@ inline std::tm gmtime(
   return gmtime(std::chrono::system_clock::to_time_t(time_point));
 }
 
+FMT_MODULE_EXPORT_END
+
 namespace detail {
 inline size_t strftime(char* str, size_t count, const char* format,
                        const std::tm* time) {
@@ -400,6 +404,8 @@ inline size_t strftime(wchar_t* str, size_t count, const wchar_t* format,
   return wcsftime(str, count, format, time);
 }
 }  // namespace detail
+
+FMT_MODULE_EXPORT_BEGIN
 
 template <typename Char, typename Duration>
 struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
@@ -1185,6 +1191,7 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
   }
 };
 
+FMT_MODULE_EXPORT_END
 FMT_END_NAMESPACE
 
 #endif  // FMT_CHRONO_H_

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -18,6 +18,7 @@
 #endif
 
 FMT_BEGIN_NAMESPACE
+FMT_MODULE_EXPORT_BEGIN
 
 enum class color : uint32_t {
   alice_blue = 0xF0F8FF,               // rgb(240,248,255)
@@ -205,6 +206,7 @@ struct rgb {
   uint8_t b;
 };
 
+FMT_MODULE_EXPORT_END
 namespace detail {
 
 // color is a struct of either a rgb color or a terminal color.
@@ -229,6 +231,7 @@ struct color_type {
   } value;
 };
 }  // namespace detail
+FMT_MODULE_EXPORT_BEGIN
 
 /** A text style consisting of foreground and background colors and emphasis. */
 class text_style {
@@ -367,6 +370,7 @@ FMT_CONSTEXPR inline text_style operator|(emphasis lhs,
   return text_style(lhs) | rhs;
 }
 
+FMT_MODULE_EXPORT_END
 namespace detail {
 
 template <typename Char> struct ansi_color_escape {
@@ -510,6 +514,7 @@ void vformat_to(buffer<Char>& buf, const text_style& ts,
   if (has_style) detail::reset_color<Char>(buf);
 }
 }  // namespace detail
+FMT_MODULE_EXPORT_BEGIN
 
 template <typename S, typename Char = char_t<S>>
 void vprint(std::FILE* f, const text_style& ts, const S& format,
@@ -619,6 +624,7 @@ inline auto format_to(OutputIt out, const text_style& ts, const S& format_str,
                     fmt::make_args_checked<Args...>(format_str, args...));
 }
 
+FMT_MODULE_EXPORT_END
 FMT_END_NAMESPACE
 
 #endif  // FMT_COLOR_H_

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -816,6 +816,8 @@ FMT_DEPRECATED auto compile(const Args&... args)
   return detail::compile(args...);
 }
 
+FMT_MODULE_EXPORT_BEGIN
+
 #if FMT_USE_CONSTEXPR
 #  ifdef __cpp_if_constexpr
 
@@ -953,6 +955,7 @@ operator""_cf() {
 }  // namespace literals
 #endif
 
+FMT_MODULE_EXPORT_END
 FMT_END_NAMESPACE
 
 #endif  // FMT_COMPILE_H_

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -204,6 +204,16 @@
     FMT_INLINE_NAMESPACE v7 {
 #endif
 
+#ifndef FMT_MODULE_EXPORT
+#  define FMT_MODULE_EXPORT
+#endif
+#ifndef FMT_MODULE_EXPORT_BEGIN
+#  define FMT_MODULE_EXPORT_BEGIN
+#endif
+#ifndef FMT_MODULE_EXPORT_END
+#  define FMT_MODULE_EXPORT_END
+#endif
+
 #if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
 #  define FMT_CLASS_API FMT_MSC_WARNING(suppress : 4275)
 #  ifdef FMT_EXPORT
@@ -370,6 +380,8 @@ namespace internal = detail;  // DEPRECATED
   compiled with a different ``-std`` option than the client code (which is not
   recommended).
  */
+FMT_MODULE_EXPORT_BEGIN
+
 template <typename Char> class basic_string_view {
  private:
   const Char* data_;
@@ -523,6 +535,7 @@ constexpr basic_string_view<typename S::char_type> to_string_view(const S& s) {
   return s;
 }
 
+FMT_MODULE_EXPORT_END
 namespace detail {
 void to_string_view(...);
 using fmt::v7::to_string_view;
@@ -560,6 +573,7 @@ struct error_handler {
   FMT_NORETURN FMT_API void on_error(const char* message);
 };
 }  // namespace detail
+FMT_MODULE_EXPORT_BEGIN
 
 /** String's character type. */
 template <typename S> using char_t = typename detail::char_t_impl<S>::type;
@@ -668,6 +682,7 @@ template <typename T> struct is_contiguous : std::false_type {};
 template <typename Char>
 struct is_contiguous<std::basic_string<Char>> : std::true_type {};
 
+FMT_MODULE_EXPORT_END
 namespace detail {
 
 // Extracts a reference to the container from back_insert_iterator.
@@ -1285,6 +1300,7 @@ enum { max_packed_args = 62 / packed_arg_bits };
 enum : unsigned long long { is_unpacked_bit = 1ULL << 63 };
 enum : unsigned long long { has_named_args_bit = 1ULL << 62 };
 }  // namespace detail
+FMT_MODULE_EXPORT_BEGIN
 
 // A formatting argument. It is a trivially copyable/constructible type to
 // allow storage in basic_memory_buffer.
@@ -1394,6 +1410,7 @@ FMT_CONSTEXPR_DECL FMT_INLINE auto visit_format_arg(
   return vis(monostate());
 }
 
+FMT_MODULE_EXPORT_END
 namespace detail {
 
 #if FMT_GCC_VERSION && FMT_GCC_VERSION < 500
@@ -1480,6 +1497,7 @@ inline basic_format_arg<Context> make_arg(const T& value) {
   return make_arg<Context>(value);
 }
 }  // namespace detail
+FMT_MODULE_EXPORT_BEGIN
 
 // Formatting context.
 template <typename OutputIt, typename Char> class basic_format_context {
@@ -1536,9 +1554,13 @@ using buffer_context =
 using format_context = buffer_context<char>;
 using wformat_context = buffer_context<wchar_t>;
 
+FMT_MODULE_EXPORT_END
+
 // Workaround an alias issue: https://stackoverflow.com/q/62767544/471164.
 #define FMT_BUFFER_CONTEXT(Char) \
   basic_format_context<detail::buffer_appender<Char>, Char>
+
+FMT_MODULE_EXPORT_BEGIN
 
 template <typename T, typename Char = char>
 using is_formattable = bool_constant<!std::is_same<
@@ -1782,6 +1804,7 @@ struct wformat_args : basic_format_args<wformat_context> {
 };
 #endif
 
+FMT_MODULE_EXPORT_END
 namespace detail {
 
 template <typename Char, FMT_ENABLE_IF(!std::is_same<Char, char>::value)>
@@ -1806,6 +1829,7 @@ FMT_API void vprint_mojibake(std::FILE*, string_view, format_args);
 inline void vprint_mojibake(std::FILE*, string_view, format_args) {}
 #endif
 }  // namespace detail
+FMT_MODULE_EXPORT_BEGIN
 
 /** Formats a string and writes the output to ``out``. */
 // GCC 8 and earlier cannot handle std::back_insert_iterator<Container> with
@@ -1954,6 +1978,8 @@ inline void print(const S& format_str, Args&&... args) {
              : detail::vprint_mojibake(stdout, to_string_view(format_str),
                                        vargs);
 }
+
+FMT_MODULE_EXPORT_END
 FMT_GCC_PRAGMA("GCC pop_options")
 FMT_END_NAMESPACE
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -692,6 +692,8 @@ void iterator_buffer<OutputIt, T, Traits>::flush() {
 }
 }  // namespace detail
 
+FMT_MODULE_EXPORT_BEGIN
+
 // The number of characters to store in the basic_memory_buffer object itself
 // to avoid dynamic memory allocation.
 enum { inline_buffer_size = 500 };
@@ -859,6 +861,7 @@ class FMT_API format_error : public std::runtime_error {
   ~format_error() FMT_NOEXCEPT FMT_OVERRIDE;
 };
 
+FMT_MODULE_EXPORT_END
 namespace detail {
 
 template <typename T>
@@ -1255,7 +1258,7 @@ template <typename Char> struct fill_t {
   }
 };
 }  // namespace detail
-
+FMT_MODULE_EXPORT_BEGIN
 // We cannot use enum classes as bit fields because of a gcc bug
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61414.
 namespace align {
@@ -1291,6 +1294,7 @@ template <typename Char> struct basic_format_specs {
 
 using format_specs = basic_format_specs<char>;
 
+FMT_MODULE_EXPORT_END
 namespace detail {
 namespace dragonbox {
 
@@ -3305,6 +3309,7 @@ FMT_API void format_error_code(buffer<char>& out, int error_code,
 FMT_API void report_error(format_func func, int error_code,
                           string_view message) FMT_NOEXCEPT;
 }  // namespace detail
+FMT_MODULE_EXPORT_BEGIN
 
 template <typename OutputIt, typename Char>
 using arg_formatter FMT_DEPRECATED_ALIAS =
@@ -3833,6 +3838,8 @@ std::basic_string<Char> to_string(const basic_memory_buffer<Char, SIZE>& buf) {
   return std::basic_string<Char>(buf.data(), size);
 }
 
+FMT_MODULE_EXPORT_END
+
 template <typename Char>
 void detail::vformat_to(
     detail::buffer<Char>& buf, basic_string_view<Char> format_str,
@@ -3880,6 +3887,8 @@ extern template int snprintf_float<long double>(long double value,
                                                 buffer<char>& buf);
 }  // namespace detail
 #endif
+
+FMT_MODULE_EXPORT_BEGIN
 
 template <typename S, typename Char = char_t<S>,
           FMT_ENABLE_IF(detail::is_string<S>::value)>
@@ -3965,6 +3974,7 @@ void vprint(basic_string_view<Char> format_str, wformat_args args) {
   vprint(stdout, format_str, args);
 }
 
+FMT_MODULE_EXPORT_END
 #if FMT_USE_USER_DEFINED_LITERALS
 namespace detail {
 template <typename Char> struct udl_formatter {
@@ -3984,6 +3994,7 @@ template <typename Char> struct udl_arg {
   }
 };
 }  // namespace detail
+FMT_MODULE_EXPORT_BEGIN
 
 inline namespace literals {
 /**
@@ -4022,6 +4033,8 @@ constexpr detail::udl_arg<wchar_t> operator"" _a(const wchar_t* s, size_t) {
   return {s};
 }
 }  // namespace literals
+
+FMT_MODULE_EXPORT_END
 #endif  // FMT_USE_USER_DEFINED_LITERALS
 FMT_END_NAMESPACE
 

--- a/include/fmt/locale.h
+++ b/include/fmt/locale.h
@@ -25,6 +25,8 @@ std::basic_string<Char> vformat(
 }
 }  // namespace detail
 
+FMT_MODULE_EXPORT_BEGIN
+
 template <typename S, typename Char = char_t<S>>
 inline std::basic_string<Char> vformat(
     const std::locale& loc, const S& format_str,
@@ -59,6 +61,7 @@ inline auto format_to(OutputIt out, const std::locale& loc, const S& format_str,
   return vformat_to(out, loc, to_string_view(format_str), vargs);
 }
 
+FMT_MODULE_EXPORT_END
 FMT_END_NAMESPACE
 
 #endif  // FMT_LOCALE_H_

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -14,8 +14,12 @@
 
 FMT_BEGIN_NAMESPACE
 
+FMT_MODULE_EXPORT_BEGIN
+
 template <typename Char> class basic_printf_parse_context;
 template <typename OutputIt, typename Char> class basic_printf_context;
+
+FMT_MODULE_EXPORT_END
 
 namespace detail {
 
@@ -151,6 +155,7 @@ struct fallback_formatter<T, Char, enable_if_t<is_streamable<T, Char>::value>>
 };
 }  // namespace detail
 
+FMT_MODULE_EXPORT
 template <typename Char>
 void vprint(std::basic_ostream<Char>& os, basic_string_view<Char> format_str,
             basic_format_args<buffer_context<type_identity_t<Char>>> args) {
@@ -168,6 +173,7 @@ void vprint(std::basic_ostream<Char>& os, basic_string_view<Char> format_str,
     fmt::print(cerr, "Don't {}!", "panic");
   \endrst
  */
+FMT_MODULE_EXPORT
 template <typename S, typename... Args,
           typename Char = enable_if_t<detail::is_string<S>::value, char_t<S>>>
 void print(std::basic_ostream<Char>& os, const S& format_str, Args&&... args) {

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -194,6 +194,7 @@ FMT_DEPRECATED void printf(detail::buffer<Char>& buf,
 }
 using detail::vprintf;
 
+// already exported through "ostream.h" above
 template <typename Char>
 class basic_printf_parse_context : public basic_format_parse_context<Char> {
   using basic_format_parse_context<Char>::basic_format_parse_context;
@@ -567,6 +568,8 @@ OutputIt basic_printf_context<OutputIt, Char>::format() {
       out, basic_string_view<Char>(start, detail::to_unsigned(it - start)));
 }
 
+FMT_MODULE_EXPORT_BEGIN
+
 template <typename Char>
 using basic_printf_context_t =
     basic_printf_context<detail::buffer_appender<Char>, Char>;
@@ -717,6 +720,8 @@ inline int fprintf(std::basic_ostream<Char>& os, const S& format_str,
   return vfprintf(os, to_string_view(format_str),
                   make_format_args<context>(args...));
 }
+
+FMT_MODULE_EXPORT_END
 FMT_END_NAMESPACE
 
 #endif  // FMT_PRINTF_H_

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -422,6 +422,8 @@ struct formatter<tuple_arg_join<Char, T...>, Char> {
   }
 };
 
+FMT_MODULE_EXPORT_BEGIN
+
 /**
   \rst
   Returns an object that formats `tuple` with elements separated by `sep`.
@@ -468,6 +470,7 @@ arg_join<const T*, const T*, wchar_t> join(std::initializer_list<T> list,
   return join(std::begin(list), std::end(list), sep);
 }
 
+FMT_MODULE_EXPORT_END
 FMT_END_NAMESPACE
 
 #endif  // FMT_RANGES_H_


### PR DESCRIPTION
Start by tagging official API for module export