### PR TITLE
Fix compilation error for ranges with ADL `begin`/`end`

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -402,8 +402,8 @@ struct formatter<
     auto out = ctx.out();
     *out++ = prefix;
     int i = 0;
-    auto it = std::begin(range);
-    auto end = std::end(range);
+    auto it = detail::range_begin(range);
+    auto end = detail::range_end(range);
     for (; it != end; ++it) {
       if (i > 0) out = detail::write_delimiter(out);
       if (custom_specs_) {

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -65,32 +65,27 @@ TEST(ranges_test, format_set) {
             "{\"one\", \"two\"}");
 }
 
-namespace adl
-{
-    struct box {
-        int value;
-    };
+namespace adl {
+struct box {
+  int value;
+};
 
-    auto begin(box & b) noexcept -> int * {
-        return std::addressof(b.value);
-    }
+auto begin(box& b) noexcept -> int* { return std::addressof(b.value); }
 
-    auto end(box & b) noexcept -> int * {
-        return std::addressof(b.value) + 1;
-    }
+auto end(box& b) noexcept -> int* { return std::addressof(b.value) + 1; }
 
-    auto begin(const box & b) noexcept -> const int * {
-        return std::addressof(b.value);
-    }
+auto begin(const box& b) noexcept -> const int* {
+  return std::addressof(b.value);
+}
 
-    auto end(const box & b) noexcept -> const int * {
-        return std::addressof(b.value) + 1;
-    }
-} // namespace adl
+auto end(const box& b) noexcept -> const int* {
+  return std::addressof(b.value) + 1;
+}
+}  // namespace adl
 
 TEST(ranges_test, format_adl_begin_end) {
-    auto b = adl::box{42};
-    EXPECT_EQ(fmt::format("{}", b), "[42]");
+  auto b = adl::box{42};
+  EXPECT_EQ(fmt::format("{}", b), "[42]");
 }
 
 TEST(ranges_test, format_pair) {

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -65,6 +65,34 @@ TEST(ranges_test, format_set) {
             "{\"one\", \"two\"}");
 }
 
+namespace adl
+{
+    struct box {
+        int value;
+    };
+
+    auto begin(box & b) noexcept -> int * {
+        return std::addressof(b.value);
+    }
+
+    auto end(box & b) noexcept -> int * {
+        return std::addressof(b.value) + 1;
+    }
+
+    auto begin(const box & b) noexcept -> const int * {
+        return std::addressof(b.value);
+    }
+
+    auto end(const box & b) noexcept -> const int * {
+        return std::addressof(b.value) + 1;
+    }
+} // namespace adl
+
+TEST(ranges_test, format_adl_begin_end) {
+    auto b = adl::box{42};
+    EXPECT_EQ(fmt::format("{}", b), "[42]");
+}
+
 TEST(ranges_test, format_pair) {
   auto p = std::pair<int, float>(42, 1.5f);
   EXPECT_EQ(fmt::format("{}", p), "(42, 1.5)");

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -70,16 +70,12 @@ struct box {
   int value;
 };
 
-auto begin(box& b) noexcept -> int* { return std::addressof(b.value); }
-
-auto end(box& b) noexcept -> int* { return std::addressof(b.value) + 1; }
-
-auto begin(const box& b) noexcept -> const int* {
-  return std::addressof(b.value);
+auto begin(const box& b) -> const int* {
+  return &b.value;
 }
 
-auto end(const box& b) noexcept -> const int* {
-  return std::addressof(b.value) + 1;
+auto end(const box& b) -> const int* {
+  return &b.value + 1;
 }
 }  // namespace adl
 


### PR DESCRIPTION
This PR should fix an issue that occurs when the range `formatter` is unable to use `begin` and `end` found by ADL.
For example, this code currently fails to compile:
```cpp
namespace adl
{
struct box
{
    int value;
};

int * begin(box & b) noexcept { return std::addressof(b.value); }
int * end(box & b)   noexcept { return std::addressof(b.value) + 1; }

int const * begin(box const & b) noexcept { return std::addressof(b.value); }
int const * end(box const & b)   noexcept { return std::addressof(b.value) + 1; }
} // namespace adl

int main()
{
    auto x = adl::box{42};
    
    // this works
    for (auto elem : x) {
        fmt::print("{}\n", elem);
    }
    
    // this compiles correctly
    static_assert(fmt::is_range<adl::box, char>::value, "");

    // but this does not compile
    fmt::print("{}\n", x);
}
```
but with the proposed patch works as expected.