### PR TITLE
suppress unused variable warnings

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -336,7 +336,7 @@ struct monostate {
 // `(void)var` method does not work on many intel compilers.  This is
 // from Herb Sutter, "Shutting up compiler warnings",
 // https://herbsutter.com/2009/10/18/mailbag-shutting-up-compiler-warnings/
-template<class T> void ignore_unused( const T& ) { }
+template <class T> void ignore_unused(const T&) {}
 
 // An enable_if helper to be used in template parameters which results in much
 // shorter symbols: https://godbolt.org/z/sWw4vP. Extra parentheses are needed

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -332,9 +332,10 @@ struct monostate {
   constexpr monostate() {}
 };
 
-// Eliminate "unused variable" warnings on all compilers.  The `(void)var` method
-// does not work on many intel compilers.  This is from Herb Sutter, "Shutting
-// up compiler warnings", https://herbsutter.com/2009/10/18/mailbag-shutting-up-compiler-warnings/
+// Eliminate "unused variable" warnings on all compilers.  The
+// `(void)var` method does not work on many intel compilers.  This is
+// from Herb Sutter, "Shutting up compiler warnings",
+// https://herbsutter.com/2009/10/18/mailbag-shutting-up-compiler-warnings/
 template<class T> void ignore_unused( const T& ) { }
 
 // An enable_if helper to be used in template parameters which results in much

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -332,6 +332,11 @@ struct monostate {
   constexpr monostate() {}
 };
 
+// Eliminate "unused variable" warnings on all compilers.  The `(void)var` method
+// does not work on many intel compilers.  This is from Herb Sutter, "Shutting
+// up compiler warnings", https://herbsutter.com/2009/10/18/mailbag-shutting-up-compiler-warnings/
+template<class T> void ignore_unused( const T& ) { }
+
 // An enable_if helper to be used in template parameters which results in much
 // shorter symbols: https://godbolt.org/z/sWw4vP. Extra parentheses are needed
 // to workaround a bug in MSVC 2019 (see #1140 and #1186).
@@ -2731,7 +2736,7 @@ void check_format_string(S format_str) {
                                         remove_cvref_t<Args>...>;
   FMT_CONSTEXPR bool invalid_format =
       (parse_format_string<true>(s, checker(s, {})), true);
-  (void)invalid_format;
+  ignore_unused(invalid_format);
 }
 
 template <typename Char>


### PR DESCRIPTION
An arguably better method for suppressing unused variable warnings.   The `(void)var` method does not work on many intel compiilers.
This is from Herb Sutter's blog post https://herbsutter.com/2009/10/18/mailbag-shutting-up-compiler-warnings/

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
