### PR TITLE
Disable the -Wstringop-overflow warning from GCC 7

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,16 @@ function(add_fmt_executable name)
   if (MINGW)
     target_link_libraries(${name} -static-libgcc -static-libstdc++)
   endif ()
+  # (Wstringop-overflow) - [meta-bug] bogus/missing -Wstringop-overflow warnings
+  #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88443
+  # Bogus -Wstringop-overflow warning
+  #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100395
+  # [10 Regression] spurious -Wstringop-overflow writing to a trailing array plus offset
+  #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95353
+  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND
+      NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+    target_link_libraries(${name} -Wno-stringop-overflow)
+  endif ()
 endfunction()
 
 # Adds a test.


### PR DESCRIPTION
Fix for false positive warnings if LTO is enabled:

```
[  6%] Building CXX object fmt/test/CMakeFiles/chrono-test.dir/chrono-test.cc.o
cd /home/.../devel/build/target_opensuse-gcc10/fmt/test && /usr/bin/g++-10  -DGTEST_HAS_STD_WSTRING=1 -D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING=1 -I/home/.../devel/fmt/src/include -isystem /home/.../devel/fmt/src/test/gtest/.  -fno-builtin-memcmp -msse -msse2 -msse3 -mssse3 -O3 -DNDEBUG -flto -fno-fat-lto-objects -fvisibility=hidden -fvisibility-inlines-hidden   -fno-delete-null-pointer-checks -std=gnu++17 -o CMakeFiles/chrono-test.dir/chrono-test.cc.o -c /home/.../devel/fmt/src/test/chrono-test.cc
[  6%] Linking CXX executable ../../bin/chrono-test
cd /home/.../devel/build/target_opensuse-gcc10/fmt/test && /usr/bin/cmake -E cmake_link_script CMakeFiles/chrono-test.dir/link.txt --verbose=1
/usr/bin/g++-10  -fno-builtin-memcmp -msse -msse2 -msse3 -mssse3 -O3 -DNDEBUG -flto -fno-fat-lto-objects  -Wl,--disable-new-dtags CMakeFiles/chrono-test.dir/chrono-test.cc.o  -o ../../bin/chrono-test  libtest-main.a ../libfmt.a gtest/libgtest.a -pthread 
In function ‘format_decimal’,
    inlined from ‘format_decimal’ at /home/.../devel/fmt/src/include/fmt/format.h:1098:28,
    inlined from ‘write.constprop’ at /home/.../devel/fmt/src/include/fmt/chrono.h:1021:36:
/home/.../devel/fmt/src/include/fmt/format.h:1051:59: warning: writing 2 bytes into a region of size 0 [-Wstringop-overflow=]
 1051 | FMT_INLINE void copy2(char* dst, const char* src) { memcpy(dst, src, 2); }
      |                                                           ^
/home/.../devel/fmt/src/include/fmt/chrono.h: In member function ‘write.constprop’:
/home/.../devel/fmt/src/include/fmt/format.h:1097:8: note: at offset -2 to object ‘buffer’ with size 10 declared here
 1097 |   Char buffer[digits10<UInt>() + 1];
      |        ^
In function ‘format_decimal’,
    inlined from ‘format_decimal’ at /home/.../devel/fmt/src/include/fmt/format.h:1098:28,
    inlined from ‘write.constprop’ at /home/.../devel/fmt/src/include/fmt/chrono.h:1021:36:
/home/.../devel/fmt/src/include/fmt/format.h:1084:12: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 1084 |     *--out = static_cast<Char>('0' + value);
      |            ^
/home/.../devel/fmt/src/include/fmt/chrono.h: In member function ‘write.constprop’:
/home/.../devel/fmt/src/include/fmt/format.h:1097:8: note: at offset -1 to object ‘buffer’ with size 10 declared here
 1097 |   Char buffer[digits10<UInt>() + 1];
      |        ^
In function ‘format_decimal’,
    inlined from ‘format_decimal’ at /home/.../devel/fmt/src/include/fmt/format.h:1098:28,
    inlined from ‘write.constprop’ at /home/.../devel/fmt/src/include/fmt/chrono.h:1021:36:
/home/.../devel/fmt/src/include/fmt/format.h:1051:59: warning: writing 2 bytes into a region of size 0 [-Wstringop-overflow=]
 1051 | FMT_INLINE void copy2(char* dst, const char* src) { memcpy(dst, src, 2); }
      |                                                           ^
/home/.../devel/fmt/src/include/fmt/chrono.h: In member function ‘write.constprop’:
/home/.../devel/fmt/src/include/fmt/format.h:1097:8: note: at offset -2 to object ‘buffer’ with size 10 declared here
 1097 |   Char buffer[digits10<UInt>() + 1];
      |        ^
In function ‘format_decimal’,
    inlined from ‘format_decimal’ at /home/.../devel/fmt/src/include/fmt/format.h:1098:28,
    inlined from ‘write.constprop’ at /home/.../devel/fmt/src/include/fmt/chrono.h:1021:36:
/home/.../devel/fmt/src/include/fmt/format.h:1084:12: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 1084 |     *--out = static_cast<Char>('0' + value);
      |            ^
/home/.../devel/fmt/src/include/fmt/chrono.h: In member function ‘write.constprop’:
/home/.../devel/fmt/src/include/fmt/format.h:1097:8: note: at offset -1 to object ‘buffer’ with size 10 declared here
 1097 |   Char buffer[digits10<UInt>() + 1];
      |        ^
make[2]: выход из каталога «/home/.../devel/build/target_opensuse-gcc10»
```

Discussion in Boost.JSON issue: https://github.com/boostorg/json/issues/597