### PR TITLE
Use builtin intrinsics on intel

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -150,16 +150,16 @@ FMT_END_NAMESPACE
 
 // __builtin_clz is broken in clang with Microsoft CodeGen:
 // https://github.com/fmtlib/fmt/issues/519
-#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_clz)) && !FMT_MSC_VER
+#if (FMT_GCC_VERSION || FMT_ICC_VERSION || FMT_HAS_BUILTIN(__builtin_clz)) && !FMT_MSC_VER
 #  define FMT_BUILTIN_CLZ(n) __builtin_clz(n)
 #endif
-#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_clzll)) && !FMT_MSC_VER
+#if (FMT_GCC_VERSION || FMT_ICC_VERSION || FMT_HAS_BUILTIN(__builtin_clzll)) && !FMT_MSC_VER
 #  define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
 #endif
-#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_ctz))
+#if (FMT_GCC_VERSION || FMT_ICC_VERSION || FMT_HAS_BUILTIN(__builtin_ctz))
 #  define FMT_BUILTIN_CTZ(n) __builtin_ctz(n)
 #endif
-#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_ctzll))
+#if (FMT_GCC_VERSION || FMT_ICC_VERSION || FMT_HAS_BUILTIN(__builtin_ctzll))
 #  define FMT_BUILTIN_CTZLL(n) __builtin_ctzll(n)
 #endif
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -150,16 +150,16 @@ FMT_END_NAMESPACE
 
 // __builtin_clz is broken in clang with Microsoft CodeGen:
 // https://github.com/fmtlib/fmt/issues/519
-#if (FMT_GCC_VERSION || FMT_ICC_VERSION || FMT_HAS_BUILTIN(__builtin_clz)) && !FMT_MSC_VER
+#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_clz) || FMT_ICC_VERSION) && !FMT_MSC_VER
 #  define FMT_BUILTIN_CLZ(n) __builtin_clz(n)
 #endif
-#if (FMT_GCC_VERSION || FMT_ICC_VERSION || FMT_HAS_BUILTIN(__builtin_clzll)) && !FMT_MSC_VER
+#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_clzll) || FMT_ICC_VERSION) && !FMT_MSC_VER
 #  define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
 #endif
-#if (FMT_GCC_VERSION || FMT_ICC_VERSION || FMT_HAS_BUILTIN(__builtin_ctz))
+#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_ctz) || FMT_ICC_VERSION)
 #  define FMT_BUILTIN_CTZ(n) __builtin_ctz(n)
 #endif
-#if (FMT_GCC_VERSION || FMT_ICC_VERSION || FMT_HAS_BUILTIN(__builtin_ctzll))
+#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_ctzll) || FMT_ICC_VERSION)
 #  define FMT_BUILTIN_CTZLL(n) __builtin_ctzll(n)
 #endif
 


### PR DESCRIPTION
I ran into a bit of a mystery when I updated to fmt 8.0.1.

I got the following build error on intel 18.0.2:

```
fmt/format-inl.h(1923): error: identifier "ctz" is undefined
    int t = ctz(n);
            ^

In file included from fmt/format.h(2825),
                 from fmt/fmt.hpp(14),
```

The mystery is that fmt 8.0.1 did compiled on intel 19.0.4 but I am just not sure why intel 19 worked without this fix.

I tested this fix on intel 18, 19, and 2021.

Here is a godbolt example that shows intel has `__builtin_ctz` but not `__has_builtin`:

https://godbolt.org/z/xKrcaas8n

**Intel Compiler Differences**
intel 18 seems to be broken on godbolt but I tested it on our cluster
intel 2021 does have `__has_builtin`