### PR TITLE
fix clang 8.0.x compilation error

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -391,7 +391,7 @@ struct ostream_params {
 };
 }  // namespace detail
 
-static constexpr detail::buffer_size buffer_size;
+static constexpr detail::buffer_size buffer_size{};
 
 /** A fast output stream which is not thread-safe. */
 class ostream final : private detail::buffer<char> {


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->

With a clang 8.0.x based toolchain, the compiler insists that the `constexpr` value must be default initialized.
