### PR TITLE
Update format.h

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -389,7 +389,7 @@ template <typename To, typename From, FMT_ENABLE_IF(sizeof(To) > sizeof(From))>
 inline auto bit_cast(const From& from) -> To {
   constexpr auto size = static_cast<int>(sizeof(From) / sizeof(unsigned));
   struct data_t {
-    unsigned value[static_cast<size_t>(size)];
+    unsigned value[to_unsigned(size)];
   } data = bit_cast<data_t>(from);
   auto result = To();
   if (const_check(is_big_endian())) {

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -389,7 +389,7 @@ template <typename To, typename From, FMT_ENABLE_IF(sizeof(To) > sizeof(From))>
 inline auto bit_cast(const From& from) -> To {
   constexpr auto size = static_cast<int>(sizeof(From) / sizeof(unsigned));
   struct data_t {
-    unsigned value[size];
+    unsigned value[static_cast<size_t>(size)];
   } data = bit_cast<data_t>(from);
   auto result = To();
   if (const_check(is_big_endian())) {


### PR DESCRIPTION
To prevent the following compiler message:
```
[...]/include/fmt/format.h:392:20: warning: conversion to 'long unsigned int' from 'int' may change the sign of the result [-Wsign-conversion]
  392 |     unsigned value[size];
      |                    ^~~~
```
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
