### PR TITLE
Fix std::variant, std::filesystem::path tests on GCC-8, Clang-7,8.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,6 +23,11 @@ jobs:
             std: 14
             install: sudo apt install g++-8
             os: ubuntu-18.04
+          - cxx: g++-8
+            build_type: Debug
+            std: 17
+            install: sudo apt install g++-8
+            os: ubuntu-18.04
           - cxx: g++-10
             build_type: Debug
             std: 17
@@ -32,6 +37,12 @@ jobs:
             std: 20
             os: ubuntu-20.04
             install: sudo apt install g++-11
+          - cxx: clang++-8
+            build_type: Debug
+            std: 17
+            cxxflags: -stdlib=libc++
+            os: ubuntu-18.04
+            install: sudo apt install clang-8 libc++-8-dev libc++abi-8-dev
           - cxx: clang++-9
             build_type: Debug
             fuzz: -DFMT_FUZZ=ON -DFMT_FUZZ_LINKMAIN=ON

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -17,10 +17,17 @@
 #if FMT_HAS_INCLUDE(<version>)
 #  include <version>
 #endif
+// Checking FMT_CPLUSPLUS for warning suppression in MSVC.
+#if FMT_CPLUSPLUS >= 201703L
+#  if FMT_HAS_INCLUDE(<filesystem>)
+#    include <filesystem>
+#  endif
+#  if FMT_HAS_INCLUDE(<variant>)
+#    include <variant>
+#  endif
+#endif
 
 #ifdef __cpp_lib_filesystem
-#  include <filesystem>
-
 FMT_BEGIN_NAMESPACE
 
 namespace detail {
@@ -71,8 +78,6 @@ struct formatter<std::thread::id, Char> : basic_ostream_formatter<Char> {};
 FMT_END_NAMESPACE
 
 #ifdef __cpp_lib_variant
-#  include <variant>
-
 FMT_BEGIN_NAMESPACE
 template <typename Char> struct formatter<std::monostate, Char> {
   template <typename ParseContext>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -78,6 +78,14 @@ add_fmt_test(printf-test)
 add_fmt_test(ranges-test ranges-odr-test.cc)
 add_fmt_test(scan-test)
 add_fmt_test(std-test)
+try_compile(compile_result_unused
+            ${CMAKE_CURRENT_BINARY_DIR}
+            SOURCES ${CMAKE_CURRENT_LIST_DIR}/detect-stdfs.cc
+            OUTPUT_VARIABLE RAWOUTPUT)
+string(REGEX REPLACE ".*libfound \"([^\"]*)\".*" "\\1" STDLIBFS "${RAWOUTPUT}")
+if (STDLIBFS)
+  target_link_libraries(std-test ${STDLIBFS})
+endif ()
 add_fmt_test(unicode-test HEADER_ONLY)
 if (MSVC)
   target_compile_options(unicode-test PRIVATE /utf-8)

--- a/test/detect-stdfs.cc
+++ b/test/detect-stdfs.cc
@@ -1,0 +1,18 @@
+// Formatting library for C++ - tests of formatters for standard library types
+//
+// Copyright (c) 2012 - present, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#include <exception>  // _GLIBCXX_RELEASE & _LIBCPP_VERSION
+
+#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE == 8
+#  error libfound "stdc++fs"
+#elif !defined(__apple_build_version__) && defined(_LIBCPP_VERSION) && \
+    _LIBCPP_VERSION >= 7000 && _LIBCPP_VERSION < 9000
+#  error libfound "c++fs"
+#else
+// none if std::filesystem does not require additional libraries
+#  error libfound ""
+#endif


### PR DESCRIPTION
``libstdc++`` from GCC-8 support std::variant.
``libstdc++`` from GCC-8 has no ``<version>`` file.
``libstdc++`` from GCC-8 defines the macro ``__cpp_lib_variant`` in ``<variant>``.

https://github.com/fmtlib/fmt/blob/6a775e95604da91d0b97799039e52860964b7dea/test/gtest/gtest/gtest.h#L2621-L2627

Because ``gtest.h`` include ``<variant>``, then the macro ``__cpp_lib_variant`` is defined in the test, but is not defined in ``"fmt/std.h"``.