### PR TITLE
export missed symbol

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,6 +44,7 @@ jobs:
             cxxflags: -stdlib=libc++
             os: ubuntu-20.04
             install: sudo apt install libc++-11-dev libc++abi-11-dev
+          - shared: -DBUILD_SHARED_LIBS=ON
 
     steps:
     - uses: actions/checkout@v2
@@ -59,8 +60,9 @@ jobs:
         CXX: ${{matrix.cxx}}
         CXXFLAGS: ${{matrix.cxxflags}}
       run: |
-        cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} ${{matrix.fuzz}} \
+        cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} ${{matrix.fuzz}} ${{matrix.shared}} \
               -DCMAKE_CXX_STANDARD=${{matrix.std}} -DFMT_DOC=OFF \
+              -DCMAKE_CXX_VISIBILITY_PRESET=hidden -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
               -DFMT_PEDANTIC=ON -DFMT_WERROR=ON $GITHUB_WORKSPACE
 
     - name: Build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,6 +8,8 @@ jobs:
     strategy:
       matrix:
         build_type: [Debug, Release]
+        include:
+          - shared: -DBUILD_SHARED_LIBS=ON
 
     steps:
     - uses: actions/checkout@v2
@@ -18,7 +20,8 @@ jobs:
     - name: Configure
       working-directory: ${{runner.workspace}}/build
       run: |
-        cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+        cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}} ${{matrix.shared}} \
+              -DCMAKE_CXX_VISIBILITY_PRESET=hidden -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
               -DFMT_DOC=OFF -DFMT_PEDANTIC=ON -DFMT_WERROR=ON $GITHUB_WORKSPACE
 
     - name: Build

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -253,6 +253,10 @@
 #  endif
 #else
 #  define FMT_CLASS_API
+#  if defined(__GNUC__) || defined(__clang__)
+#    define FMT_API __attribute__((visibility("default")))
+#    define FMT_EXTERN_TEMPLATE_API FMT_API
+#  endif
 #endif
 #ifndef FMT_API
 #  define FMT_API

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -850,7 +850,7 @@ template <typename T = void> struct basic_data {
 
   // GCC generates slightly better code for pairs than chars.
   using digit_pair = char[2];
-  static constexpr const digit_pair digits[] = {
+  FMT_API static constexpr const digit_pair digits[] = {
       {'0', '0'}, {'0', '1'}, {'0', '2'}, {'0', '3'}, {'0', '4'}, {'0', '5'},
       {'0', '6'}, {'0', '7'}, {'0', '8'}, {'0', '9'}, {'1', '0'}, {'1', '1'},
       {'1', '2'}, {'1', '3'}, {'1', '4'}, {'1', '5'}, {'1', '6'}, {'1', '7'},
@@ -869,13 +869,18 @@ template <typename T = void> struct basic_data {
       {'9', '0'}, {'9', '1'}, {'9', '2'}, {'9', '3'}, {'9', '4'}, {'9', '5'},
       {'9', '6'}, {'9', '7'}, {'9', '8'}, {'9', '9'}};
 
-  static constexpr const char hex_digits[] = "0123456789abcdef";
-  static constexpr const char signs[] = {0, '-', '+', ' '};
-  static constexpr const unsigned prefixes[4] = {0, 0, 0x1000000u | '+',
+  FMT_API static constexpr const char hex_digits[] = "0123456789abcdef";
+  FMT_API static constexpr const char signs[] = {0, '-', '+', ' '};
+  FMT_API static constexpr const unsigned prefixes[4] = {0, 0, 0x1000000u | '+',
                                                  0x1000000u | ' '};
-  static constexpr const char left_padding_shifts[] = {31, 31, 0, 1, 0};
-  static constexpr const char right_padding_shifts[] = {0, 31, 0, 1, 0};
+  FMT_API static constexpr const char left_padding_shifts[] = {31, 31, 0, 1, 0};
+  FMT_API static constexpr const char right_padding_shifts[] = {0, 31, 0, 1, 0};
 };
+
+#ifndef FMT_HEADER_ONLY
+// Required for -flto, -fivisibility=hidden and -shared to work
+extern template struct basic_data<void>;
+#endif
 
 // This is a struct rather than an alias to avoid shadowing warnings in gcc.
 struct data : basic_data<> {};

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -394,7 +394,7 @@ struct ostream_params {
 static constexpr detail::buffer_size buffer_size;
 
 /** A fast output stream which is not thread-safe. */
-class ostream final : private detail::buffer<char> {
+class FMT_API ostream final : private detail::buffer<char> {
  private:
   file file_;
 
@@ -404,7 +404,7 @@ class ostream final : private detail::buffer<char> {
     clear();
   }
 
-  FMT_API void grow(size_t) override final;
+  void grow(size_t) override;
 
   ostream(cstring_view path, const detail::ostream_params& params)
       : file_(path, params.oflag) {

--- a/src/format.cc
+++ b/src/format.cc
@@ -94,4 +94,7 @@ template FMT_API wchar_t detail::decimal_point_impl(locale_ref);
 
 template FMT_API void detail::buffer<wchar_t>::append(const wchar_t*,
                                                       const wchar_t*);
+
+template struct detail::basic_data<void>;
+
 FMT_END_NAMESPACE


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
When compiling with `-fvisibility=hidden`, linker errors occur because a symbol was not marked as being exported. The `final` keyword is not necessary for a class that is already marked as `final`.

How to reproduce:
```bash
CXXFLAGS=-fvisibility=hidden cmake -S . -B build/ -DBUILD_SHARED_LIBS:BOOL=ON -GNinja
cmake --build build/
```

[Log output](https://github.com/fmtlib/fmt/files/6504551/log.txt)
