### PR TITLE
Fix VS C4061 warning when using /Wall

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2739,6 +2739,10 @@ FMT_CONSTEXPR auto parse_float_type_spec(const basic_format_specs<Char>& specs,
   auto result = float_specs();
   result.showpoint = specs.alt;
   result.locale = specs.localized;
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4061)
+#endif
   switch (specs.type) {
   case presentation_type::none:
     result.format = float_format::general;
@@ -2769,19 +2773,13 @@ FMT_CONSTEXPR auto parse_float_type_spec(const basic_format_specs<Char>& specs,
   case presentation_type::hexfloat_lower:
     result.format = float_format::hex;
     break;
-  case presentation_type::dec:
-  case presentation_type::oct:
-  case presentation_type::hex_lower:
-  case presentation_type::hex_upper:
-  case presentation_type::bin_lower:
-  case presentation_type::bin_upper:
-  case presentation_type::chr:
-  case presentation_type::string:
-  case presentation_type::pointer:
   default:
     eh.on_error("invalid type specifier");
     break;
   }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
   return result;
 }
 

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2769,6 +2769,15 @@ FMT_CONSTEXPR auto parse_float_type_spec(const basic_format_specs<Char>& specs,
   case presentation_type::hexfloat_lower:
     result.format = float_format::hex;
     break;
+  case presentation_type::dec:
+  case presentation_type::oct:
+  case presentation_type::hex_lower:
+  case presentation_type::hex_upper:
+  case presentation_type::bin_lower:
+  case presentation_type::bin_upper:
+  case presentation_type::chr:
+  case presentation_type::string:
+  case presentation_type::pointer:
   default:
     eh.on_error("invalid type specifier");
     break;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1621,6 +1621,16 @@ FMT_CONSTEXPR FMT_INLINE auto write_int(OutputIt out, write_int_arg<T> arg,
   }
   case presentation_type::chr:
     return write_char(out, static_cast<Char>(abs_value), specs);
+  case presentation_type::hexfloat_lower:
+  case presentation_type::hexfloat_upper:
+  case presentation_type::exp_lower:
+  case presentation_type::exp_upper:
+  case presentation_type::fixed_lower:
+  case presentation_type::fixed_upper:
+  case presentation_type::general_lower:
+  case presentation_type::general_upper:
+  case presentation_type::string:
+  case presentation_type::pointer:
   default:
     throw_format_error("invalid type specifier");
   }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1572,6 +1572,10 @@ FMT_CONSTEXPR FMT_INLINE auto write_int(OutputIt out, write_int_arg<T> arg,
   static_assert(std::is_same<T, uint32_or_64_or_128_t<T>>::value, "");
   auto abs_value = arg.abs_value;
   auto prefix = arg.prefix;
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4061)
+#endif
   switch (specs.type) {
   case presentation_type::none:
   case presentation_type::dec: {
@@ -1621,19 +1625,12 @@ FMT_CONSTEXPR FMT_INLINE auto write_int(OutputIt out, write_int_arg<T> arg,
   }
   case presentation_type::chr:
     return write_char(out, static_cast<Char>(abs_value), specs);
-  case presentation_type::hexfloat_lower:
-  case presentation_type::hexfloat_upper:
-  case presentation_type::exp_lower:
-  case presentation_type::exp_upper:
-  case presentation_type::fixed_lower:
-  case presentation_type::fixed_upper:
-  case presentation_type::general_lower:
-  case presentation_type::general_upper:
-  case presentation_type::string:
-  case presentation_type::pointer:
   default:
     throw_format_error("invalid type specifier");
   }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
   return out;
 }
 template <typename Char, typename OutputIt, typename T>


### PR DESCRIPTION
Fix C4061 by adding the missing enum values to the switch statements.

(Issue 2687)