### PR TITLE
Add support for statically named arguments with `FMT_STRING`

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -191,24 +191,10 @@ constexpr const auto& get([[maybe_unused]] const T& first,
     return get<N - 1>(rest...);
 }
 
-constexpr int invalid_arg_index = -1;
-
-template <int N, typename T, typename... Args, typename Char>
-constexpr int get_arg_index_by_name(basic_string_view<Char> name) {
-  if constexpr (detail::is_statically_named_arg<T>()) {
-    if (name == T::name) return N;
-  }
-  if constexpr (sizeof...(Args) == 0) {
-    return invalid_arg_index;
-  } else {
-    return get_arg_index_by_name<N + 1, Args...>(name);
-  }
-}
-
 template <typename Char, typename... Args>
 constexpr int get_arg_index_by_name(basic_string_view<Char> name,
                                     type_list<Args...>) {
-  return get_arg_index_by_name<0, Args...>(name);
+  return get_arg_index_by_name<Args...>(name);
 }
 
 template <int N, typename> struct get_type_impl;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -255,16 +255,6 @@ inline int ctzll(uint64_t x) {
 FMT_END_NAMESPACE
 #endif
 
-#ifndef FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
-#  if defined(__cpp_nontype_template_args) &&                \
-      ((FMT_GCC_VERSION >= 903 && __cplusplus >= 201709L) || \
-       __cpp_nontype_template_args >= 201911L)
-#    define FMT_USE_NONTYPE_TEMPLATE_PARAMETERS 1
-#  else
-#    define FMT_USE_NONTYPE_TEMPLATE_PARAMETERS 0
-#  endif
-#endif
-
 FMT_BEGIN_NAMESPACE
 namespace detail {
 
@@ -3225,9 +3215,6 @@ template <typename Char> struct udl_formatter {
     return format(str, std::forward<Args>(args)...);
   }
 };
-
-template <typename T, typename = void>
-struct is_statically_named_arg : std::false_type {};
 
 #  if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
 template <typename T, typename Char, size_t N, fixed_string<Char, N> Str>


### PR DESCRIPTION
Possible with this PR and a compiler with non-type template arguments support:
```cpp
fmt::format(FMT_STRING("{foo}{bar}"), "bar"_a = "bar", "foo"_a = "foo");
"{foo}{bar}"_format("bar"_a = "bar", "foo"_a = "foo");
```

Still impossible:
```cpp
fmt::format(FMT_STRING("{foo}{bar}"), fmt::arg("bar", "bar"), fmt::arg("foo", "foo"));
```
```
/fmt/include/fmt/core.h:2310:39: error: static assertion failed: use statically named arguments with compile-time format strings: fmt::arg("name", value) -> "name"_a = value
```
