### PR TITLE
Remove incorrect C++20 check from test/CMakeLists.txt

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -137,7 +137,7 @@ endif ()
 
 message(STATUS "FMT_PEDANTIC: ${FMT_PEDANTIC}")
 
-if (FMT_PEDANTIC AND CXX_STANDARD LESS 20)
+if (FMT_PEDANTIC)
   # Test that the library can be compiled with exceptions disabled.
   # -fno-exception is broken in icc: https://github.com/fmtlib/fmt/issues/822.
   if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Intel")


### PR DESCRIPTION
This check disables entire branch of tests declaration unconditionally because `CXX_STANDARD` is not defined there. But even if we use `CMAKE_CXX_STANDARD` there, these tests should work for standards ≥20 too, IMHO.

Here are the tests:
* `std-format-test` (now removed)
* `noexception-test`
* `nolocale-test`
* `compile-error-test`

`std-format-test` does not compile after enabling it, since it's either outdated or should still be disabled. @vitaut, could you explain what should be done with it?
