### PR TITLE
Enable named arguments check in compile-time checks

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1109,6 +1109,11 @@ template <typename... Args> constexpr auto count_named_args() -> size_t {
   return count<is_named_arg<Args>::value...>();
 }
 
+template <typename... Args>
+constexpr auto count_statically_named_args() -> size_t {
+  return count<is_statically_named_arg<Args>::value...>();
+}
+
 enum class type {
   none_type,
   // Integer types should go first,
@@ -3043,7 +3048,8 @@ template <typename Char, typename... Args> class basic_format_string {
              std::is_reference<Args>::value)...>() == 0,
         "passing views as lvalues is disallowed");
 #ifdef FMT_HAS_CONSTEVAL
-    if constexpr (detail::count_named_args<Args...>() == 0) {
+    if constexpr (detail::count_named_args<Args...>() ==
+                  detail::count_statically_named_args<Args...>()) {
       using checker = detail::format_string_checker<Char, detail::error_handler,
                                                     remove_cvref_t<Args>...>;
       detail::parse_format_string<true>(str_, checker(s, {}));


### PR DESCRIPTION
Originated from https://github.com/fmtlib/fmt/issues/2640.

This check works only if all named arguments are UDL-based (`statically_named`).

Also, I'm not sure about format strings like `"{} {named1}{named2}"`, they work in `master`, but by enabling this check I also applied the same logic for them as `FMT_STRING` and `FMT_COMPILE` have. So, those format string **do not work**.

It would be nice to add some compile-time error checks for this check in this PR, but it's probably should be done in https://github.com/fmtlib/fmt/pull/2648.
