### PR TITLE
qualify unqualified calls to format in compile.h

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -534,10 +534,10 @@ FMT_INLINE std::basic_string<typename S::char_type> format(const S&,
   constexpr auto compiled = detail::compile<Args...>(S());
   if constexpr (std::is_same<remove_cvref_t<decltype(compiled)>,
                              detail::unknown_format>()) {
-    return format(static_cast<basic_string_view<typename S::char_type>>(S()),
+    return ::fmt::format(static_cast<basic_string_view<typename S::char_type>>(S()),
                   std::forward<Args>(args)...);
   } else {
-    return format(compiled, std::forward<Args>(args)...);
+    return ::fmt::format(compiled, std::forward<Args>(args)...);
   }
 }
 
@@ -547,11 +547,11 @@ FMT_CONSTEXPR OutputIt format_to(OutputIt out, const S&, Args&&... args) {
   constexpr auto compiled = detail::compile<Args...>(S());
   if constexpr (std::is_same<remove_cvref_t<decltype(compiled)>,
                              detail::unknown_format>()) {
-    return format_to(out,
+    return ::fmt::format_to(out,
                      static_cast<basic_string_view<typename S::char_type>>(S()),
                      std::forward<Args>(args)...);
   } else {
-    return format_to(out, compiled, std::forward<Args>(args)...);
+    return ::fmt::format_to(out, compiled, std::forward<Args>(args)...);
   }
 }
 #endif
@@ -560,7 +560,7 @@ template <typename OutputIt, typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
 format_to_n_result<OutputIt> format_to_n(OutputIt out, size_t n,
                                          const S& format_str, Args&&... args) {
-  auto it = format_to(detail::truncating_iterator<OutputIt>(out, n), format_str,
+  auto it = ::fmt::format_to(detail::truncating_iterator<OutputIt>(out, n), format_str,
                       std::forward<Args>(args)...);
   return {it.base(), it.count()};
 }
@@ -568,14 +568,14 @@ format_to_n_result<OutputIt> format_to_n(OutputIt out, size_t n,
 template <typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
 size_t formatted_size(const S& format_str, const Args&... args) {
-  return format_to(detail::counting_iterator(), format_str, args...).count();
+  return ::fmt::format_to(detail::counting_iterator(), format_str, args...).count();
 }
 
 template <typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
 void print(std::FILE* f, const S& format_str, const Args&... args) {
   memory_buffer buffer;
-  format_to(std::back_inserter(buffer), format_str, args...);
+  ::fmt::format_to(std::back_inserter(buffer), format_str, args...);
   detail::print(f, {buffer.data(), buffer.size()});
 }
 


### PR DESCRIPTION
Now that both libfmt and the STL have implemented P2418 our formats are no longer worse (w.r.t. overload resolution) than fmt's formats. Hilarity ensues. (libfmt probably gets `<format>` via `<chrono>`, I'm working on fixing that too, but even with the fix these calls should be qualified in case someone wants to use fmt and gets `<format>` through some other path).


Fully qualifies the problematic functions calls to avoid ambiguity. 