### PR TITLE
Implement c++20 std::chrono::duration subsecond formatting

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1420,17 +1420,6 @@ static constexpr std::chrono::duration<Rep, Period> abs(
   return d;
 }
 
-template <class Rep, class Period, class ToDuration>
-static constexpr typename ToDuration::rep get_subseconds(
-    std::chrono::duration<Rep, Period> d) {
-  return std::chrono::treat_as_floating_point<typename ToDuration::rep>::value
-             ? (abs(d) - std::chrono::duration_cast<std::chrono::seconds>(d))
-                   .count()
-             : std::chrono::duration_cast<ToDuration>(
-                   abs(d) - std::chrono::duration_cast<std::chrono::seconds>(d))
-                   .count();
-}
-
 template <typename Char, typename Rep, typename OutputIt,
           FMT_ENABLE_IF(std::is_integral<Rep>::value)>
 OutputIt format_duration_value(OutputIt out, Rep val, int) {

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1595,20 +1595,21 @@ struct chrono_formatter {
     static constexpr auto fractional_width =
         detail::num_digits(Duration::period::num, Duration::period::den);
 
-    using precision = std::chrono::duration<
+    using subsecond_precision = std::chrono::duration<
         typename std::common_type<typename Duration::rep,
                                   std::chrono::seconds::rep>::type,
         std::ratio<1, detail::pow10(fractional_width)>>;
     // We could use c++ 17 if constexpr here.
-    if (std::ratio_less<typename precision::period,
+    if (std::ratio_less<typename subsecond_precision::period,
                         std::chrono::seconds::period>::value) {
       *out++ = '.';
       const auto subseconds =
-          std::chrono::treat_as_floating_point<typename precision::rep>::value
+          std::chrono::treat_as_floating_point<
+              typename subsecond_precision::rep>::value
               ? (detail::abs(d) -
                  std::chrono::duration_cast<std::chrono::seconds>(d))
                     .count()
-              : std::chrono::duration_cast<precision>(
+              : std::chrono::duration_cast<subsecond_precision>(
                     detail::abs(d) -
                     std::chrono::duration_cast<std::chrono::seconds>(d))
                     .count();

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1389,59 +1389,47 @@ inline std::chrono::duration<Rep, std::milli> get_milliseconds(
 #endif
 }
 
-template <class Duration> class subsecond_helper {
-  // Returns the amount of digits according to the c++ 20 spec
-  // In the range [0, 18], if more than 18 fractional digits are required,
-  // then we return 6 for microseconds precision
-  static constexpr int num_digits(long long num, long long den, int n = 0) {
-    return num % den == 0 ? n : (n > 18 ? 6 : num_digits(num * 10, den, n + 1));
-  }
+// Returns the amount of digits according to the c++ 20 spec
+// In the range [0, 18], if more than 18 fractional digits are required,
+// then we return 6 for microseconds precision.
+static constexpr int num_digits(long long num, long long den, int n = 0) {
+  return num % den == 0 ? n : (n > 18 ? 6 : num_digits(num * 10, den, n + 1));
+}
 
-  static constexpr long long pow10(std::uint32_t n) {
-    return n == 0 ? 1 : 10 * pow10(n - 1);
-  }
+static constexpr long long pow10(std::uint32_t n) {
+  return n == 0 ? 1 : 10 * pow10(n - 1);
+}
 
-  template <class Rep, class Period,
-            FMT_ENABLE_IF(std::numeric_limits<Rep>::is_signed)>
-  static constexpr std::chrono::duration<Rep, Period> abs(
-      std::chrono::duration<Rep, Period> d) {
-    // We need to compare the duration using the count() method directly
-    // due to a compiler bug in clang-11 regarding the spaceship operator,
-    // when -Wzero-as-null-pointer-constant is enabled.
-    // In clang-12 the bug has been fixed. See
-    // https://bugs.llvm.org/show_bug.cgi?id=46235 and the reproducible example:
-    // https://www.godbolt.org/z/Knbb5joYx
-    return d.count() >= d.zero().count() ? d : -d;
-  }
+template <class Rep, class Period,
+          FMT_ENABLE_IF(std::numeric_limits<Rep>::is_signed)>
+static constexpr std::chrono::duration<Rep, Period> abs(
+    std::chrono::duration<Rep, Period> d) {
+  // We need to compare the duration using the count() method directly
+  // due to a compiler bug in clang-11 regarding the spaceship operator,
+  // when -Wzero-as-null-pointer-constant is enabled.
+  // In clang-12 the bug has been fixed. See
+  // https://bugs.llvm.org/show_bug.cgi?id=46235 and the reproducible example:
+  // https://www.godbolt.org/z/Knbb5joYx
+  return d.count() >= d.zero().count() ? d : -d;
+}
 
-  template <class Rep, class Period,
-            FMT_ENABLE_IF(!std::numeric_limits<Rep>::is_signed)>
-  static constexpr std::chrono::duration<Rep, Period> abs(
-      std::chrono::duration<Rep, Period> d) {
-    return d;
-  }
+template <class Rep, class Period,
+          FMT_ENABLE_IF(!std::numeric_limits<Rep>::is_signed)>
+static constexpr std::chrono::duration<Rep, Period> abs(
+    std::chrono::duration<Rep, Period> d) {
+  return d;
+}
 
- public:
-  static constexpr auto fractional_width =
-      num_digits(Duration::period::num, Duration::period::den);
-
-  using precision = std::chrono::duration<
-      typename std::common_type<typename Duration::rep,
-                                std::chrono::seconds::rep>::type,
-      std::ratio<1, pow10(fractional_width)>>;
-
-  template <class Rep, class Period>
-  static constexpr typename precision::rep get_subseconds(
-      std::chrono::duration<Rep, Period> d) {
-    return std::chrono::treat_as_floating_point<typename precision::rep>::value
-               ? (abs(d) - std::chrono::duration_cast<std::chrono::seconds>(d))
-                     .count()
-               : std::chrono::duration_cast<precision>(
-                     abs(d) -
-                     std::chrono::duration_cast<std::chrono::seconds>(d))
-                     .count();
-  }
-};
+template <class Rep, class Period, class ToDuration>
+static constexpr typename ToDuration::rep get_subseconds(
+    std::chrono::duration<Rep, Period> d) {
+  return std::chrono::treat_as_floating_point<typename ToDuration::rep>::value
+             ? (abs(d) - std::chrono::duration_cast<std::chrono::seconds>(d))
+                   .count()
+             : std::chrono::duration_cast<ToDuration>(
+                   abs(d) - std::chrono::duration_cast<std::chrono::seconds>(d))
+                   .count();
+}
 
 template <typename Char, typename Rep, typename OutputIt,
           FMT_ENABLE_IF(std::is_integral<Rep>::value)>
@@ -1593,14 +1581,45 @@ struct chrono_formatter {
     }
   }
 
-  template <typename RepType> void write(RepType value, int width) {
+  void write(Rep value, int width) {
     write_sign();
     if (isnan(value)) return write_nan();
-    uint32_or_64_or_128_t<long long> n =
-        to_unsigned(to_nonnegative_int(value, max_value<long long>()));
+    uint32_or_64_or_128_t<int> n =
+        to_unsigned(to_nonnegative_int(value, max_value<int>()));
     int num_digits = detail::count_digits(n);
     if (width > num_digits) out = std::fill_n(out, width - num_digits, '0');
     out = format_decimal<char_type>(out, n, num_digits).end;
+  }
+
+  template <class Duration> void write_fractional_seconds(Duration d) {
+    static constexpr auto fractional_width =
+        detail::num_digits(Duration::period::num, Duration::period::den);
+
+    using precision = std::chrono::duration<
+        typename std::common_type<typename Duration::rep,
+                                  std::chrono::seconds::rep>::type,
+        std::ratio<1, detail::pow10(fractional_width)>>;
+    // We could use c++ 17 if constexpr here.
+    if (std::ratio_less<typename precision::period,
+                        std::chrono::seconds::period>::value) {
+      *out++ = '.';
+      const auto subseconds =
+          std::chrono::treat_as_floating_point<typename precision::rep>::value
+              ? (detail::abs(d) -
+                 std::chrono::duration_cast<std::chrono::seconds>(d))
+                    .count()
+              : std::chrono::duration_cast<precision>(
+                    detail::abs(d) -
+                    std::chrono::duration_cast<std::chrono::seconds>(d))
+                    .count();
+      uint32_or_64_or_128_t<long long> n =
+          to_unsigned(to_nonnegative_int(subseconds, max_value<long long>()));
+      int num_digits = detail::count_digits(n);
+      if (fractional_width > num_digits) {
+        out = std::fill_n(out, fractional_width - num_digits, '0');
+      }
+      out = format_decimal<char_type>(out, n, num_digits).end;
+    }
   }
 
   void write_nan() { std::copy_n("nan", 3, out); }
@@ -1680,15 +1699,7 @@ struct chrono_formatter {
 
     if (ns == numeric_system::standard) {
       write(second(), 2);
-      using duration_rep = std::chrono::duration<rep, Period>;
-      using subsec_helper = detail::subsecond_helper<duration_rep>;
-      // Could use c++ 17 if constexpr
-      if (std::ratio_less<typename subsec_helper::precision::period,
-                          std::chrono::seconds::period>::value) {
-        *out++ = '.';
-        write(subsec_helper::get_subseconds(duration_rep{val}),
-              subsec_helper::fractional_width);
-      }
+      write_fractional_seconds(std::chrono::duration<rep, Period>{val});
       return;
     }
     auto time = tm();

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1393,8 +1393,7 @@ template <class Duration> class subsecond_helper {
   /// Returns the amount of digits according to the c++ 20 spec
   /// In the range [0, 18], if more than 18 fractional digits are required,
   /// then we return 6 for microseconds precision
-  static constexpr int num_digits(std::intmax_t num,
-                                  std::intmax_t den,
+  static constexpr int num_digits(std::intmax_t num, std::intmax_t den,
                                   int n = 0) {
     return num % den == 0 ? n : (n > 18 ? 6 : num_digits(num * 10, den, n + 1));
   }
@@ -1589,8 +1588,7 @@ struct chrono_formatter {
     }
   }
 
-  template <typename RepType>
-  void write(RepType value, int width) {
+  template <typename RepType> void write(RepType value, int width) {
     write_sign();
     if (isnan(value)) return write_nan();
     uint32_or_64_or_128_t<std::intmax_t> n =
@@ -1683,7 +1681,8 @@ struct chrono_formatter {
       if (std::ratio_less<typename subsec_helper::precision::period,
                           std::chrono::seconds::period>::value) {
         *out++ = '.';
-        write(subsec_helper::get_subseconds(duration_rep{val}), subsec_helper::fractional_width);
+        write(subsec_helper::get_subseconds(duration_rep{val}),
+              subsec_helper::fractional_width);
       }
       return;
     }

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1395,7 +1395,7 @@ template <class Duration> class subsecond_helper {
   /// then we return 6 for microseconds precision
   static constexpr int num_digits(std::intmax_t num,
                                   std::intmax_t den,
-                                  std::uint32_t n = 0) {
+                                  int n = 0) {
     return num % den == 0 ? n : (n > 18 ? 6 : num_digits(num * 10, den, n + 1));
   }
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1389,20 +1389,20 @@ inline std::chrono::duration<Rep, std::milli> get_milliseconds(
 #endif
 }
 
-// Returns the amount of digits according to the c++ 20 spec
+// Returns the number of digits according to the c++ 20 spec
 // In the range [0, 18], if more than 18 fractional digits are required,
 // then we return 6 for microseconds precision.
-static constexpr int num_digits(long long num, long long den, int n = 0) {
+constexpr int num_digits(long long num, long long den, int n = 0) {
   return num % den == 0 ? n : (n > 18 ? 6 : num_digits(num * 10, den, n + 1));
 }
 
-static constexpr long long pow10(std::uint32_t n) {
+constexpr long long pow10(std::uint32_t n) {
   return n == 0 ? 1 : 10 * pow10(n - 1);
 }
 
 template <class Rep, class Period,
           FMT_ENABLE_IF(std::numeric_limits<Rep>::is_signed)>
-static constexpr std::chrono::duration<Rep, Period> abs(
+constexpr std::chrono::duration<Rep, Period> abs(
     std::chrono::duration<Rep, Period> d) {
   // We need to compare the duration using the count() method directly
   // due to a compiler bug in clang-11 regarding the spaceship operator,
@@ -1581,7 +1581,7 @@ struct chrono_formatter {
   }
 
   template <class Duration> void write_fractional_seconds(Duration d) {
-    static constexpr auto fractional_width =
+    constexpr auto fractional_width =
         detail::num_digits(Duration::period::num, Duration::period::den);
 
     using subsecond_precision = std::chrono::duration<

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1319,20 +1319,20 @@ inline bool isfinite(T) {
 }
 
 // Converts value to int and checks that it's in the range [0, upper).
-template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
-inline std::intmax_t to_nonnegative_int(T value, std::intmax_t upper) {
+template <typename T, typename Int, FMT_ENABLE_IF(std::is_integral<T>::value)>
+inline Int to_nonnegative_int(T value, Int upper) {
   FMT_ASSERT(value >= 0 && to_unsigned(value) <= to_unsigned(upper),
              "invalid value");
   (void)upper;
-  return static_cast<std::intmax_t>(value);
+  return static_cast<Int>(value);
 }
-template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
-inline std::intmax_t to_nonnegative_int(T value, std::intmax_t upper) {
+template <typename T, typename Int, FMT_ENABLE_IF(!std::is_integral<T>::value)>
+inline Int to_nonnegative_int(T value, Int upper) {
   FMT_ASSERT(
       std::isnan(value) || (value >= 0 && value <= static_cast<T>(upper)),
       "invalid value");
   (void)upper;
-  return static_cast<std::intmax_t>(value);
+  return static_cast<Int>(value);
 }
 
 template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1589,7 +1589,8 @@ struct chrono_formatter {
     }
   }
 
-  void write(Rep value, int width) {
+  template <typename RepType>
+  void write(RepType value, int width) {
     write_sign();
     if (isnan(value)) return write_nan();
     uint32_or_64_or_128_t<std::intmax_t> n =
@@ -1676,20 +1677,13 @@ struct chrono_formatter {
 
     if (ns == numeric_system::standard) {
       write(second(), 2);
-#if FMT_SAFE_DURATION_CAST
-      // convert rep->Rep
       using duration_rep = std::chrono::duration<rep, Period>;
-      using duration_Rep = std::chrono::duration<Rep, Period>;
-      auto tmpval = fmt_safe_duration_cast<duration_Rep>(duration_rep{val});
-#else
-      auto tmpval = std::chrono::duration<Rep, Period>(val);
-#endif
-      using subsec_helper = detail::subsecond_helper<duration_Rep>;
+      using subsec_helper = detail::subsecond_helper<duration_rep>;
       // Could use c++ 17 if constexpr
       if (std::ratio_less<typename subsec_helper::precision::period,
                           std::chrono::seconds::period>::value) {
         *out++ = '.';
-        write(subsec_helper::get_subseconds(tmpval), subsec_helper::fractional_width);
+        write(subsec_helper::get_subseconds(duration_rep{val}), subsec_helper::fractional_width);
       }
       return;
     }

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1390,9 +1390,9 @@ inline std::chrono::duration<Rep, std::milli> get_milliseconds(
 }
 
 template <class Duration> class subsecond_helper {
-  /// Returns the amount of digits according to the c++ 20 spec
-  /// In the range [0, 18], if more than 18 fractional digits are required,
-  /// then we return 6 for microseconds precision
+  // Returns the amount of digits according to the c++ 20 spec
+  // In the range [0, 18], if more than 18 fractional digits are required,
+  // then we return 6 for microseconds precision
   static constexpr int num_digits(std::intmax_t num, std::intmax_t den,
                                   int n = 0) {
     return num % den == 0 ? n : (n > 18 ? 6 : num_digits(num * 10, den, n + 1));

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1318,7 +1318,7 @@ inline bool isfinite(T) {
   return true;
 }
 
-// Converts value to int and checks that it's in the range [0, upper).
+// Converts value to Int and checks that it's in the range [0, upper).
 template <typename T, typename Int, FMT_ENABLE_IF(std::is_integral<T>::value)>
 inline Int to_nonnegative_int(T value, Int upper) {
   FMT_ASSERT(value >= 0 && to_unsigned(value) <= to_unsigned(upper),

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -544,9 +544,7 @@ TEST(chrono_test, negative_durations) {
 
 TEST(chrono_test, special_durations) {
   auto value = fmt::format("{:%S}", std::chrono::duration<double>(1e20));
-  // No decimal point is printed so size() is 2.
-  EXPECT_EQ(value.size(), 2);
-  EXPECT_EQ("40", value.substr(0, 2));
+  EXPECT_EQ(value, "40");
   auto nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_EQ(
       "nan nan nan nan nan:nan nan",

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -544,8 +544,8 @@ TEST(chrono_test, negative_durations) {
 
 TEST(chrono_test, special_durations) {
   EXPECT_EQ(
-      "40.",
-      fmt::format("{:%S}", std::chrono::duration<double>(1e20)).substr(0, 3));
+      "40",
+      fmt::format("{:%S}", std::chrono::duration<double>(1e20)).substr(0, 2));
   auto nan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_EQ(
       "nan nan nan nan nan:nan nan",
@@ -583,6 +583,46 @@ TEST(chrono_test, weekday) {
     EXPECT_THAT((std::vector<std::string>{"пн", "Пн", "пнд", "Пнд"}),
                 Contains(fmt::format(loc, "{:%a}", tm)));
   }
+}
+
+TEST(chrono_test, cpp20_duration_subsecond_support) {
+  using attoseconds = std::chrono::duration<std::intmax_t, std::atto>;
+  // Check that 18 digits of subsecond precision are supported
+  EXPECT_EQ(fmt::format("{:%S}", attoseconds{673231113420148734}),
+            "00.673231113420148734");
+  EXPECT_EQ(fmt::format("{:%S}", attoseconds{-673231113420148734}),
+            "-00.673231113420148734");
+  EXPECT_EQ(fmt::format("{:%S}", std::chrono::nanoseconds{13420148734}),
+            "13.420148734");
+  EXPECT_EQ(fmt::format("{:%S}", std::chrono::nanoseconds{-13420148734}),
+            "-13.420148734");
+  EXPECT_EQ(fmt::format("{:%S}", std::chrono::milliseconds{1234}), "01.234");
+  {
+    // Check that {:%H:%M:%S} is equivalent to {:%T}
+    auto dur = std::chrono::milliseconds{3601234};
+    auto formatted_dur = fmt::format("{:%T}", dur);
+    EXPECT_EQ(formatted_dur, "01:00:01.234");
+    EXPECT_EQ(fmt::format("{:%H:%M:%S}", dur), formatted_dur);
+  }
+  using nanoseconds_dbl = std::chrono::duration<double, std::nano>;
+  EXPECT_EQ(fmt::format("{:%S}", nanoseconds_dbl{-123456789.123456789}),
+            "-00.123456789");
+  EXPECT_EQ(fmt::format("{:%S}", nanoseconds_dbl{9123456789.123456789}),
+            "09.123456789");
+  // Only seconds part is printed
+  EXPECT_EQ(fmt::format("{:%S}", nanoseconds_dbl{99123456789}), "39.123456789");
+  EXPECT_EQ(fmt::format("{:%S}", nanoseconds_dbl{99123000000}), "39.123000000");
+  {
+    // Now the hour is printed, and we also test if negative doubles work
+    auto dur = nanoseconds_dbl{-99123456789};
+    auto formatted_dur = fmt::format("{:%T}", dur);
+    EXPECT_EQ(formatted_dur, "-00:01:39.123456789");
+    EXPECT_EQ(fmt::format("{:%H:%M:%S}", dur), formatted_dur);
+  }
+  // Check that durations with precision greater than std::chrono::seconds have
+  // fixed precision and empty zeros
+  EXPECT_EQ(fmt::format("{:%S}", std::chrono::microseconds{7000000}),
+            "07.000000");
 }
 
 #endif  // FMT_STATIC_THOUSANDS_SEPARATOR

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -550,8 +550,6 @@ TEST(chrono_test, special_durations) {
   EXPECT_EQ(
       "nan nan nan nan nan:nan nan",
       fmt::format("{:%I %H %M %S %R %r}", std::chrono::duration<double>(nan)));
-  (void)fmt::format("{:%S}",
-                    std::chrono::duration<float, std::atto>(1.79400457e+31f));
   EXPECT_EQ(fmt::format("{}", std::chrono::duration<float, std::exa>(1)),
             "1Es");
   EXPECT_EQ(fmt::format("{}", std::chrono::duration<float, std::atto>(1)),
@@ -588,6 +586,8 @@ TEST(chrono_test, weekday) {
 TEST(chrono_test, cpp20_duration_subsecond_support) {
   using attoseconds = std::chrono::duration<std::intmax_t, std::atto>;
   // Check that 18 digits of subsecond precision are supported
+  EXPECT_EQ(fmt::format("{:%S}", attoseconds{999999999999999999}),
+            "00.999999999999999999");
   EXPECT_EQ(fmt::format("{:%S}", attoseconds{673231113420148734}),
             "00.673231113420148734");
   EXPECT_EQ(fmt::format("{:%S}", attoseconds{-673231113420148734}),


### PR DESCRIPTION
Hello,

I have returned with a solution to #2207, after dealing with licensing issues in PR #2554. This time I am 100% the author of the code. The solution is simplified, and could be adapted to use if-constexpr if C++17 is detected at compile-time. In fact, the solution I have proposed is working better than the current <format> MSVC implementation which leads to template overflow when `std::atto` is used as a precision. I will open an issue there. 

1. Subsecond values that are not representable in `std::intmax_t` (the standard type for chrono tick counts) cause program termination with `FMT_ASSERT()`. The standard requires us to support up to 18 decimal digits, and `std::int64_t` can store a maximum value of 9,223,372,036,854,775,807 or, 9.2e+18,. Therefore it can represent all 18 digit numbers. However the following assert test had to be removed:
```
(void)fmt::format("{:%S}",
                    std::chrono::duration<float, std::atto>(1.79400457e+31f));
```
2. The decimal point is still not formatted according to the locale but that is a general problem.