### PR TITLE
Make std::chrono::duration formatting more similar to C++20 standard

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -955,8 +955,8 @@ template <class Duration> struct subsecond_helper {
   template <class Rep, class Period>
   static FMT_CONSTEXPR std::chrono::duration<Rep, Period> abs(
       std::chrono::duration<Rep, Period> d) {
-    if FMT_CONSTEXPR (std::chrono::duration<Rep, Period>::min() <
-                      std::chrono::duration<Rep, Period>::zero()) {
+    if (std::chrono::duration<Rep, Period>::min() <
+        std::chrono::duration<Rep, Period>::zero()) {
       return d >= d.zero() ? d : -d;
     } else {
       return d;
@@ -971,8 +971,7 @@ template <class Duration> struct subsecond_helper {
   template <class Rep, class Period>
   static FMT_CONSTEXPR precision
   get_subseconds(std::chrono::duration<Rep, Period> d) {
-    if FMT_CONSTEXPR (std::chrono::treat_as_floating_point<
-                          typename precision::rep>::value) {
+    if (std::chrono::treat_as_floating_point<typename precision::rep>::value) {
       return abs(d) - std::chrono::duration_cast<std::chrono::seconds>(d);
     } else {
       return std::chrono::duration_cast<precision>(

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -536,18 +536,18 @@ TEST(chrono_test, weekday) {
 TEST(chrono_test, cpp20_duration_subsecond_support) {
   using attoseconds = std::chrono::duration<std::intmax_t, std::atto>;
   // Check that 18 digits of subsecond precision are supported
-  EXPECT_EQ(fmt::format("{:%S}", attoseconds{673'231'113'420'148'734}),
+  EXPECT_EQ(fmt::format("{:%S}", attoseconds{673231113420148734}),
             "00.673231113420148734");
-  EXPECT_EQ(fmt::format("{:%S}", attoseconds{-673'231'113'420'148'734}),
+  EXPECT_EQ(fmt::format("{:%S}", attoseconds{-673231113420148734}),
             "-00.673231113420148734");
-  EXPECT_EQ(fmt::format("{:%S}", std::chrono::nanoseconds{13'420'148'734}),
+  EXPECT_EQ(fmt::format("{:%S}", std::chrono::nanoseconds{13420148734}),
             "13.420148734");
-  EXPECT_EQ(fmt::format("{:%S}", std::chrono::nanoseconds{-13'420'148'734}),
+  EXPECT_EQ(fmt::format("{:%S}", std::chrono::nanoseconds{-13420148734}),
             "-13.420148734");
   EXPECT_EQ(fmt::format("{:%S}", std::chrono::milliseconds{1234}), "01.234");
   {
     // Check that {:%H:%M:%S} is equivalent to {:%T}
-    auto dur = std::chrono::milliseconds{3'601'234};
+    auto dur = std::chrono::milliseconds{3601234};
     auto formatted_dur = fmt::format("{:%T}", dur);
     EXPECT_EQ(formatted_dur, "01:00:01.234");
     EXPECT_EQ(fmt::format("{:%H:%M:%S}", dur), formatted_dur);
@@ -568,6 +568,6 @@ TEST(chrono_test, cpp20_duration_subsecond_support) {
   }
   // Check that durations with precision greater than std::chrono::seconds
   // with no subsecond part print as regular seconds
-  EXPECT_EQ(fmt::format("{:%S}", std::chrono::microseconds{7'000'000}), "07");
+  EXPECT_EQ(fmt::format("{:%S}", std::chrono::microseconds{7000000}), "07");
 }
 #endif  // FMT_STATIC_THOUSANDS_SEPARATOR

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -499,9 +499,6 @@ TEST(chrono_test, negative_durations) {
 }
 
 TEST(chrono_test, special_durations) {
-  EXPECT_EQ(
-      "40",
-      fmt::format("{:%S}", std::chrono::duration<double>(1e20)).substr(0, 3));
   auto nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_EQ(
       "nan nan nan nan nan:nan nan",


### PR DESCRIPTION
Hello,

Currently std::chrono::duration with the `%S` and `%T` specifiers is not printed according to the spec. This issue was addressed but later dropped in #2207. Many commits have appeared since then so I have tried to implement a new approach.

> Writes the second as a decimal number. If the number of seconds is less than 10, the result is prefixed with 0.
> If the precision of the input cannot be exactly represented with seconds, then the format is a decimal floating-point number with a fixed format and a precision matching that of the precision of the input (or to a microseconds precision if the conversion to floating-point decimal seconds cannot be made within 18 fractional digits). The character for the decimal point is localized according to the locale.

Now, the `%S` specifier only prints with millisecond precision. I have implemented the subsecond extractor,[ inspired by the MSVC STL implementation of std::format for the hh_mm_ss class](https://github.com/microsoft/STL/blob/main/stl/inc/chrono#L2158). Please see the new unit tests.

Further comments:

1. The decimal point is not formatted according to the locale
2. The `%T` specifier now behaves according to the C++20 standard and should be equivalent to `%H:%M:%S`
3. Possible but highly unlikely overflow in the `subsecond_helper` functions. Not sure if `fmt_safe_duration_cast` is required and more analysis might be needed.
4. Floating point subseconds are truncated by casting to `std::chrono::duration::period` to `std::uintmax_t`, this behavior is probably acceptable according to the spec as it only requires the value to be as precise as the the `std::ratio` in `std::chrono::duration::period` . The MSVC implementation uses `std::floor`

Comments and suggestions are welcome.

Thanks
