### PR TITLE
Use qualified name-lookup in module.

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -298,7 +298,7 @@ inline auto do_write(const std::tm& time, const std::locale& loc, char format,
   auto str = os.str();
   if (!detail::is_utf8() || loc == std::locale::classic()) return str;
   // char16_t and char32_t codecvts are broken in MSVC (linkage errors).
-  using code_unit = conditional_t<FMT_MSC_VER, wchar_t, char16_t>;
+  using code_unit = conditional_t<FMT_MSC_VER != 0, wchar_t, char16_t>;
   auto& f = std::use_facet<std::codecvt<code_unit, char, std::mbstate_t>>(loc);
   auto mb = std::mbstate_t();
   const char* from_next = nullptr;
@@ -1246,7 +1246,7 @@ struct formatter<std::chrono::duration<Rep, Period>, Char> {
           ctx, out, d);
       f.precision = precision_copy;
       f.localized = localized;
-      parse_chrono_format(begin, end, f);
+      detail::parse_chrono_format(begin, end, f);
     }
     return detail::write(
         ctx.out(), basic_string_view<Char>(buf.data(), buf.size()), specs_copy);

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2169,6 +2169,7 @@ FMT_CONSTEXPR FMT_INLINE auto parse_arg_id(const Char* begin, const Char* end,
 template <typename Char, typename Handler>
 FMT_CONSTEXPR auto parse_width(const Char* begin, const Char* end,
                                Handler&& handler) -> const Char* {
+  using detail::auto_id;
   struct width_adapter {
     Handler& handler;
 
@@ -2198,6 +2199,7 @@ FMT_CONSTEXPR auto parse_width(const Char* begin, const Char* end,
 template <typename Char, typename Handler>
 FMT_CONSTEXPR auto parse_precision(const Char* begin, const Char* end,
                                    Handler&& handler) -> const Char* {
+  using detail::auto_id;
   struct precision_adapter {
     Handler& handler;
 


### PR DESCRIPTION
And allow lookup of non-exported names from local classes in function templates.

Using declarations link these names into the body and make them available for name-lookup when the local classes are instantiated together with the function bodies that contain them.
