### PR TITLE
Docs: Fix link to "Compile-time Format String Checks" section

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -101,7 +101,7 @@ The code
   format(FMT_STRING("The answer is {:d}"), "forty-two");
 
 reports a compile-time error on compilers that support relaxed ``constexpr``.
-See `here <api.html#c.fmt>`_ for details.
+See `here <api.html#compile-time-format-string-checks>`_ for details.
 
 The following code
 


### PR DESCRIPTION
The link in the [safety section](https://fmt.dev/latest/index.html#safety) goes to a nonexistant [`c.fmt` anchor on the API page](https://fmt.dev/latest/api.html#c.fmt), when it should go to [the section for the Compile-Time Format String Checks](https://fmt.dev/latest/api.html#compile-time-format-string-checks).  I don't think the old anchor ever worked (at least, no such anchor [exists in the oldest archived copy of the page](https://web.archive.org/web/20200415062246/https://fmt.dev/latest/api.html#c.fmt)).

I haven't actually tested that this link works now because I haven't set up building the docs locally, but I'm almost certain that this is the correct way of formatting a link.