### PR TITLE
Misplaced comma in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -469,7 +469,7 @@ Boost Format
 
 This is a very powerful library which supports both ``printf``-like format
 strings and positional arguments. Its main drawback is performance. According to
-various, benchmarks it is much slower than other methods considered here. Boost
+various benchmarks, it is much slower than other methods considered here. Boost
 Format also has excessive build times and severe code bloat issues (see
 `Benchmarks`_).
 


### PR DESCRIPTION
I spotted a small typo while reading the introduction.