### PR TITLE
qualify make_format_args

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -198,7 +198,7 @@ FMT_API std::system_error vwindows_error(int error_code, string_view format_str,
 template <typename... Args>
 std::system_error windows_error(int error_code, string_view message,
                                 const Args&... args) {
-  return vwindows_error(error_code, message, make_format_args(args...));
+  return vwindows_error(error_code, message, fmt::make_format_args(args...));
 }
 
 // Reports a Windows error without throwing an exception.
@@ -269,7 +269,7 @@ class buffered_file {
 
   template <typename... Args>
   inline void print(string_view format_str, const Args&... args) {
-    vprint(format_str, make_format_args(args...));
+    vprint(format_str, fmt::make_format_args(args...));
   }
 };
 
@@ -438,7 +438,7 @@ class FMT_API ostream final : private detail::buffer<char> {
    */
   template <typename... T> void print(format_string<T...> fmt, T&&... args) {
     vformat_to(detail::buffer_appender<char>(*this), fmt,
-               make_format_args(args...));
+               fmt::make_format_args(args...));
   }
 };
 

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -621,7 +621,7 @@ template <typename S, typename... T,
           typename Char = enable_if_t<detail::is_string<S>::value, char_t<S>>>
 inline auto sprintf(const S& fmt, const T&... args) -> std::basic_string<Char> {
   using context = basic_printf_context_t<Char>;
-  return vsprintf(to_string_view(fmt), make_format_args<context>(args...));
+  return vsprintf(to_string_view(fmt), fmt::make_format_args<context>(args...));
 }
 
 template <typename S, typename Char = char_t<S>>
@@ -649,7 +649,7 @@ inline auto vfprintf(
 template <typename S, typename... T, typename Char = char_t<S>>
 inline auto fprintf(std::FILE* f, const S& fmt, const T&... args) -> int {
   using context = basic_printf_context_t<Char>;
-  return vfprintf(f, to_string_view(fmt), make_format_args<context>(args...));
+  return vfprintf(f, to_string_view(fmt), fmt::make_format_args<context>(args...));
 }
 
 template <typename S, typename Char = char_t<S>>
@@ -672,7 +672,7 @@ inline auto vprintf(
 template <typename S, typename... T, FMT_ENABLE_IF(detail::is_string<S>::value)>
 inline auto printf(const S& fmt, const T&... args) -> int {
   return vprintf(to_string_view(fmt),
-                 make_format_args<basic_printf_context_t<char_t<S>>>(args...));
+                 fmt::make_format_args<basic_printf_context_t<char_t<S>>>(args...));
 }
 
 template <typename S, typename Char = char_t<S>>
@@ -699,7 +699,7 @@ template <typename S, typename... T, typename Char = char_t<S>>
 inline auto fprintf(std::basic_ostream<Char>& os, const S& fmt,
                     const T&... args) -> int {
   return vfprintf(os, to_string_view(fmt),
-                  make_format_args<basic_printf_context_t<Char>>(args...));
+                  fmt::make_format_args<basic_printf_context_t<Char>>(args...));
 }
 
 FMT_MODULE_EXPORT_END


### PR DESCRIPTION
Latest MSVC 16.10.0 introduced a function std::make_format_args which clashes with fmt::v7::make_format_args.
This means that all calls to make_format_args need to by qualified to avoid ADL clash