### PR TITLE
Fix chrono_test.weekday on legacy glibc

### DIFF
--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -376,7 +376,7 @@ TEST(chrono_test, weekday) {
   auto mon = fmt::weekday(1);
   EXPECT_EQ(fmt::format("{}", mon), "Mon");
   if (loc != std::locale::classic()) {
-    EXPECT_THAT((std::vector<std::string>{"пн", "Пн"}),
+    EXPECT_THAT((std::vector<std::string>{"пн", "Пн", "пнд", "Пнд"}),
                 Contains(fmt::format(loc, "{:L}", mon)));
   }
 }


### PR DESCRIPTION
The weekday can be three chars long:

```
# cat /etc/SuSE-release
SUSE Linux Enterprise Server 11 (x86_64)
VERSION = 11
PATCHLEVEL = 3

# date
Чтв Июн 10 23:45:13 YEKT 2021
```