### PR TITLE
Simplify js tag in basic-bootstrap theme

### DIFF
--- a/doc/basic-bootstrap/layout.html
+++ b/doc/basic-bootstrap/layout.html
@@ -97,7 +97,7 @@
       };
     </script>
     {%- for scriptfile in script_files %}
-    <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
+    {{ js_tag(scriptfile) }}
     {%- endfor %}
 {%- endmacro %}
 


### PR DESCRIPTION
When build the docs for debian package, it uses a sphinx building
helper, which does a sanity check for the output.

The sanity check complains missing data-url_root attribute in the
js tag. So this patch changes the js tag to use the same function like
the origin basic theme, which adds additional information like
data-url_root.

Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=997437