### PR TITLE
Fix compilation when user-defined formatter provided for class instances

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1300,7 +1300,9 @@ template <typename Context> struct arg_mapper {
   // We use SFINAE instead of a const T* parameter to avoid conflicting with
   // the C array overload.
   template <typename T>
-  FMT_CONSTEXPR auto map(T) -> enable_if_t<std::is_pointer<T>::value, int> {
+  FMT_CONSTEXPR auto map(T) -> enable_if_t<std::is_pointer<T>::value &&
+                                           !has_formatter<T, Context>::value &&
+                                           !has_fallback_formatter<T, char_type>::value, int> {
     // Formatting of arbitrary pointers is disallowed. If you want to output
     // a pointer cast it to "void *" or "const void *". In particular, this
     // forbids formatting of "[const] volatile char *" which is printed as bool


### PR DESCRIPTION
Fix compilation when user-defined formatter provided for class instances like

```
template <>
struct fmt::formatter<Player*>
{
	static constexpr auto parse(format_parse_context &ctx)
	{
		return ctx.end();
	}

	template <typename FormatContext>
	auto format(const Player *player, FormatContext &ctx) const
	{
		return format_to(ctx.out(), "{}, device {}", player->id, player->device);
	}
};
```

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
