### PR TITLE
Remove unused `exp_`

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -564,7 +564,6 @@ class bigint {
       sum >>= bits<bigit>::value;
     }
     remove_leading_zeros();
-    exp_ *= 2;
   }
 
   // If this bigint has a bigger exponent than other, adds trailing zero to make


### PR DESCRIPTION
If the test cases
(format_test.format_float, bigint_test.square,
printf_test.fixed_large_exponent, bigint_test.divmod_assign_unaligned,
format_test.format_double) are correct then this line can be removed.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
