### PR TITLE
Cleanup warnings with nvhpc/21.9.

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -279,7 +279,7 @@
 
 // Enable minimal optimizations for more compact code in debug mode.
 FMT_GCC_PRAGMA("GCC push_options")
-#ifndef __OPTIMIZE__
+#if !defined(__OPTIMIZE__) && !defined(__NVCOMPILER)
 FMT_GCC_PRAGMA("GCC optimize(\"Og\")")
 #endif
 

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -18,16 +18,31 @@
 // The fmt library version in the form major * 10000 + minor * 100 + patch.
 #define FMT_VERSION 80001
 
+#if defined(__NVCOMPILER)
+#  define FMT_NVHPC_VERSION                                      \
+    (__NVCOMPILER_MAJOR__ * 10000 + __NVCOMPILER_MINOR__ * 100 + \
+     __NVCOMPILER_PATCHLEVEL__)
+#else
+#  define FMT_NVHPC_VERSION 0
+#endif
+
 #if defined (__clang__ ) && !defined(__ibmxl__)
 #  define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
 #else
 #  define FMT_CLANG_VERSION 0
 #endif
 
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && !defined(__NVCOMPILER)
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && \
+    !defined(__NVCOMPILER)
 #  define FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #else
 #  define FMT_GCC_VERSION 0
+#endif
+
+#if FMT_NVHPC_VERSION > 0
+#  define FMT_NVHPC_PRAGMA(arg) _Pragma(arg)
+#else
+#  define FMT_NVHPC_PRAGMA(arg)
 #endif
 
 #ifndef FMT_GCC_PRAGMA

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -24,7 +24,7 @@
 #  define FMT_CLANG_VERSION 0
 #endif
 
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && !defined(__NVCOMPILER)
 #  define FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #else
 #  define FMT_GCC_VERSION 0
@@ -279,7 +279,7 @@
 
 // Enable minimal optimizations for more compact code in debug mode.
 FMT_GCC_PRAGMA("GCC push_options")
-#if !defined(__OPTIMIZE__) && !defined(__NVCOMPILER)
+#ifndef __OPTIMIZE__
 FMT_GCC_PRAGMA("GCC optimize(\"Og\")")
 #endif
 

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -18,14 +18,6 @@
 // The fmt library version in the form major * 10000 + minor * 100 + patch.
 #define FMT_VERSION 80001
 
-#if defined(__NVCOMPILER)
-#  define FMT_NVHPC_VERSION                                      \
-    (__NVCOMPILER_MAJOR__ * 10000 + __NVCOMPILER_MINOR__ * 100 + \
-     __NVCOMPILER_PATCHLEVEL__)
-#else
-#  define FMT_NVHPC_VERSION 0
-#endif
-
 #if defined (__clang__ ) && !defined(__ibmxl__)
 #  define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
 #else
@@ -37,12 +29,6 @@
 #  define FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #else
 #  define FMT_GCC_VERSION 0
-#endif
-
-#if FMT_NVHPC_VERSION > 0
-#  define FMT_NVHPC_PRAGMA(arg) _Pragma(arg)
-#else
-#  define FMT_NVHPC_PRAGMA(arg)
 #endif
 
 #ifndef FMT_GCC_PRAGMA

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -967,17 +967,16 @@ FMT_CONSTEXPR20 inline auto count_digits(uint64_t n) -> int {
 template <int BITS, typename UInt>
 FMT_CONSTEXPR auto count_digits(UInt n) -> int {
 #ifdef FMT_BUILTIN_CLZ
-  if (num_bits<UInt>() == 32) {
+  if (num_bits<UInt>() == 32)
     return (FMT_BUILTIN_CLZ(static_cast<uint32_t>(n) | 1) ^ 31) / BITS + 1;
-  } else
 #endif
-  {
-    int num_digits = 0;
-    do {
-      ++num_digits;
-    } while ((n >>= BITS) != 0);
-    return num_digits;
-  }
+  FMT_NVHPC_PRAGMA("diag_suppress initialization_not_reachable")
+  int num_digits = 0;
+  FMT_NVHPC_PRAGMA("diag_default initialization_not_reachable")
+  do {
+    ++num_digits;
+  } while ((n >>= BITS) != 0);
+  return num_digits;
 }
 
 template <> auto count_digits<4>(detail::fallback_uintptr n) -> int;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -970,13 +970,14 @@ FMT_CONSTEXPR auto count_digits(UInt n) -> int {
   if (num_bits<UInt>() == 32)
     return (FMT_BUILTIN_CLZ(static_cast<uint32_t>(n) | 1) ^ 31) / BITS + 1;
 #endif
-  FMT_NVHPC_PRAGMA("diag_suppress initialization_not_reachable")
-  int num_digits = 0;
-  FMT_NVHPC_PRAGMA("diag_default initialization_not_reachable")
-  do {
-    ++num_digits;
-  } while ((n >>= BITS) != 0);
-  return num_digits;
+  // Lambda avoids unreachable code warnings from NVHPC.
+  return [](UInt n) {
+    int num_digits = 0;
+    do {
+      ++num_digits;
+    } while ((n >>= BITS) != 0);
+    return num_digits;
+  }(n);
 }
 
 template <> auto count_digits<4>(detail::fallback_uintptr n) -> int;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -967,14 +967,17 @@ FMT_CONSTEXPR20 inline auto count_digits(uint64_t n) -> int {
 template <int BITS, typename UInt>
 FMT_CONSTEXPR auto count_digits(UInt n) -> int {
 #ifdef FMT_BUILTIN_CLZ
-  if (num_bits<UInt>() == 32)
+  if (num_bits<UInt>() == 32) {
     return (FMT_BUILTIN_CLZ(static_cast<uint32_t>(n) | 1) ^ 31) / BITS + 1;
+  } else
 #endif
-  int num_digits = 0;
-  do {
-    ++num_digits;
-  } while ((n >>= BITS) != 0);
-  return num_digits;
+  {
+    int num_digits = 0;
+    do {
+      ++num_digits;
+    } while ((n >>= BITS) != 0);
+    return num_digits;
+  }
 }
 
 template <> auto count_digits<4>(detail::fallback_uintptr n) -> int;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -971,11 +971,11 @@ FMT_CONSTEXPR auto count_digits(UInt n) -> int {
     return (FMT_BUILTIN_CLZ(static_cast<uint32_t>(n) | 1) ^ 31) / BITS + 1;
 #endif
   // Lambda avoids unreachable code warnings from NVHPC.
-  return [](UInt n) {
+  return [](UInt m) {
     int num_digits = 0;
     do {
       ++num_digits;
-    } while ((n >>= BITS) != 0);
+    } while ((m >>= BITS) != 0);
     return num_digits;
   }(n);
 }


### PR DESCRIPTION
This squashes a couple of warnings when building fmt 8.0.1 with version 21.9 of the NVIDIA HPC compiler.

```
"{path}/fmt/include/fmt/core.h", line 313: warning #1676-D: unrecognized GCC pragma
  FMT_GCC_PRAGMA("GCC optimize(\"Og\")")
  ^

"{path}/fmt/include/fmt/format.h", line 948: warning #185-D: dynamic initialization in unreachable code
    int num_digits = 0;
        ^
          detected during:
            instantiation of "auto fmt::v8::detail::count_digits<BITS,UInt>(UInt)->int [with BITS=4, UInt=uint32_t]" at line 1499
            instantiation of "auto fmt::v8::detail::write_int(OutputIt, fmt::v8::detail::write_int_arg<T>, const fmt::v8::basic_format_specs<Char> &, fmt::v8::detail::locale_ref)->OutputIt [with Char=char
, OutputIt=fmt::v8::detail::buffer_appender<char>, T=uint32_t]" at line 1540
            instantiation of "auto fmt::v8::detail::write(OutputIt, T, const fmt::v8::basic_format_specs<Char> &, fmt::v8::detail::locale_ref)->OutputIt [with Char=char, OutputIt=fmt::v8::detail::buffer_a
ppender<char>, T=int, <unnamed>=0]" at line 1912
            instantiation of "auto fmt::v8::detail::write(OutputIt, T, const fmt::v8::basic_format_specs<Char> &, fmt::v8::detail::locale_ref)->OutputIt [with Char=char, OutputIt=fmt::v8::detail::buffer_a
ppender<char>, T=bool, <unnamed>=0]" at line 1969
            instantiation of "auto fmt::v8::detail::default_arg_formatter<Char>::operator()(T)->fmt::v8::detail::default_arg_formatter<Char>::iterator [with Char=char, T=bool]" at line 1465 of "{path}/fmt/include/fmt/core.h"
            instantiation of "auto fmt::v8::visit_format_arg(Visitor &&, const fmt::v8::basic_format_arg<Context> &)->decltype((<expression>)) [with Visitor=fmt::v8::detail::default_arg_formatter<char>, C
ontext=fmt::v8::format_context]" at line 2649
            instantiation of "void fmt::v8::detail::vformat_to(fmt::v8::detail::buffer<Char> &, fmt::v8::basic_string_view<Char>, fmt::v8::basic_format_args<fmt::v8::basic_format_context<fmt::v8::detail::
buffer_appender<fmt::v8::type_identity_t<Char>>, fmt::v8::type_identity_t<Char>>>, fmt::v8::detail::locale_ref) [with Char=char]" at line 2895 of "{path}/fmt/include/fmt/core.h"
            instantiation of "auto fmt::v8::vformat_to(OutputIt, fmt::v8::string_view, fmt::v8::format_args)->OutputIt [with OutputIt=std::back_insert_iterator<spdlog::memory_buf_t>, <unnamed>=0]" at line
 2915 of "{path}/fmt/include/fmt/core.h"
            instantiation of "auto fmt::v8::format_to(OutputIt, fmt::v8::format_string<T...>, T &&...)->OutputIt [with OutputIt=std::back_insert_iterator<spdlog::memory_buf_t>, T=<int &>, <unnamed>=0]" at
 line 58 of "{path}/spdlog/include/spdlog/details/fmt_helper.h"
```