### PR TITLE
Fix invalid code and bad codegen (gcc, msvc)

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -153,6 +153,9 @@ template <typename T> constexpr const unsigned basic_data<T>::prefixes[];
 template <typename T> constexpr const char basic_data<T>::left_padding_shifts[];
 template <typename T>
 constexpr const char basic_data<T>::right_padding_shifts[];
+template <typename T> constexpr const uint16_t basic_data<T>::bsr2log10[];
+template <typename T>
+constexpr const uint64_t basic_data<T>::zero_or_powers_of_10[];
 #endif
 
 template <typename T> struct bits {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,8 +99,8 @@ if (FMT_CAN_MODULE)
 
   add_fmt_test(module-test MODULE)
   if (MSVC)
-    target_compile_options(test-module PRIVATE /utf-8)
-    target_compile_options(module-test PRIVATE /utf-8)
+    target_compile_options(test-module PRIVATE /utf-8 /Zc:__cplusplus)
+    target_compile_options(module-test PRIVATE /utf-8 /Zc:__cplusplus)
   endif ()
 endif ()
 


### PR DESCRIPTION
Found with tests in Windows when `__cplusplus` returns C++20

- `static constexpr var` is invalid within `constexpr` function.
- make lookup tables `static constexpr`
- instruct msvc to report the true value in `__cplusplus` in _some_ tests to improve test coverage and catch similar problems in the future

For details on codegen have a peek here: [https://godbolt.org/z/Evj57ra7r](https://godbolt.org/z/Evj57ra7r)
MSVC and gcc have similar code generation. The macro `LOCAL` toggles between old and new.