### PR TITLE
fix module test odr violations

### DIFF
--- a/test/gtest-extra.h
+++ b/test/gtest-extra.h
@@ -12,7 +12,12 @@
 
 #include <string>
 
+#ifdef FMT_MODULE_TEST
+import fmt;
+#else
 #include "fmt/os.h"
+#endif // FMG_MODULE_TEST
+
 #include "gmock/gmock.h"
 
 #define FMT_TEST_THROW_(statement, expected_exception, expected_message, fail) \

--- a/test/module-test.cc
+++ b/test/module-test.cc
@@ -15,6 +15,8 @@
 #  define FMT_HIDE_MODULE_BUGS
 #endif
 
+#define FMT_MODULE_TEST
+
 #include <bit>
 #include <chrono>
 #include <exception>

--- a/test/util.h
+++ b/test/util.h
@@ -10,7 +10,11 @@
 #include <locale>
 #include <string>
 
+#ifdef FMT_MODULE_TEST
+import fmt;
+#else
 #include "fmt/os.h"
+#endif // FMT_MODULE_TEST
 
 #ifdef _MSC_VER
 #  define FMT_VSNPRINTF vsprintf_s


### PR DESCRIPTION
As of 16.11 Preview 3 the MSVC compiler will no longer be, erroneously, be injecting header include guard macros when importing a module interface.  The bugfix exposed some issues related to textually including fmt headers in the test code which causes odr violations with the imported interface.