### PR TITLE
Provide a module interface unit

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -270,6 +270,7 @@ FMT_GCC_PRAGMA("GCC optimize(\"Og\")")
 #endif
 
 FMT_BEGIN_NAMESPACE
+FMT_MODULE_EXPORT_BEGIN
 
 // Implementations of enable_if_t and other metafunctions for older systems.
 template <bool B, class T = void>
@@ -287,6 +288,8 @@ template <typename T> struct type_identity { using type = T; };
 template <typename T> using type_identity_t = typename type_identity<T>::type;
 
 struct monostate {};
+
+FMT_MODULE_EXPORT_END
 
 // An enable_if helper to be used in template parameters which results in much
 // shorter symbols: https://godbolt.org/z/sWw4vP. Extra parentheses are needed

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -14,12 +14,8 @@
 
 FMT_BEGIN_NAMESPACE
 
-FMT_MODULE_EXPORT_BEGIN
-
 template <typename Char> class basic_printf_parse_context;
 template <typename OutputIt, typename Char> class basic_printf_context;
-
-FMT_MODULE_EXPORT_END
 
 namespace detail {
 

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -195,12 +195,15 @@ FMT_DEPRECATED void printf(detail::buffer<Char>& buf,
 }
 using detail::vprintf;
 
-// Exported from ostream.h.
+FMT_MODULE_EXPORT_BEGIN
+
 template <typename Char>
 class basic_printf_parse_context : public basic_format_parse_context<Char> {
   using basic_format_parse_context<Char>::basic_format_parse_context;
 };
 template <typename OutputIt, typename Char> class basic_printf_context;
+
+FMT_MODULE_EXPORT_END
 
 /**
   \rst

--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -1,0 +1,87 @@
+module;
+// put all implementation-provided headers into the global module fragment
+// to prevent attachment to this module
+#if !defined(_CRT_SECURE_NO_WARNINGS) && defined(_MSC_VER)
+#  define _CRT_SECURE_NO_WARNINGS
+#endif
+#if !defined(WIN32_LEAN_AND_MEAN) && defined(_WIN32)
+#  define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <cctype>
+#include <cerrno>
+#include <climits>
+#include <clocale>
+#include <cmath>
+#include <cstdarg>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <cwchar>
+
+#include <algorithm>
+#include <chrono>
+#include <exception>
+#include <functional>
+#include <iterator>
+#include <limits>
+#include <locale>
+#include <memory>
+#include <ostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#if _MSC_VER
+#  include <intrin.h>
+#endif
+#if defined __APPLE__ || defined(__FreeBSD__)
+#  include <xlocale.h>
+#endif
+#if __has_include(<winapifamily.h>)
+#  include <winapifamily.h>
+#endif
+#if (__has_include(<fcntl.h>) || defined(__APPLE__) || \
+     defined(__linux__)) &&                            \
+    (!defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP))
+#  include <fcntl.h>
+#  include <sys/stat.h>
+#  include <sys/types.h>
+#  ifndef _WIN32
+#    include <unistd.h>
+#  else
+#    include <io.h>
+#  endif
+#endif
+#ifdef _WIN32
+#  include <windows.h>
+#endif
+
+export module fmt;
+
+#define FMT_MODULE_EXPORT export
+#define FMT_MODULE_EXPORT_BEGIN export {
+#define FMT_MODULE_EXPORT_END }
+
+// all library-provided declarations and definitions
+// must be in the module purview to be exported
+#include "fmt/format.h"
+#include "fmt/args.h"
+#include "fmt/color.h"
+#include "fmt/compile.h"
+#include "fmt/locale.h"
+#include "fmt/chrono.h"
+#include "fmt/printf.h"
+#include "fmt/os.h"
+
+module : private;
+
+#include "format.cc"
+#include "os.cc"


### PR DESCRIPTION
To compile {fmt} as named module, there must be at least the source provided with the (primary) module interface.

I chose the most elegant and probably the most desirable implementation strategy: a single-file module with a private module partition. This has these benefits:

- easiest to use
- the existing headers require no changes other than providing macro hooks for the exported entities (if implemented cleanly)
- all macros are available during compilation and require no further attention
- the existing source parts all go into the non-exported, unreachable private module partition, which is basically a module implementation unit that's directly fused to end of the module interface unit
- there are only 2 artefacts created:
  1. the object file
  2. the built module interface (BMI)

The macro-based interfaces FMT_STRING and FMT_COMPILE are not yet implemented. Macros cannot get exported from modules.

The inclusion of the 'os' part is optional an can be configured from the command line at build time.
The module name can be configured from the command line at build time. By default it is 'fmt'.
The module may be configured and provided as a static or dynamic-load lib as before.

This requires a sufficiently complete and bug-free implementation of C++20 modules to compile!

At present, msvc 16.10-pre2 requires a workaround for successful compilation (which is not included). 16.10-pre3 is reportedly fine according the the compiler devs.
I have no experience how gcc and clang fare. Let's give them a serious drill!

@vitaut : this is how I do it n my own repo. Let's discuss this.