### PR TITLE
djgpp compatibility

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -244,7 +244,7 @@
 #else
 #  define FMT_CLASS_API
 #  if defined(FMT_EXPORT) || defined(FMT_SHARED)
-#    if defined(__GNUC__) || defined(__clang__)
+#    if (defined(__GNUC__) || defined(__clang__)) && !defined(DJGPP)
 #      define FMT_API __attribute__((visibility("default")))
 #    endif
 #  endif

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -300,6 +300,9 @@ FMT_GCC_PRAGMA("GCC optimize(\"Og\")")
 FMT_BEGIN_NAMESPACE
 FMT_MODULE_EXPORT_BEGIN
 
+// Alias for older systems where std::wstring isn't defined.
+using wstring = std::basic_string<wchar_t>;
+
 // Implementations of enable_if_t and other metafunctions for older systems.
 template <bool B, typename T = void>
 using enable_if_t = typename std::enable_if<B, T>::type;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -48,7 +48,7 @@
 
 #include "core.h"
 
-#if FMT_GCC_VERSION
+#if FMT_GCC_VERSION && !defined(DJGPP)
 #  define FMT_GCC_VISIBILITY_HIDDEN __attribute__((visibility("hidden")))
 #else
 #  define FMT_GCC_VISIBILITY_HIDDEN

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1232,7 +1232,7 @@ class utf8_to_utf16 {
   operator basic_string_view<wchar_t>() const { return {&buffer_[0], size()}; }
   auto size() const -> size_t { return buffer_.size() - 1; }
   auto c_str() const -> const wchar_t* { return &buffer_[0]; }
-  auto str() const -> std::wstring { return {&buffer_[0], size()}; }
+  auto str() const -> wstring { return {&buffer_[0], size()}; }
 };
 
 namespace dragonbox {

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -138,9 +138,13 @@ void print(std::ostream& os, format_string<Args...> fmt, Args&&... args) {
   vprint(os, fmt, fmt::make_format_args(args...));
 }
 
+// Alias for older systems where std::wostream isn't defined.
+FMT_MODULE_EXPORT
+using wostream = std::basic_ostream<wchar_t>;
+
 FMT_MODULE_EXPORT
 template <typename... Args>
-void print(std::wostream& os,
+void print(wostream& os,
            basic_format_string<wchar_t, type_identity_t<Args>...> fmt,
            Args&&... args) {
   vprint(os, fmt, fmt::make_format_args<buffer_context<wchar_t>>(args...));

--- a/include/fmt/xchar.h
+++ b/include/fmt/xchar.h
@@ -227,7 +227,7 @@ template <typename... T> void print(wformat_string<T...> fmt, T&&... args) {
 /**
   Converts *value* to ``std::wstring`` using the default format for type *T*.
  */
-template <typename T> inline auto to_wstring(const T& value) -> std::wstring {
+template <typename T> inline auto to_wstring(const T& value) -> wstring {
   return format(FMT_STRING(L"{}"), value);
 }
 FMT_MODULE_EXPORT_END

--- a/src/os.cc
+++ b/src/os.cc
@@ -51,6 +51,10 @@
 #  include <windows.h>
 #endif
 
+#ifdef DJGPP
+#  include <dpmi.h>
+#endif
+
 #ifdef fileno
 #  undef fileno
 #endif
@@ -354,6 +358,11 @@ long getpagesize() {
   SYSTEM_INFO si;
   GetSystemInfo(&si);
   return si.dwPageSize;
+#  elif defined(DJGPP)
+  unsigned long size;
+  if (__dpmi_get_page_size(&size) != 0)
+    FMT_THROW(system_error(ENOSYS, "cannot get memory page size"));
+  return size;
 #  else
   long size = FMT_POSIX_CALL(sysconf(_SC_PAGESIZE));
   if (size < 0) FMT_THROW(system_error(errno, "cannot get memory page size"));


### PR DESCRIPTION
These two patches make the library compile on djgpp (using gcc 10.3.0).  Everything seems to work, although the test cases don't compile, due to excessive usage of `std::wstring`.  They would probably work if you replaced all those, but I don't really see the purpose in doing that.

I've wanted to use fmtlib for a long time, but making it compatible with djgpp always seemed like a lot of work, so I kept putting it off.  I thought everything related to wide character strings would have to be `#ifdef`'d out.
Turns out the only problem is `std::wstring`, which is only ever used on *two* lines. :)
