### PR TITLE
Warning removals in test code

### DIFF
--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -151,7 +151,9 @@ TEST(buffer_test, indestructible) {
 template <typename T> struct mock_buffer final : buffer<T> {
   MOCK_METHOD1(do_grow, size_t(size_t capacity));
 
-  void grow(size_t capacity) { this->set(this->data(), do_grow(capacity)); }
+  void grow(size_t capacity) override {
+    this->set(this->data(), do_grow(capacity));
+  }
 
   mock_buffer(T* data = nullptr, size_t buf_capacity = 0) {
     this->set(data, buf_capacity);
@@ -452,7 +454,7 @@ struct check_custom {
     struct test_buffer final : fmt::detail::buffer<char> {
       char data[10];
       test_buffer() : fmt::detail::buffer<char>(data, 0, 10) {}
-      void grow(size_t) {}
+      void grow(size_t) override {}
     } buffer;
     auto parse_ctx = fmt::format_parse_context("");
     auto ctx = fmt::format_context(fmt::detail::buffer_appender<char>(buffer),

--- a/test/gtest-extra.h
+++ b/test/gtest-extra.h
@@ -116,7 +116,7 @@ class output_redirect {
 class suppress_assert {
  private:
   _invalid_parameter_handler original_handler_;
-  FMT_MAYBE_UNUSED int original_report_mode_;
+  int original_report_mode_;
 
   static void handle_invalid_parameter(const wchar_t*, const wchar_t*,
                                        const wchar_t*, unsigned, uintptr_t) {}
@@ -129,6 +129,7 @@ class suppress_assert {
   ~suppress_assert() {
     _set_invalid_parameter_handler(original_handler_);
     _CrtSetReportMode(_CRT_ASSERT, original_report_mode_);
+    (void)original_report_mode_;
   }
 };
 

--- a/test/gtest-extra.h
+++ b/test/gtest-extra.h
@@ -116,7 +116,7 @@ class output_redirect {
 class suppress_assert {
  private:
   _invalid_parameter_handler original_handler_;
-  int original_report_mode_;
+  FMT_MAYBE_UNUSED int original_report_mode_;
 
   static void handle_invalid_parameter(const wchar_t*, const wchar_t*,
                                        const wchar_t*, unsigned, uintptr_t) {}

--- a/test/os-test.cc
+++ b/test/os-test.cc
@@ -41,9 +41,9 @@ TEST(util_test, utf16_to_utf8_empty_string) {
 }
 
 template <typename Converter, typename Char>
-void check_utf_conversion_error(
-    const char* message,
-    fmt::basic_string_view<Char> str = fmt::basic_string_view<Char>(0, 1)) {
+void check_utf_conversion_error(const char* message,
+                                fmt::basic_string_view<Char> str =
+                                    fmt::basic_string_view<Char>(nullptr, 1)) {
   fmt::memory_buffer out;
   fmt::detail::format_windows_error(out, ERROR_INVALID_PARAMETER, message);
   auto error = std::system_error(std::error_code());
@@ -63,7 +63,7 @@ TEST(util_test, utf16_to_utf8_error) {
 
 TEST(util_test, utf16_to_utf8_convert) {
   fmt::detail::utf16_to_utf8 u;
-  EXPECT_EQ(ERROR_INVALID_PARAMETER, u.convert(wstring_view(0, 1)));
+  EXPECT_EQ(ERROR_INVALID_PARAMETER, u.convert(wstring_view(nullptr, 1)));
   EXPECT_EQ(ERROR_INVALID_PARAMETER,
             u.convert(wstring_view(L"foo", INT_MAX + 1u)));
 }
@@ -81,12 +81,12 @@ TEST(os_test, format_std_error_code) {
 }
 
 TEST(os_test, format_windows_error) {
-  LPWSTR message = 0;
+  LPWSTR message = nullptr;
   auto result = FormatMessageW(
       FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
           FORMAT_MESSAGE_IGNORE_INSERTS,
-      0, ERROR_FILE_EXISTS, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-      reinterpret_cast<LPWSTR>(&message), 0, 0);
+      nullptr, ERROR_FILE_EXISTS, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      reinterpret_cast<LPWSTR>(&message), 0, nullptr);
   fmt::detail::utf16_to_utf8 utf8_message(wstring_view(message, result - 2));
   LocalFree(message);
   fmt::memory_buffer actual_message;
@@ -97,17 +97,17 @@ TEST(os_test, format_windows_error) {
 }
 
 TEST(os_test, format_long_windows_error) {
-  LPWSTR message = 0;
+  LPWSTR message = nullptr;
   // this error code is not available on all Windows platforms and
   // Windows SDKs, so do not fail the test if the error string cannot
   // be retrieved.
   int provisioning_not_allowed = 0x80284013L;  // TBS_E_PROVISIONING_NOT_ALLOWED
-  auto result = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER |
-                                   FORMAT_MESSAGE_FROM_SYSTEM |
-                                   FORMAT_MESSAGE_IGNORE_INSERTS,
-                               0, static_cast<DWORD>(provisioning_not_allowed),
-                               MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                               reinterpret_cast<LPWSTR>(&message), 0, 0);
+  auto result = FormatMessageW(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+          FORMAT_MESSAGE_IGNORE_INSERTS,
+      nullptr, static_cast<DWORD>(provisioning_not_allowed),
+      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      reinterpret_cast<LPWSTR>(&message), 0, nullptr);
   if (result == 0) {
     LocalFree(message);
     return;

--- a/test/ostream-test.cc
+++ b/test/ostream-test.cc
@@ -115,12 +115,12 @@ TEST(ostream_test, write_to_ostream_max_size) {
   struct test_buffer final : fmt::detail::buffer<char> {
     explicit test_buffer(size_t size)
         : fmt::detail::buffer<char>(nullptr, size, size) {}
-    void grow(size_t) {}
+    void grow(size_t) override {}
   } buffer(max_size);
 
   struct mock_streambuf : std::streambuf {
     MOCK_METHOD2(xsputn, std::streamsize(const void* s, std::streamsize n));
-    std::streamsize xsputn(const char* s, std::streamsize n) {
+    std::streamsize xsputn(const char* s, std::streamsize n) override {
       const void* v = s;
       return xsputn(v, n);
     }

--- a/test/util.h
+++ b/test/util.h
@@ -34,7 +34,7 @@ fmt::buffered_file open_buffered_file(FILE** fp = nullptr);
 inline FILE* safe_fopen(const char* filename, const char* mode) {
 #if defined(_WIN32) && !defined(__MINGW32__)
   // Fix MSVC warning about "unsafe" fopen.
-  FILE* f = 0;
+  FILE* f = nullptr;
   errno = fopen_s(&f, filename, mode);
   return f;
 #else


### PR DESCRIPTION
Mostly 0 to nullptr and adding override to virtual function implementations.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
