### PR TITLE
Implement styled arguments

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -644,29 +644,29 @@ struct formatter<detail::styled_arg<T>, Char> : formatter<T, Char> {
     const auto& value = arg.value;
     auto out = ctx.out();
 
-    using detail::get_buffer;
-    auto&& buf = get_buffer<Char>(out);
-
     bool has_style = false;
     if (ts.has_emphasis()) {
       has_style = true;
       auto emphasis = detail::make_emphasis<Char>(ts.get_emphasis());
-      buf.append(emphasis.begin(), emphasis.end());
+      out = std::copy(emphasis.begin(), emphasis.end(), out);
     }
     if (ts.has_foreground()) {
       has_style = true;
       auto foreground =
           detail::make_foreground_color<Char>(ts.get_foreground());
-      buf.append(foreground.begin(), foreground.end());
+      out = std::copy(foreground.begin(), foreground.end(), out);
     }
     if (ts.has_background()) {
       has_style = true;
       auto background =
           detail::make_background_color<Char>(ts.get_background());
-      buf.append(background.begin(), background.end());
+      out = std::copy(background.begin(), background.end(), out);
     }
     out = formatter<T, Char>::format(value, ctx);
-    if (has_style) detail::reset_color<Char>(buf);
+    if (has_style) {
+      auto reset_color = string_view("\x1b[0m");
+      out = std::copy(reset_color.begin(), reset_color.end(), out);
+    }
     return out;
   }
 };

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -643,22 +643,7 @@ template <typename Arg> struct styled_arg {
 FMT_END_DETAIL_NAMESPACE
 
 template <typename Arg, typename Char>
-struct formatter<detail::styled_arg<Arg>, Char> {
- private:
-  using value_type = Arg;
-  using formatter_type =
-      conditional_t<is_formattable<value_type, Char>::value,
-                    formatter<remove_cvref_t<value_type>, Char>,
-                    detail::fallback_formatter<value_type, Char>>;
-
-  formatter_type value_formatter_;
-
- public:
-  template <typename ParseContext>
-  FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
-    return value_formatter_.parse(ctx);
-  }
-
+struct formatter<detail::styled_arg<Arg>, Char> : formatter<Arg, Char> {
   template <typename FormatContext>
   auto format(detail::styled_arg<Arg> const& arg, FormatContext& ctx) const
       -> decltype(ctx.out()) {
@@ -687,7 +672,7 @@ struct formatter<detail::styled_arg<Arg>, Char> {
           detail::make_background_color<Char>(ts.get_background());
       buf.append(background.begin(), background.end());
     }
-    out = value_formatter_.format(value, ctx);
+    out = formatter<Arg, Char>::format(value, ctx);
     if (has_style) detail::reset_color<Char>(buf);
     return out;
   }

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -493,7 +493,7 @@ template <typename Char> inline void reset_color(buffer<Char>& buffer) {
 }
 
 template <typename Arg> struct styled_arg {
-  FMT_CONSTEXPR styled_arg(Arg const& format_argument, text_style format_style)
+  FMT_CONSTEXPR styled_arg(const Arg& format_argument, text_style format_style)
       : argument(format_argument), style(format_style) {}
 
   const Arg& argument;
@@ -641,10 +641,10 @@ inline auto format_to(OutputIt out, const text_style& ts, const S& format_str,
 template <typename Arg, typename Char>
 struct formatter<detail::styled_arg<Arg>, Char> : formatter<Arg, Char> {
   template <typename FormatContext>
-  auto format(detail::styled_arg<Arg> const& arg, FormatContext& ctx) const
+  auto format(const detail::styled_arg<Arg>& arg, FormatContext& ctx) const
       -> decltype(ctx.out()) {
-    auto const& ts = arg.style;
-    auto const& value = arg.argument;
+    const auto& ts = arg.style;
+    const auto& value = arg.argument;
     auto out = ctx.out();
 
     using detail::get_buffer;

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -679,45 +679,13 @@ struct formatter<detail::styled_arg<T>, Char> : formatter<T, Char> {
   **Example**::
 
     fmt::print("Elapsed time: {s:.2f} seconds",
-               fmt::styled(1.23, fmt::fg(fmt::colors::green) |
-  fmt::bg(fmt::color::blue))); \endrst
+               fmt::styled(1.23, fmt::fg(fmt::colors::green) | fmt::bg(fmt::color::blue)));
+  \endrst
  */
 template <typename T>
 FMT_CONSTEXPR auto styled(const T& value, text_style ts = {})
     -> detail::styled_arg<remove_cvref_t<T>> {
   return detail::styled_arg<remove_cvref_t<T>>{value, ts};
-}
-
-/**
-  \rst
-  Returns an argument surrounded by the ANSI escape sequences of the color,
-  to be used in a formatting function.
-
-  **Example**::
-
-    fmt::print("Elapsed time: {s:.2f} seconds", fmt::styled(1.23,
-  fmt::colors::green)); \endrst
- */
-template <typename T>
-FMT_CONSTEXPR auto styled(const T& value, detail::color_type color)
-    -> detail::styled_arg<remove_cvref_t<T>> {
-  return detail::styled_arg<remove_cvref_t<T>>{value, fg(color)};
-}
-
-/**
-  \rst
-  Returns an argument associated with an emphasis, to be used
-  in a formatting function.
-
-  **Example**::
-
-    fmt::print("Elapsed time: {s:.2f} seconds", fmt::styled(1.23,
-  fmt::emphasis::italic)); \endrst
- */
-template <typename T>
-FMT_CONSTEXPR auto styled(const T& value, emphasis em)
-    -> detail::styled_arg<remove_cvref_t<T>> {
-  return detail::styled_arg<remove_cvref_t<T>>{value, text_style(em)};
 }
 
 FMT_MODULE_EXPORT_END

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -683,7 +683,7 @@ struct formatter<detail::styled_arg<T>, Char> : formatter<T, Char> {
   \endrst
  */
 template <typename T>
-FMT_CONSTEXPR auto styled(const T& value, text_style ts = {})
+FMT_CONSTEXPR auto styled(const T& value, text_style ts)
     -> detail::styled_arg<remove_cvref_t<T>> {
   return detail::styled_arg<remove_cvref_t<T>>{value, ts};
 }

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -492,6 +492,14 @@ template <typename Char> inline void reset_color(buffer<Char>& buffer) {
   buffer.append(reset_color.begin(), reset_color.end());
 }
 
+template <typename Arg> struct styled_arg {
+  FMT_CONSTEXPR styled_arg(Arg const& argument, text_style style)
+      : argument(argument), style(style) {}
+
+  const Arg& argument;
+  text_style style;
+};
+
 template <typename Char>
 void vformat_to(buffer<Char>& buf, const text_style& ts,
                 basic_string_view<Char> format_str,
@@ -629,18 +637,6 @@ inline auto format_to(OutputIt out, const text_style& ts, const S& format_str,
   return vformat_to(out, ts, to_string_view(format_str),
                     fmt::make_format_args<buffer_context<char_t<S>>>(args...));
 }
-
-FMT_BEGIN_DETAIL_NAMESPACE
-
-template <typename Arg> struct styled_arg {
-  FMT_CONSTEXPR styled_arg(Arg const& argument, text_style style)
-      : argument(argument), style(style) {}
-
-  const Arg& argument;
-  text_style style;
-};
-
-FMT_END_DETAIL_NAMESPACE
 
 template <typename Arg, typename Char>
 struct formatter<detail::styled_arg<Arg>, Char> : formatter<Arg, Char> {

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -493,8 +493,8 @@ template <typename Char> inline void reset_color(buffer<Char>& buffer) {
 }
 
 template <typename Arg> struct styled_arg {
-  FMT_CONSTEXPR styled_arg(Arg const& argument, text_style style)
-      : argument(argument), style(style) {}
+  FMT_CONSTEXPR styled_arg(Arg const& format_argument, text_style format_style)
+      : argument(format_argument), style(format_style) {}
 
   const Arg& argument;
   text_style style;

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -492,11 +492,8 @@ template <typename Char> inline void reset_color(buffer<Char>& buffer) {
   buffer.append(reset_color.begin(), reset_color.end());
 }
 
-template <typename Arg> struct styled_arg {
-  FMT_CONSTEXPR styled_arg(const Arg& format_argument, text_style format_style)
-      : argument(format_argument), style(format_style) {}
-
-  const Arg& argument;
+template <typename T> struct styled_arg {
+  const T& value;
   text_style style;
 };
 
@@ -638,13 +635,13 @@ inline auto format_to(OutputIt out, const text_style& ts, const S& format_str,
                     fmt::make_format_args<buffer_context<char_t<S>>>(args...));
 }
 
-template <typename Arg, typename Char>
-struct formatter<detail::styled_arg<Arg>, Char> : formatter<Arg, Char> {
+template <typename T, typename Char>
+struct formatter<detail::styled_arg<T>, Char> : formatter<T, Char> {
   template <typename FormatContext>
-  auto format(const detail::styled_arg<Arg>& arg, FormatContext& ctx) const
+  auto format(const detail::styled_arg<T>& arg, FormatContext& ctx) const
       -> decltype(ctx.out()) {
     const auto& ts = arg.style;
-    const auto& value = arg.argument;
+    const auto& value = arg.value;
     auto out = ctx.out();
 
     using detail::get_buffer;
@@ -668,7 +665,7 @@ struct formatter<detail::styled_arg<Arg>, Char> : formatter<Arg, Char> {
           detail::make_background_color<Char>(ts.get_background());
       buf.append(background.begin(), background.end());
     }
-    out = formatter<Arg, Char>::format(value, ctx);
+    out = formatter<T, Char>::format(value, ctx);
     if (has_style) detail::reset_color<Char>(buf);
     return out;
   }
@@ -685,10 +682,10 @@ struct formatter<detail::styled_arg<Arg>, Char> : formatter<Arg, Char> {
                fmt::styled(1.23, fmt::fg(fmt::colors::green) |
   fmt::bg(fmt::color::blue))); \endrst
  */
-template <typename Arg>
-FMT_CONSTEXPR auto styled(const Arg& arg, text_style ts = {})
-    -> detail::styled_arg<remove_cvref_t<Arg>> {
-  return detail::styled_arg<remove_cvref_t<Arg>>(arg, ts);
+template <typename T>
+FMT_CONSTEXPR auto styled(const T& value, text_style ts = {})
+    -> detail::styled_arg<remove_cvref_t<T>> {
+  return detail::styled_arg<remove_cvref_t<T>>{value, ts};
 }
 
 /**
@@ -701,10 +698,10 @@ FMT_CONSTEXPR auto styled(const Arg& arg, text_style ts = {})
     fmt::print("Elapsed time: {s:.2f} seconds", fmt::styled(1.23,
   fmt::colors::green)); \endrst
  */
-template <typename Arg>
-FMT_CONSTEXPR auto styled(const Arg& arg, detail::color_type color)
-    -> detail::styled_arg<remove_cvref_t<Arg>> {
-  return detail::styled_arg<remove_cvref_t<Arg>>(arg, fg(color));
+template <typename T>
+FMT_CONSTEXPR auto styled(const T& value, detail::color_type color)
+    -> detail::styled_arg<remove_cvref_t<T>> {
+  return detail::styled_arg<remove_cvref_t<T>>{value, fg(color)};
 }
 
 /**
@@ -717,10 +714,10 @@ FMT_CONSTEXPR auto styled(const Arg& arg, detail::color_type color)
     fmt::print("Elapsed time: {s:.2f} seconds", fmt::styled(1.23,
   fmt::emphasis::italic)); \endrst
  */
-template <typename Arg>
-FMT_CONSTEXPR auto styled(const Arg& arg, emphasis em)
-    -> detail::styled_arg<remove_cvref_t<Arg>> {
-  return detail::styled_arg<remove_cvref_t<Arg>>(arg, text_style(em));
+template <typename T>
+FMT_CONSTEXPR auto styled(const T& value, emphasis em)
+    -> detail::styled_arg<remove_cvref_t<T>> {
+  return detail::styled_arg<remove_cvref_t<T>>{value, text_style(em)};
 }
 
 FMT_MODULE_EXPORT_END

--- a/test/color-test.cc
+++ b/test/color-test.cc
@@ -50,6 +50,12 @@ TEST(color_test, format) {
             "\x1b[105mtbmagenta\x1b[0m");
   EXPECT_EQ(fmt::format(fg(fmt::terminal_color::red), "{}", "foo"),
             "\x1b[31mfoo\x1b[0m");
+  EXPECT_EQ(fmt::format("{}{}", fmt::styled("red", fmt::color::red),
+                        fmt::styled("bold", fmt::emphasis::bold)),
+            "\x1b[38;2;255;000;000mred\x1b[0m\x1b[1mbold\x1b[0m");
+  EXPECT_EQ(fmt::format("{}", fmt::styled("bar", fg(fmt::color::blue) |
+                                                     fmt::emphasis::underline)),
+            "\x1b[4m\x1b[38;2;000;000;255mbar\x1b[0m");
 }
 
 TEST(color_test, format_to) {

--- a/test/color-test.cc
+++ b/test/color-test.cc
@@ -50,7 +50,7 @@ TEST(color_test, format) {
             "\x1b[105mtbmagenta\x1b[0m");
   EXPECT_EQ(fmt::format(fg(fmt::terminal_color::red), "{}", "foo"),
             "\x1b[31mfoo\x1b[0m");
-  EXPECT_EQ(fmt::format("{}{}", fmt::styled("red", fmt::color::red),
+  EXPECT_EQ(fmt::format("{}{}", fmt::styled("red", fg(fmt::color::red)),
                         fmt::styled("bold", fmt::emphasis::bold)),
             "\x1b[38;2;255;000;000mred\x1b[0m\x1b[1mbold\x1b[0m");
   EXPECT_EQ(fmt::format("{}", fmt::styled("bar", fg(fmt::color::blue) |


### PR DESCRIPTION
Hello,
this PR implements a way to apply different styles to different arguments in a single `format` (or `print`) call.
It is done by introducing a new function, `fmt::styled`, which takes an argument of arbitrary type and a color, an `emphasis` or a `text_style`, and creates a wrapper around the argument that will be formatted it in the requested style.

A simple example of usage:
```
void log(std::string_view caller, std::string_view message, bool error = false)
{
    fmt::print("[{}] {}: {}\n",
                fmt::styled(std::chrono::system_clock::now(), fmt::emphasis::bold),
                fmt::styled(caller, error ? fmt::color::red : fmt::color::green),
                message
    );
}
```