### PR TITLE
Remove unneeded `num_result_bigits` decrement

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -563,7 +563,6 @@ class bigint {
       (*this)[bigit_index] = static_cast<bigit>(sum);
       sum >>= bits<bigit>::value;
     }
-    --num_result_bigits;
     remove_leading_zeros();
     exp_ *= 2;
   }


### PR DESCRIPTION
For what I see this seems unused?

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
