### PR TITLE
Update integer presentation types documentation.

### DIFF
--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -203,6 +203,8 @@ The available integer presentation types are:
 |         | ``'#'`` option with this type adds the prefix ``"0B"``   |
 |         | to the output value.                                     |
 +---------+----------------------------------------------------------+
+| ``'c'`` | Character format. Outputs the number as a character.     |
++---------+----------------------------------------------------------+
 | ``'d'`` | Decimal integer. Outputs the number in base 10.          |
 +---------+----------------------------------------------------------+
 | ``'o'`` | Octal format. Outputs the number in base 8.              |


### PR DESCRIPTION
Documents that the 'c' type is a valid type for integer types. Since
boolean uses the same types as integer its documentation is
automatically updated.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
