### PR TITLE
Optimize %T in tm formatting

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -564,10 +564,13 @@ template <typename Char> struct formatter<std::tm, Char> {
     while (end != ctx.end() && *end != '}') ++end;
     auto size = detail::to_unsigned(end - it);
     specs = {it, size};
-    if (specs == string_view("%F", 2))
-      spec_ = spec::year_month_day;
-    else if (specs == string_view("%T", 2))
-      spec_ = spec::hh_mm_ss;
+    // basic_string_view<>::compare isn't constexpr before C++17
+    if (specs.size() == 2 && specs[0] == Char('%')) {
+      if (specs[1] == Char('F'))
+        spec_ = spec::year_month_day;
+      else if (specs[1] == Char('T'))
+        spec_ = spec::hh_mm_ss;
+    }
     return end;
   }
 

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -49,6 +49,7 @@ TEST(chrono_test, format_tm) {
   EXPECT_EQ(fmt::format("The date is {:%Y-%m-%d %H:%M:%S}.", tm),
             "The date is 2016-04-25 11:22:33.");
   EXPECT_EQ(fmt::format("{:%F}", tm), "2016-04-25");
+  EXPECT_EQ(fmt::format("{:%T}", tm), "11:22:33");
 }
 
 TEST(chrono_test, grow_buffer) {

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -261,6 +261,8 @@ TEST(xchar_test, chrono) {
   EXPECT_EQ(fmt::format("The date is {:%Y-%m-%d %H:%M:%S}.", tm),
             "The date is 2016-04-25 11:22:33.");
   EXPECT_EQ(L"42s", fmt::format(L"{}", std::chrono::seconds(42)));
+  EXPECT_EQ(fmt::format(L"{:%F}", tm), L"2016-04-25");
+  EXPECT_EQ(fmt::format(L"{:%T}", tm), L"11:22:33");
 }
 
 TEST(xchar_test, color) {


### PR DESCRIPTION
Optimization ```%T``` in tm formatting like this: https://github.com/fmtlib/fmt/commit/67cb2dad37c5949d8902ba25e703991eadcc3874

And fix wchar_t tm formatting error:
```
/.../fmt/include/fmt/chrono.h:567:15: error: no match for ‘operator==’ (operand types are ‘fmt::v8::basic_string_view<wchar_t>’ and ‘fmt::v8::string_view {aka fmt::v8::basic_string_view<char>}’)
     if (specs == string_view("%F", 2))
```

Maybe I should add the use of ```write_digit2_separated``` for formats:

- ```%Y-%m-%d```
- ```%H:%M:%S```
- ```%Y-%m-%d %H:%M:%S```
- ```%Y-%m-%dT%H:%M:%S```

?