### PR TITLE
Ignore zero-padding for non-finite floating points

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1948,7 +1948,7 @@ template <typename Char> class specs_setter {
   FMT_CONSTEXPR void on_localized() { specs_.localized = true; }
 
   FMT_CONSTEXPR void on_zero() {
-    specs_.align = align::numeric;
+    if (specs_.align == align::none) specs_.align = align::numeric;
     specs_.fill[0] = Char('0');
   }
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1591,7 +1591,7 @@ OutputIt write_nonfinite(OutputIt out, bool isinf,
   constexpr size_t str_size = 3;
   auto sign = fspecs.sign;
   auto size = str_size + (sign ? 1 : 0);
-  // replace '0'-padding with space for non-finite values
+  // Replace '0'-padding with space for non-finite values.
   const bool is_zero_fill =
       specs.fill.size() == 1 && *specs.fill.data() == static_cast<Char>('0');
   if (is_zero_fill) specs.fill[0] = static_cast<Char>(' ');

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1591,10 +1591,15 @@ OutputIt write_nonfinite(OutputIt out, bool isinf,
   constexpr size_t str_size = 3;
   auto sign = fspecs.sign;
   auto size = str_size + (sign ? 1 : 0);
-  return write_padded(out, specs, size, [=](reserve_iterator<OutputIt> it) {
+  auto copy_it = [=](reserve_iterator<OutputIt> it) {
     if (sign) *it++ = static_cast<Char>(data::signs[sign]);
     return copy_str<Char>(str, str + str_size, it);
-  });
+  };
+  // no '0'-padding applied for non-finite values
+  const bool is_zero_fill =
+      specs.fill.size() == 1 && *specs.fill.data() == static_cast<Char>('0');
+  return is_zero_fill ? base_iterator(out, copy_it(reserve(out, size)))
+                      : write_padded<align::right>(out, specs, size, copy_it);
 }
 
 // A decimal floating-point number significand * pow(10, exp).

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1297,7 +1297,7 @@ TEST(format_test, format_infinity) {
   EXPECT_EQ("-inf", fmt::format("{}", -inf));
   EXPECT_EQ("  +inf", fmt::format("{:+06}", inf));
   EXPECT_EQ("  -inf", fmt::format("{:+06}", -inf));
-   // '0'-fill option sets alignment to numeric overwriting any user-provided
+  // '0'-fill option sets alignment to numeric overwriting any user-provided
   // alignment
   EXPECT_EQ("  +inf", fmt::format("{:^+06}", inf));
   EXPECT_EQ("  +inf", fmt::format("{:<+06}", inf));

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1273,10 +1273,8 @@ TEST(format_test, format_nan) {
   EXPECT_EQ("nan", fmt::format("{}", nan));
   EXPECT_EQ("+nan", fmt::format("{:+}", nan));
   EXPECT_EQ("  +nan", fmt::format("{:+06}", nan));
-  // '0'-fill option sets alignment to numeric overwriting any user-provided
-  // alignment
-  EXPECT_EQ("  +nan", fmt::format("{:^+06}", nan));
-  EXPECT_EQ("  +nan", fmt::format("{:<+06}", nan));
+  EXPECT_EQ("+nan  ", fmt::format("{:<+06}", nan));
+  EXPECT_EQ(" +nan ", fmt::format("{:^+06}", nan));
   EXPECT_EQ("  +nan", fmt::format("{:>+06}", nan));
   if (std::signbit(-nan)) {
     EXPECT_EQ("-nan", fmt::format("{}", -nan));
@@ -1297,10 +1295,8 @@ TEST(format_test, format_infinity) {
   EXPECT_EQ("-inf", fmt::format("{}", -inf));
   EXPECT_EQ("  +inf", fmt::format("{:+06}", inf));
   EXPECT_EQ("  -inf", fmt::format("{:+06}", -inf));
-  // '0'-fill option sets alignment to numeric overwriting any user-provided
-  // alignment
-  EXPECT_EQ("  +inf", fmt::format("{:^+06}", inf));
-  EXPECT_EQ("  +inf", fmt::format("{:<+06}", inf));
+  EXPECT_EQ("+inf  ", fmt::format("{:<+06}", inf));
+  EXPECT_EQ(" +inf ", fmt::format("{:^+06}", inf));
   EXPECT_EQ("  +inf", fmt::format("{:>+06}", inf));
   EXPECT_EQ(" inf", fmt::format("{: }", inf));
   EXPECT_EQ("INF", fmt::format("{:F}", inf));

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1272,9 +1272,11 @@ TEST(format_test, format_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_EQ("nan", fmt::format("{}", nan));
   EXPECT_EQ("+nan", fmt::format("{:+}", nan));
-  if (std::signbit(-nan))
+  EXPECT_EQ("+nan", fmt::format("{:+06}", nan));
+  if (std::signbit(-nan)) {
     EXPECT_EQ("-nan", fmt::format("{}", -nan));
-  else
+    EXPECT_EQ("-nan", fmt::format("{:+06}", -nan));
+  } else
     fmt::print("Warning: compiler doesn't handle negative NaN correctly");
   EXPECT_EQ(" nan", fmt::format("{: }", nan));
   EXPECT_EQ("NAN", fmt::format("{:F}", nan));
@@ -1288,6 +1290,8 @@ TEST(format_test, format_infinity) {
   EXPECT_EQ("inf", fmt::format("{}", inf));
   EXPECT_EQ("+inf", fmt::format("{:+}", inf));
   EXPECT_EQ("-inf", fmt::format("{}", -inf));
+  EXPECT_EQ("+inf", fmt::format("{:+06}", inf));
+  EXPECT_EQ("-inf", fmt::format("{:+06}", -inf));
   EXPECT_EQ(" inf", fmt::format("{: }", inf));
   EXPECT_EQ("INF", fmt::format("{:F}", inf));
   EXPECT_EQ("inf    ", fmt::format("{:<7}", inf));

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1272,10 +1272,15 @@ TEST(format_test, format_nan) {
   double nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_EQ("nan", fmt::format("{}", nan));
   EXPECT_EQ("+nan", fmt::format("{:+}", nan));
-  EXPECT_EQ("+nan", fmt::format("{:+06}", nan));
+  EXPECT_EQ("  +nan", fmt::format("{:+06}", nan));
+  // '0'-fill option sets alignment to numeric overwriting any user-provided
+  // alignment
+  EXPECT_EQ("  +nan", fmt::format("{:^+06}", nan));
+  EXPECT_EQ("  +nan", fmt::format("{:<+06}", nan));
+  EXPECT_EQ("  +nan", fmt::format("{:>+06}", nan));
   if (std::signbit(-nan)) {
     EXPECT_EQ("-nan", fmt::format("{}", -nan));
-    EXPECT_EQ("-nan", fmt::format("{:+06}", -nan));
+    EXPECT_EQ("  -nan", fmt::format("{:+06}", -nan));
   } else
     fmt::print("Warning: compiler doesn't handle negative NaN correctly");
   EXPECT_EQ(" nan", fmt::format("{: }", nan));
@@ -1290,8 +1295,13 @@ TEST(format_test, format_infinity) {
   EXPECT_EQ("inf", fmt::format("{}", inf));
   EXPECT_EQ("+inf", fmt::format("{:+}", inf));
   EXPECT_EQ("-inf", fmt::format("{}", -inf));
-  EXPECT_EQ("+inf", fmt::format("{:+06}", inf));
-  EXPECT_EQ("-inf", fmt::format("{:+06}", -inf));
+  EXPECT_EQ("  +inf", fmt::format("{:+06}", inf));
+  EXPECT_EQ("  -inf", fmt::format("{:+06}", -inf));
+   // '0'-fill option sets alignment to numeric overwriting any user-provided
+  // alignment
+  EXPECT_EQ("  +inf", fmt::format("{:^+06}", inf));
+  EXPECT_EQ("  +inf", fmt::format("{:<+06}", inf));
+  EXPECT_EQ("  +inf", fmt::format("{:>+06}", inf));
   EXPECT_EQ(" inf", fmt::format("{: }", inf));
   EXPECT_EQ("INF", fmt::format("{:F}", inf));
   EXPECT_EQ("inf    ", fmt::format("{:<7}", inf));

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1279,8 +1279,9 @@ TEST(format_test, format_nan) {
   if (std::signbit(-nan)) {
     EXPECT_EQ("-nan", fmt::format("{}", -nan));
     EXPECT_EQ("  -nan", fmt::format("{:+06}", -nan));
-  } else
+  } else {
     fmt::print("Warning: compiler doesn't handle negative NaN correctly");
+  }
   EXPECT_EQ(" nan", fmt::format("{: }", nan));
   EXPECT_EQ("NAN", fmt::format("{:F}", nan));
   EXPECT_EQ("nan    ", fmt::format("{:<7}", nan));


### PR DESCRIPTION
Fixes #2305.

Is there a better way to check for the `0`-padding-option than what I wrote?