### PR TITLE
Ignore clang ``-Wliteral-range`` warning

### DIFF
--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -948,8 +948,10 @@ TEST(format_test, precision) {
   EXPECT_THAT(outputs,
               testing::Contains(fmt::format("{:.838A}", -2.14001164E+38)));
 
-  auto ld = 8.43821965335442234493E-4933L;
-  EXPECT_EQ(fmt::format("{:.0}", ld), ld != 0 ? "8e-4933" : "0");
+  if (std::numeric_limits<long double>::digits == 64) {
+    auto ld = (std::numeric_limits<long double>::min)();
+    EXPECT_EQ(fmt::format("{:.0}", ld), "3e-4932");
+  }
 
   EXPECT_EQ("123.", fmt::format("{:#.0f}", 123.0));
   EXPECT_EQ("1.23", fmt::format("{:.02f}", 1.234));


### PR DESCRIPTION
Fix for build error on Apple M1 Max (XCode 13):

```
[ 31%] Building CXX object test/CMakeFiles/format-test.dir/format-test.cc.o
cd /Users/phprus/Devel/fmt/build/cxx20/test && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DGTEST_HAS_STD_WSTRING=1 -D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING=1 -I/Users/phprus/Devel/fmt/include -isystem /Users/phprus/Devel/fmt/test/gtest/. -O2 -g -DNDEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -pedantic -Wconversion -Wundef -Wdeprecated -Wweak-vtables -Wshadow -Wno-gnu-zero-variadic-macro-arguments -Wzero-as-null-pointer-constant -Werror -fno-delete-null-pointer-checks -std=gnu++2a -MD -MT test/CMakeFiles/format-test.dir/format-test.cc.o -MF CMakeFiles/format-test.dir/format-test.cc.o.d -o CMakeFiles/format-test.dir/format-test.cc.o -c /Users/phprus/Devel/fmt/test/format-test.cc
/Users/phprus/Devel/fmt/test/format-test.cc:951:13: error: magnitude of floating-point constant too small for type 'long double'; minimum is 4.9406564584124654E-324 [-Werror,-Wliteral-range]
  auto ld = 8.43821965335442234493E-4933L;
            ^
1 error generated.
```