### PR TITLE
fix -Wsign-conversion warnings

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2887,8 +2887,8 @@ class format_string_checker {
   using parse_func = const Char* (*)(parse_context_type&);
 
   parse_context_type context_;
-  parse_func parse_funcs_[num_args > 0 ? num_args : 1];
-  type types_[num_args > 0 ? num_args : 1];
+  parse_func parse_funcs_[num_args > 0 ? static_cast<size_t>(num_args) : 1];
+  type types_[num_args > 0 ? static_cast<size_t>(num_args) : 1];
 
  public:
   explicit FMT_CONSTEXPR format_string_checker(


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->

Fixing the two following warnings:
include/fmt/core.h:2890:40: warning: conversion to 'long unsigned int' from 'const int' may change the sign of the result [-Wsign-conversion]
 2890 |   parse_func parse_funcs_[num_args > 0 ? num_args : 1];
include/fmt/core.h:2891:28: warning: conversion to 'long unsigned int' from 'const int' may change the sign of the result [-Wsign-conversion]
 2891 |   type types_[num_args > 0 ? num_args : 1];