### PR TITLE
CI: set up multi-thread build for all platforms

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,7 +67,9 @@ jobs:
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config ${{matrix.build_type}}
+      run: |
+        threads=`nproc`
+        cmake --build . --config ${{matrix.build_type}} --parallel $threads
 
     - name: Test
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,7 +26,9 @@ jobs:
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config ${{matrix.build_type}}
+      run: |
+        threads=`sysctl -n hw.logicalcpu`
+        cmake --build . --config ${{matrix.build_type}} --parallel $threads
 
     - name: Test
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,7 +49,9 @@ jobs:
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config ${{matrix.build_type}}
+      run: |
+        $threads = (Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors
+        cmake --build . --config ${{matrix.build_type}} --parallel $threads
 
     - name: Test
       working-directory: ${{runner.workspace}}/build


### PR DESCRIPTION
Few points for this PR, as usual:
* I use `--parallel` option of `cmake --build` subcommand to pass threads count in a cross-compile way, it's available with CMake 3.12+, [all containers](https://github.com/actions/virtual-environments#available-environments) of GitHub Actions have 3.20+
* each platform use different approaches to get the number of threads:
  * `nproc` for Linux, returns `2`
  * `sysctl -n hw.logicalcpu` for macOS, since there is no `nproc`, returns `3`
  * `(Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors` for Windows, returns `2`
  
  of course, these values could be hardcoded according to [Supported runners and hardware resources](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources), but since we can retrieve this info, hardcoding is not needed.
* my results show a decrease of build time for all platforms, but let's look at results for this PR.
