### PR TITLE
Add a formatter specialization for std::error_code.

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -129,6 +129,23 @@ class error_code {
   int get() const FMT_NOEXCEPT { return value_; }
 };
 
+template <typename Char> struct formatter<std::error_code, Char> {
+  template <typename ParseContext>
+  FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  FMT_CONSTEXPR auto format(const std::error_code& ec, FormatContext& ctx) const
+      -> decltype(ctx.out()) {
+    auto out = ctx.out();
+    out = detail::write<Char>(out, to_string_view(ec.category().name()));
+    out = detail::write<Char>(out, Char(':'));
+    out = detail::write<Char>(out, ec.value());
+    return out;
+  }
+};
+
 #ifdef _WIN32
 namespace detail {
 // A converter from UTF-16 to UTF-8.

--- a/test/os-test.cc
+++ b/test/os-test.cc
@@ -74,6 +74,30 @@ TEST(os_test, error_code) {
   EXPECT_EQ(error_code(42).get(), 42);
 }
 
+TEST(os_test, format_std_error_code) {
+  EXPECT_EQ("generic:42",
+            fmt::format(FMT_STRING("{0}"),
+                        std::error_code(42, std::generic_category())));
+  EXPECT_EQ("system:42",
+            fmt::format(FMT_STRING("{0}"),
+                        std::error_code(42, std::system_category())));
+  EXPECT_EQ("system:-42",
+            fmt::format(FMT_STRING("{0}"),
+                        std::error_code(-42, std::system_category())));
+}
+
+TEST(os_test, format_std_error_code_wide) {
+  EXPECT_EQ(L"generic:42",
+            fmt::format(FMT_STRING(L"{0}"),
+                        std::error_code(42, std::generic_category())));
+  EXPECT_EQ(L"system:42",
+            fmt::format(FMT_STRING(L"{0}"),
+                        std::error_code(42, std::system_category())));
+  EXPECT_EQ(L"system:-42",
+            fmt::format(FMT_STRING(L"{0}"),
+                        std::error_code(-42, std::system_category())));
+}
+
 TEST(os_test, format_windows_error) {
   LPWSTR message = 0;
   auto result = FormatMessageW(


### PR DESCRIPTION
Discussion: https://github.com/fmtlib/fmt/issues/2269