### PR TITLE
Fixed join_view formatter for wchar_t

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2535,7 +2535,7 @@ struct formatter<join_view<It, Sentinel, Char>, Char> {
   }
 
   using formatter_type =
-      conditional_t<is_formattable<value_type>::value,
+      conditional_t<is_formattable<value_type, Char>::value,
                     formatter<remove_cvref_t<decltype(map(
                                   std::declval<const value_type&>()))>,
                               Char>,


### PR DESCRIPTION
Fixed compile error when trying to format a range with a value type formattable only to wide strings.