### PR TITLE
use qualified format_to call in format-inl.h

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -62,8 +62,8 @@ FMT_FUNC void format_error_code(detail::buffer<char>& out, int error_code,
   error_code_size += detail::to_unsigned(detail::count_digits(abs_value));
   auto it = buffer_appender<char>(out);
   if (message.size() <= inline_buffer_size - error_code_size)
-    format_to(it, FMT_STRING("{}{}"), message, SEP);
-  format_to(it, FMT_STRING("{}{}"), ERROR_STR, error_code);
+    fmt::format_to(it, FMT_STRING("{}{}"), message, SEP);
+  fmt::format_to(it, FMT_STRING("{}{}"), ERROR_STR, error_code);
   FMT_ASSERT(out.size() <= inline_buffer_size, "");
 }
 


### PR DESCRIPTION
Error message:
```
[3]>::format_arg_store<fmt::v8::string_view&,const char(&)[3]>(fmt::v8::string_view &,const char (&)[3])' being compiled
C:\vcpkg\buildtrees\fmt\src\8.1.1-11f8359597.clean\include\fmt\core.h(3148): note: see reference to function template instantiation 'fmt::v8::format_arg_store<fmt::v8::format_context,fmt::v8::basic_string_view<char>,char [3]> fmt::v8::make_format_args<fmt::v8::format_context,fmt::v8::string_view&,const char(&)[3]>(fmt::v8::string_view &,const char (&)[3])' being compiled
C:\vcpkg\buildtrees\fmt\src\8.1.1-11f8359597.clean\include\fmt/format-inl.h(78): note: see reference to function template instantiation 'OutputIt fmt::v8::format_to<fmt::v8::appender,fmt::v8::string_view&,const char(&)[3],0>(OutputIt,fmt::v8::basic_format_string<char,fmt::v8::string_view &,const char (&)[3]>,fmt::v8::string_view &,const char (&)[3])' being compiled
        with
        [
            OutputIt=fmt::v8::appender
        ]
```
See https://github.com/microsoft/vcpkg/issues/25109
