### PR TITLE
Replace ``make_args_checked`` with ``make_format_args``

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -113,8 +113,7 @@ binary footprint, for example (https://godbolt.org/z/oba4Mc):
 
     template <typename S, typename... Args>
     void log(const char* file, int line, const S& format, Args&&... args) {
-      vlog(file, line, format,
-          fmt::make_args_checked<Args...>(format, args...));
+      vlog(file, line, format, fmt::make_format_args(args...));
     }
 
     #define MY_LOG(format, ...) \
@@ -124,8 +123,6 @@ binary footprint, for example (https://godbolt.org/z/oba4Mc):
 
 Note that ``vlog`` is not parameterized on argument types which improves compile
 times and reduces binary code size compared to a fully parameterized version.
-
-.. doxygenfunction:: fmt::make_args_checked(const S&, const remove_reference_t<Args>&...)
 
 .. doxygenfunction:: fmt::make_format_args(const Args&...)
 

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -547,7 +547,7 @@ template <typename S, typename... Args,
 void print(std::FILE* f, const text_style& ts, const S& format_str,
            const Args&... args) {
   vprint(f, ts, format_str,
-         fmt::make_args_checked<Args...>(format_str, args...));
+         fmt::make_format_args<buffer_context<char_t<S>>>(args...));
 }
 
 /**
@@ -592,7 +592,7 @@ template <typename S, typename... Args, typename Char = char_t<S>>
 inline std::basic_string<Char> format(const text_style& ts, const S& format_str,
                                       const Args&... args) {
   return fmt::vformat(ts, to_string_view(format_str),
-                      fmt::make_args_checked<Args...>(format_str, args...));
+                      fmt::make_format_args<buffer_context<Char>>(args...));
 }
 
 /**
@@ -627,7 +627,7 @@ inline auto format_to(OutputIt out, const text_style& ts, const S& format_str,
                       Args&&... args) ->
     typename std::enable_if<enable, OutputIt>::type {
   return vformat_to(out, ts, to_string_view(format_str),
-                    fmt::make_args_checked<Args...>(format_str, args...));
+                    fmt::make_format_args<buffer_context<char_t<S>>>(args...));
 }
 
 FMT_MODULE_EXPORT_END

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2561,7 +2561,7 @@ template <typename Char> struct udl_formatter {
 
   template <typename... T>
   auto operator()(T&&... args) const -> std::basic_string<Char> {
-    return vformat(str, fmt::make_args_checked<T...>(str, args...));
+    return vformat(str, fmt::make_format_args<buffer_context<Char>>(args...));
   }
 };
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -834,8 +834,8 @@ class FMT_API format_error : public std::runtime_error {
   \endrst
  */
 template <typename... Args, typename S, typename Char = char_t<S>>
-FMT_INLINE auto make_args_checked(const S& fmt,
-                                  const remove_reference_t<Args>&... args)
+FMT_DEPRECATED FMT_INLINE auto make_args_checked(
+    const S& fmt, const remove_reference_t<Args>&... args)
     -> format_arg_store<buffer_context<Char>, remove_reference_t<Args>...> {
   static_assert(
       detail::count<(

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -136,7 +136,7 @@ template <typename S, typename... Args,
           typename Char = enable_if_t<detail::is_string<S>::value, char_t<S>>>
 void print(std::basic_ostream<Char>& os, const S& format_str, Args&&... args) {
   vprint(os, to_string_view(format_str),
-         fmt::make_args_checked<Args...>(format_str, args...));
+         fmt::make_format_args<buffer_context<Char>>(args...));
 }
 FMT_END_NAMESPACE
 

--- a/include/fmt/xchar.h
+++ b/include/fmt/xchar.h
@@ -92,8 +92,8 @@ auto vformat(basic_string_view<Char> format_str,
 template <typename S, typename... Args, typename Char = char_t<S>,
           FMT_ENABLE_IF(!std::is_same<Char, char>::value)>
 auto format(const S& format_str, Args&&... args) -> std::basic_string<Char> {
-  const auto& vargs = fmt::make_args_checked<Args...>(format_str, args...);
-  return vformat(to_string_view(format_str), vargs);
+  return vformat(to_string_view(format_str),
+                 fmt::make_format_args<buffer_context<Char>>(args...));
 }
 
 template <typename Locale, typename S, typename Char = char_t<S>,
@@ -113,7 +113,7 @@ template <typename Locale, typename S, typename... Args,
 inline auto format(const Locale& loc, const S& format_str, Args&&... args)
     -> std::basic_string<Char> {
   return detail::vformat(loc, to_string_view(format_str),
-                         fmt::make_args_checked<Args...>(format_str, args...));
+                         fmt::make_format_args<buffer_context<Char>>(args...));
 }
 
 template <typename OutputIt, typename S, typename Char = char_t<S>,
@@ -132,8 +132,8 @@ template <typename OutputIt, typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, Char>::value&&
                             detail::is_exotic_char<Char>::value)>
 inline auto format_to(OutputIt out, const S& fmt, Args&&... args) -> OutputIt {
-  const auto& vargs = fmt::make_args_checked<Args...>(fmt, args...);
-  return vformat_to(out, to_string_view(fmt), vargs);
+  return vformat_to(out, to_string_view(fmt),
+                    fmt::make_format_args<buffer_context<Char>>(args...));
 }
 
 template <typename S, typename... Args, typename Char, size_t SIZE,
@@ -141,8 +141,8 @@ template <typename S, typename... Args, typename Char, size_t SIZE,
 FMT_DEPRECATED auto format_to(basic_memory_buffer<Char, SIZE, Allocator>& buf,
                               const S& format_str, Args&&... args) ->
     typename buffer_context<Char>::iterator {
-  const auto& vargs = fmt::make_args_checked<Args...>(format_str, args...);
-  detail::vformat_to(buf, to_string_view(format_str), vargs, {});
+  detail::vformat_to(buf, to_string_view(format_str),
+                     fmt::make_format_args<buffer_context<Char>>(args...), {});
   return detail::buffer_appender<Char>(buf);
 }
 
@@ -167,8 +167,8 @@ template <
 inline auto format_to(OutputIt out, const Locale& loc, const S& format_str,
                       Args&&... args) ->
     typename std::enable_if<enable, OutputIt>::type {
-  const auto& vargs = fmt::make_args_checked<Args...>(format_str, args...);
-  return vformat_to(out, loc, to_string_view(format_str), vargs);
+  return vformat_to(out, loc, to_string_view(format_str),
+                    fmt::make_format_args<buffer_context<Char>>(args...));
 }
 
 template <typename OutputIt, typename Char, typename... Args,
@@ -190,16 +190,16 @@ template <typename OutputIt, typename S, typename... Args,
                             detail::is_exotic_char<Char>::value)>
 inline auto format_to_n(OutputIt out, size_t n, const S& fmt,
                         const Args&... args) -> format_to_n_result<OutputIt> {
-  const auto& vargs = fmt::make_args_checked<Args...>(fmt, args...);
-  return vformat_to_n(out, n, to_string_view(fmt), vargs);
+  return vformat_to_n(out, n, to_string_view(fmt),
+                      fmt::make_format_args<buffer_context<Char>>(args...));
 }
 
 template <typename S, typename... Args, typename Char = char_t<S>,
           FMT_ENABLE_IF(detail::is_exotic_char<Char>::value)>
 inline auto formatted_size(const S& fmt, Args&&... args) -> size_t {
   detail::counting_buffer<Char> buf;
-  const auto& vargs = fmt::make_args_checked<Args...>(fmt, args...);
-  detail::vformat_to(buf, to_string_view(fmt), vargs);
+  detail::vformat_to(buf, to_string_view(fmt),
+                     fmt::make_format_args<buffer_context<Char>>(args...));
   return buf.count();
 }
 

--- a/test/module-test.cc
+++ b/test/module-test.cc
@@ -195,13 +195,6 @@ TEST(module_test, wformat_args) {
   EXPECT_TRUE(args.get(0));
 }
 
-TEST(module_test, checked_format_args) {
-  fmt::basic_format_args args = fmt::make_args_checked<int>("{}", 42);
-  EXPECT_TRUE(args.get(0));
-  fmt::basic_format_args wargs = fmt::make_args_checked<int>(L"{}", 42);
-  EXPECT_TRUE(wargs.get(0));
-}
-
 TEST(module_test, dynamic_format_args) {
   fmt::dynamic_format_arg_store<fmt::format_context> dyn_store;
   dyn_store.push_back(fmt::arg("a42", 42));


### PR DESCRIPTION
Replace ``make_args_checked`` with ``make_format_args`` and remove legacy ``make_args_checked``.

See: https://github.com/fmtlib/fmt/issues/2746#issuecomment-1033347178

@vitaut, please review these changes. I am not sure of their correctness.