### PR TITLE
Fix `throw` with exceptions disabled

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -707,7 +707,7 @@ FMT_INLINE FMT_CONSTEXPR20 digits::result grisu_gen_digits(
     int precision_offset = exp + handler.exp10;
     if (precision_offset > 0 &&
         handler.precision > max_value<int>() - precision_offset) {
-      throw format_error("number is too big");
+      FMT_THROW(format_error("number is too big"));
     }
     handler.precision += precision_offset;
     // Check if precision is satisfied just by leading zeros, e.g.


### PR DESCRIPTION
Originated from https://github.com/fmtlib/fmt/commit/215f21a0382d325efa66df53fbfbfddb020a2234#r61421336.

`throw` replaced with `FMT_THROW`, nothing more.

But the most interesting part here is why it was not detected by tests - it's described in https://github.com/fmtlib/fmt/pull/2648.
