### PR TITLE
Fix build in platformio by renaming really common parameter name.

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1053,8 +1053,8 @@ FMT_CONSTEXPR FMT_INLINE void init_named_args(std::nullptr_t, int, int,
                                               const Args&...) {}
 
 template <bool B = false> constexpr auto count() -> size_t { return B ? 1 : 0; }
-template <bool B1, bool B2, bool... Tail> constexpr auto count() -> size_t {
-  return (B1 ? 1 : 0) + count<B2, Tail...>();
+template <bool B1_, bool B2_, bool... Tail> constexpr auto count() -> size_t {
+  return (B1_ ? 1 : 0) + count<B2_, Tail...>();
 }
 
 template <typename... Args> constexpr auto count_named_args() -> size_t {


### PR DESCRIPTION
I don't know if this is an overkill but "B1" is a really common variable/parameter name. In particular it conflicts with .platformio/packages/framework-arduinoespressif8266/cores/esp8266/binary.h, which is used throughout the espressif framework.

Part of the file:
#define B000000 0
#define B0000000 0
#define B00000000 0
#define B1 1
#define B01 1
#define B001 1
#define B0001 1