### PR TITLE
Supporting nested format specs for ranges.

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -633,7 +633,7 @@ struct formatter<
     if (it == end || *it == '}') return it;
 
     if (*it != ':')
-      throw format_error("no top-level range formatters supported");
+      FMT_THROW(format_error("no top-level range formatters supported"));
 
     custom_specs_ = true;
     ++it;

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -601,12 +601,12 @@ struct formatter<
   template <typename T,
             FMT_ENABLE_IF(has_formatter<remove_cvref_t<T>, context>::value)>
   static auto map(T&& value) -> T&& {
-    return (T &&) value;
+    return static_cast<T&&>(value);
   }
   template <typename T,
             FMT_ENABLE_IF(!has_formatter<remove_cvref_t<T>, context>::value)>
-  static auto map(T&& value) -> decltype(mapper().map((T &&) value)) {
-    return mapper().map((T &&) value);
+  static auto map(T&& value) -> decltype(mapper().map(static_cast<T&&>(value))) {
+    return mapper().map(static_cast<T&&>(value));
   }
 
   using formatter_type = conditional_t<

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -222,8 +222,13 @@ template <class Tuple, class F> void for_each(Tuple&& tup, F&& f) {
 }
 
 template <typename Range>
-using uncvref_type =
-    remove_cvref_t<decltype(*detail::range_begin(std::declval<Range>()))>;
+using range_reference_type =
+    decltype(*detail::range_begin(std::declval<Range>()));
+
+// We don't use the Range's value_type for anything, but we do need the Range's
+// reference type, with cv-ref stripped
+template <typename Range>
+using uncvref_type = remove_cvref_t<range_reference_type<Range>>;
 
 template <typename OutputIt> OutputIt write_delimiter(OutputIt out) {
   *out++ = ',';

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -221,9 +221,23 @@ template <class Tuple, class F> void for_each(Tuple&& tup, F&& f) {
   for_each(indexes, std::forward<Tuple>(tup), std::forward<F>(f));
 }
 
+#if FMT_MSC_VER
+// older MSVC doesn't get the reference type correctly for arrays
+template <typename R> struct range_reference_type_impl {
+  using type = decltype(*detail::range_begin(std::declval<R&>()));
+};
+
+template <typename T, std::size_t N> struct range_reference_type_impl<T[N]> {
+  using type = T&;
+};
+
+template <typename T>
+using range_reference_type = typename range_reference_type_impl<T>::type;
+#else
 template <typename Range>
 using range_reference_type =
-    decltype(*detail::range_begin(std::declval<Range>()));
+    decltype(*detail::range_begin(std::declval<Range&>()));
+#endif
 
 // We don't use the Range's value_type for anything, but we do need the Range's
 // reference type, with cv-ref stripped

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -654,6 +654,7 @@ struct formatter<
     Char prefix = detail::is_set<R>::value ? '{' : '[';
     Char postfix = detail::is_set<R>::value ? '}' : ']';
 #endif
+    detail::range_mapper<buffer_context<Char>, detail::uncvref_type<R>> mapper;
     auto out = ctx.out();
     *out++ = prefix;
     int i = 0;
@@ -663,7 +664,7 @@ struct formatter<
       if (i > 0) out = detail::write_delimiter(out);
       if (custom_specs_) {
         ctx.advance_to(out);
-        out = underlying_.format(*it, ctx);
+        out = underlying_.format(mapper.map(*it), ctx);
       } else {
         out = detail::write_range_entry<Char>(out, *it);
       }

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -605,7 +605,8 @@ struct formatter<
   }
   template <typename T,
             FMT_ENABLE_IF(!has_formatter<remove_cvref_t<T>, context>::value)>
-  static auto map(T&& value) -> decltype(mapper().map(static_cast<T&&>(value))) {
+  static auto map(T&& value)
+      -> decltype(mapper().map(static_cast<T&&>(value))) {
     return mapper().map(static_cast<T&&>(value));
   }
 

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -46,11 +46,13 @@ TEST(ranges_test, format_array_of_literals) {
 TEST(ranges_test, format_vector) {
   auto v = std::vector<int>{1, 2, 3, 5, 7, 11};
   EXPECT_EQ(fmt::format("{}", v), "[1, 2, 3, 5, 7, 11]");
+  EXPECT_EQ(fmt::format("{::#x}", v), "[0x1, 0x2, 0x3, 0x5, 0x7, 0xb]");
 }
 
 TEST(ranges_test, format_vector2) {
   auto v = std::vector<std::vector<int>>{{1, 2}, {3, 5}, {7, 11}};
   EXPECT_EQ(fmt::format("{}", v), "[[1, 2], [3, 5], [7, 11]]");
+  EXPECT_EQ(fmt::format("{:::#x}", v), "[[0x1, 0x2], [0x3, 0x5], [0x7, 0xb]]");
 }
 
 TEST(ranges_test, format_map) {
@@ -296,6 +298,7 @@ static_assert(std::input_iterator<cpp20_only_range::iterator>);
 TEST(ranges_test, join_sentinel) {
   auto hello = zstring{"hello"};
   EXPECT_EQ(fmt::format("{}", hello), "['h', 'e', 'l', 'l', 'o']");
+  EXPECT_EQ(fmt::format("{::}", hello), "[h, e, l, l, o]");
   EXPECT_EQ(fmt::format("{}", fmt::join(hello, "_")), "h_e_l_l_o");
 }
 


### PR DESCRIPTION
Basic support for nested formatters for ranges from P2286. This does not add any top-level range format specifiers (pad/align/width/empty/delimiter), but does add the placeholder colon for them for the future. 