### PR TITLE
Use proper check for non-type template parameters

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,17 +12,23 @@ jobs:
         os: [windows-2016, windows-2019]
         platform: [Win32, x64]
         build_type: [Debug, Release]
+        standard: [11, 17, 20]
         include:
-          - os: windows-2016
-            standard: 11
-          - os: windows-2019
-            standard: 17
           - os: windows-2016
             platform: Win32
             build_type: Debug
             shared: -DBUILD_SHARED_LIBS=ON
         exclude:
           - os: windows-2016
+            platform: Win32
+          - os: windows-2016
+            standard: 17
+          - os: windows-2016
+            standard: 20
+          - os: windows-2019
+            standard: 11
+          - os: windows-2019
+            standard: 20
             platform: Win32
 
     steps:

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -48,7 +48,7 @@
 // MSVC, libc++: always if __cplusplus >= 201703L
 // NOTE: FMT_GCC_VERSION  - is not libstdc++ version.
 //       _GLIBCXX_RELEASE - is present in GCC 7 libstdc++ and newer.
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #  ifndef __GLIBCXX__
 #    define FMT_CONSTEXPR_CHAR_TRAITS constexpr
 #  elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 7

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -264,8 +264,9 @@ FMT_END_NAMESPACE
 #endif
 
 #ifndef FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
-#  if defined(__cpp_nontype_template_parameter_class) && \
-      (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 903)
+#  if defined(__cpp_nontype_template_args) &&                \
+      ((FMT_GCC_VERSION >= 903 && __cplusplus >= 201709L) || \
+       __cpp_nontype_template_args >= 201911L)
 #    define FMT_USE_NONTYPE_TEMPLATE_PARAMETERS 1
 #  else
 #    define FMT_USE_NONTYPE_TEMPLATE_PARAMETERS 0


### PR DESCRIPTION
More info here - https://github.com/fmtlib/fmt/pull/2240#discussion_r618631034

Also, `FMT_CONSTEXPR_CHAR_TRAITS` was fixed for MSVC and two C++20 MSVC configurations were added to CI:
 * x64, Debug
 * x64, Release
