### PR TITLE
Feature/complete module

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -164,7 +164,8 @@ struct is_compiled_string : std::is_base_of<compiled_string, S> {};
 #endif
 
 #if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
-template <typename Char, size_t N, fixed_string<Char, N> Str>
+template <typename Char, size_t N,
+          fmt::detail_exported::fixed_string<Char, N> Str>
 struct udl_compiled_string : compiled_string {
   using char_type = Char;
   constexpr operator basic_string_view<char_type>() const {
@@ -622,7 +623,7 @@ void print(const S& format_str, const Args&... args) {
 
 #if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
 inline namespace literals {
-template <detail::fixed_string Str>
+template <detail_exported::fixed_string Str>
 constexpr detail::udl_compiled_string<
     remove_cvref_t<decltype(Str.data[0])>,
     sizeof(Str.data) / sizeof(decltype(Str.data[0])), Str>

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2624,6 +2624,20 @@ template <typename Char>
 void vformat_to(buffer<Char>& buf, basic_string_view<Char> fmt,
                 basic_format_args<buffer_context<type_identity_t<Char>>> args,
                 locale_ref loc) {
+  // workaround for msvc bug regarding name-lookup in module
+  // link names into function scope
+  using detail::arg_formatter;
+  using detail::buffer_appender;
+  using detail::custom_formatter;
+  using detail::default_arg_formatter;
+  using detail::get_arg;
+  using detail::locale_ref;
+  using detail::parse_format_specs;
+  using detail::specs_checker;
+  using detail::specs_handler;
+  using detail::to_unsigned;
+  using detail::type;
+  using detail::write;
   auto out = buffer_appender<Char>(buf);
   if (fmt.size() == 2 && equal2(fmt.data(), "{}")) {
     auto arg = args.get(0);
@@ -2680,13 +2694,12 @@ void vformat_to(buffer<Char>& buf, basic_string_view<Char> fmt,
       begin = parse_format_specs(begin, end, handler);
       if (begin == end || *begin != '}')
         on_error("missing '}' in format string");
-      auto f =
-          detail::arg_formatter<Char>{context.out(), specs, context.locale()};
+      auto f = arg_formatter<Char>{context.out(), specs, context.locale()};
       context.advance_to(visit_format_arg(f, arg));
       return begin;
     }
   };
-  parse_format_string<false>(fmt, format_handler(out, fmt, args, loc));
+  detail::parse_format_string<false>(fmt, format_handler(out, fmt, args, loc));
 }
 
 #ifndef FMT_HEADER_ONLY

--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -1,4 +1,8 @@
 module;
+#ifndef __cpp_modules
+#  error Module not supported.
+#endif
+
 // put all implementation-provided headers into the global module fragment
 // to prevent attachment to this module
 #if !defined(_CRT_SECURE_NO_WARNINGS) && defined(_MSC_VER)
@@ -75,10 +79,6 @@ export module fmt;
 #define FMT_END_DETAIL_NAMESPACE \
   }                              \
   export {
-
-#if defined(_MSC_FULL_VER) && _MSC_FULL_VER > 192930036
-#define FMT_USE_NONTYPE_TEMPLATE_PARAMETERS 0
-#endif
 
 // all library-provided declarations and definitions
 // must be in the module purview to be exported

--- a/test/module-test.cc
+++ b/test/module-test.cc
@@ -445,3 +445,11 @@ TEST(module_test, has_formatter) {
 TEST(module_test, is_formattable) {
   EXPECT_FALSE(fmt::is_formattable<disabled_formatter>::value);
 }
+
+TEST(module_test, compile_format_string) {
+  using namespace fmt::literals;
+  EXPECT_EQ("42", fmt::format("{0:x}"_cf, 0x42));
+  EXPECT_EQ(L"42", fmt::format(L"{:}"_cf, 42));
+  EXPECT_EQ("4.2", fmt::format("{arg:3.1f}"_cf, "arg"_a = 4.2));
+  EXPECT_EQ(L" 42", fmt::format(L"{arg:>3}"_cf, L"arg"_a = L"42"));
+}


### PR DESCRIPTION
Add all missing pieces to complete {fmt} as module:

- support non-`char` overloads
- support compile-time argument type checking
- support compile-time format string compilation

This includes the macro-based API `FMT_STRING` and `FMT_COMPILE` by means of a module companion header `fmt.h`
