### PR TITLE
adding a default format for std::chrono::time_point<std::chrono::syst…

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -451,10 +451,10 @@ FMT_END_DETAIL_NAMESPACE
 template <typename Char, typename Duration>
 struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
                  Char> : formatter<std::tm, Char> {
-  FMT_CONSTEXPR FMT_INLINE void generate_defalut_spec(char) {
+  FMT_CONSTEXPR FMT_INLINE void generate_default_spec(char) {
     this->specs = {"%Y-%m-%d %H:%M:%S", 17};
   }
-  FMT_CONSTEXPR FMT_INLINE void generate_defalut_spec(wchar_t) {
+  FMT_CONSTEXPR FMT_INLINE void generate_default_spec(wchar_t) {
     this->specs = {L"%Y-%m-%d %H:%M:%S", 17};
   }
 
@@ -465,7 +465,7 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
     auto end = it;
     while (end != ctx.end() && *end != '}') ++end;
     if (end == it) {
-      generate_defalut_spec(typename ParseContext::char_type{});
+      generate_default_spec(typename ParseContext::char_type{});
     } else {
       this->specs = {it, detail::to_unsigned(end - it)};
     }

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -451,24 +451,16 @@ FMT_END_DETAIL_NAMESPACE
 template <typename Char, typename Duration>
 struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
                  Char> : formatter<std::tm, Char> {
-  FMT_CONSTEXPR FMT_INLINE void generate_default_spec(char) {
-    this->specs = {"%Y-%m-%d %H:%M:%S", 17};
-  }
-  FMT_CONSTEXPR FMT_INLINE void generate_default_spec(wchar_t) {
-    this->specs = {L"%Y-%m-%d %H:%M:%S", 17};
-  }
-
   template <typename ParseContext>
   FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
     auto it = ctx.begin();
     if (it != ctx.end() && *it == ':') ++it;
     auto end = it;
     while (end != ctx.end() && *end != '}') ++end;
-    if (end == it) {
-      generate_default_spec(typename ParseContext::char_type{});
-    } else {
+    if (end == it)
+      this->specs = {default_spec, 17};
+    else
       this->specs = {it, detail::to_unsigned(end - it)};
-    }
     return end;
   }
 
@@ -478,6 +470,10 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
     std::tm time = localtime(val);
     return formatter<std::tm, Char>::format(time, ctx);
   }
+  
+  static constexpr Char default_spec[] = {'%', 'Y', '-', '%', 'm', '-',
+                                          '%', 'd', ' ', '%', 'H', ':',
+                                          '%', 'M', ':', '%', 'S'};
 };
 
 template <typename Char> struct formatter<std::tm, Char> {

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -451,9 +451,7 @@ FMT_END_DETAIL_NAMESPACE
 template <typename Char, typename Duration>
 struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
                  Char> : formatter<std::tm, Char> {
-  FMT_CONSTEXPR formatter() {
-    this->specs = {default_specs, 17};
-  }
+  FMT_CONSTEXPR formatter() { this->specs = {default_specs, 17}; }
 
   template <typename ParseContext>
   FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
@@ -473,8 +471,8 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
   }
 
   static constexpr Char default_specs[] = {'%', 'Y', '-', '%', 'm', '-',
-                                          '%', 'd', ' ', '%', 'H', ':',
-                                          '%', 'M', ':', '%', 'S'};
+                                           '%', 'd', ' ', '%', 'H', ':',
+                                           '%', 'M', ':', '%', 'S'};
 };
 
 template <typename Char, typename Duration>

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -452,10 +452,10 @@ template <typename Char, typename Duration>
 struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
                  Char> : formatter<std::tm, Char> {
   FMT_CONSTEXPR FMT_INLINE void generate_defalut_spec(char) {
-    this->specs = "%Y-%m-%d %H:%M:%S";
+    this->specs = {"%Y-%m-%d %H:%M:%S", 17};
   }
   FMT_CONSTEXPR FMT_INLINE void generate_defalut_spec(wchar_t) {
-    this->specs = L"%Y-%m-%d %H:%M:%S";
+    this->specs = {L"%Y-%m-%d %H:%M:%S", 17};
   }
 
   template <typename ParseContext>

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -451,7 +451,9 @@ FMT_END_DETAIL_NAMESPACE
 template <typename Char, typename Duration>
 struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
                  Char> : formatter<std::tm, Char> {
-  FMT_CONSTEXPR formatter() { this->specs = {default_specs, 17}; }
+  FMT_CONSTEXPR formatter() {
+    this->specs = {default_specs, sizeof(default_specs) / sizeof(Char)};
+  }
 
   template <typename ParseContext>
   FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -472,8 +472,8 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
   }
 
   static constexpr Char default_spec[] = {'%', 'Y', '-', '%', 'm', '-',
-                                                '%', 'd', ' ', '%', 'H', ':',
-                                                '%', 'M', ':', '%', 'S'};
+                                          '%', 'd', ' ', '%', 'H', ':',
+                                          '%', 'M', ':', '%', 'S'};
 };
 
 template <typename Char, typename Duration>

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -451,6 +451,27 @@ FMT_END_DETAIL_NAMESPACE
 template <typename Char, typename Duration>
 struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
                  Char> : formatter<std::tm, Char> {
+  FMT_CONSTEXPR FMT_INLINE void generate_defalut_spec(char) {
+    this->specs = "%Y-%m-%d %H:%M:%S";
+  }
+  FMT_CONSTEXPR FMT_INLINE void generate_defalut_spec(wchar_t) {
+    this->specs = L"%Y-%m-%d %H:%M:%S";
+  }
+
+  template <typename ParseContext>
+  FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+    auto it = ctx.begin();
+    if (it != ctx.end() && *it == ':') ++it;
+    auto end = it;
+    while (end != ctx.end() && *end != '}') ++end;
+    if (end == it) {
+      generate_defalut_spec(typename ParseContext::char_type{});
+    } else {
+      this->specs = {it, detail::to_unsigned(end - it)};
+    }
+    return end;
+  }
+
   template <typename FormatContext>
   auto format(std::chrono::time_point<std::chrono::system_clock> val,
               FormatContext& ctx) -> decltype(ctx.out()) {

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -458,8 +458,7 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
     auto end = it;
     while (end != ctx.end() && *end != '}') ++end;
     if (end == it)
-      this->specs = {default_spec,
-                     std::end(default_spec) - std::begin(default_spec)};
+      this->specs = {default_spec, 17};
     else
       this->specs = {it, detail::to_unsigned(end - it)};
     return end;
@@ -472,10 +471,15 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
     return formatter<std::tm, Char>::format(time, ctx);
   }
 
-  static constexpr inline Char default_spec[] = {'%', 'Y', '-', '%', 'm', '-',
-                                                 '%', 'd', ' ', '%', 'H', ':',
-                                                 '%', 'M', ':', '%', 'S'};
+  static constexpr Char default_spec[] = {'%', 'Y', '-', '%', 'm', '-',
+                                                '%', 'd', ' ', '%', 'H', ':',
+                                                '%', 'M', ':', '%', 'S'};
 };
+
+template <typename Char, typename Duration>
+constexpr Char
+    formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
+              Char>::default_spec[];
 
 template <typename Char> struct formatter<std::tm, Char> {
   template <typename ParseContext>

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -458,7 +458,8 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
     auto end = it;
     while (end != ctx.end() && *end != '}') ++end;
     if (end == it)
-      this->specs = {default_spec, 17};
+      this->specs = {default_spec,
+                     std::end(default_spec) - std::begin(default_spec)};
     else
       this->specs = {it, detail::to_unsigned(end - it)};
     return end;
@@ -470,10 +471,10 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
     std::tm time = localtime(val);
     return formatter<std::tm, Char>::format(time, ctx);
   }
-  
-  static constexpr Char default_spec[] = {'%', 'Y', '-', '%', 'm', '-',
-                                          '%', 'd', ' ', '%', 'H', ':',
-                                          '%', 'M', ':', '%', 'S'};
+
+  static constexpr inline Char default_spec[] = {'%', 'Y', '-', '%', 'm', '-',
+                                                 '%', 'd', ' ', '%', 'H', ':',
+                                                 '%', 'M', ':', '%', 'S'};
 };
 
 template <typename Char> struct formatter<std::tm, Char> {

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -451,16 +451,17 @@ FMT_END_DETAIL_NAMESPACE
 template <typename Char, typename Duration>
 struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
                  Char> : formatter<std::tm, Char> {
+  FMT_CONSTEXPR formatter() {
+    this->specs = {default_spec, 17};
+  }
+
   template <typename ParseContext>
   FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
     auto it = ctx.begin();
     if (it != ctx.end() && *it == ':') ++it;
     auto end = it;
     while (end != ctx.end() && *end != '}') ++end;
-    if (end == it)
-      this->specs = {default_spec, 17};
-    else
-      this->specs = {it, detail::to_unsigned(end - it)};
+    if (end != it) this->specs = {it, detail::to_unsigned(end - it)};
     return end;
   }
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -452,7 +452,7 @@ template <typename Char, typename Duration>
 struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
                  Char> : formatter<std::tm, Char> {
   FMT_CONSTEXPR formatter() {
-    this->specs = {default_spec, 17};
+    this->specs = {default_specs, 17};
   }
 
   template <typename ParseContext>
@@ -472,7 +472,7 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
     return formatter<std::tm, Char>::format(time, ctx);
   }
 
-  static constexpr Char default_spec[] = {'%', 'Y', '-', '%', 'm', '-',
+  static constexpr Char default_specs[] = {'%', 'Y', '-', '%', 'm', '-',
                                           '%', 'd', ' ', '%', 'H', ':',
                                           '%', 'M', ':', '%', 'S'};
 };
@@ -480,7 +480,7 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
 template <typename Char, typename Duration>
 constexpr Char
     formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
-              Char>::default_spec[];
+              Char>::default_specs[];
 
 template <typename Char> struct formatter<std::tm, Char> {
   template <typename ParseContext>

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -99,6 +99,7 @@ template <typename TimePoint> auto strftime(TimePoint tp) -> std::string {
 TEST(chrono_test, time_point) {
   auto t1 = std::chrono::system_clock::now();
   EXPECT_EQ(strftime(t1), fmt::format("{:%Y-%m-%d %H:%M:%S}", t1));
+  EXPECT_EQ(strftime(t1), fmt::format("{}", t1));
   using time_point =
       std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>;
   auto t2 = time_point(std::chrono::seconds(42));

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -92,6 +92,8 @@ TEST(compile_test, format_default) {
   EXPECT_EQ("foo", fmt::format(FMT_COMPILE("{}"), "foo"));
   EXPECT_EQ("foo", fmt::format(FMT_COMPILE("{}"), std::string("foo")));
   EXPECT_EQ("foo", fmt::format(FMT_COMPILE("{}"), test_formattable()));
+  auto t = std::chrono::system_clock::now();
+  EXPECT_EQ(fmt::format("{}", t), fmt::format(FMT_COMPILE("{}"), t));
 #  ifdef __cpp_lib_byte
   EXPECT_EQ("42", fmt::format(FMT_COMPILE("{}"), std::byte{42}));
 #  endif


### PR DESCRIPTION
For https://github.com/fmtlib/fmt/issues/2319, I add a defalut spec when the format is `{}`.

Here I use function overload to avoid `if constexpr` or different template specializations. If you want to support more char types, you can provide with more overload resolutions, or use some template metaprogramming techniques (to restrict `sizeof(Char)` ).

