### PR TITLE
Avoid unwanted sign extensions from MSVC in is_utf8.

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -391,11 +391,11 @@ FMT_CONSTEXPR typename std::make_unsigned<Int>::type to_unsigned(Int value) {
 FMT_MSC_WARNING(suppress : 4566) constexpr unsigned char micro[] = "\u00B5";
 
 constexpr bool is_utf8() {
-  // avoid buggy sign extensions in MSVC's constant evaluation mode
+  // Avoid buggy sign extensions in MSVC's constant evaluation mode.
   // https://developercommunity.visualstudio.com/t/C-difference-in-behavior-for-unsigned/1233612
   using uchar = unsigned char;
-  return FMT_UNICODE || (sizeof(micro) == 3 && uchar{micro[0]} == 0xC2 &&
-                         uchar{micro[1]} == 0xB5);
+  return FMT_UNICODE || (sizeof(micro) == 3 && uchar(micro[0]) == 0xC2 &&
+                         uchar(micro[1]) == 0xB5);
 }
 FMT_END_DETAIL_NAMESPACE
 

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -391,8 +391,11 @@ FMT_CONSTEXPR typename std::make_unsigned<Int>::type to_unsigned(Int value) {
 FMT_MSC_WARNING(suppress : 4566) constexpr unsigned char micro[] = "\u00B5";
 
 constexpr bool is_utf8() {
-  return FMT_UNICODE ||
-         (sizeof(micro) == 3 && micro[0] == 0xC2 && micro[1] == 0xB5);
+  // avoid buggy sign extensions in MSVC's constant evaluation mode
+  // https://developercommunity.visualstudio.com/t/C-difference-in-behavior-for-unsigned/1233612
+  using uchar = unsigned char;
+  return FMT_UNICODE || (sizeof(micro) == 3 && uchar{micro[0]} == 0xC2 &&
+                         uchar{micro[1]} == 0xB5);
 }
 FMT_END_DETAIL_NAMESPACE
 


### PR DESCRIPTION
Microsoft's constexpr evaluator treats the type of micro[0] and micro[1] as
plain char, and so sign extends before comparing them to ints.
The normal compiler, including the optimizer, does not fail in this way,
so this is merely a "future proof" change in case someone uses is_utf8()
in a constant expression.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
