### PR TITLE
Improve std formatters

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -19,14 +19,9 @@
 #ifdef __cpp_lib_filesystem
 #  include <filesystem>
 
-template <>
-struct fmt::formatter<std::filesystem::path> : formatter<string_view> {
-  template <typename FormatContext>
-  auto format(const std::filesystem::path& p, FormatContext& ctx) const ->
-      typename FormatContext::iterator {
-    return formatter<string_view>::format(p.string(), ctx);
-  }
-};
+FMT_BEGIN_NAMESPACE
+template <> struct formatter<std::filesystem::path> : ostream_formatter {};
+FMT_END_NAMESPACE
 #endif
 
 FMT_BEGIN_NAMESPACE

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -20,12 +20,15 @@
 #  include <filesystem>
 
 FMT_BEGIN_NAMESPACE
-template <> struct formatter<std::filesystem::path> : ostream_formatter {};
+template <typename Char>
+struct formatter<std::filesystem::path, Char> : basic_ostream_formatter<Char> {
+};
 FMT_END_NAMESPACE
 #endif
 
 FMT_BEGIN_NAMESPACE
-template <> struct formatter<std::thread::id> : ostream_formatter {};
+template <typename Char>
+struct formatter<std::thread::id, Char> : basic_ostream_formatter<Char> {};
 FMT_END_NAMESPACE
 
 #endif  // FMT_STD_H_

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -12,6 +12,8 @@
 TEST(std_test, path) {
 #ifdef __cpp_lib_filesystem
   EXPECT_EQ(fmt::format("{:8}", std::filesystem::path("foo")), "\"foo\"   ");
+  EXPECT_EQ(fmt::format("{}", std::filesystem::path("foo\"bar.txt")),
+            "\"foo\\\"bar.txt\"");
 #endif
 }
 

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -11,7 +11,7 @@
 
 TEST(std_test, path) {
 #ifdef __cpp_lib_filesystem
-  EXPECT_EQ(fmt::format("{:8}", std::filesystem::path("foo")), "foo     ");
+  EXPECT_EQ(fmt::format("{:8}", std::filesystem::path("foo")), "\"foo\"   ");
 #endif
 }
 


### PR DESCRIPTION
1) Improve ``std::filesystem::path`` formatter (https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1636r2.pdf).
2) Improve xchar support for std formatters.

Discussion:
https://github.com/fmtlib/fmt/commit/f0903ad9df429f3a610da45de5161c076cf2d268