### PR TITLE
WIP: async format_arg_store buffer storage support

### DIFF
--- a/include/fmt/async.h
+++ b/include/fmt/async.h
@@ -1,0 +1,323 @@
+#ifndef FMT_ASYNC_H_
+#define FMT_ASYNC_H_
+
+#include "format.h"
+#include <tuple>
+
+namespace fmt {
+
+template <typename Context> struct basic_async_entry {
+protected:
+    using char_type = typename Context::char_type;
+    using format_arg = typename basic_format_args<Context>::format_arg;
+    using arg_destructor = void (*)(void *p);
+
+    basic_string_view<char_type> format_;
+    unsigned long long desc_;
+    arg_destructor dtor_;
+
+    FMT_CONSTEXPR basic_async_entry(basic_string_view<char_type> format) : format_(format), desc_(0), dtor_(0) {}
+    const format_arg* get_format_args() const;
+
+    template <typename OutIt, typename T = OutIt>
+    using enable_out = enable_if_t<detail::is_output_iterator<OutIt, char_type>::value, T>;
+
+    void destruct() { if (dtor_) dtor_(this); }
+public:
+    struct dtor_sentry {
+        dtor_sentry(basic_async_entry& entry) : entry_(entry) {}
+        ~dtor_sentry() { entry_.destruct(); }
+        basic_async_entry& entry_;
+    };
+
+    // libfmt public APIs
+    std::basic_string<char_type> format() const { return vformat(format_, {desc_, get_format_args()}); }
+
+    template <typename OutIt>
+    auto format_to(OutIt out) const -> enable_out<OutIt> {
+        return vformat_to(out, format_, {desc_, get_format_args()});
+    }
+
+    // template <typename OutIt>
+    // auto format_to(OutIt out, size_t n) const -> enable_out<OutIt, format_to_n_result<OutIt>> {
+    //     return vformat_to(detail::truncating_iterator<OutIt>(out, n), format_, {desc_, get_format_args()});
+    // }
+
+    size_t formatted_size() const {
+        detail::counting_buffer<> buf;
+        format_to(buf);
+        return buf.count();
+    }
+
+    void print(std::FILE* file = stdout) const { return vprint(file, format_, {desc_, get_format_args()}); }
+
+};
+
+template <typename Context, typename... Args> struct async_entry : basic_async_entry<Context> {
+    using entry = basic_async_entry<Context>;
+
+    format_arg_store<Context, Args...> arg_store_;
+
+    template <typename S>
+    FMT_CONSTEXPR async_entry(const S& format_str, const Args&... args) : entry(to_string_view(format_str)), arg_store_(args...) {
+        entry::desc_ = arg_store_.desc;
+    }
+    FMT_CONSTEXPR void set_dtor(typename entry::arg_destructor dtor) { this->dtor_ = dtor; }
+};
+
+template <typename Context>
+inline const typename basic_async_entry<Context>::format_arg* basic_async_entry<Context>::get_format_args() const {
+    union obfuscated_args {
+        const detail::value<Context>* values_;
+        const format_arg* args_;
+        intptr_t pointer_; // more efficient to add integer with size, as the compiler is able to avoid emitting branch
+    } args;
+    auto& entry = static_cast<const async_entry<Context>&>(*this);
+    args.values_ = entry.arg_store_.data_.args_;
+    if (entry.desc_ & detail::has_named_args_bit) {
+        args.pointer_ += (desc_ & detail::is_unpacked_bit) ? sizeof(*args.args_) : sizeof(*args.values_);
+    }
+    return args.args_;
+}
+
+//
+// A stored entry looks like:
+// -----------------------------------------------------------------------
+// | basic_async_entry | arg_store | stored_objs... | stored_buffers... |
+// -----------------------------------------------------------------------
+//
+namespace async {
+namespace detail {
+namespace detail = fmt::detail;
+template <typename T> using decay_t = typename std::decay<T>::type;
+template <typename T> using add_const_t = typename std::add_const<T>::type;
+template <typename...> struct disjunction : std::false_type {};
+template <typename B1> struct disjunction<B1> : B1 {};
+template <typename B1, typename... Bn> struct disjunction<B1, Bn...> : conditional_t<bool(B1::value), B1, disjunction<Bn...>> {};
+
+enum class store_method {
+    numeric,        // stored by libfmt as numeric value, no need for extra storage
+    object,         // stored by libfmt as object, copy/move construct the object manually (requires properly calling destructor)
+    buffer,         // string/hexdump, store the string/binary trivially as buffer.
+    constexpr_str   // compile-time string, can be stored as pointer directly (requires c++20 is_constant_evaluated())
+};
+
+template <store_method method> using store_method_constant = std::integral_constant<store_method, method>;
+using store_as_object = store_method_constant<store_method::object>;
+using store_as_buffer = store_method_constant<store_method::buffer>;
+
+template <typename Type>
+using stored_as_numeric = std::integral_constant<bool, detail::is_arithmetic_type(Type::value) || Type::value == detail::type::pointer_type>;
+template <typename Type>
+using stored_as_string = std::integral_constant<bool, Type::value == detail::type::cstring_type || Type::value == detail::type::string_type>;
+template <typename T> struct is_basic_string : std::false_type {};
+template <typename C, typename T, typename A> struct is_basic_string<std::basic_string<C, T, A>> : std::true_type {};
+template <typename Type, typename T>
+using stored_as_string_object = std::integral_constant<bool, stored_as_string<Type>::value && is_basic_string<remove_reference_t<T>>::value && std::is_rvalue_reference<T>::value>;
+
+struct custom_store_method_checker {
+    template <typename Arg, typename Context, typename RawT = decay_t<Arg>, typename Formatter = typename Context::template formatter_type<RawT>>
+    static enable_if_t<has_formatter<RawT, Context>::value, std::tuple<std::true_type, decltype(Formatter::store(std::declval<char*&>(), std::declval<Arg>()))>> test(double);
+    template <typename Arg, typename Context, typename RawT = decay_t<Arg>, typename Formatter = typename Context::template formatter_type<RawT>>
+    static enable_if_t<has_formatter<RawT, Context>::value, std::tuple<std::false_type, decltype(Formatter::store(std::declval<char*>(), std::declval<Arg>()))>> test(int);
+    template <typename Arg, typename Context>
+    static std::tuple<std::false_type, store_as_object> test(...);
+};
+
+template <typename Arg, typename Context>
+struct custom_store_method {
+    using transformed_type = typename std::tuple_element<1, decltype(custom_store_method_checker::template test<Arg, Context>(0))>::type;
+    static constexpr bool custom_store = std::tuple_element<0, decltype(custom_store_method_checker::template test<Arg, Context>(0))>::type::value && !std::is_same<transformed_type, store_as_object>::value;
+    using store_type = conditional_t<std::is_same<transformed_type, store_as_object>::value, store_as_object, store_as_buffer>;
+};
+
+template <typename Arg, typename Context, typename Type = detail::mapped_type_constant<remove_reference_t<Arg>, Context>>
+struct stored_method_constant : std::integral_constant<store_method,  // using class (not template using) to allow easier partial specialization.
+    stored_as_numeric<Type>::value ? store_method::numeric :
+    stored_as_string<Type>::value ? (stored_as_string_object<Type, Arg>::value ? store_method::object : store_method::buffer) :
+    // store_method::object> {};
+    custom_store_method<Arg, Context>::store_type::value> {};
+
+// Check for integer_sequence
+#if defined(__cpp_lib_integer_sequence) || FMT_MSC_VER >= 1900
+template <typename T, T... N>
+using integer_sequence = std::integer_sequence<T, N...>;
+template <size_t... N> using index_sequence = std::index_sequence<N...>;
+template <size_t N> using make_index_sequence = std::make_index_sequence<N>;
+#else
+template <typename T, T... N> struct integer_sequence {
+  using value_type = T;
+
+  static FMT_CONSTEXPR size_t size() { return sizeof...(N); }
+};
+
+template <size_t... N> using index_sequence = integer_sequence<size_t, N...>;
+
+template <typename T, size_t N, T... Ns>
+struct make_integer_sequence : make_integer_sequence<T, N - 1, N - 1, Ns...> {};
+template <typename T, T... Ns>
+struct make_integer_sequence<T, 0, Ns...> : integer_sequence<T, Ns...> {};
+
+template <size_t N>
+using make_index_sequence = make_integer_sequence<size_t, N>;
+#endif
+
+template <typename... Args>
+struct arg_transformer {
+    using arg_tuple = std::tuple<Args...>;
+    template <size_t N> using arg_at = typename std::tuple_element<N, arg_tuple>::type;
+    using type_tuple = std::tuple<decay_t<Args>...>;
+    template <size_t N> using type_at = typename std::tuple_element<N, type_tuple>::type;
+    template <size_t N> using size_at = std::integral_constant<size_t, sizeof(type_at<N>)>;
+    template <typename Context, size_t N> using objsize_at = conditional_t<stored_method_constant<arg_at<N>, Context>::value == store_method::object, size_at<N>, std::integral_constant<size_t, 0>>;
+    template <typename Context, size_t N> struct objsizesum_at : std::integral_constant<size_t, conditional_t<N == 0, std::integral_constant<size_t, 0>, objsizesum_at<Context, N - 1>>::value + objsize_at<Context, N>::value> {};
+    template <typename Context, size_t N> using objoffset_at = conditional_t<N == 0, std::integral_constant<size_t, 0>, objsizesum_at<Context, N - 1>>;
+};
+
+template <typename Arg, typename Context, typename Type = detail::mapped_type_constant<remove_reference_t<Arg>, Context>>
+using transformed_arg_type = conditional_t<custom_store_method<Arg, Context>::custom_store, typename custom_store_method<Arg, Context>::transformed_type,
+                             conditional_t<stored_as_string<Type>::value && !stored_as_string_object<Type, Arg>::value, basic_string_view<typename Context::char_type>, add_const_t<remove_reference_t<Arg>>&>
+                             >;
+
+template <typename Context, typename... Args>
+struct async_entry_constructor {
+    template <typename S>
+    static size_t construct(void* buf, const S& format_str, Args... args) {
+        return async_entry_constructor<Context, Args...>(buf, format_str, range(), std::forward<Args>(args)...).get_total_size();
+    }
+
+private:
+    using entry = async_entry<Context, decay_t<transformed_arg_type<Args, Context>>...>;
+    using trans = arg_transformer<Args...>;
+    using char_type = typename Context::char_type;
+    using range = make_index_sequence<sizeof...(Args)>;
+
+    template <typename S, size_t... Indice>
+    FMT_CONSTEXPR async_entry_constructor(void* buf, const S& format_str, index_sequence<Indice...>, Args... args) : pentry(reinterpret_cast<char*>(buf)), pBuffer(get_buffer_store(buf)) {
+        auto p = new(buf) entry(format_str, store<Indice>(std::forward<Args>(args))...);
+        if (disjunction<need_destruct<Indice>...>::value) p->set_dtor(destructor<Indice...>::dtor);
+    }
+
+    template <size_t N> using arg_at = typename trans::template arg_at<N>;
+    template <size_t N> using type_at = typename trans::template type_at<N>;
+
+    template <size_t N> using need_destruct = std::integral_constant<bool, stored_method_constant<arg_at<N>, Context>::value == store_method::object && std::is_destructible<arg_at<N>>::value && !std::is_trivially_destructible<arg_at<N>>::value>;
+    template <size_t N> static bool destruct(void *p, std::true_type) { reinterpret_cast<type_at<N>*>(p + sizeof(entry) + trans::template objoffset_at<Context, N>::value)->~type_at<N>(); return true; }
+    template <size_t N> static bool destruct(void *p, std::false_type) { return false; }
+    template <size_t... Indice> struct destructor {
+        static void dummy(...) {}
+        static void dtor(void *p) { dummy(destruct<Indice>(p, need_destruct<Indice>())...); }
+    };
+
+    template <size_t N> transformed_arg_type<arg_at<N>, Context> store(arg_at<N> arg) {
+        using Arg = arg_at<N>;
+        using select_store_method = custom_store_method<Arg, Context>;
+        using mapped_type = detail::mapped_type_constant<remove_reference_t<Arg>, Context>;
+        if constexpr (select_store_method::custom_store == true) {
+            using Formatter = typename Context::template formatter_type<decay_t<Arg>>;
+
+            return Formatter::store(pBuffer, std::forward<Arg>(arg));
+        }
+        else if constexpr (stored_as_string<mapped_type>::value && !stored_as_string_object<mapped_type, Arg>::value) {
+            return copy_string(pBuffer, detail::arg_mapper<Context>().map(std::forward<Arg>(arg)));
+        }
+        else if constexpr (stored_as_numeric<mapped_type>::value) {
+            return std::forward<Arg>(arg);
+        }
+        else {
+            char* const pobjs = pentry + sizeof(entry);
+            char* const pobj = pobjs + trans::template objoffset_at<Context, N>::value;
+            using Type = type_at<N>;
+            auto p = new(pobj) Type(std::forward<Arg>(arg));
+            return *p;
+        }
+    }
+
+    static basic_string_view<char_type> copy_string(char*& pBuffer, const char_type* cstr) {
+        if constexpr (std::is_same<char_type, wchar_t>::value) {
+            wchar_t* pStart = reinterpret_cast<wchar_t*>(pBuffer);
+            wchar_t* pEnd = wcpcpy(pStart, cstr);
+            pBuffer = reinterpret_cast<char*>(pEnd);
+            return basic_string_view<wchar_t>(pStart, pEnd - pStart);
+        }
+        else {
+            char* pStart = pBuffer;
+            char* pEnd = stpcpy(pStart, cstr);
+            pBuffer = pEnd;
+            return basic_string_view<char>(pStart, pEnd - pStart);
+        }
+    }
+    static basic_string_view<char_type> copy_string(char*& pBuffer, basic_string_view<char_type> sv) {
+        char_type* pStart = reinterpret_cast<char_type*>(pBuffer);
+        size_t size = sizeof(char_type) * sv.size();
+        std::memcpy(pStart, sv.data(), size);
+        pBuffer += size;
+        return basic_string_view<char_type>(pStart, sv.size());
+    }
+
+    static FMT_CONSTEXPR char* get_buffer_store(void* buf) {
+        char* const pentry = reinterpret_cast<char*>(buf);      // entry will be constructed here
+        char* const pobjs = pentry + sizeof(entry);             // objects will be stored starting here
+        char* const pbufs = pobjs + get_obj_size();             // buffers will be stored starting here
+        return pbufs;
+    }
+    static constexpr size_t get_obj_size() { return trans::template objsizesum_at<Context, sizeof...(Args) - 1>::value; }
+    constexpr size_t get_total_size() const { return pBuffer - pentry; }
+    char* const pentry;
+    char* pBuffer;
+};
+
+}  // namespace detail
+
+template <typename S, typename... Args, typename Char = char_t<S>>
+inline size_t store(void* buf, const S& format_str, Args&&... args) {
+    using Context = buffer_context<Char>;
+    using Constructor = detail::async_entry_constructor<Context, Args&&...>;
+    return Constructor::construct(buf, format_str, std::forward<Args>(args)...);
+}
+
+template <typename Context>
+inline auto format(basic_async_entry<Context>& entry) -> decltype(entry.format()) {
+    typename basic_async_entry<Context>::dtor_sentry _(entry);
+    return entry.format();
+}
+
+template <typename OutIt, typename Context>
+inline auto format_to(basic_async_entry<Context>& entry, OutIt out) -> decltype(entry.format_to(out)) {
+    typename basic_async_entry<Context>::dtor_sentry _(entry);
+    return entry.format_to(out);
+}
+
+// template <typename OutIt, typename Context>
+// inline auto format_to(basic_async_entry<Context>& entry, OutIt out, size_t n) -> decltype(entry.format_to_n(out, n)) {
+//     typename basic_async_entry<Context>::dtor_sentry _(entry);
+//     return entry.format_to(out, n);
+// }
+
+template <typename Context>
+inline void print(basic_async_entry<Context>& entry, std::FILE* f = stdout) {
+    typename basic_async_entry<Context>::dtor_sentry _(entry);
+    entry.print(f);
+}
+
+// TODO should we add wrappers like this?
+// template <typename Context = format_context>
+// inline auto format(void* entry) -> decltype(format(std::declval<basic_async_entry<Context>&>())) {
+//     return format(*reinterpret_cast<basic_async_entry<Context>*>(entry));
+// }
+// inline auto wformat(void* entry) -> decltype(format<wformat_context>(entry)) { return format<wformat_context>(entry); }
+
+}  // namespace async
+
+template <typename S, typename... Args, typename Char = char_t<S>>
+inline auto make_async_entry(const S& format_str, Args&&... args) -> async_entry<buffer_context<Char>, remove_reference_t<Args>...> {
+    return { format_str, args... };
+}
+
+template <typename S, typename... Args, typename Char = char_t<S>>
+inline size_t store_async_entry(void* buf, const S& format_str, Args&&... args) {
+    return async::store(buf, format_str, std::forward<Args>(args)...);
+}
+
+}  // namespace fmt
+#endif  // FMT_ASYNC_H_

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1612,6 +1612,7 @@ class format_arg_store
   using value_type = conditional_t<is_packed, detail::value<Context>,
                                    basic_format_arg<Context>>;
 
+ public:
   detail::arg_data<value_type, typename Context::char_type, num_args,
                    num_named_args>
       data_;
@@ -1625,7 +1626,6 @@ class format_arg_store
            ? static_cast<unsigned long long>(detail::has_named_args_bit)
            : 0);
 
- public:
   FMT_CONSTEXPR FMT_INLINE format_arg_store(const Args&... args)
       :
 #if FMT_GCC_VERSION && FMT_GCC_VERSION < 409
@@ -1734,13 +1734,13 @@ template <typename Context> class basic_format_args {
     return static_cast<detail::type>((desc_ >> shift) & mask);
   }
 
+ public:
   constexpr FMT_INLINE basic_format_args(unsigned long long desc,
                                          const detail::value<Context>* values)
       : desc_(desc), values_(values) {}
   constexpr basic_format_args(unsigned long long desc, const format_arg* args)
       : desc_(desc), args_(args) {}
 
- public:
   constexpr basic_format_args() : desc_(0), args_(nullptr) {}
 
   /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ endfunction()
 
 add_fmt_test(args-test)
 add_fmt_test(assert-test)
+add_fmt_test(async-test)
 add_fmt_test(chrono-test)
 add_fmt_test(color-test)
 add_fmt_test(core-test)

--- a/test/async-test.cc
+++ b/test/async-test.cc
@@ -1,0 +1,126 @@
+
+#ifdef WIN32
+#  define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include "fmt/async.h"
+#include "gtest-extra.h"
+
+#define TWENTY_ARGS "{} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} {} "
+static const char multiple_brackets[] = TWENTY_ARGS;
+static fmt::string_view get_format_string(size_t num_args) { return fmt::string_view(&multiple_brackets[(20 - num_args)*3], num_args * 3); }
+
+namespace trivial_entry_test {
+template <typename... Args>
+inline void make_async_entry_test(Args&&... args) {
+    std::string formatted = fmt::format(std::forward<Args>(args)...);
+    // format_arg_store containing named_args are not copy-constructible, auto&& is required.
+    auto&& entry = fmt::make_async_entry(std::forward<Args>(args)...);
+    EXPECT_EQ(formatted, fmt::async::format(entry));
+}
+
+template <typename... Args>
+inline void make_async_entry_test_args(Args&&... args) {
+    make_async_entry_test(get_format_string(sizeof...(args)), std::forward<Args>(args)...);
+}
+
+void make_async_entry_and_alter(const std::string& s) {
+    std::string str = s;
+    std::string formatted = fmt::format("{}", str);
+    auto entry = fmt::make_async_entry("{}", str);
+    str.front() =  formatted.front() = '#';
+    str.back() = formatted.back() = '#';
+    EXPECT_EQ(formatted, fmt::format("{}", str));
+    EXPECT_EQ(formatted, fmt::async::format(entry));
+}
+}
+
+namespace stored_entry_test {
+static char buf[1 * 1024 * 1024] = {}; // 1M should be enough for this test
+static fmt::basic_async_entry<fmt::format_context>& entry = reinterpret_cast<fmt::basic_async_entry<fmt::format_context>&>(buf);
+
+template <typename... Args>
+inline void make_async_entry_test(Args&&... args) {
+    std::string formatted = fmt::format(std::forward<Args>(args)...);
+    // FIXME: how to test entry_size?
+    size_t entry_size = fmt::store_async_entry(buf, std::forward<Args>(args)...);
+    EXPECT_EQ(formatted, fmt::async::format(entry));
+}
+
+template <typename... Args>
+inline void make_async_entry_test_args(Args&&... args) {
+    make_async_entry_test(get_format_string(sizeof...(args)), std::forward<Args>(args)...);
+}
+
+void make_async_entry_and_alter(const std::string& s) {
+    std::string str = s;
+    std::string formatted = fmt::format("{}", str);
+    size_t entry_size = fmt::store_async_entry(buf, "{}", str);
+    str.front() = str.back() = '#';
+    EXPECT_EQ(formatted, fmt::async::format(entry));
+    formatted.front() = formatted.back() = '#';
+    EXPECT_EQ(formatted, fmt::format("{}", str));
+}
+
+void make_async_entry_dtor_test(std::string s) {
+    static void* constructed;
+    static void* destructed;
+    struct my_string : std::string {
+        my_string(const std::string& s) : std::string(s) {
+            constructed = this;
+        }
+        ~my_string() { destructed = this; }
+    };
+    {
+        my_string str(s);
+        size_t entry_size = fmt::store_async_entry(buf, "{}", str);
+        fmt::async::format(entry);
+    }
+    EXPECT_NE(nullptr, constructed);
+    EXPECT_EQ(constructed, destructed);
+};
+
+
+}
+
+TEST(AsyncTest, TrivialEntry) {
+    using namespace trivial_entry_test;
+    // basic test
+    make_async_entry_test("The answer is {}", 42);
+    // index
+    make_async_entry_test("The answer of {2}*{1} is {0}", 42, 6, 7);
+
+    // named args
+    using namespace fmt::literals;
+    make_async_entry_test("The answer of {}*{a} is {product}", 6, "product"_a=42, "a"_a=7);
+
+    // long arg list (>=16, as max_packed_args = 15)
+    make_async_entry_test_args(short(1), (unsigned short)2, 3, 4U, 5L, 6UL, 7LL, 8ULL, 9.0F, 10.0, 11, 12, 13, 14, 15, 16, 17, 18);
+    make_async_entry_test(TWENTY_ARGS "{narg}", 1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,0/*ignore*/,"narg"_a="bingo");
+
+    // this API copies only reference.
+    make_async_entry_and_alter("[change me]");
+}
+
+
+TEST(AsyncTest, StoredEntry) {
+    using namespace stored_entry_test;
+    // basic test
+    make_async_entry_test("The answer is {}", 42);
+    // index
+    make_async_entry_test("The answer of {2}*{1} is {0}", 42, 6, 7);
+
+    // named args
+    using namespace fmt::literals;
+    // make_async_entry_test("The answer of {}*{a} is {product}", 6, "product"_a=42, "a"_a=7);
+
+    // long arg list (>=16, as max_packed_args = 15)
+    make_async_entry_test_args(short(1), (unsigned short)2, 3, 4U, 5L, 6UL, 7LL, 8ULL, 9.0F, 10.0, 11, 12, 13, 14, 15, 16, 17, 18);
+    // make_async_entry_test(TWENTY_ARGS "{narg}", 1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,0/*ignore*/,"narg"_a="bingo");
+
+    // this API copies buffer.
+    make_async_entry_and_alter("[change me]");
+
+    // dtor
+    make_async_entry_dtor_test("custom string copied as object");
+}


### PR DESCRIPTION
## WIP: async format_arg_store buffer storage support

The idea of **async** storage is similar to `dynamic_format_arg_store`, by doing so, the **arg_store** and **format_str** can be queued up and let a consumer (it can be another thread) do the actual formatting. A typical scenario of it is a genuine **async** logger. I'd call it **async formatting logger**, rather than the common idea **async logger** which usually refers to **async flushing logger**.

But `dynamic_format_arg_store` has its drawbacks. It breaks triviality and aggregate construction, allocates memory by using a `std::vector`, disqualifies *is_packed* optimization...

To get rid from the overhead of `dynamic_format_arg_store`, here comes the idea of **async**. Initially it was called `fmtlog` because as explained above, the main scenario is **async formatting logger**. It's has been used in production in house for several months.  
When I was considering contributing this to public, I came up with the name **async**, because obviously async is not anything to be formatted by `libfmt` as other extensions, so there should not be a name confliction.  

## PR status
The logger part is not part of the contribution.  
This is quite immature on some parts of the design see **to be implemented/fixed/discussed** section.  
Also currently the code works on c++17 (or relaxed g++ that allows you using `if constexpr` without `c++17`) and un*x.  
code-style will be formatted whe it gets mature.

## features
* async - producing the `stored_entry` and cosuming it can happen on different threads.
* As fast as pure libfmt - if you just use it on the same thread (limited to non-copy types, explained below, see **layout**).
  * and even nearly identical assembly code, despite you must allocate some buffer large enough to hold things on the stack.  
    (say if you know the size in advance, which is possible right now if there is no copied buffers, you can almost make the identical code)
  * any optimization effort done by `libfmt` (like *is_packed*) is preserved.
  * despited copied buffers (see **layout**), any other offset/size of an arg is `constexpr`.
* No extra overhead on both producer side and consumer side, on both runtime-wise and template-bloat-wise.
  * producer: the constructor is as trivial as `format_arg_store`. This guarentees any possible optimizations from the compilers don't get disqualified.
  * consumer: the constructed entry itself already contains a `arg_store` that is layout-and-value-idential to `format_arg_store`. This guarantees the `fmt::format()` and likewise function can use it directly without extra processing.
* custom types supported, with **custom storage** support (as an extension to custom storage)

## modifications on libfmt
A private constructor of `basic_format_args` and a `static constexpr` member field of `format_arg_store` must be accessible. Currently this is done by making them public. Of course we can use `friend` declaration instead.

## layout
```
// A stored entry looks like:
// -----------------------------------------------------------------------
// | basic_async_entry | arg_store | stored_objs... | stored_buffers... |
// -----------------------------------------------------------------------
```
* basic_async_entry contains `format_str`, `desc_` (the `static constexpr` field mentioned above), and `dtor` (in case object copy happens and the destructor is non-trivial).
* arg_store is `format_arg_store` itself. layout-wise identical. aggregate construction.
* stored_objs stores any temproray objects (custom types), including move-constructed `std::string` from `std::string&&`.
* stored_buffers stores any buffer, like a **string** copied by buffer directly from `std::string_view|const std::string&|const char*`. Also custom storage is supported. For example you can let **hexdump** only copies the buffer, and let the consumer do the bin-to-hex conversion.
 
## public APIs
* `auto make_async_entry(format_str, args...)` creates an async entry. Only scalar types supported. It's maybe just used to demonstrate the **nealy identicaly assembly code to libfmt** feature.
* `size_t store_async_entry(void* buf, format_str, args...)` creates an async entry on **buf** (placement-new) with **transformed args** (*copy/move-construct args according to some rule*).
  * returns total size of the entry. Summing up all 4 sections mentioned above.
  * The basic idea is just (not the actual code, only for demonstration purpose):
    ```
    template <typename S, typename... Args, typename Char = char_t<S>>
    size_t store_async_entry(void* buf, const S& format_str, Args&&... args) {
        using async_entry_type = ...;
        using TRANSFORMER = ...;
        TRANSFORMER x(buf);
        new (buf) async_entry_type(   x.transform(std::forward<Args>(args))...   );
        // sizeof(async_entry_type) == sizeof(basic_async_entry) + sizeof(arg_store)
        // x.total_size() == sizeof(async_entry_type) + sizeof(stored_objs... and stored_buffers...)
        return x.total_size();
    }
    ```
  * Like memtioned above in **layout**, strings of different types will be handled distinguishedly. Eventually they will be transformed to `string_view`.
* `format|format_to|print(entry&, ...)` same usage as `libfmt` APIs.
* `entry.format|format_to|print(...)` don't destruct the `entry`.
  * use `entry::dtor_sentry(entry)` to destruct the `entry` upon the sentry destruction.

### custom buffer storage
An example of **hexdump**.
```
template <typename Iterator>
struct formatter<fmtlog::detail::hexdump_range<Iterator>> {
    fmtlog::detail::hexdump_format parsed_format;

    template<typename ParseContext>
    auto parse(ParseContext& ctx) -> decltype(ctx.begin()) { return parsed_format.parse(ctx); }

    template<typename FormatContext>
    auto format(const fmtlog::detail::hexdump_range<Iterator>& range, FormatContext& ctx) -> decltype(ctx.out()) {
        return range.format(ctx, parsed_format);
    }

//////////////////////////////////////
//// 1. note the return type. Then hexdump_stored_buffer& will take place of the original arg, and will be forwarded into entry construction.
//// 2. must be static
//// 3. the first argument is reference.
//// 4. you can even add another overload of T&&.
//// 5. of course this design is immature, but it wfm.
    static fmtlog::detail::hexdump_stored_buffer& store(char*& dest, const fmtlog::detail::hexdump_range<Iterator>& range) {
        return fmtlog::detail::hexdump_stored_buffer::store(dest, range);
    }
//////////////////////////////////////
};
```

## limitation
* no alignment specification support on stored buffer
* the entry must be aligned to 16 bytes(libfmt limitation). currently the public APIs don't do this for you. you may consider write a wrapper function before you use.
* `format_str` must be compile-time string. It's never copied.


## to be implemented/fixed/discussed (help from community wanted)
* named_arg not working on `store_async_entry()` yet. I just don't have the time to do it so far(because we don't use this feature in house). Sould be easy to implement.
* `std::ref()` support to capture the reference rather than copy the object.
* Compile-time string-literals in args don't need a whole copy of the string. However it's impossible to distinguish them so they're still copied.
  * solution1: `std::ref("my compile-time string")`
  * solution2: `c++11` custom string literals, like `"my compile-time string"cts` (cts: compile-time-string)
    * I'm seeing some discussion to enforce compile-time string check on `format_string`, if the UDL solution is chosen, we can use the same suffix.
* Currently there is no way to check if the buffer size is efficient. This is limited by the **custom storage** feature. Maybe we can change the prototype of custom storage function from  
  `static ret_type store(char*&, const T&/T&&)`  
  to  
  `static std::pair<ret_type, size_t> store(BUFFER_ITERATOR&, const T&/T&&)`  
  (where **BUFFER_ITERATOR** is a template argument, which can be something like `decltype(detail::counting_buffer<>().begin())`).
* Non-un*x OS support lacking because of the use of `stpcpy()|wcpcpy()`. `C23` has `memccpy()` and Windows has [`_memccpy()`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/memccpy). But I haven't tested the performance of `memccpy()` vs `strlen(); memcpy()`.
* And... of course, the test is pending enriched... Though there are already some production code in house using different args and placing the buffer on different memory addresses running for months so the basic functionality should be ok... Any suggestion like adding a test case is welcomed.
* code clean-up is welcomed too.
  * If you found a more intuitive way to write some part of the code.
  * compatibility/portable issues.
    * currently there are 4 `if constexpr` that needs to be converted to `c++11/14` friendly style.
* **code-styling** not open for now (except for CamelCase/snake_case fix). When this gets ready to merge, I'll format the code according to `libfmt` code style.

Should you feel needed, please feel free to open an issue/pr ticket on my fork (for example you think a new thread is a better way to track some specific discussion topic).

### P.S.  
In case you're curious: I do use *reddit*. I'm mainly a shit-poster on /r/dota2(afk for a long time since reddit got blocked in China). So let's discuss things here on github.  
Something happens on *reddit* and *another repo* just copies my idea of string buffer storage according to my **interpretation**, yes, I know that guy in person, and I believe he doesn't understand my code (obviously I showed him the experimental code `essential fmtlog done` which later became the motivation of his work) and I did interprete the detail to him.  
I don't want any drama happen on github, let's discuss and **improve the design and code**.