### PR TITLE
Fix 'duplicate symbol' error.

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -30,8 +30,8 @@ void write_escaped_path(basic_memory_buffer<Char>& quoted,
 }
 #  ifdef _WIN32
 template <>
-void write_escaped_path<char>(basic_memory_buffer<char>& quoted,
-                              const std::filesystem::path& p) {
+inline void write_escaped_path<char>(basic_memory_buffer<char>& quoted,
+                                     const std::filesystem::path& p) {
   auto s = p.u8string();
   write_escaped_string<char>(
       std::back_inserter(quoted),
@@ -39,7 +39,7 @@ void write_escaped_path<char>(basic_memory_buffer<char>& quoted,
 }
 #  endif
 template <>
-void write_escaped_path<std::filesystem::path::value_type>(
+inline void write_escaped_path<std::filesystem::path::value_type>(
     basic_memory_buffer<std::filesystem::path::value_type>& quoted,
     const std::filesystem::path& p) {
   write_escaped_string<std::filesystem::path::value_type>(


### PR DESCRIPTION
Error:
```
duplicate symbol 'void fmt::v8::detail::write_escaped_path<char>(fmt::v8::basic_memory_buffer<char, 500ul, std::__1::allocator<char> >&, std::__1::__fs::filesystem::path const&)' in:
    CMakeFiles/src1.cpp.o
    CMakeFiles/src2.cpp.o
ld: 2 duplicate symbols for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

The bug was introduced in PR #2918 (I am sorry...).
