### PR TITLE
add missing header

### DIFF
--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -35,6 +35,7 @@ module;
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <type_traits>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
The exception-related changes added this new dependency that must be synchronized to the primary module interface unit.