### PR TITLE
Restore FMT_API on error_handler::on_error()

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -601,7 +601,8 @@ struct error_handler {
   constexpr error_handler(const error_handler&) = default;
 
   // This function is intentionally not constexpr to give a compile-time error.
-  void on_error(const char* message) { throw_format_error(message); }
+  // This function is marked as FMT_API for backwards compatibility, see #2695.
+  FMT_NORETURN FMT_API void on_error(const char* message) { throw_format_error(message); }
 };
 FMT_END_DETAIL_NAMESPACE
 


### PR DESCRIPTION
this fixes a breaking ABI change that was introduce in the upgrade from
8.0.1 to 8.1.0.

Fixes #2695.