### PR TITLE
Suppress a -Wliteral-range warning on Apple M1

### DIFF
--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1009,8 +1009,9 @@ TEST(format_test, precision) {
   if (std::numeric_limits<long double>::digits == 64) {
     auto ld = (std::numeric_limits<long double>::min)();
     EXPECT_EQ(fmt::format("{:.0}", ld), "3e-4932");
-    EXPECT_EQ(fmt::format("{:0g}", 5.02957084971264961283E-4940L),
-              "5.02957e-4940");
+    EXPECT_EQ(
+        fmt::format("{:0g}", std::numeric_limits<long double>::denorm_min()),
+        "3.6452e-4951");
   }
 
   EXPECT_EQ("123.", fmt::format("{:#.0f}", 123.0));


### PR DESCRIPTION
Fix issue #2860

``std::numeric_limits<long double>::digits`` is equal to ``LDBL_MANT_DIG ``
https://en.cppreference.com/w/cpp/types/numeric_limits/digits