### PR TITLE
fmt: disable consteval with clang

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -247,7 +247,7 @@
 #endif
 
 #ifndef FMT_CONSTEVAL
-#  if ((FMT_GCC_VERSION >= 1000 || FMT_CLANG_VERSION >= 1101) && \
+#  if ((FMT_GCC_VERSION >= 1000) && \
        __cplusplus > 201703L) ||                                 \
       (defined(__cpp_consteval) &&                               \
        !FMT_MSC_VER)  // consteval is broken in MSVC.


### PR DESCRIPTION
clang (at least appleclang 12.5/13) ICEs when consteval is enabled.

reduced test case: https://bugs.llvm.org/show_bug.cgi?id=51938

