### PR TITLE
Only use format_as if no formatter is available

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1423,7 +1423,9 @@ template <typename Context> struct arg_mapper {
   }
 
   template <typename T, typename U = decltype(format_as(T())),
-            FMT_ENABLE_IF(std::is_enum<T>::value&& std::is_integral<U>::value)>
+            FMT_ENABLE_IF(std::is_enum<T>::value && std::is_integral<U>::value &&
+                !has_formatter<T, Context>::value &&
+                !has_fallback_formatter<T, char_type>::value)>
   FMT_CONSTEXPR FMT_INLINE auto map(const T& val)
       -> decltype(std::declval<arg_mapper>().map(U())) {
     return map(format_as(val));


### PR DESCRIPTION
When we have an enum like `test::formattable_formatter_scoped_enum` in the PR that has both ADL `format_as` and a formatter specialization, things get a bit nasty. Two `map` overloads are viable:

```cpp
  template <typename T, typename U = decltype(format_as(T())),
            FMT_ENABLE_IF(std::is_enum<T>::value&& std::is_integral<U>::value)>
  FMT_CONSTEXPR FMT_INLINE auto map(const T& val)
      -> decltype(std::declval<arg_mapper>().map(U())) {
    return map(format_as(val));
  }

  template <typename T, typename U = remove_cvref_t<T>,
            FMT_ENABLE_IF(!is_string<U>::value && !is_char<U>::value &&
                          !std::is_array<U>::value &&
                          (has_formatter<U, Context>::value ||
                           has_fallback_formatter<U, char_type>::value))>
  FMT_CONSTEXPR FMT_INLINE auto map(T&& val)
      -> decltype(this->do_map(std::forward<T>(val))) {
    return do_map(std::forward<T>(val));
  }
```

Compounding the problem, the second overload takes by `T&&` while the first overload takes by `const T&`, so we actually pick different overloads depending on whether the source is const-qualified (const arguments would use `format_as`, while non-const arguments will use the formatter). `mapped_type_constant`, however, always uses a const lvalue for its test, so we end up with a type mismatch when a non-const argument is used.

This PR limits the use of ADL `format_as` to types that don't have formatter specializations of their own. This allows things like

```cpp
namespace X {
    enum class A{}; enum class B{};
    // lots more enums
    using fmt::enums::format_as;
}
// I want to handle X::A and X::B specially, but every other enum in X should be formatted as their underlying type.
template<> struct fmt::formatter<X::A> { /* stuff */ };
template<> struct fmt::formatter<X::A> { /* stuff */ };
```