### PR TITLE
MSVC CMake generation optimization (13.6s -> 5.7s)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
   "${CMAKE_CURRENT_SOURCE_DIR}/support/cmake")
 
 include(cxx14)
-include(CheckCXXCompilerFlag)
 include(JoinPaths)
 
 list(FIND CMAKE_CXX_COMPILE_FEATURES "cxx_variadic_templates" index)

--- a/support/cmake/cxx14.cmake
+++ b/support/cmake/cxx14.cmake
@@ -1,7 +1,11 @@
 # C++14 feature support detection
 
-include(CheckCXXSourceCompiles)
 include(CheckCXXCompilerFlag)
+function (fmt_check_cxx_compiler_flag flag result)
+  if (NOT MSVC)
+    check_cxx_compiler_flag("${flag}" ${result})
+  endif ()
+endfunction ()
 
 if (NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
@@ -9,35 +13,38 @@ endif()
 message(STATUS "CXX_STANDARD: ${CMAKE_CXX_STANDARD}")
 
 if (CMAKE_CXX_STANDARD EQUAL 20)
-  check_cxx_compiler_flag(-std=c++20 has_std_20_flag)
-  check_cxx_compiler_flag(-std=c++2a has_std_2a_flag)
+  fmt_check_cxx_compiler_flag(-std=c++20 has_std_20_flag)
+  fmt_check_cxx_compiler_flag(-std=c++2a has_std_2a_flag)
 
   if (has_std_20_flag)
     set(CXX_STANDARD_FLAG -std=c++20)
   elseif (has_std_2a_flag)
     set(CXX_STANDARD_FLAG -std=c++2a)
   endif ()
+
 elseif (CMAKE_CXX_STANDARD EQUAL 17)
-  check_cxx_compiler_flag(-std=c++17 has_std_17_flag)
-  check_cxx_compiler_flag(-std=c++1z has_std_1z_flag)
+  fmt_check_cxx_compiler_flag(-std=c++17 has_std_17_flag)
+  fmt_check_cxx_compiler_flag(-std=c++1z has_std_1z_flag)
 
   if (has_std_17_flag)
     set(CXX_STANDARD_FLAG -std=c++17)
   elseif (has_std_1z_flag)
     set(CXX_STANDARD_FLAG -std=c++1z)
   endif ()
+
 elseif (CMAKE_CXX_STANDARD EQUAL 14)
-  check_cxx_compiler_flag(-std=c++14 has_std_14_flag)
-  check_cxx_compiler_flag(-std=c++1y has_std_1y_flag)
+  fmt_check_cxx_compiler_flag(-std=c++14 has_std_14_flag)
+  fmt_check_cxx_compiler_flag(-std=c++1y has_std_1y_flag)
 
   if (has_std_14_flag)
     set(CXX_STANDARD_FLAG -std=c++14)
   elseif (has_std_1y_flag)
     set(CXX_STANDARD_FLAG -std=c++1y)
   endif ()
+
 elseif (CMAKE_CXX_STANDARD EQUAL 11)
-  check_cxx_compiler_flag(-std=c++11 has_std_11_flag)
-  check_cxx_compiler_flag(-std=c++0x has_std_0x_flag)
+  fmt_check_cxx_compiler_flag(-std=c++11 has_std_11_flag)
+  fmt_check_cxx_compiler_flag(-std=c++0x has_std_0x_flag)
 
   if (has_std_11_flag)
     set(CXX_STANDARD_FLAG -std=c++11)
@@ -45,26 +52,3 @@ elseif (CMAKE_CXX_STANDARD EQUAL 11)
     set(CXX_STANDARD_FLAG -std=c++0x)
   endif ()
 endif ()
-
-set(CMAKE_REQUIRED_FLAGS ${CXX_STANDARD_FLAG})
-
-# Check if user-defined literals are available
-check_cxx_source_compiles("
-  void operator\"\" _udl(long double);
-  int main() {}"
-  SUPPORTS_USER_DEFINED_LITERALS)
-if (NOT SUPPORTS_USER_DEFINED_LITERALS)
-  set (SUPPORTS_USER_DEFINED_LITERALS OFF)
-endif ()
-
-# Check if <variant> is available
-set(CMAKE_REQUIRED_FLAGS -std=c++1z)
-check_cxx_source_compiles("
-  #include <variant>
-  int main() {}"
-  FMT_HAS_VARIANT)
-if (NOT FMT_HAS_VARIANT)
-  set (FMT_HAS_VARIANT OFF)
-endif ()
-
-set(CMAKE_REQUIRED_FLAGS )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,8 +6,6 @@ target_include_directories(test-main PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 target_link_libraries(test-main gtest fmt)
 
-include(CheckCXXCompilerFlag)
-
 function(add_fmt_executable name)
   add_executable(${name} ${ARGN})
   if (MINGW)
@@ -145,9 +143,7 @@ if (FMT_PEDANTIC)
     target_include_directories(
       noexception-test PRIVATE ${PROJECT_SOURCE_DIR}/include)
     target_compile_options(noexception-test PRIVATE -fno-exceptions)
-    if (FMT_PEDANTIC)
-      target_compile_options(noexception-test PRIVATE ${PEDANTIC_COMPILE_FLAGS})
-    endif ()
+    target_compile_options(noexception-test PRIVATE ${PEDANTIC_COMPILE_FLAGS})
   endif ()
 
   # Test that the library compiles without locale.
@@ -171,8 +167,8 @@ if (FMT_PEDANTIC AND NOT WIN32)
     "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
     "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
     "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
-    "-DFMT_DIR=${CMAKE_SOURCE_DIR}"
-    "-DSUPPORTS_USER_DEFINED_LITERALS=${SUPPORTS_USER_DEFINED_LITERALS}")
+    "-DCXX_STANDARD_FLAG=${CXX_STANDARD_FLAG}"
+    "-DFMT_DIR=${CMAKE_SOURCE_DIR}")
 
   # Test if the targets are found from the build directory.
   add_test(find-package-test ${CMAKE_CTEST_COMMAND}

--- a/test/compile-error-test/CMakeLists.txt
+++ b/test/compile-error-test/CMakeLists.txt
@@ -166,6 +166,18 @@ expect_compile(format-lots-of-arguments-with-function "
   fmt::format(\"\", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, f);
 " ERROR)
 
+# Check if user-defined literals are available
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_FLAGS ${CXX_STANDARD_FLAG})
+check_cxx_source_compiles("
+  void operator\"\" _udl(long double);
+  int main() {}"
+  SUPPORTS_USER_DEFINED_LITERALS)
+set(CMAKE_REQUIRED_FLAGS )
+if (NOT SUPPORTS_USER_DEFINED_LITERALS)
+  set (SUPPORTS_USER_DEFINED_LITERALS OFF)
+endif ()
+
 # Make sure that compiler features detected in the header
 # match the features detected in CMake.
 if (SUPPORTS_USER_DEFINED_LITERALS)

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -18,7 +18,7 @@ else ()
 endif ()
 
 # Workaround GTest bug https://github.com/google/googletest/issues/705.
-check_cxx_compiler_flag(
+fmt_check_cxx_compiler_flag(
   -fno-delete-null-pointer-checks HAVE_FNO_DELETE_NULL_POINTER_CHECKS)
 if (HAVE_FNO_DELETE_NULL_POINTER_CHECKS)
   target_compile_options(gtest PUBLIC -fno-delete-null-pointer-checks)


### PR DESCRIPTION
The following CMake changes reduce project generation on Win11 with MSVC 2022 from 13.6s to 5.7s. (Using a deskop system with Ryzen 3900X / M.2 SSD).

Motivation: 
* Tests in cxx14.cmake are using Clang/GCC style flags, these are all invalid on MSVC.
* The flag SUPPORTS_USER_DEFINED_LITERALS is only used for tests that are disabled on WIN32.
* The flag FMT_HAS_VARIANT is not used at all from what I can see. (?)
* check_cxx_compiler_flag(-fno-exceptions) is always invalid on MSVC.
* check_cxx_compiler_flag(-fno-delete-null-pointer-checks) is always invalid on MSVC.

With FMT_TEST=OFF, project generation takes 4.3s and is almost instant when included as sub-project.

Note, correct check on MSVC would be like this:
```
check_cxx_compiler_flag("/std:c++20" has_std_20_flag)
```

But it might be better to use CMake checks instead of testing flags, like 'CMAKE_CXX_COMPILE_FEATURES' (available from CMake 3.1).
