### PR TITLE
Eliminate intel compiler warning

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -24,7 +24,7 @@
 #  define FMT_CLANG_VERSION 0
 #endif
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #  define FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #  define FMT_GCC_PRAGMA(arg) _Pragma(arg)
 #else


### PR DESCRIPTION
The intel compiler defines `__GNUC__`, but does not support the gcc `_Pragma`.  This PR filters out the intel compiler to avoid warnings about an unrecognized function.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
