### PR TITLE
Fix `FMT_COMPILE()` with custom types

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1140,7 +1140,7 @@ template <typename Context> class value {
   FMT_INLINE value(const named_arg_info<char_type>* args, size_t size)
       : named_args{args, size} {}
 
-  template <typename T> FMT_INLINE value(const T& val) {
+  template <typename T> FMT_CONSTEXPR FMT_INLINE value(const T& val) {
     custom.value = &val;
     // Get the formatter type through the context to allow different contexts
     // have different extension points, e.g. `formatter<T>` for `format` and

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1936,10 +1936,11 @@ OutputIt write(OutputIt out, const T* value,
 }
 
 template <typename Char, typename OutputIt, typename T>
-auto write(OutputIt out, const T& value) -> typename std::enable_if<
-    mapped_type_constant<T, basic_format_context<OutputIt, Char>>::value ==
-        type::custom_type,
-    OutputIt>::type {
+FMT_CONSTEXPR auto write(OutputIt out, const T& value) ->
+    typename std::enable_if<
+        mapped_type_constant<T, basic_format_context<OutputIt, Char>>::value ==
+            type::custom_type,
+        OutputIt>::type {
   using context_type = basic_format_context<OutputIt, Char>;
   using formatter_type =
       conditional_t<has_formatter<T, context_type>::value,


### PR DESCRIPTION
By reading the changelog for upcoming release, I realized that it does not mention one of the major breaking change of custom formatters for compile-time formatting - `const`-qualified `format` method, so I decided to check how do custom formatters work at compile-time and realized that they actually don't work.

There are 3 commits, by the complexity of changes from the commit that just fixes the library, to the commit that adds dynamic width handling for the `test_formattable` class in compile-test.cc. The latter two can be removed or squashed into the first one, on demand. This time I cannot [use custom formatters](https://github.com/fmtlib/fmt/pull/2129#discussion_r575826176) from `chrono.h` because they use `memory_buffer` and it's not ready to be used at compile-time yet.