### PR TITLE
Resolve default constructor error in Xcode 7.2.1 and 8.2.1

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -394,7 +394,9 @@ struct ostream_params {
 
 FMT_END_DETAIL_NAMESPACE
 
-constexpr detail::buffer_size buffer_size;
+// Added {} below to work around default constructor error known to
+// occur in Xcode versions 7.2.1 and 8.2.1.
+constexpr detail::buffer_size buffer_size{};
 
 /** A fast output stream which is not thread-safe. */
 class FMT_API ostream final : private detail::buffer<char> {


### PR DESCRIPTION
Fix issue that produces the error 'default initialization of an object
of const type 'const detail::buffer_size' without a user-provided
default constructor'
