### PR TITLE
Fix -Wconversion warning 

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1214,7 +1214,7 @@ template <typename OutputIt, typename Char> class tm_writer {
     char buf[10];
     size_t offset = 0;
     if (year >= 0 && year < 10000) {
-      copy2(buf, digits2(static_cast<size_t>(to_unsigned(year / 100))));
+      copy2(buf, digits2(static_cast<size_t>(year / 100)));
     } else {
       offset = 4;
       write_year_extended(year);

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1214,7 +1214,7 @@ template <typename OutputIt, typename Char> class tm_writer {
     char buf[10];
     size_t offset = 0;
     if (year >= 0 && year < 10000) {
-      copy2(buf, digits2(to_unsigned(year / 100)));
+      copy2(buf, digits2(static_cast<size_t>(to_unsigned(year / 100))));
     } else {
       offset = 4;
       write_year_extended(year);


### PR DESCRIPTION
Thanks for your great work and the great fmt library.

I have a small problem. When I cross-compile (with dockcross/linux-armv7 https://github.com/dockcross/dockcross to Raspberry Pi ARMv7) my source code with your fmt-library, I receive this warning:

```
/work/build_armv7/_deps/fmt-src/include/fmt/chrono.h:1217:37: warning: conversion from 'std::make_unsigned<long long int>::type' {aka 'long long unsigned int'} to 'size_t' {aka 'unsigned int'} may change value [-Wconversion]
 1217 |       copy2(buf, digits2(to_unsigned(year / 100)));
      |                          ~~~~~~~~~~~^~~~~~~~~~~~
```

Not using the -Wconversion flag is not an option because I want to use the flag to detect as many errors as possible.
And I'm not able to configure CMake, CPMAddPackage and `target_include_directories`+`SYSTEM` correctly to ignore warnings from your library 🙈.

My solution (adding const_cast<size_t>) works for me but I don't know if this is a clean solution. I'm not a C++ expert.