### PR TITLE
Making target_compile_options PRIVATE, fix #2726, fix #2507

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ endif ()
 if (MINGW)
   check_cxx_compiler_flag("-Wa,-mbig-obj" FMT_HAS_MBIG_OBJ)
   if (${FMT_HAS_MBIG_OBJ})
-    target_compile_options(fmt PUBLIC "-Wa,-mbig-obj")
+    target_compile_options(fmt PRIVATE "-Wa,-mbig-obj")
   endif()
 endif ()
 


### PR DESCRIPTION
I weren't able to reach @ambitslix in the issue #1684 so I am not sure what exactly caused the problem for him. I think that making compile options private is a good compromise. It is always easier to add an option to the project using the library than removing an option set by an included library and unconditionally propagated to the whole project using it. This should close #2726 and also solve an already closed #2507. Probably this target_compile_options can be removed completely, I don't think there was an issue building the library itself, but I don't have an environment to reproduce the error that this line solved on the first place.