### PR TITLE
Document output_file default behavior correctly

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -460,7 +460,7 @@ class FMT_API ostream final : private detail::buffer<char> {
 
   * ``<integer>``: Flags passed to `open
     <https://pubs.opengroup.org/onlinepubs/007904875/functions/open.html>`_
-    (``file::WRONLY | file::CREATE`` by default)
+    (``file::WRONLY | file::CREATE | file::TRUNC`` by default)
   * ``buffer_size=<integer>``: Output buffer size
 
   **Example**::


### PR DESCRIPTION
The documentation for output_file incorrectly says that opening an output file happens with `file::WRONLY | file::CREATE` by default, but this includes `file::TRUNC` is also included since 119f7dc3d.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
