### PR TITLE
Fix is_formattable for tuple-like types.

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -206,10 +206,11 @@ template <typename T>
 using tuple_index_sequence = make_index_sequence<std::tuple_size<T>::value>;
 
 template <typename T, typename C, bool = is_tuple_like_<T>::value>
-struct is_tuple_formattable_ {
+class is_tuple_formattable_ {
+ public:
   static constexpr const bool value = false;
 };
-template <typename T, typename C> struct is_tuple_formattable_<T, C, true> {
+template <typename T, typename C> class is_tuple_formattable_<T, C, true> {
   template <std::size_t... I>
   static std::true_type check2(index_sequence<I...>,
                                integer_sequence<bool, (I == I)...>);

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -203,7 +203,7 @@ using make_index_sequence = make_integer_sequence<size_t, N>;
 #endif
 
 template <typename T>
-using tuple_index_sequence = make_index_sequence<std::tuple_size_v<T>>;
+using tuple_index_sequence = make_index_sequence<std::tuple_size<T>::value>;
 
 template <typename T, bool = is_tuple_like_<T>::value>
 struct is_tuple_formattable_ {
@@ -211,9 +211,14 @@ struct is_tuple_formattable_ {
 };
 template <typename T> struct is_tuple_formattable_<T, true> {
   template <std::size_t... I>
-  static std::integral_constant<
-      bool, (fmt::is_formattable<std::tuple_element_t<I, T>>::value && ...)>
-      check(index_sequence<I...>);
+  static std::true_type
+    check2(index_sequence<I...>,integer_sequence<bool,(I == I)...>);
+  static std::false_type
+    check2(...);
+  template <std::size_t... I>
+  static decltype(check2(index_sequence<I...>{},
+			 integer_sequence<bool,(fmt::is_formattable<typename std::tuple_element<I, T>::type>::value)...>{}))
+    check(index_sequence<I...>);
 
  public:
   static constexpr const bool value =

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -219,9 +219,8 @@ template <typename T, typename C> class is_tuple_formattable_<T, C, true> {
   static decltype(check2(
       index_sequence<I...>{},
       integer_sequence<
-          bool, (fmt::is_formattable<typename std::tuple_element<I, T>::type,
-                                     C>::value)...>{}))
-      check(index_sequence<I...>);
+          bool, (is_formattable<typename std::tuple_element<I, T>::type,
+                                C>::value)...>{})) check(index_sequence<I...>);
 
  public:
   static constexpr const bool value =

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -90,6 +90,18 @@ TEST(ranges_test, format_tuple) {
       std::tuple<int, float, std::string, char>(42, 1.5f, "this is tuple", 'i');
   EXPECT_EQ(fmt::format("{}", t), "(42, 1.5, \"this is tuple\", 'i')");
   EXPECT_EQ(fmt::format("{}", std::tuple<>()), "()");
+
+  enum class noformatenum{b};
+  struct noformatstruct{};
+  EXPECT_TRUE((fmt::is_formattable<std::tuple<>>::value));
+  EXPECT_FALSE((fmt::is_formattable<noformatenum>::value));
+  EXPECT_FALSE((fmt::is_formattable<noformatstruct>::value));
+  EXPECT_FALSE((fmt::is_formattable<std::tuple<noformatenum>>::value));
+  EXPECT_FALSE((fmt::is_formattable<std::tuple<noformatstruct>>::value));
+  EXPECT_FALSE((fmt::is_formattable<std::tuple<noformatstruct,int>>::value));
+  EXPECT_FALSE((fmt::is_formattable<std::tuple<int,noformatenum>>::value));
+  EXPECT_FALSE((fmt::is_formattable<std::tuple<noformatstruct,noformatenum>>::value));
+  EXPECT_TRUE((fmt::is_formattable<std::tuple<int,float>>::value));
 }
 
 #ifdef FMT_RANGES_TEST_ENABLE_FORMAT_STRUCT

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -85,23 +85,22 @@ TEST(ranges_test, format_pair) {
   EXPECT_EQ(fmt::format("{}", p), "(42, 1.5)");
 }
 
+struct unformattable {};
+
 TEST(ranges_test, format_tuple) {
   auto t =
       std::tuple<int, float, std::string, char>(42, 1.5f, "this is tuple", 'i');
   EXPECT_EQ(fmt::format("{}", t), "(42, 1.5, \"this is tuple\", 'i')");
   EXPECT_EQ(fmt::format("{}", std::tuple<>()), "()");
 
-  enum class noformatenum{b};
-  struct noformatstruct{};
   EXPECT_TRUE((fmt::is_formattable<std::tuple<>>::value));
-  EXPECT_FALSE((fmt::is_formattable<noformatenum>::value));
-  EXPECT_FALSE((fmt::is_formattable<noformatstruct>::value));
-  EXPECT_FALSE((fmt::is_formattable<std::tuple<noformatenum>>::value));
-  EXPECT_FALSE((fmt::is_formattable<std::tuple<noformatstruct>>::value));
-  EXPECT_FALSE((fmt::is_formattable<std::tuple<noformatstruct,int>>::value));
-  EXPECT_FALSE((fmt::is_formattable<std::tuple<int,noformatenum>>::value));
-  EXPECT_FALSE((fmt::is_formattable<std::tuple<noformatstruct,noformatenum>>::value));
-  EXPECT_TRUE((fmt::is_formattable<std::tuple<int,float>>::value));
+  EXPECT_FALSE((fmt::is_formattable<unformattable>::value));
+  EXPECT_FALSE((fmt::is_formattable<std::tuple<unformattable>>::value));
+  EXPECT_FALSE((fmt::is_formattable<std::tuple<unformattable, int>>::value));
+  EXPECT_FALSE((fmt::is_formattable<std::tuple<int, unformattable>>::value));
+  EXPECT_FALSE(
+      (fmt::is_formattable<std::tuple<unformattable, unformattable>>::value));
+  EXPECT_TRUE((fmt::is_formattable<std::tuple<int, float>>::value));
 }
 
 #ifdef FMT_RANGES_TEST_ENABLE_FORMAT_STRUCT
@@ -232,7 +231,6 @@ TEST(ranges_test, enum_range) {
 }
 
 #if !FMT_MSC_VERSION
-struct unformattable {};
 
 TEST(ranges_test, unformattable_range) {
   EXPECT_FALSE((fmt::has_formatter<std::vector<unformattable>,

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -315,10 +315,12 @@ TEST(xchar_test, ostream) {
 #endif
 }
 
+#ifdef FMT_XCHAR_TEST_ENABLE_FORMAT_MAP
 TEST(xchar_test, format_map) {
   auto m = std::map<std::wstring, int>{{L"one", 1}, {L"t\"wo", 2}};
   EXPECT_EQ(fmt::format(L"{}", m), L"{\"one\": 1, \"t\\\"wo\": 2}");
 }
+#endif
 
 TEST(xchar_test, escape_string) {
   using vec = std::vector<std::wstring>;

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -315,12 +315,10 @@ TEST(xchar_test, ostream) {
 #endif
 }
 
-#ifdef FMT_XCHAR_TEST_ENABLE_FORMAT_MAP
 TEST(xchar_test, format_map) {
   auto m = std::map<std::wstring, int>{{L"one", 1}, {L"t\"wo", 2}};
   EXPECT_EQ(fmt::format(L"{}", m), L"{\"one\": 1, \"t\\\"wo\": 2}");
 }
-#endif
 
 TEST(xchar_test, escape_string) {
   using vec = std::vector<std::wstring>;


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
Fixes #2939.

Added a `is_tuple_formattable` helper value-trait to compute the formattability of the element-types of a tuple. Tried to make it look like `is_tuple_like` and `is_tuple_like_`. 

Made the `xchar_test.format_map` conditional. This test formats a map, whose value-type is `std::pair<const std::wstring,int>`. Because tuple-likes now also take the formattability of element-types into account, and because `is_formattable<std::wstring>` was false locally, this test no longer compiled. I was surprised that something that is not formattable could be formatted in the first place, and chose flight rather than fight.