### PR TITLE
Extending fmt::join to support C++20-only ranges.

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2749,11 +2749,11 @@ template <typename It, typename Sentinel, typename Char>
 struct formatter<join_view<It, Sentinel, Char>, Char> {
  private:
   using value_type =
-    #ifdef __cpp_lib_ranges
-    std::iter_value_t<It>;
-    #else
-    typename std::iterator_traits<It>::value_type;
-    #endif
+#ifdef __cpp_lib_ranges
+      std::iter_value_t<It>;
+#else
+      typename std::iterator_traits<It>::value_type;
+#endif
   using context = buffer_context<Char>;
   using mapper = detail::arg_mapper<context>;
 

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -258,7 +258,7 @@ struct zstring {
   zstring_sentinel end() const { return {}; }
 };
 
-#ifdef __cpp_lib_ranges
+#  ifdef __cpp_lib_ranges
 struct cpp20_only_range {
   struct iterator {
     int val = 0;
@@ -268,9 +268,12 @@ struct cpp20_only_range {
     using iterator_concept = std::input_iterator_tag;
 
     iterator() = default;
-    iterator(int i) : val(i) { }
+    iterator(int i) : val(i) {}
     int operator*() const { return val; }
-    iterator& operator++() { ++val; return *this; }
+    iterator& operator++() {
+      ++val;
+      return *this;
+    }
     void operator++(int) { ++*this; }
     bool operator==(const iterator& rhs) const { return val == rhs.val; }
   };
@@ -283,7 +286,7 @@ struct cpp20_only_range {
 };
 
 static_assert(std::input_iterator<cpp20_only_range::iterator>);
-#endif
+#  endif
 
 TEST(ranges_test, join_sentinel) {
   auto hello = zstring{"hello"};
@@ -310,10 +313,13 @@ TEST(ranges_test, join_range) {
   const auto z = std::vector<int>(3u, 0);
   EXPECT_EQ(fmt::format("{}", fmt::join(z, ",")), "0,0,0");
 
-  #ifdef __cpp_lib_ranges
-  EXPECT_EQ(fmt::format("{}", cpp20_only_range{.lo=0, .hi=5}), "[0, 1, 2, 3, 4]");
-  EXPECT_EQ(fmt::format("{}", fmt::join(cpp20_only_range{.lo=0, .hi=5}, ",")), "0,1,2,3,4");
-  #endif
+#  ifdef __cpp_lib_ranges
+  EXPECT_EQ(fmt::format("{}", cpp20_only_range{.lo = 0, .hi = 5}),
+            "[0, 1, 2, 3, 4]");
+  EXPECT_EQ(
+      fmt::format("{}", fmt::join(cpp20_only_range{.lo = 0, .hi = 5}, ",")),
+      "0,1,2,3,4");
+#  endif
 }
 #endif  // FMT_RANGES_TEST_ENABLE_JOIN
 


### PR DESCRIPTION
The C++20 Ranges model means that you can have a type which is a C++20 range but not a C++17 range (an example of such is `views::join` on a range of prvalue ranges, or `views::iota` if the underlying type doesn't satisfy `incrementable`). 

We just have to use `std::iter_value_t<It>` instead of going through `std::iterator_traits` directly (bonus, it's shorter, and no `typename`) and we have to not use `*it++` and instead manually do `*it` and then `++it`, since C++20 input iterators are allowed to have `it++` be `void`. 