### PR TITLE
Optimize tm formatting

### DIFF
--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -49,7 +49,14 @@ std::string system_strftime(const std::string& format, const std::tm* timeptr,
   os.imbue(loc);
   facet.put(os, os, ' ', timeptr, format.c_str(),
             format.c_str() + format.size());
+#ifdef _WIN32
+  // Workaround a bug in older versions of Universal CRT.
+  auto str = os.str();
+  if (str == "-0000") str = "+0000";
+  return str;
+#else
   return os.str();
+#endif
 }
 
 FMT_CONSTEXPR std::tm make_tm(int year, int mon, int mday, int hour, int min,

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -277,7 +277,14 @@ std::wstring system_wcsftime(const std::wstring& format, const std::tm* timeptr,
   os.imbue(loc);
   facet.put(os, os, L' ', timeptr, format.c_str(),
             format.c_str() + format.size());
+#ifdef _WIN32
+  // Workaround a bug in older versions of Universal CRT.
+  auto str = os.str();
+  if (str == L"-0000") str = L"+0000";
+  return str;
+#else
   return os.str();
+#endif
 }
 
 TEST(chrono_test, time_point) {


### PR DESCRIPTION
Optimize tm formatting for:

- C-locale and alternative representation.
- ``%z`` format (timezone offset from UTC).