### PR TITLE
Fix udl_compiled_string with non-byte chars (e.g. wchar)

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -947,8 +947,9 @@ size_t formatted_size(const CompiledFormat& cf, const Args&... args) {
 #if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
 inline namespace literals {
 template <detail::fixed_string Str>
-constexpr detail::udl_compiled_string<remove_cvref_t<decltype(Str.data[0])>,
-                                      sizeof(Str.data), Str>
+constexpr detail::udl_compiled_string<
+    remove_cvref_t<decltype(Str.data[0])>,
+    sizeof(Str.data) / sizeof(decltype(Str.data[0])), Str>
 operator""_cf() {
   return {};
 }

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -316,6 +316,7 @@ TEST(CompileTest, CompileFormatStringLiteral) {
   using namespace fmt::literals;
   EXPECT_EQ("", fmt::format(""_cf));
   EXPECT_EQ("42", fmt::format("{}"_cf, 42));
+  EXPECT_EQ(L"42", fmt::format(L"{}"_cf, 42));
 }
 #endif
 


### PR DESCRIPTION
Without this fix, `udl_compiled_string` works only for char types that have a 1-byte size.
