### PR TITLE
Include `<bit>` when using `std::bit_cast`

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -41,6 +41,10 @@
 #include <system_error>  // std::system_error
 #include <utility>       // std::swap
 
+#ifdef __cpp_lib_bit_cast
+#include <bit>           // std::bitcast
+#endif
+
 #include "core.h"
 
 #if FMT_GCC_VERSION


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->

Seems like clang14 needs this.