### PR TITLE
Compile-time named arguments

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -532,7 +532,7 @@ template <typename Char> struct code_unit {
   }
 };
 
-// This ensures that the argument type is convertile to `const T&`.
+// This ensures that the argument type is convertible to `const T&`.
 template <typename T, int N, typename... Args>
 constexpr const T& get_arg_checked(const Args&... args) {
   const auto& arg = get<N>(args...);
@@ -552,8 +552,7 @@ template <typename Char, typename T, int N> struct field {
 
   template <typename OutputIt, typename... Args>
   constexpr OutputIt format(OutputIt out, const Args&... args) const {
-    const T& arg = get_arg_checked<T, N>(args...);
-    return write<Char>(out, arg);
+    return write<Char>(out, get_arg_checked<T, N>(args...));
   }
 };
 
@@ -599,11 +598,10 @@ template <typename Char, typename T, int N> struct spec_field {
 
   template <typename OutputIt, typename... Args>
   constexpr OutputIt format(OutputIt out, const Args&... args) const {
-    const T& arg = get_arg_checked<T, N>(args...);
     const auto& vargs =
         make_format_args<basic_format_context<OutputIt, Char>>(args...);
     basic_format_context<OutputIt, Char> ctx(out, vargs);
-    return fmt.format(arg, ctx);
+    return fmt.format(get_arg_checked<T, N>(args...), ctx);
   }
 };
 

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -13,15 +13,6 @@
 
 #include "format.h"
 
-#ifndef FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
-#  if defined(__cpp_nontype_template_parameter_class) && \
-      (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 903)
-#    define FMT_USE_NONTYPE_TEMPLATE_PARAMETERS 1
-#  else
-#    define FMT_USE_NONTYPE_TEMPLATE_PARAMETERS 0
-#  endif
-#endif
-
 FMT_BEGIN_NAMESPACE
 namespace detail {
 
@@ -126,14 +117,6 @@ struct is_compiled_string : std::is_base_of<compiled_string, S> {};
 #define FMT_COMPILE(s) FMT_STRING_IMPL(s, fmt::detail::compiled_string)
 
 #if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
-template <typename Char, size_t N> struct fixed_string {
-  constexpr fixed_string(const Char (&str)[N]) {
-    copy_str<Char, const Char*, Char*>(static_cast<const Char*>(str), str + N,
-                                       data);
-  }
-  Char data[N]{};
-};
-
 template <typename Char, size_t N, fixed_string<Char, N> Str>
 struct udl_compiled_string : compiled_string {
   using char_type = Char;

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -448,7 +448,8 @@ template <typename Char> class basic_string_view {
     return result;
   }
 
-  friend bool operator==(basic_string_view lhs, basic_string_view rhs) {
+  FMT_CONSTEXPR_CHAR_TRAITS friend bool operator==(basic_string_view lhs,
+                                                   basic_string_view rhs) {
     return lhs.compare(rhs) == 0;
   }
   friend bool operator!=(basic_string_view lhs, basic_string_view rhs) {

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -975,16 +975,22 @@ struct arg_data<T, Char, NUM_ARGS, 0> {
 template <typename Char>
 inline void init_named_args(named_arg_info<Char>*, int, int) {}
 
-template <typename Char, typename T, typename... Tail>
+template <typename T> struct is_named_arg : std::false_type {};
+
+template <typename T, typename Char>
+struct is_named_arg<named_arg<Char, T>> : std::true_type {};
+
+template <typename Char, typename T, typename... Tail,
+          FMT_ENABLE_IF(!is_named_arg<T>::value)>
 void init_named_args(named_arg_info<Char>* named_args, int arg_count,
                      int named_arg_count, const T&, const Tail&... args) {
   init_named_args(named_args, arg_count + 1, named_arg_count, args...);
 }
 
-template <typename Char, typename T, typename... Tail>
+template <typename Char, typename T, typename... Tail,
+          FMT_ENABLE_IF(is_named_arg<T>::value)>
 void init_named_args(named_arg_info<Char>* named_args, int arg_count,
-                     int named_arg_count, const named_arg<Char, T>& arg,
-                     const Tail&... args) {
+                     int named_arg_count, const T& arg, const Tail&... args) {
   named_args[named_arg_count++] = {arg.name, arg_count};
   init_named_args(named_args, arg_count + 1, named_arg_count, args...);
 }
@@ -992,11 +998,6 @@ void init_named_args(named_arg_info<Char>* named_args, int arg_count,
 template <typename... Args>
 FMT_CONSTEXPR FMT_INLINE void init_named_args(std::nullptr_t, int, int,
                                               const Args&...) {}
-
-template <typename T> struct is_named_arg : std::false_type {};
-
-template <typename T, typename Char>
-struct is_named_arg<named_arg<Char, T>> : std::true_type {};
 
 template <bool B = false> constexpr size_t count() { return B ? 1 : 0; }
 template <bool B1, bool B2, bool... Tail> constexpr size_t count() {
@@ -1273,10 +1274,10 @@ template <typename Context> struct arg_mapper {
     return val;
   }
 
-  template <typename T>
-  FMT_CONSTEXPR FMT_INLINE auto map(const named_arg<char_type, T>& val)
-      -> decltype(std::declval<arg_mapper>().map(val.value)) {
-    return map(val.value);
+  template <typename T, FMT_ENABLE_IF(is_named_arg<T>::value)>
+  FMT_CONSTEXPR FMT_INLINE auto map(const T& named_arg)
+      -> decltype(std::declval<arg_mapper>().map(named_arg.value)) {
+    return map(named_arg.value);
   }
 
   unformattable map(...) { return {}; }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -263,6 +263,15 @@ inline int ctzll(uint64_t x) {
 FMT_END_NAMESPACE
 #endif
 
+#ifndef FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
+#  if defined(__cpp_nontype_template_parameter_class) && \
+      (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 903)
+#    define FMT_USE_NONTYPE_TEMPLATE_PARAMETERS 1
+#  else
+#    define FMT_USE_NONTYPE_TEMPLATE_PARAMETERS 0
+#  endif
+#endif
+
 FMT_BEGIN_NAMESPACE
 namespace detail {
 
@@ -3908,6 +3917,19 @@ void vprint(basic_string_view<Char> format_str, wformat_args args) {
 }
 
 FMT_MODULE_EXPORT_END
+
+#if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
+namespace detail {
+template <typename Char, size_t N> struct fixed_string {
+  constexpr fixed_string(const Char (&str)[N]) {
+    copy_str<Char, const Char*, Char*>(static_cast<const Char*>(str), str + N,
+                                       data);
+  }
+  Char data[N]{};
+};
+}  // namespace detail
+#endif
+
 #if FMT_USE_USER_DEFINED_LITERALS
 namespace detail {
 template <typename Char> struct udl_formatter {

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3941,6 +3941,9 @@ template <typename Char> struct udl_formatter {
   }
 };
 
+template <typename T, typename = void>
+struct is_statically_named_arg : std::false_type {};
+
 #  if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
 template <typename T, typename Char, size_t N, fixed_string<Char, N> Str>
 struct statically_named_arg : view {
@@ -3952,6 +3955,10 @@ struct statically_named_arg : view {
 
 template <typename T, typename Char, size_t N, fixed_string<Char, N> Str>
 struct is_named_arg<statically_named_arg<T, Char, N, Str>> : std::true_type {};
+
+template <typename T, typename Char, size_t N, fixed_string<Char, N> Str>
+struct is_statically_named_arg<statically_named_arg<T, Char, N, Str>>
+    : std::true_type {};
 
 template <typename Char, size_t N, fixed_string<Char, N> Str> struct udl_arg {
   template <typename T> auto operator=(T&& value) const {

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -210,6 +210,11 @@ TEST(CompileTest, ManualOrdering) {
 }
 
 TEST(CompileTest, Named) {
+  auto runtime_named_field_compiled =
+      fmt::detail::compile<decltype(fmt::arg("arg", 42))>(FMT_COMPILE("{arg}"));
+  static_assert(std::is_same_v<decltype(runtime_named_field_compiled),
+                               fmt::detail::runtime_named_field<char>>);
+
   EXPECT_EQ("42", fmt::format(FMT_COMPILE("{}"), fmt::arg("arg", 42)));
   EXPECT_EQ("41 43", fmt::format(FMT_COMPILE("{} {}"), fmt::arg("arg", 41),
                                  fmt::arg("arg", 43)));
@@ -237,6 +242,19 @@ TEST(CompileTest, Named) {
 
   EXPECT_THROW(fmt::format(FMT_COMPILE("{invalid}"), fmt::arg("valid", 42)),
                fmt::format_error);
+
+#  if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
+  using namespace fmt::literals;
+  auto statically_named_field_compiled =
+      fmt::detail::compile<decltype("arg"_a = 42)>(FMT_COMPILE("{arg}"));
+  static_assert(std::is_same_v<decltype(statically_named_field_compiled),
+                               fmt::detail::field<char, int, 0>>);
+
+  EXPECT_EQ("41 43",
+            fmt::format(FMT_COMPILE("{a0} {a1}"), "a0"_a = 41, "a1"_a = 43));
+  EXPECT_EQ("41 43",
+            fmt::format(FMT_COMPILE("{a1} {a0}"), "a0"_a = 43, "a1"_a = 41));
+#  endif
 }
 
 TEST(CompileTest, FormatTo) {


### PR DESCRIPTION
This PR makes the name of named arguments created via `_a` literal be available at compile-time. So named arguments can be checked at compile-time now exactly like non-named ones. 
I haven't implemented these checks for `FMT_STRING`, but I did it for compile-time API. Thus these lines:
```cpp
fmt::format(FMT_COMPILE("{0}"), 42);
fmt::format(FMT_COMPILE("{arg}"), "arg"_a = 42);
```
produce the same compiled format, so it's zero-overhead for arguments naming. Of course, `fmt::arg(name, value)`-based named arguments still have this overhead because they cannot provide their names at compile-time. Here are [the results](https://github.com/alexezeder/fmt_bnchmrk/tree/feature/named_args):

| Benchmark                         |    Time     |       CPU | Iterations |
| ----------------------------------|-------------|-----------|------------|
| FMTNonNamed/42                    | 14.3 ns     |   14.3 ns |   47750054 |
| FMTRuntimeNamed/42                | 28.0 ns     |   28.0 ns |   25015214 |
| FMTCompileNonNamed/42             | 2.28 ns     |   2.28 ns |  307524148 |
| FMTCompileRuntimeNamed/42         | 3.05 ns     |   3.05 ns |  229333563 |
| FMTCompileCompileTimeNamed/42     | 2.23 ns     |   2.23 ns |  316913616 |

Besides that performance improvement, a fallback to runtime API is no longer needed for named arguments with specs because type information is available at compile-time. Here are [the results](https://github.com/alexezeder/fmt_bnchmrk/tree/feature/named_args_with_specs):

| Benchmark                         |    Time     |       CPU | Iterations |
| ----------------------------------|-------------|-----------|------------|
| FMTNonNamed/42                    | 46.0 ns     |   46.0 ns |   15185138 |
| FMTRuntimeNamed/42                | 54.5 ns     |   54.5 ns |   12507523 |
| FMTCompileNonNamed/42             | 30.2 ns     |   30.2 ns |   23434189 |
| FMTCompileRuntimeNamed/42         | 54.3 ns     |   54.3 ns |   12678573 |
| FMTCompileCompileTimeNamed/42     | 29.8 ns     |   29.8 ns |   23493430 |

Some points for this PR:

* `_a` literal provides statically named argument (i.e. its name available at compile-time) in form of `statically_named_arg` type
* existing `fixed_string` struct moved from `compile.h` to `format.h` because it's used in `statically_named_arg`, `FMT_USE_NONTYPE_TEMPLATE_PARAMETERS` macro definition also moved there
* some `is_named_arg`-related fixes applied for correct `statically_named_arg` treating as named argument
* `field` struct creation and `field::format()` changed to have the value type of named argument stored as a template `T` parameter (not `named_arg<T>`), same with `spec_field`
* some part of `compile_format_string()` moved to separate function `parse_replacement_field_then_tail()` because it was duplicated 3 times, so maybe one more instantiation is not so bad 🤔
* there is no other option but to use `runtime_named_field` for all named arguments that are not found
* test for compiled format representation added
