### PR TITLE
Improved performance of `std::tm` formatting

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -86,7 +86,8 @@ FMT_CONSTEXPR To lossless_integral_conversion(const From from, int& ec) {
     }
   }
 
-  if (detail::const_check(!F::is_signed && T::is_signed && F::digits >= T::digits) &&
+  if (detail::const_check(!F::is_signed && T::is_signed &&
+                          F::digits >= T::digits) &&
       from > static_cast<From>(detail::max_value<To>())) {
     ec = 1;
     return {};
@@ -582,13 +583,13 @@ template <typename Char> struct formatter<std::tm, Char> {
       detail::write_digit2_separated(buf + 2, year % 100,
                                      detail::to_unsigned(tm.tm_mon + 1),
                                      detail::to_unsigned(tm.tm_mday), '-');
-      return std::copy_n(buf, sizeof(buf), ctx.out());
+      return detail::copy_str<Char>(std::begin(buf), std::end(buf), ctx.out());
     } else if (spec_ == spec::hh_mm_ss) {
       char buf[8];
       detail::write_digit2_separated(buf, detail::to_unsigned(tm.tm_hour),
                                      detail::to_unsigned(tm.tm_min),
                                      detail::to_unsigned(tm.tm_sec), ':');
-      return std::copy_n(buf, sizeof(buf), ctx.out());
+      return detail::copy_str<Char>(std::begin(buf), std::end(buf), ctx.out());
     }
     basic_memory_buffer<Char> tm_format;
     tm_format.append(specs.begin(), specs.end());
@@ -610,7 +611,7 @@ template <typename Char> struct formatter<std::tm, Char> {
       buf.reserve(buf.capacity() + (size > MIN_GROWTH ? size : MIN_GROWTH));
     }
     // Remove the extra space.
-    return std::copy(buf.begin(), buf.end() - 1, ctx.out());
+    return detail::copy_str<Char>(buf.begin(), buf.end() - 1, ctx.out());
   }
 };
 


### PR DESCRIPTION
Improved performance by removing penalty of copying a char span via abstracted output iterator.

Quick and dirty perf test results (timings in nanoseconds):
<table>
<thead>
  <tr>
    <th rowspan="2"></th>
    <th colspan="2">%Y</th>
    <th colspan="2">%F %T</th>
    <th colspan="2">%Y-%m-%d %H:%M:%S</th>
    <th colspan="2">"%a, %d %b %Y %T %z</th>
  </tr>
  <tr>
    <th>before</th>
    <th>after</th>
    <th>before</th>
    <th>after</th>
    <th>before</th>
    <th>after</th>
    <th>before</th>
    <th>after</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td>fmt_tm</td>
    <td>313</td>
    <td>301</td>
    <td>449</td>
    <td>425</td>
    <td>477</td>
    <td>460</td>
    <td>547</td>
    <td>501</td>
  </tr>
  <tr>
    <td>fmt_tm_compile</td>
    <td>285</td>
    <td>276</td>
    <td>378</td>
    <td>390</td>
    <td>408</td>
    <td>407</td>
    <td>459</td>
    <td>467</td>
  </tr>
</tbody>
</table>

where **fmt_tm** code looks like:
```c++
fmt::format_to(buf, formatString, tm);
```
and **fmt_tm_compile** code looks like:
```c++
fmt::format_to(buf, FMT_COMPILE(formatString), t);
```
Notice that the time does not change for `FMT_COMPILE` case since it does not have that kind of overhead.