### PR TITLE
Instruct msvc to report the true value in `__cplusplus`

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2656,21 +2656,28 @@ constexpr auto get_arg_index_by_name(basic_string_view<Char> name) -> int {
   if constexpr (detail::is_statically_named_arg<T>()) {
     if (name == T::name) return N;
   }
-  if constexpr (sizeof...(Args) > 0)
+  if constexpr (sizeof...(Args) > 0) {
     return get_arg_index_by_name<N + 1, Args...>(name);
-  (void)name;  // Workaround an MSVC bug about "unused" parameter.
-  return invalid_arg_index;
+  } else {
+    (void)name;  // Workaround an MSVC bug about "unused" parameter.
+    return invalid_arg_index;
+  }
 }
 #endif
 
 template <typename... Args, typename Char>
 FMT_CONSTEXPR auto get_arg_index_by_name(basic_string_view<Char> name) -> int {
 #if FMT_USE_NONTYPE_TEMPLATE_PARAMETERS
-  if constexpr (sizeof...(Args) > 0)
+  if constexpr (sizeof...(Args) > 0) {
     return get_arg_index_by_name<0, Args...>(name);
-#endif
+  } else {
+    (void)name;
+    return invalid_arg_index;
+  }
+#else
   (void)name;
   return invalid_arg_index;
+#endif
 }
 
 template <typename Char, typename ErrorHandler, typename... Args>

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -394,7 +394,7 @@ struct ostream_params {
 
 FMT_END_DETAIL_NAMESPACE
 
-static constexpr detail::buffer_size buffer_size;
+constexpr detail::buffer_size buffer_size;
 
 /** A fast output stream which is not thread-safe. */
 class FMT_API ostream final : private detail::buffer<char> {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,8 +99,10 @@ if (FMT_CAN_MODULE)
 
   add_fmt_test(module-test MODULE)
   if (MSVC)
-    target_compile_options(test-module PRIVATE /utf-8)
-    target_compile_options(module-test PRIVATE /utf-8)
+    target_compile_options(test-module PRIVATE /utf-8 /Zc:__cplusplus
+                           /Zc:externConstexpr /Zc:inline)
+    target_compile_options(module-test PRIVATE /utf-8 /Zc:__cplusplus
+                           /Zc:externConstexpr /Zc:inline)
   endif ()
 endif ()
 


### PR DESCRIPTION
Do this  in _some_ tests to improve test coverage and catch possible problems due to that.
