### PR TITLE
Fix MSVC warning C4819

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -520,9 +520,9 @@ FMT_CONSTEXPR inline size_t compute_width(string_view s) {
           1 +
           (error == 0 && cp >= 0x1100 &&
            (cp <= 0x115f ||  // Hangul Jamo init. consonants
-            cp == 0x2329 ||  // LEFT-POINTING ANGLE BRACKET〈
-            cp == 0x232a ||  // RIGHT-POINTING ANGLE BRACKET 〉
-            // CJK ... Yi except Unicode Character “〿”:
+            cp == 0x2329 ||  // LEFT-POINTING ANGLE BRACKET
+            cp == 0x232a ||  // RIGHT-POINTING ANGLE BRACKET
+            // CJK ... Yi except IDEOGRAPHIC HALF FILL SPACE:
             (cp >= 0x2e80 && cp <= 0xa4cf && cp != 0x303f) ||
             (cp >= 0xac00 && cp <= 0xd7a3) ||    // Hangul Syllables
             (cp >= 0xf900 && cp <= 0xfaff) ||    // CJK Compatibility Ideographs


### PR DESCRIPTION
Hi,

I'm using Visual Studio 2019 Version 16.10.2 on Windows with Japanese system locale (code page 932).

Upgrading from fmt 7.1.3 to 8.0.0 resulted in [Compiler Warning (level 1) C4819](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4819):

```
warning C4819: The file contains a character that cannot be represented in the current code page (932). Save the file in Unicode format to prevent data loss
```

The issue was introduced in 7e72673d87cc44340f4b808d0b536e4e191342b5.