### PR TITLE
changed detection of Intel Compiler Classic to distinguish MS-Windows

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -34,13 +34,13 @@
 
 #ifdef __ICL
 #  define FMT_ICC_VERSION __ICL
-#  define FMT_ICC_ON_WINDOWS 1
+#  define FMT_ICC_POSIX 0
 #elif defined(__INTEL_COMPILER)
 #  define FMT_ICC_VERSION __INTEL_COMPILER
-#  define FMT_ICC_ON_WINDOWS 0
+#  define FMT_ICC_POSIX 1
 #else
 #  define FMT_ICC_VERSION 0
-#  define FMT_ICC_ON_WINDOWS 0
+#  define FMT_ICC_POSIX 1
 #endif
 
 #ifdef __NVCC__

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -32,10 +32,15 @@
 #  define FMT_GCC_PRAGMA(arg)
 #endif
 
-#if defined(__INTEL_COMPILER)
+#ifdef __ICL
+#  define FMT_ICC_VERSION __ICL
+#  define FMT_ICC_ON_WINDOWS 1
+#elif defined(__INTEL_COMPILER)
 #  define FMT_ICC_VERSION __INTEL_COMPILER
+#  define FMT_ICC_ON_WINDOWS 0
 #else
 #  define FMT_ICC_VERSION 0
+#  define FMT_ICC_ON_WINDOWS 0
 #endif
 
 #ifdef __NVCC__

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -34,13 +34,13 @@
 
 #ifdef __ICL
 #  define FMT_ICC_VERSION __ICL
-#  define FMT_ICC_POSIX 0
+#  define FMT_ICC_INTRINSIC_BUG 1
 #elif defined(__INTEL_COMPILER)
 #  define FMT_ICC_VERSION __INTEL_COMPILER
-#  define FMT_ICC_POSIX 1
+#  define FMT_ICC_INTRINSIC_BUG 0
 #else
 #  define FMT_ICC_VERSION 0
-#  define FMT_ICC_POSIX 1
+#  define FMT_ICC_INTRINSIC_BUG 0
 #endif
 
 #ifdef __NVCC__

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -166,12 +166,12 @@ FMT_END_NAMESPACE
 #  define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
 #endif
 #if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_ctz) || FMT_ICC_VERSION) && \
-    FMT_ICC_POSIX
+    !FMT_ICC_INTRINSIC_BUG
 #  define FMT_BUILTIN_CTZ(n) __builtin_ctz(n)
 #endif
 #if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_ctzll) || \
      FMT_ICC_VERSION) &&                                    \
-    FMT_ICC_POSIX
+    !FMT_ICC_INTRINSIC_BUG
 #  define FMT_BUILTIN_CTZLL(n) __builtin_ctzll(n)
 #endif
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -49,14 +49,6 @@
 #  define FMT_GCC_VISIBILITY_HIDDEN
 #endif
 
-#ifdef __INTEL_COMPILER
-#  define FMT_ICC_VERSION __INTEL_COMPILER
-#elif defined(__ICL)
-#  define FMT_ICC_VERSION __ICL
-#else
-#  define FMT_ICC_VERSION 0
-#endif
-
 #ifdef __NVCC__
 #  define FMT_CUDA_VERSION (__CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__)
 #else
@@ -173,10 +165,13 @@ FMT_END_NAMESPACE
     !FMT_MSC_VER
 #  define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
 #endif
-#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_ctz) || FMT_ICC_VERSION)
+#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_ctz) || FMT_ICC_VERSION) && \
+    !FMT_ICC_ON_WINDOWS
 #  define FMT_BUILTIN_CTZ(n) __builtin_ctz(n)
 #endif
-#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_ctzll) || FMT_ICC_VERSION)
+#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_ctzll) || \
+     FMT_ICC_VERSION) &&                                    \
+    !FMT_ICC_ON_WINDOWS
 #  define FMT_BUILTIN_CTZLL(n) __builtin_ctzll(n)
 #endif
 
@@ -192,7 +187,9 @@ FMT_BEGIN_NAMESPACE
 namespace detail {
 // Avoid Clang with Microsoft CodeGen's -Wunknown-pragmas warning.
 #  if !defined(__clang__)
-#    pragma managed(push, off)
+#    if !defined(__ICL)
+#       pragma managed(push, off)
+#    endif
 #    pragma intrinsic(_BitScanForward)
 #    pragma intrinsic(_BitScanReverse)
 #    if defined(_WIN64)
@@ -255,7 +252,9 @@ inline auto ctzll(uint64_t x) -> int {
 }
 #  define FMT_BUILTIN_CTZLL(n) detail::ctzll(n)
 #  if !defined(__clang__)
-#    pragma managed(pop)
+#      if !defined(__ICL)
+#        pragma managed(pop)
+#      endif
 #  endif
 }  // namespace detail
 FMT_END_NAMESPACE

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -166,12 +166,12 @@ FMT_END_NAMESPACE
 #  define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
 #endif
 #if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_ctz) || FMT_ICC_VERSION) && \
-    !FMT_ICC_ON_WINDOWS
+    FMT_ICC_POSIX
 #  define FMT_BUILTIN_CTZ(n) __builtin_ctz(n)
 #endif
 #if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_ctzll) || \
      FMT_ICC_VERSION) &&                                    \
-    !FMT_ICC_ON_WINDOWS
+    FMT_ICC_POSIX
 #  define FMT_BUILTIN_CTZLL(n) __builtin_ctzll(n)
 #endif
 
@@ -187,9 +187,6 @@ FMT_BEGIN_NAMESPACE
 namespace detail {
 // Avoid Clang with Microsoft CodeGen's -Wunknown-pragmas warning.
 #  if !defined(__clang__)
-#    if !defined(__ICL)
-#       pragma managed(push, off)
-#    endif
 #    pragma intrinsic(_BitScanForward)
 #    pragma intrinsic(_BitScanReverse)
 #    if defined(_WIN64)
@@ -251,11 +248,6 @@ inline auto ctzll(uint64_t x) -> int {
   return static_cast<int>(r);
 }
 #  define FMT_BUILTIN_CTZLL(n) detail::ctzll(n)
-#  if !defined(__clang__)
-#      if !defined(__ICL)
-#        pragma managed(pop)
-#      endif
-#  endif
 }  // namespace detail
 FMT_END_NAMESPACE
 #endif


### PR DESCRIPTION
The Intel Compiler Classic on MS-Windows doesn't have the intrinsics "__builtin_ctz" nor "__builtin_ctzll". Instead, it emulates MSVC. Unfortunately, "__has_builtin" works for version 2021, but results in a linker error nonetheless. 
This pull request changes the detection of these intrinsics accordingly.
I also took the liberty to remove it from format.h, because it was already defined in core.h.
The Intel compiler also doesn't know "#pragma managed(push/pop", so I guarded those as well to get rid of the resulting warnings.

Best Regards,
Mathias