### PR TITLE
Fix bug in cmake join function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif ()
 
 # Joins arguments and places the results in ${result_var}.
 function(join result_var)
-  set(result )
+  set(result "")
   foreach (arg ${ARGN})
     set(result "${result}${arg}")
   endforeach ()


### PR DESCRIPTION
CMake: 3.15.4

Master project cmake output:
```
-- Version: 7.1.4
```

Tests output:

```Start 20: add-subdirectory-test``` (cmake output):
```
20: Version: 7.1.4
```

```Start 21: static-export-test``` (cmake output):
```
21: Version: TRUE7.1.4
```