### PR TITLE
fuzzer maintenance

### DIFF
--- a/test/fuzzing/build.sh
+++ b/test/fuzzing/build.sh
@@ -22,6 +22,8 @@ here=$(pwd)
 CXXFLAGSALL="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION= -g"
 CMAKEFLAGSALL="$root -GNinja -DCMAKE_BUILD_TYPE=Debug -DFMT_DOC=Off -DFMT_TEST=Off -DFMT_FUZZ=On -DCMAKE_CXX_STANDARD=17"
 
+CLANG=clang++-11
+
 # For performance analysis of the fuzzers.
 builddir=$here/build-fuzzers-perfanalysis
 mkdir -p $builddir
@@ -37,7 +39,7 @@ cmake --build $builddir
 builddir=$here/build-fuzzers-ossfuzz
 mkdir -p $builddir
 cd $builddir
-CXX="clang++" \
+CXX=$CLANG \
 CXXFLAGS="$CXXFLAGSALL -fsanitize=fuzzer-no-link" cmake \
 cmake $CMAKEFLAGSALL \
 -DFMT_FUZZ_LINKMAIN=Off \
@@ -50,7 +52,7 @@ cmake --build $builddir
 builddir=$here/build-fuzzers-libfuzzer
 mkdir -p $builddir
 cd $builddir
-CXX="clang++" \
+CXX=$CLANG \
 CXXFLAGS="$CXXFLAGSALL -fsanitize=fuzzer-no-link,address,undefined" cmake \
 cmake $CMAKEFLAGSALL \
 -DFMT_FUZZ_LINKMAIN=Off \
@@ -62,7 +64,7 @@ cmake --build $builddir
 builddir=$here/build-fuzzers-fast
 mkdir -p $builddir
 cd $builddir
-CXX="clang++" \
+CXX=$CLANG \
 CXXFLAGS="$CXXFLAGSALL -fsanitize=fuzzer-no-link -O3" cmake \
 cmake $CMAKEFLAGSALL \
 -DFMT_FUZZ_LINKMAIN=Off \

--- a/test/fuzzing/chrono-duration.cc
+++ b/test/fuzzing/chrono-duration.cc
@@ -1,8 +1,9 @@
 // Copyright (c) 2019, Paul Dreik
 // For the license information refer to format.h.
 
-#include <cstdint>
 #include <fmt/chrono.h>
+
+#include <cstdint>
 
 #include "fuzzer-common.h"
 
@@ -31,7 +32,7 @@ void invoke_outer(const uint8_t* data, size_t size, int period) {
   data += fixed_size;
   size -= fixed_size;
 
-  // data is already allocated separately in libFuzzer so reading past the end 
+  // data is already allocated separately in libFuzzer so reading past the end
   // will most likely be detected anyway.
   const auto format_str = fmt::string_view(as_chars(data), size);
 
@@ -86,7 +87,7 @@ void invoke_outer(const uint8_t* data, size_t size, int period) {
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  if (size <= 4)  return 0;
+  if (size <= 4) return 0;
 
   const auto representation = data[0];
   const auto period = data[1];

--- a/test/fuzzing/float.cc
+++ b/test/fuzzing/float.cc
@@ -1,11 +1,12 @@
 // A fuzzer for floating-point formatter.
 // For the license information refer to format.h.
 
+#include <fmt/format.h>
+
 #include <cstdint>
 #include <cstdlib>
-#include <stdexcept>
 #include <limits>
-#include <fmt/format.h>
+#include <stdexcept>
 
 #include "fuzzer-common.h"
 
@@ -24,8 +25,7 @@ void check_round_trip(fmt::string_view format_str, double value) {
   char* ptr = nullptr;
   if (std::strtod(buffer.data(), &ptr) != value)
     throw std::runtime_error("round trip failure");
-  if (ptr + 1 != buffer.end())
-    throw std::runtime_error("unparsed output");
+  if (ptr + 1 != buffer.end()) throw std::runtime_error("unparsed output");
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {

--- a/test/fuzzing/fuzzer-common.h
+++ b/test/fuzzing/fuzzer-common.h
@@ -56,7 +56,9 @@ struct data_to_string {
 
   data_to_string(const uint8_t* data, size_t size, bool add_terminator = false)
       : buffer(size + (add_terminator ? 1 : 0)) {
-    std::memcpy(buffer.data(), data, size);
+    if (size) {
+      std::memcpy(buffer.data(), data, size);
+    }
   }
 
   fmt::string_view get() const { return {buffer.data(), buffer.size()}; }

--- a/test/fuzzing/fuzzer-common.h
+++ b/test/fuzzing/fuzzer-common.h
@@ -4,11 +4,11 @@
 #ifndef FUZZER_COMMON_H
 #define FUZZER_COMMON_H
 
-#include <cstdint>      // std::uint8_t
-#include <cstring>      // memcpy
-#include <vector>
-
 #include <fmt/core.h>
+
+#include <cstdint>  // std::uint8_t
+#include <cstring>  // memcpy
+#include <vector>
 
 // One can format to either a string, or a buffer. The latter is faster, but
 // one may be interested in formatting to a string instead to verify it works

--- a/test/fuzzing/named-arg.cc
+++ b/test/fuzzing/named-arg.cc
@@ -1,10 +1,11 @@
 // Copyright (c) 2019, Paul Dreik
 // For the license information refer to format.h.
 
+#include <fmt/chrono.h>
+
 #include <cstdint>
 #include <type_traits>
 #include <vector>
-#include <fmt/chrono.h>
 
 #include "fuzzer-common.h"
 
@@ -25,7 +26,7 @@ void invoke_fmt(const uint8_t* data, size_t size, unsigned arg_name_size) {
   try {
 #if FMT_FUZZ_FORMAT_TO_STRING
     std::string message =
-      fmt::format(format_str.get(), fmt::arg(arg_name.data(), value));
+        fmt::format(format_str.get(), fmt::arg(arg_name.data(), value));
 #else
     fmt::memory_buffer out;
     fmt::format_to(out, format_str.get(), fmt::arg(arg_name.data(), value));

--- a/test/fuzzing/one-arg.cc
+++ b/test/fuzzing/one-arg.cc
@@ -1,17 +1,18 @@
 // Copyright (c) 2019, Paul Dreik
 // For the license information refer to format.h.
 
+#include <fmt/chrono.h>
+
 #include <cstdint>
 #include <exception>
-#include <fmt/chrono.h>
 
 #include "fuzzer-common.h"
 
-template <typename T, typename Repr>
-const T* from_repr(const Repr& r) { return &r; }
+template <typename T, typename Repr> const T* from_repr(const Repr& r) {
+  return &r;
+}
 
-template <>
-const std::tm* from_repr<std::tm>(const std::time_t& t) {
+template <> const std::tm* from_repr<std::tm>(const std::time_t& t) {
   return std::localtime(&t);
 }
 

--- a/test/fuzzing/two-args.cc
+++ b/test/fuzzing/two-args.cc
@@ -1,10 +1,11 @@
 // Copyright (c) 2019, Paul Dreik
 // For the license information refer to format.h.
 
+#include <fmt/format.h>
+
 #include <cstdint>
 #include <exception>
 #include <string>
-#include <fmt/format.h>
 
 #include "fuzzer-common.h"
 


### PR DESCRIPTION
* auto format the code using clang format 11
* fixes UB in a fuzzer helper function, not triggered by the existing fuzzers but by an experimental fuzzer not yet published
* sets the path to clang in one place instead of several (just used manually, not in any automated scripts that I know of)