### PR TITLE
fix compile error on msvc preview 4 (16.10) involving lookup clash

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2781,7 +2781,7 @@ FMT_API auto vformat(string_view fmt, format_args args) -> std::string;
 */
 template <typename... T>
 FMT_INLINE auto format(format_string<T...> fmt, T&&... args) -> std::string {
-  return vformat(fmt, make_format_args(args...));
+  return vformat(fmt, fmt::make_format_args(args...));
 }
 
 /** Formats a string and writes the output to ``out``. */


### PR DESCRIPTION
This PR resolves the issue mentioned in #2295 caused by a clash in the lookup between the `STL` shipped in vs2019 preview 4 (16.10) and `fmt`.

There's several other unqualified lookups to that function in particular, but as I didn't notice any causing issues I left them alone. If that changes I'll make a new PR to deal with them.