### PR TITLE
Fix enable_ifs for map formatter: map formatter requires std::pair formatter but never uses it

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -269,6 +269,14 @@ using range_reference_type =
 template <typename Range>
 using uncvref_type = remove_cvref_t<range_reference_type<Range>>;
 
+template <typename Range>
+using uncvref_first_type = remove_cvref_t<
+    decltype(std::declval<range_reference_type<Range>>().first)>;
+
+template <typename Range>
+using uncvref_second_type = remove_cvref_t<
+    decltype(std::declval<range_reference_type<Range>>().second)>;
+
 template <typename OutputIt> OutputIt write_delimiter(OutputIt out) {
   *out++ = ',';
   *out++ = ' ';
@@ -452,11 +460,12 @@ struct formatter<
     enable_if_t<detail::is_map<T>::value
 // Workaround a bug in MSVC 2019 and earlier.
 #if !FMT_MSC_VERSION
-                && (is_formattable<detail::uncvref_type<T>, Char>::value ||
-                    detail::has_fallback_formatter<detail::uncvref_type<T>,
-                                                   Char>::value)
+        && (is_formattable<detail::uncvref_first_type<T>, Char>::value ||
+            detail::has_fallback_formatter<detail::uncvref_first_type<T>, Char>::value)
+        && (is_formattable<detail::uncvref_second_type<T>, Char>::value ||
+            detail::has_fallback_formatter<detail::uncvref_second_type<T>, Char>::value)
 #endif
-                >> {
+    >> {
   template <typename ParseContext>
   FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
     return ctx.begin();


### PR DESCRIPTION
I am referring to L455 in the formatter<T> definition if `is_map<T>` is true:

https://github.com/fmtlib/fmt/blob/568233889171e0ee91bf28879b1482b038e84cc2/include/fmt/ranges.h#L449-L456

Please note: `T` is the map type. We are using `detail::uncvref_type<T>` here, which gives the type of a dereferenced iterator of `T`, i.e. a `std::pair<const K,V>` in case of a `std::map<K, V>`.
This formatter is never used, though, as key and value are formatted separately:

https://github.com/fmtlib/fmt/blob/568233889171e0ee91bf28879b1482b038e84cc2/include/fmt/ranges.h#L476-L479

Thus, a formatter for the `std::pair` is not needed, or more generally speeking: L455 isn't checking the correct thing.

I stumbled upon this with a custom map which isn't using `std::pair` internally, and doesn't have a formatter for the internal `pair` type.  But this shouldn't hinder this formatter from being used.
Additionally, the `pair<K, V>` formatter is no guarantee that we have formatters for `K` and `V` of the map (although it probably would be bad code not to use them in the pair formatter).