### PR TITLE
[doc] FMT_STRING supports C++14 and no-op in C++11

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -69,10 +69,10 @@ checked at compile time in C++20. To pass a runtime format string wrap it in
 Compile-time Format String Checks
 ---------------------------------
 
-Requires C++14 and it's no-op in C++11.
 Compile-time checks are enabled when using ``FMT_STRING``. They support built-in
 and string types as well as user-defined types with ``constexpr`` ``parse``
 functions in their ``formatter`` specializations.
+Requires C++14 and is a no-op in C++11.
 
 .. doxygendefine:: FMT_STRING
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -69,6 +69,7 @@ checked at compile time in C++20. To pass a runtime format string wrap it in
 Compile-time Format String Checks
 ---------------------------------
 
+Requires C++14 and it's no-op in C++11.
 Compile-time checks are enabled when using ``FMT_STRING``. They support built-in
 and string types as well as user-defined types with ``constexpr`` ``parse``
 functions in their ``formatter`` specializations.


### PR DESCRIPTION
Hi, I want to use FMT_STRING in a C++11 project and found that FMT_STRING doesn't support C++11.
It emits exception instead of compile time error in this [demo](https://godbolt.org/z/ocn5WdW1M).

Then I found that in #2039, @vitaut stated that FMT_STRING a no-op in C++11, but there is no documentation specify this limitation.

I decide to put the requirement in the first line, so one will find the limitation immediately.
So here's my simple PR. Hopefully it doesn't break google's documentation guide line.