### PR TITLE
Do not detect LLVM based IBMXL compiler (on ppc) as clang

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -18,7 +18,7 @@
 // The fmt library version in the form major * 10000 + minor * 100 + patch.
 #define FMT_VERSION 80001
 
-#ifdef __clang__
+#if defined (__clang__ ) && !defined(__ibmxl__)
 #  define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
 #else
 #  define FMT_CLANG_VERSION 0


### PR DESCRIPTION
This change avoids compilation problems on IBM PowerPC based Linux boxes using IBM's "native" compilers which are LLVM based but not fully clang compatible.
