### PR TITLE
Replacing strftime with std::time_put

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1393,11 +1393,38 @@ struct tm_format_checker : null_chrono_spec_handler<tm_format_checker> {
   FMT_CONSTEXPR void on_tz_name() {}
 };
 
+inline const char* tm_wday_full_name(int wday) {
+  static constexpr const char* full_name_list[] = {
+      "Sunday",   "Monday", "Tuesday", "Wednesday",
+      "Thursday", "Friday", "Saturday"};
+  return wday >= 0 && wday <= 6 ? full_name_list[wday] : "?";
+}
+inline const char* tm_wday_short_name(int wday) {
+  static constexpr const char* short_name_list[] = {"Sun", "Mon", "Tue", "Wed",
+                                                    "Thu", "Fri", "Sat"};
+  return wday >= 0 && wday <= 6 ? short_name_list[wday] : "???";
+}
+
+inline const char* tm_mon_full_name(int mon) {
+  static constexpr const char* full_name_list[] = {
+      "January", "February", "March",     "April",   "May",      "June",
+      "July",    "August",   "September", "October", "November", "December"};
+  return mon >= 0 && mon <= 11 ? full_name_list[mon] : "?";
+}
+inline const char* tm_mon_short_name(int mon) {
+  static constexpr const char* short_name_list[] = {
+      "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+  };
+  return mon >= 0 && mon <= 11 ? short_name_list[mon] : "???";
+}
+
 template <typename OutputIt, typename Char> class tm_writer {
  private:
   static constexpr int days_per_week = 7;
 
   const std::locale& loc_;
+  const bool is_classic_;
   OutputIt out_;
   const std::tm& tm_;
 
@@ -1514,7 +1541,10 @@ template <typename OutputIt, typename Char> class tm_writer {
 
  public:
   explicit tm_writer(const std::locale& loc, OutputIt out, const std::tm& tm)
-      : loc_(loc), out_(out), tm_(tm) {}
+      : loc_(loc),
+        is_classic_(loc_ == std::locale::classic()),
+        out_(out),
+        tm_(tm) {}
 
   OutputIt out() const { return out_; }
 
@@ -1522,8 +1552,18 @@ template <typename OutputIt, typename Char> class tm_writer {
     out_ = copy_str<Char>(begin, end, out_);
   }
 
-  void on_abbr_weekday() { format_localized('a'); }
-  void on_full_weekday() { format_localized('A'); }
+  void on_abbr_weekday() {
+    if (is_classic_)
+      out_ = write(out_, tm_wday_short_name(tm_wday()));
+    else
+      format_localized('a');
+  }
+  void on_full_weekday() {
+    if (is_classic_)
+      out_ = write(out_, tm_wday_full_name(tm_wday()));
+    else
+      format_localized('A');
+  }
   void on_dec0_weekday(numeric_system ns) {
     if (ns != numeric_system::standard) return format_localized('w', 'O');
     write1(tm_wday());
@@ -1534,17 +1574,51 @@ template <typename OutputIt, typename Char> class tm_writer {
     write1(wday == 0 ? days_per_week : wday);
   }
 
-  void on_abbr_month() { format_localized('b'); }
-  void on_full_month() { format_localized('B'); }
+  void on_abbr_month() {
+    if (is_classic_)
+      out_ = write(out_, tm_mon_short_name(tm_mon()));
+    else
+      format_localized('b');
+  }
+  void on_full_month() {
+    if (is_classic_)
+      out_ = write(out_, tm_mon_full_name(tm_mon()));
+    else
+      format_localized('B');
+  }
 
   void on_datetime(numeric_system ns) {
-    format_localized('c', ns == numeric_system::standard ? '\0' : 'E');
+    if (is_classic_) {
+#ifdef _WIN32
+      on_us_date();
+      *out_++ = ' ';
+      on_iso_time();
+#else
+      on_abbr_weekday();
+      *out_++ = ' ';
+      on_abbr_month();
+      *out_++ = ' ';
+      on_day_of_month_space(numeric_system::standard);
+      *out_++ = ' ';
+      on_iso_time();
+      *out_++ = ' ';
+      on_year(numeric_system::standard);
+#endif
+    } else {
+      format_localized('c', ns == numeric_system::standard ? '\0' : 'E');
+    }
   }
   void on_loc_date(numeric_system ns) {
-    format_localized('x', ns == numeric_system::standard ? '\0' : 'E');
+    if (is_classic_)
+      on_us_date();
+    else
+      format_localized('x', ns == numeric_system::standard ? '\0' : 'E');
   }
   void on_loc_time(numeric_system ns) {
-    format_localized('X', ns == numeric_system::standard ? '\0' : 'E');
+    if (is_classic_)
+      on_iso_time();
+    else
+      format_localized('X', ns == numeric_system::standard ? '\0' : 'E');
   }
   void on_us_date() {
     char buf[8];
@@ -1658,7 +1732,22 @@ template <typename OutputIt, typename Char> class tm_writer {
     write2(tm_sec());
   }
 
-  void on_12_hour_time() { format_localized('r'); }
+  void on_12_hour_time() {
+    if (is_classic_) {
+#ifdef _WIN32
+      on_iso_time();
+#else
+      char buf[8];
+      write_digit2_separated(buf, to_unsigned(tm_hour12()),
+                             to_unsigned(tm_min()), to_unsigned(tm_sec()), ':');
+      out_ = copy_str<Char>(std::begin(buf), std::end(buf), out_);
+      *out_++ = ' ';
+      on_am_pm();
+#endif
+    } else {
+      format_localized('r');
+    }
+  }
   void on_24_hour_time() {
     write2(tm_hour());
     *out_++ = ':';
@@ -1671,7 +1760,14 @@ template <typename OutputIt, typename Char> class tm_writer {
     out_ = copy_str<Char>(std::begin(buf), std::end(buf), out_);
   }
 
-  void on_am_pm() { format_localized('p'); }
+  void on_am_pm() {
+    if (is_classic_) {
+      *out_++ = tm_hour() < 12 ? 'A' : 'P';
+      *out_++ = 'M';
+    } else {
+      format_localized('p');
+    }
+  }
 
   // These apply to chrono durations but not tm.
   void on_duration_value() {}

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1459,8 +1459,9 @@ template <typename OutputIt, typename Char> class tm_writer {
   }
 
   auto tm_hour12() const noexcept -> int {
-    auto hour = tm_hour() % 12;
-    return hour == 0 ? 12 : hour;
+    const auto h = tm_hour();
+    const auto z = h < 12 ? h : h - 12;
+    return z == 0 ? 12 : z;
   }
 
   // POSIX and the C Standard are unclear or inconsistent about what %C and %y

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1744,7 +1744,9 @@ template <typename Char> struct formatter<std::tm, Char> {
   template <typename FormatContext>
   auto format(const std::tm& tm, FormatContext& ctx) const
       -> decltype(ctx.out()) {
-    const auto& loc = std::locale::classic();
+    const auto& loc_ref = ctx.locale();
+    const auto& loc =
+        loc_ref ? loc_ref.template get<std::locale>() : std::locale::classic();
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), tm);
     if (spec_ == spec::year_month_day)
       w.on_iso_date();

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1590,11 +1590,6 @@ template <typename OutputIt, typename Char> class tm_writer {
 
   void on_datetime(numeric_system ns) {
     if (is_classic_) {
-#ifdef _WIN32
-      on_us_date();
-      *out_++ = ' ';
-      on_iso_time();
-#else
       on_abbr_weekday();
       *out_++ = ' ';
       on_abbr_month();
@@ -1604,7 +1599,6 @@ template <typename OutputIt, typename Char> class tm_writer {
       on_iso_time();
       *out_++ = ' ';
       on_year(numeric_system::standard);
-#endif
     } else {
       format_localized('c', ns == numeric_system::standard ? '\0' : 'E');
     }
@@ -1735,16 +1729,12 @@ template <typename OutputIt, typename Char> class tm_writer {
 
   void on_12_hour_time() {
     if (is_classic_) {
-#ifdef _WIN32
-      on_iso_time();
-#else
       char buf[8];
       write_digit2_separated(buf, to_unsigned(tm_hour12()),
                              to_unsigned(tm_min()), to_unsigned(tm_sec()), ':');
       out_ = copy_str<Char>(std::begin(buf), std::end(buf), out_);
       *out_++ = ' ';
       on_am_pm();
-#endif
     } else {
       format_localized('r');
     }

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -536,10 +536,18 @@ TEST(chrono_test, weekday) {
   auto loc = get_locale("ru_RU.UTF-8");
   std::locale::global(loc);
   auto mon = fmt::weekday(1);
+
+  auto tm = std::tm();
+  tm.tm_wday = static_cast<int>(mon.c_encoding());
+
   EXPECT_EQ(fmt::format("{}", mon), "Mon");
+  EXPECT_EQ(fmt::format("{:%a}", tm), "Mon");
+
   if (loc != std::locale::classic()) {
     EXPECT_THAT((std::vector<std::string>{"пн", "Пн", "пнд", "Пнд"}),
                 Contains(fmt::format(loc, "{:L}", mon)));
+    EXPECT_THAT((std::vector<std::string>{"пн", "Пн", "пнд", "Пнд"}),
+                Contains(fmt::format(loc, "{:%a}", tm)));
   }
 }
 

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -42,11 +42,14 @@ auto make_second(int s) -> std::tm {
 }
 
 std::string system_strftime(const std::string& format, const std::tm* timeptr,
-                            size_t maxsize = 1024) {
-  std::vector<char> output(maxsize);
-  auto size =
-      std::strftime(output.data(), output.size(), format.c_str(), timeptr);
-  return std::string(output.data(), size);
+                            std::locale* locptr = nullptr) {
+  auto loc = locptr ? *locptr : std::locale::classic();
+  auto& facet = std::use_facet<std::time_put<char>>(loc);
+  std::ostringstream os;
+  os.imbue(loc);
+  facet.put(os, os, ' ', timeptr, format.c_str(),
+            format.c_str() + format.size());
+  return os.str();
 }
 
 FMT_CONSTEXPR std::tm make_tm(int year, int mon, int mday, int hour, int min,

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -248,13 +248,19 @@ TEST(chrono_test, time_point) {
   EXPECT_EQ(strftime_full(t2), fmt::format("{:%Y-%m-%d %H:%M:%S}", t2));
 
   std::vector<std::string> spec_list = {
-      "%%",  "%n",  "%t",  "%Y",  "%EY", "%y",  "%Oy", "%Ey", "%C",  "%EC",
-      "%G",  "%g",  "%b",  "%h",  "%B",  "%m",  "%Om", "%U",  "%OU", "%W",
-      "%OW", "%V",  "%OV", "%j",  "%d",  "%Od", "%e",  "%Oe", "%a",  "%A",
-      "%w",  "%Ow", "%u",  "%Ou", "%H",  "%OH", "%I",  "%OI", "%M",  "%OM",
-      "%S",  "%OS", "%c",  "%Ec", "%x",  "%Ex", "%X",  "%EX", "%D",  "%F",
-      "%r",  "%R",  "%T",  "%p",  "%z",  "%Z"};
+      "%%",  "%n",  "%t",  "%Y",  "%EY", "%y",  "%Oy", "%Ey", "%C",
+      "%EC", "%G",  "%g",  "%b",  "%h",  "%B",  "%m",  "%Om", "%U",
+      "%OU", "%W",  "%OW", "%V",  "%OV", "%j",  "%d",  "%Od", "%e",
+      "%Oe", "%a",  "%A",  "%w",  "%Ow", "%u",  "%Ou", "%H",  "%OH",
+      "%I",  "%OI", "%M",  "%OM", "%S",  "%OS", "%x",  "%Ex", "%X",
+      "%EX", "%D",  "%F",  "%R",  "%T",  "%p",  "%z",  "%Z"};
   spec_list.push_back("%Y-%m-%d %H:%M:%S");
+#ifndef _WIN32
+  // Disabled on Windows, because these formats is not consistent among
+  // platforms.
+  spec_list.insert(spec_list.end(), {"%c", "%Ec", "%r"});
+#endif
+
   for (const auto& spec : spec_list) {
     auto t = std::chrono::system_clock::to_time_t(t1);
     auto tm = *std::localtime(&t);

--- a/test/unicode-test.cc
+++ b/test/unicode-test.cc
@@ -18,7 +18,7 @@ using testing::Contains;
 TEST(unicode_test, is_utf8) { EXPECT_TRUE(fmt::detail::is_utf8()); }
 
 TEST(unicode_test, legacy_locale) {
-  auto loc = get_locale("ru_RU.CP1251", "Russian.1251");
+  auto loc = get_locale("ru_RU.CP1251", "Russian_Russia.1251");
   if (loc == std::locale::classic()) return;
 
   auto s = std::string();

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -15,9 +15,11 @@
 #include "fmt/color.h"
 #include "fmt/ostream.h"
 #include "fmt/ranges.h"
-#include "gtest/gtest.h"
+#include "gtest-extra.h"  // Contains
+#include "util.h"         // get_locale
 
 using fmt::detail::max_value;
+using testing::Contains;
 
 namespace test_ns {
 template <typename Char> class test_string {
@@ -464,6 +466,22 @@ TEST(locale_test, complex) {
   EXPECT_EQ(s, "(1+2i)");
   EXPECT_EQ(fmt::format("{:.2f}", std::complex<double>(1, 2)), "(1.00+2.00i)");
   EXPECT_EQ(fmt::format("{:8}", std::complex<double>(1, 2)), "  (1+2i)");
+}
+
+TEST(locale_test, chrono_weekday) {
+  auto loc = get_locale("ru_RU.UTF-8", "Russian_Russia.1251");
+  auto loc_old = std::locale::global(loc);
+  auto mon = fmt::weekday(1);
+  EXPECT_EQ(fmt::format(L"{}", mon), L"Mon");
+  if (loc != std::locale::classic()) {
+    // {L"\x43F\x43D", L"\x41F\x43D", L"\x43F\x43D\x434", L"\x41F\x43D\x434"}
+    // {L"пн", L"Пн", L"пнд", L"Пнд"}
+    EXPECT_THAT(
+        (std::vector<std::wstring>{L"\x43F\x43D", L"\x41F\x43D",
+                                   L"\x43F\x43D\x434", L"\x41F\x43D\x434"}),
+        Contains(fmt::format(loc, L"{:L}", mon)));
+  }
+  std::locale::global(loc_old);
 }
 
 #endif  // FMT_STATIC_THOUSANDS_SEPARATOR

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -284,14 +284,19 @@ TEST(chrono_test, time_point) {
   auto t1 = std::chrono::system_clock::now();
 
   std::vector<std::wstring> spec_list = {
-      L"%%",  L"%n",  L"%t",  L"%Y",  L"%EY", L"%y",  L"%Oy", L"%Ey",
-      L"%C",  L"%EC", L"%G",  L"%g",  L"%b",  L"%h",  L"%B",  L"%m",
-      L"%Om", L"%U",  L"%OU", L"%W",  L"%OW", L"%V",  L"%OV", L"%j",
-      L"%d",  L"%Od", L"%e",  L"%Oe", L"%a",  L"%A",  L"%w",  L"%Ow",
-      L"%u",  L"%Ou", L"%H",  L"%OH", L"%I",  L"%OI", L"%M",  L"%OM",
-      L"%S",  L"%OS", L"%c",  L"%Ec", L"%x",  L"%Ex", L"%X",  L"%EX",
-      L"%D",  L"%F",  L"%r",  L"%R",  L"%T",  L"%p",  L"%z",  L"%Z"};
+      L"%%",  L"%n",  L"%t",  L"%Y",  L"%EY", L"%y",  L"%Oy", L"%Ey", L"%C",
+      L"%EC", L"%G",  L"%g",  L"%b",  L"%h",  L"%B",  L"%m",  L"%Om", L"%U",
+      L"%OU", L"%W",  L"%OW", L"%V",  L"%OV", L"%j",  L"%d",  L"%Od", L"%e",
+      L"%Oe", L"%a",  L"%A",  L"%w",  L"%Ow", L"%u",  L"%Ou", L"%H",  L"%OH",
+      L"%I",  L"%OI", L"%M",  L"%OM", L"%S",  L"%OS", L"%x",  L"%Ex", L"%X",
+      L"%EX", L"%D",  L"%F",  L"%R",  L"%T",  L"%p",  L"%z",  L"%Z"};
   spec_list.push_back(L"%Y-%m-%d %H:%M:%S");
+#ifndef _WIN32
+  // Disabled on Windows, because these formats is not consistent among
+  // platforms.
+  spec_list.insert(spec_list.end(), {L"%c", L"%Ec", L"%r"});
+#endif
+
   for (const auto& spec : spec_list) {
     auto t = std::chrono::system_clock::to_time_t(t1);
     auto tm = *std::localtime(&t);

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -270,11 +270,14 @@ TEST(xchar_test, chrono) {
 }
 
 std::wstring system_wcsftime(const std::wstring& format, const std::tm* timeptr,
-                             size_t maxsize = 1024) {
-  std::vector<wchar_t> output(maxsize);
-  auto size =
-      std::wcsftime(output.data(), output.size(), format.c_str(), timeptr);
-  return std::wstring(output.data(), size);
+                             std::locale* locptr = nullptr) {
+  auto loc = locptr ? *locptr : std::locale::classic();
+  auto& facet = std::use_facet<std::time_put<wchar_t>>(loc);
+  std::wostringstream os;
+  os.imbue(loc);
+  facet.put(os, os, L' ', timeptr, format.c_str(),
+            format.c_str() + format.size());
+  return os.str();
 }
 
 TEST(chrono_test, time_point) {


### PR DESCRIPTION
Continuation of PR #2544.

~~Draft, because I haven't yet tested the PR in all my environments.~~

@vitaut, what do you think about using the built-in month and weekday names in the case of the ``std::locale::classic()`` locale (without ``std::time_put`` calls)?