### PR TITLE
Make colored print handle UTF-8

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -530,7 +530,10 @@ void vprint(std::FILE* f, const text_style& ts, const S& format,
   basic_memory_buffer<Char> buf;
   detail::vformat_to(buf, ts, to_string_view(format), args);
   buf.push_back(Char(0));
-  detail::fputs(buf.data(), f);
+  if (detail::is_utf8())
+    detail::print(f, basic_string_view<Char>(buf.begin(), buf.size()));
+  else
+    detail::fputs(buf.data(), f);
 }
 
 /**

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -474,26 +474,27 @@ FMT_CONSTEXPR ansi_color_escape<Char> make_emphasis(emphasis em) FMT_NOEXCEPT {
   return ansi_color_escape<Char>(em);
 }
 
-template <typename Char>
-inline void fputs(const Char* chars, FILE* stream) FMT_NOEXCEPT {
-  std::fputs(chars, stream);
+template <typename Char> inline void fputs(const Char* chars, FILE* stream) {
+  int result = std::fputs(chars, stream);
+  if (result < 0)
+    FMT_THROW(system_error(errno, FMT_STRING("cannot write to file")));
 }
 
-template <>
-inline void fputs<wchar_t>(const wchar_t* chars, FILE* stream) FMT_NOEXCEPT {
-  std::fputws(chars, stream);
+template <> inline void fputs<wchar_t>(const wchar_t* chars, FILE* stream) {
+  int result = std::fputws(chars, stream);
+  if (result < 0)
+    FMT_THROW(system_error(errno, FMT_STRING("cannot write to file")));
 }
 
-template <typename Char> inline void reset_color(FILE* stream) FMT_NOEXCEPT {
+template <typename Char> inline void reset_color(FILE* stream) {
   fputs("\x1b[0m", stream);
 }
 
-template <> inline void reset_color<wchar_t>(FILE* stream) FMT_NOEXCEPT {
+template <> inline void reset_color<wchar_t>(FILE* stream) {
   fputs(L"\x1b[0m", stream);
 }
 
-template <typename Char>
-inline void reset_color(buffer<Char>& buffer) FMT_NOEXCEPT {
+template <typename Char> inline void reset_color(buffer<Char>& buffer) {
   auto reset_color = string_view("\x1b[0m");
   buffer.append(reset_color.begin(), reset_color.end());
 }
@@ -529,9 +530,9 @@ void vprint(std::FILE* f, const text_style& ts, const S& format,
             basic_format_args<buffer_context<type_identity_t<Char>>> args) {
   basic_memory_buffer<Char> buf;
   detail::vformat_to(buf, ts, to_string_view(format), args);
-  if (detail::is_utf8())
+  if (detail::is_utf8()) {
     detail::print(f, basic_string_view<Char>(buf.begin(), buf.size()));
-  else {
+  } else {
     buf.push_back(Char(0));
     detail::fputs(buf.data(), f);
   }

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -530,9 +530,11 @@ void vprint(std::FILE* f, const text_style& ts, const S& format,
   basic_memory_buffer<Char> buf;
   detail::vformat_to(buf, ts, to_string_view(format), args);
   buf.push_back(Char(0));
+#ifdef _WIN32
   if (detail::is_utf8())
     detail::print(f, basic_string_view<Char>(buf.begin(), buf.size()));
   else
+#endif
     detail::fputs(buf.data(), f);
 }
 

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -529,13 +529,12 @@ void vprint(std::FILE* f, const text_style& ts, const S& format,
             basic_format_args<buffer_context<type_identity_t<Char>>> args) {
   basic_memory_buffer<Char> buf;
   detail::vformat_to(buf, ts, to_string_view(format), args);
-  buf.push_back(Char(0));
-#ifdef _WIN32
   if (detail::is_utf8())
     detail::print(f, basic_string_view<Char>(buf.begin(), buf.size()));
-  else
-#endif
+  else {
+    buf.push_back(Char(0));
     detail::fputs(buf.data(), f);
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #2681 

The working flow:
 * With `is_utf8()` calls `detail::print` that specifically converts to UTF-16 and calls `WriteConsoleW` 
 * Without `is_utf8()` calls `fwrite_fully`

The broken flow:
 * Always call `fputs`

The fix:
 * With `is_utf8()` call `detail::print` 
 * Without `is_utf8()` keep calling `fputs`, as `fwrite_fully` is not exported

This is tested on Windows only. On Windows `fputs` does not do any magic, and color sequences are processed by `WriteConsole`. I'm not sure if on other platform `fputs` processes these ANSI escape sequences, or `fwrite` will also do.