### PR TITLE
Speed up C string formatting

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1112,8 +1112,8 @@ enum class type {
 
 template <typename Char> struct basic_c_string_view : basic_string_view<Char> {
   using basic_string_view<Char>::basic_string_view;
-  FMT_CONSTEXPR basic_c_string_view() = default;
-  FMT_CONSTEXPR basic_c_string_view(const Char* val)
+  constexpr basic_c_string_view() = default;
+  FMT_CONSTEXPR_CHAR_TRAITS basic_c_string_view(const Char* val)
       : basic_string_view<Char>{
             val, val ? std::char_traits<Char>::length(val) : 0} {}
 };

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -2558,7 +2558,8 @@ FMT_FUNC void format_system_error(detail::buffer<char>& out, int error_code,
                                   const char* message) FMT_NOEXCEPT {
   FMT_TRY {
     auto ec = std::error_code(error_code, std::generic_category());
-    write(std::back_inserter(out), std::system_error(ec, message).what());
+    write(std::back_inserter(out), detail::basic_c_string_view<char>{
+                                       std::system_error(ec, message).what()});
     return;
   }
   FMT_CATCH(...) {}

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -42,7 +42,7 @@
 #include <utility>       // std::swap
 
 #ifdef __cpp_lib_bit_cast
-#include <bit>           // std::bitcast
+#  include <bit>  // std::bitcast
 #endif
 
 #include "core.h"
@@ -1720,7 +1720,7 @@ inline auto write_significand(Char* out, UInt significand, int significand_size,
   out += significand_size + 1;
   Char* end = out;
   int floating_size = significand_size - integral_size;
-  for(int i = floating_size / 2; i > 0; --i) {
+  for (int i = floating_size / 2; i > 0; --i) {
     out -= 2;
     copy2(out, digits2(significand % 100));
     significand /= 100;

--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -414,9 +414,11 @@ TEST(arg_test, string_arg) {
   char str_data[] = "test";
   char* str = str_data;
   const char* cstr = str;
-  CHECK_ARG(char, cstr, str);
+  CHECK_ARG(char, fmt::detail::basic_c_string_view<char>{str}, str);
+  CHECK_ARG(char, fmt::detail::basic_c_string_view<char>{str}, cstr);
 
   auto sv = fmt::string_view(str);
+  CHECK_ARG(char, sv, sv);
   CHECK_ARG(char, sv, std::string(str));
 }
 
@@ -424,10 +426,10 @@ TEST(arg_test, wstring_arg) {
   wchar_t str_data[] = L"test";
   wchar_t* str = str_data;
   const wchar_t* cstr = str;
+  CHECK_ARG(wchar_t, fmt::detail::basic_c_string_view<wchar_t>{str}, str);
+  CHECK_ARG(wchar_t, fmt::detail::basic_c_string_view<wchar_t>{str}, cstr);
 
   auto sv = fmt::basic_string_view<wchar_t>(str);
-  CHECK_ARG(wchar_t, cstr, str);
-  CHECK_ARG(wchar_t, cstr, cstr);
   CHECK_ARG(wchar_t, sv, std::wstring(str));
   CHECK_ARG(wchar_t, sv, fmt::basic_string_view<wchar_t>(str));
 }


### PR DESCRIPTION
Currently length calculation of C strings happens after type erasure where the compiler most probably have already lost information about where the pointer comes from.

If we calculate length before type erasure happens, we give the compiler an opportunity to apply `strlen` elision optimization.

To make it very obvious, I tested it with very long string.
<details>
<summary>test code</summary>

```c++
const char text[] = "this is a test string this is a test string this is a test string this is a test string this is a test string "
"this is a test string this is a test string this is a test string this is a test string this is a test string "
"this is a test string this is a test string this is a test string this is a test string this is a test string "
"this is a test string this is a test string this is a test string this is a test string this is a test string "
"this is a test string this is a test string this is a test string this is a test string this is a test string";

static void c_string(benchmark::State &state) {
  char buf[1000] = {};
  for (auto _ : state) {
    fmt::format_to(buf, "{}", text);
    benchmark::DoNotOptimize(buf);
  }
}
BENCHMARK(c_string);

static void c_string_compile(benchmark::State &state) {
  char buf[1000] = {};
  for (auto _ : state) {
    fmt::format_to(buf, FMT_COMPILE("{}"), text);
    benchmark::DoNotOptimize(buf);
  }
}
BENCHMARK(c_string_compile);

static void string_view(benchmark::State &state) {
  char buf[1000] = {};
  const auto s = std::string_view{ text };
  for (auto _ : state) {
    fmt::format_to(buf, "{}", s);
    benchmark::DoNotOptimize(buf);
  }
}
BENCHMARK(string_view);

static void string_view_compile(benchmark::State &state) {
  char buf[1000] = {};
  const auto s = std::string_view{ text };
  for (auto _ : state) {
    fmt::format_to(buf, FMT_COMPILE("{}"), s);
    benchmark::DoNotOptimize(buf);
  }
}
BENCHMARK(string_view_compile);
```

</details>
Test results:

<table>
<thead>
  <tr>
    <th rowspan="2"></th>
    <th colspan="2">before</th>
    <th colspan="2">after</th>
  </tr>
  <tr>
    <th>MSVC</th>
    <th>Clang</th>
    <th>MSVC</th>
    <th>Clang</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td>c_string</td>
    <td>223</td>
    <td>71.7</td>
    <td>24.8</td>
    <td>21.9</td>
  </tr>
  <tr>
    <td>c_string_compile</td>
    <td>11.2</td>
    <td>10.9</td>
    <td>10.8</td>
    <td>11.5</td>
  </tr>
  <tr>
    <td>string_view</td>
    <td>27</td>
    <td>20.6</td>
    <td>25.3</td>
    <td>19.2</td>
  </tr>
  <tr>
    <td>string_view_compile</td>
    <td>10.4</td>
    <td>10.6</td>
    <td>10.7</td>
    <td>11.5</td>
  </tr>
</tbody>
</table>

With these changes both MSVC and Clang are able to apply `strlen` elision optimization in the first case of "runtime" formatting of C string (row "c_string").

I tried to make minimal changes to make it work.\
These changes seem to work and pass all unit tests, though they are a bit janky to my taste. I believe they can be made better depending on what parts are allowed to be modified, see comments in code.

