### PR TITLE
Annotate fmt::format and fmt::formatted_size as [[nodiscard]]

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -18,7 +18,7 @@
 // The fmt library version in the form major * 10000 + minor * 100 + patch.
 #define FMT_VERSION 80001
 
-#if defined (__clang__ ) && !defined(__ibmxl__)
+#if defined(__clang__) && !defined(__ibmxl__)
 #  define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
 #else
 #  define FMT_CLANG_VERSION 0
@@ -187,6 +187,14 @@
 #  define FMT_FALLTHROUGH
 #endif
 
+#ifndef FMT_NODISCARD
+#  if FMT_HAS_CPP17_ATTRIBUTE(nodiscard)
+#    define FMT_NODISCARD [[nodiscard]]
+#  else
+#    define FMT_NODISCARD
+#  endif
+#endif
+
 #ifndef FMT_USE_FLOAT
 #  define FMT_USE_FLOAT 1
 #endif
@@ -259,8 +267,9 @@
 #ifndef FMT_CONSTEVAL
 #  if ((FMT_GCC_VERSION >= 1000 || FMT_CLANG_VERSION >= 1101) &&      \
        __cplusplus > 201703L && !defined(__apple_build_version__)) || \
-      (defined(__cpp_consteval) && (!FMT_MSC_VER || _MSC_FULL_VER >= 193030704))
-  // consteval is broken in MSVC before VS2022 and Apple clang 13.
+      (defined(__cpp_consteval) &&                                    \
+       (!FMT_MSC_VER || _MSC_FULL_VER >= 193030704))
+// consteval is broken in MSVC before VS2022 and Apple clang 13.
 #    define FMT_CONSTEVAL consteval
 #    define FMT_HAS_CONSTEVAL
 #  else
@@ -3071,7 +3080,8 @@ FMT_API auto vformat(string_view fmt, format_args args) -> std::string;
   \endrst
 */
 template <typename... T>
-FMT_INLINE auto format(format_string<T...> fmt, T&&... args) -> std::string {
+FMT_NODISCARD FMT_INLINE auto format(format_string<T...> fmt, T&&... args)
+    -> std::string {
   return vformat(fmt, fmt::make_format_args(args...));
 }
 
@@ -3138,7 +3148,8 @@ FMT_INLINE auto format_to_n(OutputIt out, size_t n, format_string<T...> fmt,
 
 /** Returns the number of chars in the output of ``format(fmt, args...)``. */
 template <typename... T>
-FMT_INLINE auto formatted_size(format_string<T...> fmt, T&&... args) -> size_t {
+FMT_NODISCARD FMT_INLINE auto formatted_size(format_string<T...> fmt,
+                                             T&&... args) -> size_t {
   auto buf = detail::counting_buffer<>();
   detail::vformat_to(buf, string_view(fmt), fmt::make_format_args(args...), {});
   return buf.count();

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2863,7 +2863,7 @@ inline auto to_string(const T& value) -> std::string {
 }
 
 template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
-inline auto to_string(T value) -> std::string {
+FMT_NODISCARD inline auto to_string(T value) -> std::string {
   // The buffer should be large enough to store the number including the sign
   // or "false" for bool.
   constexpr int max_size = detail::digits10<T>() + 2;
@@ -2873,7 +2873,7 @@ inline auto to_string(T value) -> std::string {
 }
 
 template <typename Char, size_t SIZE>
-auto to_string(const basic_memory_buffer<Char, SIZE>& buf)
+FMT_NODISCARD auto to_string(const basic_memory_buffer<Char, SIZE>& buf)
     -> std::basic_string<Char> {
   auto size = buf.size();
   detail::assume(size < std::basic_string<Char>().max_size());

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -199,7 +199,7 @@ TEST(chrono_test, grow_buffer) {
   for (int i = 0; i < 30; ++i) s += "%c";
   s += "}\n";
   auto t = std::time(nullptr);
-  fmt::format(fmt::runtime(s), *std::localtime(&t));
+  (void)fmt::format(fmt::runtime(s), *std::localtime(&t));
 }
 
 TEST(chrono_test, format_to_empty_container) {
@@ -364,41 +364,41 @@ TEST(chrono_test, format_specs) {
 
 TEST(chrono_test, invalid_specs) {
   auto sec = std::chrono::seconds(0);
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%a}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%a}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%A}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%A}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%c}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%c}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%x}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%x}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%Ex}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%Ex}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%X}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%X}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%EX}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%EX}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%D}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%D}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%F}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%F}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%Ec}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%Ec}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%w}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%w}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%u}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%u}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%b}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%b}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%B}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%B}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%z}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%z}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%Z}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%Z}"), sec), fmt::format_error,
                    "no date");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%Eq}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%Eq}"), sec), fmt::format_error,
                    "invalid format");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:%Oq}"), sec), fmt::format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%Oq}"), sec), fmt::format_error,
                    "invalid format");
 }
 
@@ -446,7 +446,7 @@ TEST(chrono_test, format_default_fp) {
 }
 
 TEST(chrono_test, format_precision) {
-  EXPECT_THROW_MSG(fmt::format(runtime("{:.2}"), std::chrono::seconds(42)),
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:.2}"), std::chrono::seconds(42)),
                    fmt::format_error,
                    "precision not allowed for this argument type");
   EXPECT_EQ("1ms", fmt::format("{:.0}", dms(1.234)));
@@ -486,7 +486,7 @@ TEST(chrono_test, format_simple_q) {
 }
 
 TEST(chrono_test, format_precision_q) {
-  EXPECT_THROW_MSG(fmt::format(runtime("{:.2%Q %q}"), std::chrono::seconds(42)),
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:.2%Q %q}"), std::chrono::seconds(42)),
                    fmt::format_error,
                    "precision not allowed for this argument type");
   EXPECT_EQ("1.2 ms", fmt::format("{:.1%Q %q}", dms(1.234)));
@@ -511,12 +511,12 @@ TEST(chrono_test, format_full_specs_q) {
 }
 
 TEST(chrono_test, invalid_width_id) {
-  EXPECT_THROW(fmt::format(runtime("{:{o}"), std::chrono::seconds(0)),
+  EXPECT_THROW((void)fmt::format(runtime("{:{o}"), std::chrono::seconds(0)),
                fmt::format_error);
 }
 
 TEST(chrono_test, invalid_colons) {
-  EXPECT_THROW(fmt::format(runtime("{0}=:{0::"), std::chrono::seconds(0)),
+  EXPECT_THROW((void)fmt::format(runtime("{0}=:{0::"), std::chrono::seconds(0)),
                fmt::format_error);
 }
 
@@ -543,7 +543,7 @@ TEST(chrono_test, special_durations) {
   EXPECT_EQ(
       "nan nan nan nan nan:nan nan",
       fmt::format("{:%I %H %M %S %R %r}", std::chrono::duration<double>(nan)));
-  fmt::format("{:%S}",
+  (void)fmt::format("{:%S}",
               std::chrono::duration<float, std::atto>(1.79400457e+31f));
   EXPECT_EQ(fmt::format("{}", std::chrono::duration<float, std::exa>(1)),
             "1Es");

--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -902,10 +902,10 @@ TEST(core_test, adl) {
   if (fmt::detail::const_check(true)) return;
   auto s = adl_test::string();
   char buf[10];
-  fmt::format("{}", s);
+  (void)fmt::format("{}", s);
   fmt::format_to(buf, "{}", s);
   fmt::format_to_n(buf, 10, "{}", s);
-  fmt::formatted_size("{}", s);
+  (void)fmt::formatted_size("{}", s);
   fmt::print("{}", s);
   fmt::print(stdout, "{}", s);
 }

--- a/test/enforce-checks-test.cc
+++ b/test/enforce-checks-test.cc
@@ -17,12 +17,12 @@
 
 // Exercise the API to verify that everything we expect to can compile.
 void test_format_api() {
-  fmt::format(FMT_STRING("{}"), 42);
-  fmt::format(FMT_STRING(L"{}"), 42);
-  fmt::format(FMT_STRING("noop"));
+  (void)fmt::format(FMT_STRING("{}"), 42);
+  (void)fmt::format(FMT_STRING(L"{}"), 42);
+  (void)fmt::format(FMT_STRING("noop"));
 
-  fmt::to_string(42);
-  fmt::to_wstring(42);
+  (void)fmt::to_string(42);
+  (void)fmt::to_wstring(42);
 
   std::vector<char> out;
   fmt::format_to(std::back_inserter(out), FMT_STRING("{}"), 42);
@@ -35,13 +35,13 @@ void test_format_api() {
 }
 
 void test_chrono() {
-  fmt::format(FMT_STRING("{}"), std::chrono::seconds(42));
-  fmt::format(FMT_STRING(L"{}"), std::chrono::seconds(42));
+  (void)fmt::format(FMT_STRING("{}"), std::chrono::seconds(42));
+  (void)fmt::format(FMT_STRING(L"{}"), std::chrono::seconds(42));
 }
 
 void test_text_style() {
   fmt::print(fg(fmt::rgb(255, 20, 30)), FMT_STRING("{}"), "rgb(255,20,30)");
-  fmt::format(fg(fmt::rgb(255, 20, 30)), FMT_STRING("{}"), "rgb(255,20,30)");
+  (void)fmt::format(fg(fmt::rgb(255, 20, 30)), FMT_STRING("{}"), "rgb(255,20,30)");
 
   fmt::text_style ts = fg(fmt::rgb(255, 20, 30));
   std::string out;
@@ -51,7 +51,7 @@ void test_text_style() {
 
 void test_range() {
   std::vector<char> hello = {'h', 'e', 'l', 'l', 'o'};
-  fmt::format(FMT_STRING("{}"), hello);
+  (void)fmt::format(FMT_STRING("{}"), hello);
 }
 
 int main() {

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -370,11 +370,11 @@ TEST(format_test, escape) {
 }
 
 TEST(format_test, unmatched_braces) {
-  EXPECT_THROW_MSG(fmt::format(runtime("{")), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{")), format_error,
                    "invalid format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("}")), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("}")), format_error,
                    "unmatched '}' in format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0{}")), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0{}")), format_error,
                    "invalid format string");
 }
 
@@ -391,30 +391,30 @@ TEST(format_test, args_in_different_positions) {
 }
 
 TEST(format_test, arg_errors) {
-  EXPECT_THROW_MSG(fmt::format(runtime("{")), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{")), format_error,
                    "invalid format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("{?}")), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{?}")), format_error,
                    "invalid format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0")), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0")), format_error,
                    "invalid format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0}")), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0}")), format_error,
                    "argument not found");
-  EXPECT_THROW_MSG(fmt::format(runtime("{00}"), 42), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{00}"), 42), format_error,
                    "invalid format string");
 
   char format_str[buffer_size];
   safe_sprintf(format_str, "{%u", INT_MAX);
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str)), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str)), format_error,
                    "invalid format string");
   safe_sprintf(format_str, "{%u}", INT_MAX);
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str)), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str)), format_error,
                    "argument not found");
 
   safe_sprintf(format_str, "{%u", INT_MAX + 1u);
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str)), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str)), format_error,
                    "invalid format string");
   safe_sprintf(format_str, "{%u}", INT_MAX + 1u);
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str)), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str)), format_error,
                    "argument not found");
 }
 
@@ -458,24 +458,24 @@ TEST(format_test, named_arg) {
                         fmt::arg("i", 0), fmt::arg("j", 0), fmt::arg("k", 0),
                         fmt::arg("l", 0), fmt::arg("m", 0), fmt::arg("n", 0),
                         fmt::arg("o", 0), fmt::arg("p", 0)));
-  EXPECT_THROW_MSG(fmt::format(runtime("{a}")), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{a}")), format_error,
                    "argument not found");
-  EXPECT_THROW_MSG(fmt::format(runtime("{a}"), 42), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{a}"), 42), format_error,
                    "argument not found");
 }
 
 TEST(format_test, auto_arg_index) {
   EXPECT_EQ("abc", fmt::format("{}{}{}", 'a', 'b', 'c'));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0}{}"), 'a', 'b'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0}{}"), 'a', 'b'), format_error,
                    "cannot switch from manual to automatic argument indexing");
-  EXPECT_THROW_MSG(fmt::format(runtime("{}{0}"), 'a', 'b'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{}{0}"), 'a', 'b'), format_error,
                    "cannot switch from automatic to manual argument indexing");
   EXPECT_EQ("1.2", fmt::format("{:.{}}", 1.2345, 2));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0}:.{}"), 1.2345, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0}:.{}"), 1.2345, 2), format_error,
                    "cannot switch from manual to automatic argument indexing");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:.{0}}"), 1.2345, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:.{0}}"), 1.2345, 2), format_error,
                    "cannot switch from automatic to manual argument indexing");
-  EXPECT_THROW_MSG(fmt::format(runtime("{}")), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{}")), format_error,
                    "argument not found");
 }
 
@@ -533,9 +533,9 @@ TEST(format_test, center_align) {
 }
 
 TEST(format_test, fill) {
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{<5}"), 'c'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{<5}"), 'c'), format_error,
                    "invalid fill character '{'");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{<5}}"), 'c'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{<5}}"), 'c'), format_error,
                    "invalid fill character '{'");
   EXPECT_EQ("**42", fmt::format("{0:*>4}", 42));
   EXPECT_EQ("**-42", fmt::format("{0:*>5}", -42));
@@ -554,7 +554,7 @@ TEST(format_test, fill) {
   EXPECT_EQ(std::string("\0\0\0*", 4),
             fmt::format(string_view("{:\0>4}", 6), '*'));
   EXPECT_EQ("жж42", fmt::format("{0:ж>4}", 42));
-  EXPECT_THROW_MSG(fmt::format(runtime("{:\x80\x80\x80\x80\x80>}"), 0),
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:\x80\x80\x80\x80\x80>}"), 0),
                    format_error, "invalid type specifier");
 }
 
@@ -562,23 +562,23 @@ TEST(format_test, plus_sign) {
   EXPECT_EQ("+42", fmt::format("{0:+}", 42));
   EXPECT_EQ("-42", fmt::format("{0:+}", -42));
   EXPECT_EQ("+42", fmt::format("{0:+}", 42));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:+}"), 42u), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:+}"), 42u), format_error,
                    "format specifier requires signed argument");
   EXPECT_EQ("+42", fmt::format("{0:+}", 42l));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:+}"), 42ul), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:+}"), 42ul), format_error,
                    "format specifier requires signed argument");
   EXPECT_EQ("+42", fmt::format("{0:+}", 42ll));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:+}"), 42ull), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:+}"), 42ull), format_error,
                    "format specifier requires signed argument");
   EXPECT_EQ("+42", fmt::format("{0:+}", 42.0));
   EXPECT_EQ("+42", fmt::format("{0:+}", 42.0l));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:+"), 'c'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:+"), 'c'), format_error,
                    "missing '}' in format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:+}"), 'c'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:+}"), 'c'), format_error,
                    "invalid format specifier for char");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:+}"), "abc"), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:+}"), "abc"), format_error,
                    "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:+}"), reinterpret_cast<void*>(0x42)),
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:+}"), reinterpret_cast<void*>(0x42)),
                    format_error, "format specifier requires numeric argument");
 }
 
@@ -586,23 +586,23 @@ TEST(format_test, minus_sign) {
   EXPECT_EQ("42", fmt::format("{0:-}", 42));
   EXPECT_EQ("-42", fmt::format("{0:-}", -42));
   EXPECT_EQ("42", fmt::format("{0:-}", 42));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:-}"), 42u), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:-}"), 42u), format_error,
                    "format specifier requires signed argument");
   EXPECT_EQ("42", fmt::format("{0:-}", 42l));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:-}"), 42ul), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:-}"), 42ul), format_error,
                    "format specifier requires signed argument");
   EXPECT_EQ("42", fmt::format("{0:-}", 42ll));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:-}"), 42ull), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:-}"), 42ull), format_error,
                    "format specifier requires signed argument");
   EXPECT_EQ("42", fmt::format("{0:-}", 42.0));
   EXPECT_EQ("42", fmt::format("{0:-}", 42.0l));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:-"), 'c'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:-"), 'c'), format_error,
                    "missing '}' in format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:-}"), 'c'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:-}"), 'c'), format_error,
                    "invalid format specifier for char");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:-}"), "abc"), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:-}"), "abc"), format_error,
                    "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:-}"), reinterpret_cast<void*>(0x42)),
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:-}"), reinterpret_cast<void*>(0x42)),
                    format_error, "format specifier requires numeric argument");
 }
 
@@ -610,23 +610,23 @@ TEST(format_test, space_sign) {
   EXPECT_EQ(" 42", fmt::format("{0: }", 42));
   EXPECT_EQ("-42", fmt::format("{0: }", -42));
   EXPECT_EQ(" 42", fmt::format("{0: }", 42));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0: }"), 42u), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0: }"), 42u), format_error,
                    "format specifier requires signed argument");
   EXPECT_EQ(" 42", fmt::format("{0: }", 42l));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0: }"), 42ul), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0: }"), 42ul), format_error,
                    "format specifier requires signed argument");
   EXPECT_EQ(" 42", fmt::format("{0: }", 42ll));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0: }"), 42ull), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0: }"), 42ull), format_error,
                    "format specifier requires signed argument");
   EXPECT_EQ(" 42", fmt::format("{0: }", 42.0));
   EXPECT_EQ(" 42", fmt::format("{0: }", 42.0l));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0: "), 'c'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0: "), 'c'), format_error,
                    "missing '}' in format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0: }"), 'c'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0: }"), 'c'), format_error,
                    "invalid format specifier for char");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0: }"), "abc"), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0: }"), "abc"), format_error,
                    "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0: }"), reinterpret_cast<void*>(0x42)),
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0: }"), reinterpret_cast<void*>(0x42)),
                    format_error, "format specifier requires numeric argument");
 }
 
@@ -670,13 +670,13 @@ TEST(format_test, hash_flag) {
   EXPECT_EQ("0.", fmt::format("{:#.0f}", 0.01));
   EXPECT_EQ("0.50", fmt::format("{:#.2g}", 0.5));
   EXPECT_EQ("0.", fmt::format("{:#.0f}", 0.5));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:#"), 'c'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:#"), 'c'), format_error,
                    "missing '}' in format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:#}"), 'c'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:#}"), 'c'), format_error,
                    "invalid format specifier for char");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:#}"), "abc"), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:#}"), "abc"), format_error,
                    "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:#}"), reinterpret_cast<void*>(0x42)),
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:#}"), reinterpret_cast<void*>(0x42)),
                    format_error, "format specifier requires numeric argument");
 }
 
@@ -690,14 +690,14 @@ TEST(format_test, zero_flag) {
   EXPECT_EQ("00042", fmt::format("{0:05}", 42ull));
   EXPECT_EQ("-000042", fmt::format("{0:07}", -42.0));
   EXPECT_EQ("-000042", fmt::format("{0:07}", -42.0l));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:0"), 'c'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:0"), 'c'), format_error,
                    "missing '}' in format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:05}"), 'c'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:05}"), 'c'), format_error,
                    "invalid format specifier for char");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:05}"), "abc"), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:05}"), "abc"), format_error,
                    "format specifier requires numeric argument");
   EXPECT_THROW_MSG(
-      fmt::format(runtime("{0:05}"), reinterpret_cast<void*>(0x42)),
+      (void)fmt::format(runtime("{0:05}"), reinterpret_cast<void*>(0x42)),
       format_error, "format specifier requires numeric argument");
 }
 
@@ -705,19 +705,19 @@ TEST(format_test, width) {
   char format_str[buffer_size];
   safe_sprintf(format_str, "{0:%u", UINT_MAX);
   increment(format_str + 3);
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "number is too big");
   size_t size = std::strlen(format_str);
   format_str[size] = '}';
   format_str[size + 1] = 0;
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "number is too big");
 
   safe_sprintf(format_str, "{0:%u", INT_MAX + 1u);
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "number is too big");
   safe_sprintf(format_str, "{0:%u}", INT_MAX + 1u);
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "number is too big");
   EXPECT_EQ(" -42", fmt::format("{0:4}", -42));
   EXPECT_EQ("   42", fmt::format("{0:5}", 42u));
@@ -742,47 +742,47 @@ TEST(format_test, runtime_width) {
   char format_str[buffer_size];
   safe_sprintf(format_str, "{0:{%u", UINT_MAX);
   increment(format_str + 4);
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "invalid format string");
   size_t size = std::strlen(format_str);
   format_str[size] = '}';
   format_str[size + 1] = 0;
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "argument not found");
   format_str[size + 1] = '}';
   format_str[size + 2] = 0;
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "argument not found");
 
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{"), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{"), 0), format_error,
                    "invalid format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{}"), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{}"), 0), format_error,
                    "cannot switch from manual to automatic argument indexing");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{?}}"), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{?}}"), 0), format_error,
                    "invalid format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{1}}"), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{1}}"), 0), format_error,
                    "argument not found");
 
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{0:}}"), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{0:}}"), 0), format_error,
                    "invalid format string");
 
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{1}}"), 0, -1), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{1}}"), 0, -1), format_error,
                    "negative width");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{1}}"), 0, (INT_MAX + 1u)),
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{1}}"), 0, (INT_MAX + 1u)),
                    format_error, "number is too big");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{1}}"), 0, -1l), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{1}}"), 0, -1l), format_error,
                    "negative width");
   if (fmt::detail::const_check(sizeof(long) > sizeof(int))) {
     long value = INT_MAX;
-    EXPECT_THROW_MSG(fmt::format(runtime("{0:{1}}"), 0, (value + 1)),
+    EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{1}}"), 0, (value + 1)),
                      format_error, "number is too big");
   }
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{1}}"), 0, (INT_MAX + 1ul)),
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{1}}"), 0, (INT_MAX + 1ul)),
                    format_error, "number is too big");
 
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{1}}"), 0, '0'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{1}}"), 0, '0'), format_error,
                    "width is not integer");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{1}}"), 0, 0.0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{1}}"), 0, 0.0), format_error,
                    "width is not integer");
 
   EXPECT_EQ(" -42", fmt::format("{0:{1}}", -42, 4));
@@ -803,53 +803,53 @@ TEST(format_test, precision) {
   char format_str[buffer_size];
   safe_sprintf(format_str, "{0:.%u", UINT_MAX);
   increment(format_str + 4);
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "number is too big");
   size_t size = std::strlen(format_str);
   format_str[size] = '}';
   format_str[size + 1] = 0;
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "number is too big");
 
   safe_sprintf(format_str, "{0:.%u", INT_MAX + 1u);
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "number is too big");
   safe_sprintf(format_str, "{0:.%u}", INT_MAX + 1u);
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "number is too big");
 
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:."), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:."), 0), format_error,
                    "missing precision specifier");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.}"), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.}"), 0), format_error,
                    "missing precision specifier");
 
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.2"), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.2"), 0), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.2}"), 42), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.2}"), 42), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.2f}"), 42), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.2f}"), 42), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.2}"), 42u), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.2}"), 42u), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.2f}"), 42u), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.2f}"), 42u), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.2}"), 42l), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.2}"), 42l), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.2f}"), 42l), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.2f}"), 42l), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.2}"), 42ul), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.2}"), 42ul), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.2f}"), 42ul), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.2f}"), 42ul), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.2}"), 42ll), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.2}"), 42ll), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.2f}"), 42ll), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.2f}"), 42ll), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.2}"), 42ull), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.2}"), 42ull), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.2f}"), 42ull), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.2f}"), 42ull), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:3.0}"), 'x'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:3.0}"), 'x'), format_error,
                    "precision not allowed for this argument type");
   EXPECT_EQ("1.2", fmt::format("{0:.2}", 1.2345));
   EXPECT_EQ("1.2", fmt::format("{0:.2}", 1.2345l));
@@ -903,13 +903,13 @@ TEST(format_test, precision) {
   EXPECT_EQ("1.0e-34", fmt::format("{:.1e}", 1e-34));
 
   EXPECT_THROW_MSG(
-      fmt::format(runtime("{0:.2}"), reinterpret_cast<void*>(0xcafe)),
+      (void)fmt::format(runtime("{0:.2}"), reinterpret_cast<void*>(0xcafe)),
       format_error, "precision not allowed for this argument type");
   EXPECT_THROW_MSG(
-      fmt::format(runtime("{0:.2f}"), reinterpret_cast<void*>(0xcafe)),
+      (void)fmt::format(runtime("{0:.2f}"), reinterpret_cast<void*>(0xcafe)),
       format_error, "precision not allowed for this argument type");
   EXPECT_THROW_MSG(
-      fmt::format(runtime("{:.{}e}"), 42.0, fmt::detail::max_value<int>()),
+      (void)fmt::format(runtime("{:.{}e}"), 42.0, fmt::detail::max_value<int>()),
       format_error, "number is too big");
 
   EXPECT_EQ("st", fmt::format("{0:.2}", "str"));
@@ -919,85 +919,85 @@ TEST(format_test, runtime_precision) {
   char format_str[buffer_size];
   safe_sprintf(format_str, "{0:.{%u", UINT_MAX);
   increment(format_str + 5);
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "invalid format string");
   size_t size = std::strlen(format_str);
   format_str[size] = '}';
   format_str[size + 1] = 0;
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "argument not found");
   format_str[size + 1] = '}';
   format_str[size + 2] = 0;
-  EXPECT_THROW_MSG(fmt::format(runtime(format_str), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), 0), format_error,
                    "argument not found");
 
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{"), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{"), 0), format_error,
                    "invalid format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{}"), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{}"), 0), format_error,
                    "cannot switch from manual to automatic argument indexing");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{?}}"), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{?}}"), 0), format_error,
                    "invalid format string");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}"), 0, 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}"), 0, 0), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 0), format_error,
                    "argument not found");
 
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{0:}}"), 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{0:}}"), 0), format_error,
                    "invalid format string");
 
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 0, -1), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 0, -1), format_error,
                    "negative precision");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 0, (INT_MAX + 1u)),
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 0, (INT_MAX + 1u)),
                    format_error, "number is too big");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 0, -1l), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 0, -1l), format_error,
                    "negative precision");
   if (fmt::detail::const_check(sizeof(long) > sizeof(int))) {
     long value = INT_MAX;
-    EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 0, (value + 1)),
+    EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 0, (value + 1)),
                      format_error, "number is too big");
   }
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 0, (INT_MAX + 1ul)),
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 0, (INT_MAX + 1ul)),
                    format_error, "number is too big");
 
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 0, '0'), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 0, '0'), format_error,
                    "precision is not integer");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 0, 0.0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 0, 0.0), format_error,
                    "precision is not integer");
 
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 42, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 42, 2), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}f}"), 42, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}f}"), 42, 2), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 42u, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 42u, 2), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}f}"), 42u, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}f}"), 42u, 2), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 42l, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 42l, 2), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}f}"), 42l, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}f}"), 42l, 2), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 42ul, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 42ul, 2), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}f}"), 42ul, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}f}"), 42ul, 2), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 42ll, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 42ll, 2), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}f}"), 42ll, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}f}"), 42ll, 2), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}}"), 42ull, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}}"), 42ull, 2), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:.{1}f}"), 42ull, 2), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:.{1}f}"), 42ull, 2), format_error,
                    "precision not allowed for this argument type");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:3.{1}}"), 'x', 0), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:3.{1}}"), 'x', 0), format_error,
                    "precision not allowed for this argument type");
   EXPECT_EQ("1.2", fmt::format("{0:.{1}}", 1.2345, 2));
   EXPECT_EQ("1.2", fmt::format("{1:.{0}}", 2, 1.2345l));
 
   EXPECT_THROW_MSG(
-      fmt::format(runtime("{0:.{1}}"), reinterpret_cast<void*>(0xcafe), 2),
+      (void)fmt::format(runtime("{0:.{1}}"), reinterpret_cast<void*>(0xcafe), 2),
       format_error, "precision not allowed for this argument type");
   EXPECT_THROW_MSG(
-      fmt::format(runtime("{0:.{1}f}"), reinterpret_cast<void*>(0xcafe), 2),
+      (void)fmt::format(runtime("{0:.{1}f}"), reinterpret_cast<void*>(0xcafe), 2),
       format_error, "precision not allowed for this argument type");
 
   EXPECT_EQ("st", fmt::format("{0:.{1}}", "str", 2));
@@ -1029,14 +1029,14 @@ void check_unknown_types(const T& value, const char* types, const char*) {
     if (std::strchr(types, c) || std::strchr(special, c) || !c) continue;
     safe_sprintf(format_str, "{0:10%c}", c);
     const char* message = "invalid type specifier";
-    EXPECT_THROW_MSG(fmt::format(runtime(format_str), value), format_error,
+    EXPECT_THROW_MSG((void)fmt::format(runtime(format_str), value), format_error,
                      message)
         << format_str << " " << message;
   }
 }
 
 TEST(format_test, format_int) {
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:v"), 42), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:v"), 42), format_error,
                    "invalid type specifier");
   check_unknown_types(42, "bBdoxXnLc", "integer");
   EXPECT_EQ("x", fmt::format("{:c}", static_cast<int>('x')));
@@ -1345,7 +1345,7 @@ TEST(format_test, format_cstring) {
   char nonconst[] = "nonconst";
   EXPECT_EQ("nonconst", fmt::format("{0}", nonconst));
   EXPECT_THROW_MSG(
-      fmt::format(runtime("{0}"), static_cast<const char*>(nullptr)),
+      (void)fmt::format(runtime("{0}"), static_cast<const char*>(nullptr)),
       format_error, "string pointer is null");
 }
 
@@ -1390,7 +1390,7 @@ TEST(format_test, format_pointer) {
 
 TEST(format_test, format_string) {
   EXPECT_EQ("test", fmt::format("{0}", std::string("test")));
-  EXPECT_THROW(fmt::format(fmt::runtime("{:x}"), std::string("test")),
+  EXPECT_THROW((void)fmt::format(fmt::runtime("{:x}"), std::string("test")),
                fmt::format_error);
 }
 
@@ -1481,7 +1481,7 @@ template <> struct formatter<Answer> : formatter<int> {
 FMT_END_NAMESPACE
 
 TEST(format_test, format_custom) {
-  EXPECT_THROW_MSG(fmt::format(runtime("{:s}"), date(2012, 12, 9)),
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:s}"), date(2012, 12, 9)),
                    format_error, "unknown format specifier");
   EXPECT_EQ("42", fmt::format("{0}", Answer()));
   EXPECT_EQ("0042", fmt::format("{:04}", Answer()));
@@ -1558,7 +1558,7 @@ TEST(format_test, format_examples) {
             fmt::format("int: {0:d};  hex: {0:#x};  oct: {0:#o}", 42));
 
   EXPECT_EQ("The answer is 42", fmt::format("The answer is {}", 42));
-  EXPECT_THROW_MSG(fmt::format(runtime("The answer is {:d}"), "forty-two"),
+  EXPECT_THROW_MSG((void)fmt::format(runtime("The answer is {:d}"), "forty-two"),
                    format_error, "invalid type specifier");
 
   EXPECT_WRITE(
@@ -1782,21 +1782,21 @@ TEST(format_test, dynamic_formatter) {
   EXPECT_EQ("42", fmt::format("{:d}", num));
   EXPECT_EQ("foo", fmt::format("{:s}", str));
   EXPECT_EQ(" 42 foo ", fmt::format("{:{}} {:{}}", num, 3, str, 4));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:{}}"), num), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:{}}"), num), format_error,
                    "cannot switch from manual to automatic argument indexing");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:{0}}"), num), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:{0}}"), num), format_error,
                    "cannot switch from automatic to manual argument indexing");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:+}"), str), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:+}"), str), format_error,
                    "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:-}"), str), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:-}"), str), format_error,
                    "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(fmt::format(runtime("{: }"), str), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{: }"), str), format_error,
                    "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:#}"), str), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:#}"), str), format_error,
                    "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:0}"), str), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:0}"), str), format_error,
                    "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(fmt::format(runtime("{:.2}"), num), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:.2}"), num), format_error,
                    "precision not allowed for this argument type");
 }
 

--- a/test/ostream-test.cc
+++ b/test/ostream-test.cc
@@ -70,15 +70,15 @@ TEST(ostream_test, format_specs) {
   EXPECT_EQ("  def", fmt::format("{0:>5}", test_string("def")));
   EXPECT_EQ(" def ", fmt::format("{0:^5}", test_string("def")));
   EXPECT_EQ("def**", fmt::format("{0:*<5}", test_string("def")));
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:+}"), test_string()), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:+}"), test_string()), format_error,
                    "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:-}"), test_string()), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:-}"), test_string()), format_error,
                    "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0: }"), test_string()), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0: }"), test_string()), format_error,
                    "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:#}"), test_string()), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:#}"), test_string()), format_error,
                    "format specifier requires numeric argument");
-  EXPECT_THROW_MSG(fmt::format(runtime("{0:05}"), test_string()), format_error,
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{0:05}"), test_string()), format_error,
                    "format specifier requires numeric argument");
   EXPECT_EQ("test         ", fmt::format("{0:13}", test_string("test")));
   EXPECT_EQ("test         ", fmt::format("{0:{1}}", test_string("test"), 13));


### PR DESCRIPTION
This prevents accidentally writing fmt::format when fmt::print was
intended. Other than running tests, there's not a good use case for
discarding the formatted output.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
