### PR TITLE
Fix negative zero output when formatting flaoting point values close to zero

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2554,10 +2554,29 @@ template <typename Char> struct arg_formatter {
   FMT_CONSTEXPR FMT_INLINE auto operator()(T value) -> iterator {
     return detail::write(out, value, specs, locale);
   }
+
+  FMT_CONSTEXPR FMT_INLINE auto operator()(float value) -> iterator {
+    return detail::write(out, prevent_negative_zero(value), specs, locale);
+  }
+  FMT_CONSTEXPR FMT_INLINE auto operator()(double value) -> iterator {
+    return detail::write(out, prevent_negative_zero(value), specs, locale);
+  }
+  FMT_CONSTEXPR FMT_INLINE auto operator()(long double value) -> iterator {
+    return detail::write(out, prevent_negative_zero(value), specs, locale);
+  }
   auto operator()(typename basic_format_arg<context>::handle) -> iterator {
     // User-defined types are handled separately because they require access
     // to the parse context.
     return out;
+  }
+ private:
+  template <typename T>
+  FMT_CONSTEXPR FMT_INLINE auto prevent_negative_zero(T value) -> T {
+    if (this->specs.precision > 0 and
+        (T{1} / static_cast<T>(std::pow(10, this->specs.precision)) > std::fabs(value))) {
+      value = 0;
+    }
+    return value;
   }
 };
 

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -267,6 +267,10 @@ class printf_arg_formatter : public arg_formatter<Char> {
 
   template <typename T, FMT_ENABLE_IF(std::is_floating_point<T>::value)>
   OutputIt operator()(T value) {
+    if (this->specs.precision > 0 and
+        (T{1} / static_cast<T>(std::pow(10, this->specs.precision)) > std::fabs(value))) {
+      value = 0;
+    }
     return base::operator()(value);
   }
 

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -581,3 +581,35 @@ TEST(printf_test, vsprintf_make_wargs_example) {
             fmt::vsprintf(L"[%d] %s happened",
                           {fmt::make_wprintf_args(42, L"something")}));
 }
+
+TEST(printf_test, check_sign_truncation_on_zero) {
+  float fval = 0.0f - 1e-7f;
+  EXPECT_EQ(fmt::vsprintf("%1.7f", {fmt::make_printf_args(fval)}), "-0.0000001");
+  EXPECT_EQ(fmt::format("{:1.7f}", fval), "-0.0000001");
+  fval = std::nexttoward(fval, 1.f);
+  EXPECT_EQ(fmt::vsprintf("%1.7f", {fmt::make_printf_args(fval)}), "0.0000000");
+  EXPECT_EQ(fmt::format("{:1.7f}", fval), "0.0000000");
+  fval = std::nexttoward(fval, -1.f);
+  EXPECT_EQ(fmt::vsprintf("%1.7f", {fmt::make_printf_args(fval)}), "-0.0000001");
+  EXPECT_EQ(fmt::format("{:1.7f}", fval), "-0.0000001");
+
+  double dval = 0.0 - 1e-15;
+  EXPECT_EQ(fmt::vsprintf("%1.15lf", {fmt::make_printf_args(dval)}), "-0.000000000000001");
+  EXPECT_EQ(fmt::format("{:1.15f}", dval), "-0.000000000000001");
+  dval = std::nexttoward(dval, 1.f);
+  EXPECT_EQ(fmt::vsprintf("%1.15lf", {fmt::make_printf_args(dval)}), "0.000000000000000");
+  EXPECT_EQ(fmt::format("{:1.15f}", dval), "0.000000000000000");
+  dval = std::nexttoward(dval, -1.f);
+  EXPECT_EQ(fmt::vsprintf("%1.15lf", {fmt::make_printf_args(dval)}), "-0.000000000000001");
+  EXPECT_EQ(fmt::format("{:1.15f}", dval), "-0.000000000000001");
+
+  long double ldval = 0.0L - 1e-18L;
+  EXPECT_EQ(fmt::vsprintf("%1.18Lf", {fmt::make_printf_args(ldval)}), "-0.000000000000000001");
+  EXPECT_EQ(fmt::format("{:1.18f}", ldval), "-0.000000000000000001");
+  ldval = std::nexttoward(ldval, 1.f);
+  EXPECT_EQ(fmt::vsprintf("%1.18Lf", {fmt::make_printf_args(ldval)}), "0.000000000000000000");
+  EXPECT_EQ(fmt::format("{:1.18f}", ldval), "0.000000000000000000");
+  ldval = std::nexttoward(ldval, -1.f);
+  EXPECT_EQ(fmt::vsprintf("%1.18Lf", {fmt::make_printf_args(ldval)}), "-0.000000000000000001");
+  EXPECT_EQ(fmt::format("{:1.18f}", ldval), "-0.000000000000000001");
+}


### PR DESCRIPTION
I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.

I work for the Profidata AG which is using the libfmt version 6. Since we want to switch to version 8 the contribution I made earlier ([PullRequest](https://github.com/fmtlib/fmt/pull/1093)) is no longer available. To solve the issue I spend some time to figure out how to achieve the same behavior with the new libfmt version. I hope I came up with an acceptable answer since we need this library in production within a year from now.

Brief explanation of my change:
I altered the default behavior of printf and format in a way, that it checks for arguments which values would be printed as "-0.0". For every argument that would be printed like this to this, I set the value to zero to prevent the negative sign to be printed. This happens when a negative value is close to zero, but the fraction is not revealed due to the precision.

All tests are green, but I still hope I covered all edge cases.

Looking forward hearing from you.