### PR TITLE
Fix throw with exceptions disabled and improve noexception test

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1404,7 +1404,7 @@ inline Int to_nonnegative_int(T value, Int upper) {
 template <typename T, typename Int, FMT_ENABLE_IF(!std::is_integral<T>::value)>
 inline Int to_nonnegative_int(T value, Int upper) {
   if (value < 0 || value > static_cast<T>(upper))
-    throw format_error("invalid value");
+    FMT_THROW(format_error("invalid value"));
   return static_cast<Int>(value);
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -144,7 +144,7 @@ if (FMT_PEDANTIC)
     check_cxx_compiler_flag(-fno-exceptions HAVE_FNO_EXCEPTIONS_FLAG)
   endif ()
   if (HAVE_FNO_EXCEPTIONS_FLAG)
-    add_library(noexception-test ../src/format.cc)
+    add_library(noexception-test ../src/format.cc noexception-test.cc)
     target_include_directories(
       noexception-test PRIVATE ${PROJECT_SOURCE_DIR}/include)
     target_compile_options(noexception-test PRIVATE -fno-exceptions)

--- a/test/noexception-test.cc
+++ b/test/noexception-test.cc
@@ -1,0 +1,18 @@
+// Formatting library for C++ - Noexception tests
+//
+// Copyright (c) 2012 - present, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#include "fmt/args.h"
+#include "fmt/chrono.h"
+#include "fmt/color.h"
+#include "fmt/compile.h"
+#include "fmt/core.h"
+#include "fmt/format.h"
+#include "fmt/os.h"
+#include "fmt/ostream.h"
+#include "fmt/printf.h"
+#include "fmt/ranges.h"
+#include "fmt/xchar.h"


### PR DESCRIPTION
``throw`` replaced with ``FMT_THROW`` in ``chrono.h``.
Improve noexception test.