### PR TITLE
Adding a put API to basic_format_context.

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1776,6 +1776,15 @@ template <typename OutputIt, typename Char> class basic_format_context {
     if (!detail::is_back_insert_iterator<iterator>()) out_ = it;
   }
 
+  FMT_CONSTEXPR auto put(char_type c) -> iterator {
+    *out_++ = c;
+    return out;
+  }
+  FMT_CONSTEXPR auto put(basic_string_view<char_type> sv) -> iterator {
+    detail::copy_str<char_type>(sv.data(), sv.data() + sv.size(), out);
+    return out;
+  }
+
   FMT_CONSTEXPR auto locale() -> detail::locale_ref { return loc_; }
 };
 

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1778,11 +1778,18 @@ template <typename OutputIt, typename Char> class basic_format_context {
 
   FMT_CONSTEXPR auto put(char_type c) -> iterator {
     *out_++ = c;
-    return out;
+    return out_;
   }
   FMT_CONSTEXPR auto put(basic_string_view<char_type> sv) -> iterator {
-    detail::copy_str<char_type>(sv.data(), sv.data() + sv.size(), out);
-    return out;
+    detail::copy_str<char_type>(sv.data(), sv.data() + sv.size(), out_);
+    return out_;
+  }
+
+  template <typename T, typename U,
+            FMT_ENABLE_IF(std::is_same<T, std::remove_const_t<U>>::value)>
+  FMT_CONSTEXPR auto put(formatter<T>& f, U& object) -> iterator {
+    advance_to(f.format(object, *this));
+    return out_;
   }
 
   FMT_CONSTEXPR auto locale() -> detail::locale_ref { return loc_; }

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1786,7 +1786,8 @@ template <typename OutputIt, typename Char> class basic_format_context {
   }
 
   template <typename T, typename U,
-            FMT_ENABLE_IF(std::is_same<T, std::remove_const_t<U>>::value)>
+            FMT_ENABLE_IF(
+                std::is_same<T, typename std::remove_const<U>::type>::value)>
   FMT_CONSTEXPR auto put(formatter<T>& f, U& object) -> iterator {
     advance_to(f.format(object, *this));
     return out_;

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2194,3 +2194,30 @@ TEST(format_int_test, format_int) {
   os << max_value<int64_t>();
   EXPECT_EQ(os.str(), fmt::format_int(max_value<int64_t>()).str());
 }
+
+struct put_on_the_ritz {
+  int i;
+};
+
+FMT_BEGIN_NAMESPACE
+template <> struct formatter<put_on_the_ritz> {
+  formatter<int> underlying;
+
+  FMT_CONSTEXPR auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+    return underlying.parse(ctx);
+  }
+
+  auto format(put_on_the_ritz r, format_context& ctx) -> decltype(ctx.out()) {
+    ctx.put('{');
+    ctx.put(".i=");
+    ctx.put(underlying, r.i);
+    ctx.put('}');
+    return ctx.out();
+  }
+};
+FMT_END_NAMESPACE
+
+TEST(format_test, format_context_put) {
+  EXPECT_EQ(fmt::format("[{}]", put_on_the_ritz{42}), "[{.i=42}]");
+  EXPECT_EQ(fmt::format("[{:#x}]", put_on_the_ritz{42}), "[{.i=0x2a}]");
+}


### PR DESCRIPTION
This is inspired by Peter Dimov's email. tl;dr This PR adds an API onto basic_format_context that makes it more convenient and, more importantly, potentially more performant.

---

A lot of the time when we're formatting, we're either copying a single character or a string_view into the output iterator. So you get a bunch of either:

```cpp
auto out = ctx.out();
*out++ = c;
out = std::ranges::copy("whatever"sv, out).out;
```

This works fine. But it could be better. The C++ output iterator model is very limited to just writing one thing at a time and doesn't have range support -- but if we (the implementation) know what our iterator is, we can do better than that if we just expose that kind of ability to the user.

{fmt} already has `copy_str` which takes advantage of that knowledge.

This PR simply exposes that to the user by way of a member functions on the format_context that take either a char or a string_view (maybe this should be an arbitrary range instead or something?). I named it `put`  after D's output range model (and this library already has enough things named write). The `put` API should be at least as efficient as what the user could write.

As an added bonus, occasionally you need to also go through an underlying formatter. At that point, you have to carefully:

```cpp
ctx.advance_to(out);
out = underlying.format(some_object, ctx);
*out++ = '};
return out;
```

This back and forth is a little jarring, so I also added a `put` overload that takes a `formatter<T>` and a `T`/`const T` so that you can just do:
```cpp
ctx.put(c);
ctx.put("whatever"sv); // or even just "whatever" if we stick with string_view
ctx.put(underlying, some_object);
ctx.put('}');
return ctx.out();
```
