### PR TITLE
Skip cmake targets inclusion if fmt::fmt already exists

### DIFF
--- a/support/cmake/fmt-config.cmake.in
+++ b/support/cmake/fmt-config.cmake.in
@@ -1,4 +1,7 @@
 @PACKAGE_INIT@
 
-include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)
+if (NOT TARGET fmt::fmt)
+  include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)
+endif ()
+
 check_required_components(fmt)


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
This allows `find_package(fmt)` to succeed if fmt is included in a project via `add_subdirectory`. This can help projects that want to support using either a system install or an in-tree package of fmt.