### PR TITLE
Don't explicitly delete copy ctor of dynamic_format_arg_store

### DIFF
--- a/include/fmt/args.h
+++ b/include/fmt/args.h
@@ -145,9 +145,6 @@ class dynamic_format_arg_store
  public:
   constexpr dynamic_format_arg_store() = default;
 
-  constexpr dynamic_format_arg_store(
-      const dynamic_format_arg_store<Context>& store) = delete;
-
   /**
     \rst
     Adds an argument into the dynamic store for later passing to a formatting

--- a/test/args-test.cc
+++ b/test/args-test.cc
@@ -171,3 +171,21 @@ TEST(args_test, throw_on_copy) {
   }
   EXPECT_EQ(fmt::vformat("{}", store), "foo");
 }
+
+TEST(args_test, move_constructor) {
+  const int test_integer = 42;
+  const char* const test_c_string = "foo";
+
+  auto store_uptr =
+      std::make_unique<fmt::dynamic_format_arg_store<fmt::format_context>>();
+  store_uptr->push_back(test_integer);
+  store_uptr->push_back(std::string(test_c_string));
+  store_uptr->push_back(fmt::arg("a1", test_c_string));
+
+  fmt::dynamic_format_arg_store<fmt::format_context> moved_store(
+      std::move(*store_uptr));
+  store_uptr.reset();
+  EXPECT_EQ(
+      fmt::vformat("{} {} {a1}", moved_store),
+      std::to_string(test_integer) + " " + test_c_string + " " + test_c_string);
+}

--- a/test/args-test.cc
+++ b/test/args-test.cc
@@ -7,6 +7,8 @@
 
 #include "fmt/args.h"
 
+#include <memory>
+
 #include "gtest/gtest.h"
 
 TEST(args_test, basic) {
@@ -176,8 +178,8 @@ TEST(args_test, move_constructor) {
   const int test_integer = 42;
   const char* const test_c_string = "foo";
 
-  auto store_uptr =
-      std::make_unique<fmt::dynamic_format_arg_store<fmt::format_context>>();
+  std::unique_ptr<fmt::dynamic_format_arg_store<fmt::format_context>>
+      store_uptr(new fmt::dynamic_format_arg_store<fmt::format_context>());
   store_uptr->push_back(test_integer);
   store_uptr->push_back(std::string(test_c_string));
   store_uptr->push_back(fmt::arg("a1", test_c_string));


### PR DESCRIPTION
Explicitly deleting the copy ctor causes the move constructor to not be
implicitly generated. This behaviour is different than what was in
v8.0.1 and causes code that relied on the move ctor of
dynamic_format_arg_store to break.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
