### PR TITLE
Add support Microsoft Visual Studio 2022.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,9 +10,10 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        # windows-2019 has MSVC 2019 installed:
+        # windows-2019 has MSVC 2019 installed;
+        # windows-2022 has MSVC 2022 installed:
         # https://github.com/actions/virtual-environments.
-        os: [windows-2019]
+        os: [windows-2019, windows-2022]
         platform: [Win32, x64]
         build_type: [Debug, Release]
         standard: [11, 17, 20]
@@ -28,6 +29,8 @@ jobs:
           - os: windows-2019
             standard: 20
             platform: Win32
+          - os: windows-2022
+            standard: 11
 
     steps:
     - uses: actions/checkout@v2

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -93,7 +93,7 @@
 // GCC doesn't allow throw in constexpr until version 6 (bug 67371).
 #ifndef FMT_USE_CONSTEXPR
 #  if (FMT_HAS_FEATURE(cxx_relaxed_constexpr) || FMT_MSC_VERSION >= 1912 || \
-       (FMT_GCC_VERSION >= 600 && __cplusplus >= 201402L)) &&               \
+       (FMT_GCC_VERSION >= 600 && FMT_CPLUSPLUS >= 201402L)) &&             \
       !FMT_ICC_VERSION && !defined(__NVCC__)
 #    define FMT_USE_CONSTEXPR 1
 #  else
@@ -106,9 +106,9 @@
 #  define FMT_CONSTEXPR
 #endif
 
-#if ((__cplusplus >= 202002L) &&                              \
+#if ((FMT_CPLUSPLUS >= 202002L) &&                            \
      (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE > 9)) || \
-    (__cplusplus >= 201709L && FMT_GCC_VERSION >= 1002)
+    (FMT_CPLUSPLUS >= 201709L && FMT_GCC_VERSION >= 1002)
 #  define FMT_CONSTEXPR20 constexpr
 #else
 #  define FMT_CONSTEXPR20
@@ -116,11 +116,11 @@
 
 // Check if constexpr std::char_traits<>::{compare,length} are supported.
 #if defined(__GLIBCXX__)
-#  if __cplusplus >= 201703L && defined(_GLIBCXX_RELEASE) && \
+#  if FMT_CPLUSPLUS >= 201703L && defined(_GLIBCXX_RELEASE) && \
       _GLIBCXX_RELEASE >= 7  // GCC 7+ libstdc++ has _GLIBCXX_RELEASE.
 #    define FMT_CONSTEXPR_CHAR_TRAITS constexpr
 #  endif
-#elif defined(_LIBCPP_VERSION) && __cplusplus >= 201703L && \
+#elif defined(_LIBCPP_VERSION) && FMT_CPLUSPLUS >= 201703L && \
     _LIBCPP_VERSION >= 4000
 #  define FMT_CONSTEXPR_CHAR_TRAITS constexpr
 #elif FMT_MSC_VERSION >= 1914 && FMT_CPLUSPLUS >= 201703L
@@ -248,7 +248,7 @@
     (FMT_CPLUSPLUS >= 201703L || defined(_LIBCPP_VERSION))
 #  include <string_view>
 #  define FMT_USE_STRING_VIEW
-#elif FMT_HAS_INCLUDE("experimental/string_view") && __cplusplus >= 201402L
+#elif FMT_HAS_INCLUDE("experimental/string_view") && FMT_CPLUSPLUS >= 201402L
 #  include <experimental/string_view>
 #  define FMT_USE_EXPERIMENTAL_STRING_VIEW
 #endif
@@ -258,9 +258,9 @@
 #endif
 
 #ifndef FMT_CONSTEVAL
-#  if ((FMT_GCC_VERSION >= 1000 || FMT_CLANG_VERSION >= 1101) &&       \
-       __cplusplus >= 202002L && !defined(__apple_build_version__)) || \
-      (defined(__cpp_consteval) &&                                     \
+#  if ((FMT_GCC_VERSION >= 1000 || FMT_CLANG_VERSION >= 1101) &&         \
+       FMT_CPLUSPLUS >= 202002L && !defined(__apple_build_version__)) || \
+      (defined(__cpp_consteval) &&                                       \
        (!FMT_MSC_VERSION || _MSC_FULL_VER >= 193030704))
 // consteval is broken in MSVC before VS2022 and Apple clang 13.
 #    define FMT_CONSTEVAL consteval
@@ -271,8 +271,8 @@
 #endif
 
 #ifndef FMT_USE_NONTYPE_TEMPLATE_ARGS
-#  if defined(__cpp_nontype_template_args) &&                \
-      ((FMT_GCC_VERSION >= 903 && __cplusplus >= 201709L) || \
+#  if defined(__cpp_nontype_template_args) &&                  \
+      ((FMT_GCC_VERSION >= 903 && FMT_CPLUSPLUS >= 201709L) || \
        __cpp_nontype_template_args >= 201911L)
 #    define FMT_USE_NONTYPE_TEMPLATE_ARGS 1
 #  else

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1516,7 +1516,7 @@ template <typename T = void> struct basic_data {
       10000000000000000000ULL};
 };
 
-#if __cplusplus < 201703L
+#if FMT_CPLUSPLUS < 201703L
 template <typename T> constexpr uint64_t basic_data<T>::pow10_significands[];
 template <typename T> constexpr int16_t basic_data<T>::pow10_exponents[];
 template <typename T> constexpr uint64_t basic_data<T>::power_of_10_64[];

--- a/test/compile-fp-test.cc
+++ b/test/compile-fp-test.cc
@@ -11,7 +11,7 @@
 #if defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806 && \
     defined(__cpp_constexpr) && __cpp_constexpr >= 201907 &&       \
     defined(__cpp_constexpr_dynamic_alloc) &&                      \
-    __cpp_constexpr_dynamic_alloc >= 201907 && __cplusplus >= 202002L
+    __cpp_constexpr_dynamic_alloc >= 201907 && FMT_CPLUSPLUS >= 202002L
 template <size_t max_string_length, typename Char = char> struct test_string {
   template <typename T> constexpr bool operator==(const T& rhs) const noexcept {
     return fmt::basic_string_view<Char>(rhs).compare(buffer) == 0;

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -294,7 +294,14 @@ TEST(compile_test, compile_format_string_literal) {
 }
 #endif
 
-#if FMT_CPLUSPLUS >= 202002L || \
+// MSVS 2019 19.29.30145.0 - Support C++20 and OK.
+// MSVS 2022 19.32.31332.0 - compile-test.cc(362,3): fatal error C1001: Internal
+// compiler error.
+//  (compiler file
+//  'D:\a\_work\1\s\src\vctools\Compiler\CxxFE\sl\p1\c\constexpr\constexpr.cpp',
+//  line 8635)
+#if ((FMT_CPLUSPLUS >= 202002L) &&                    \
+     (!FMT_MSC_VERSION || FMT_MSC_VERSION < 1930)) || \
     (FMT_CPLUSPLUS >= 201709L && FMT_GCC_VERSION >= 1002)
 template <size_t max_string_length, typename Char = char> struct test_string {
   template <typename T> constexpr bool operator==(const T& rhs) const noexcept {

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -294,8 +294,8 @@ TEST(compile_test, compile_format_string_literal) {
 }
 #endif
 
-#if __cplusplus >= 202002L || \
-    (__cplusplus >= 201709L && FMT_GCC_VERSION >= 1002)
+#if FMT_CPLUSPLUS >= 202002L || \
+    (FMT_CPLUSPLUS >= 201709L && FMT_GCC_VERSION >= 1002)
 template <size_t max_string_length, typename Char = char> struct test_string {
   template <typename T> constexpr bool operator==(const T& rhs) const noexcept {
     return fmt::basic_string_view<Char>(rhs).compare(buffer) == 0;

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1860,11 +1860,11 @@ TEST(format_test, compile_time_string) {
 
   (void)with_null;
   (void)no_null;
-#if __cplusplus >= 201703L
+#if FMT_CPLUSPLUS >= 201703L
   EXPECT_EQ("42", fmt::format(FMT_STRING(with_null), 42));
   EXPECT_EQ("42", fmt::format(FMT_STRING(no_null), 42));
 #endif
-#if defined(FMT_USE_STRING_VIEW) && __cplusplus >= 201703L
+#if defined(FMT_USE_STRING_VIEW) && FMT_CPLUSPLUS >= 201703L
   EXPECT_EQ("42", fmt::format(FMT_STRING(std::string_view("{}")), 42));
 #endif
 }
@@ -2233,7 +2233,7 @@ TEST(format_test, char_traits_is_not_ambiguous) {
   using namespace std;
   auto c = char_traits<char>::char_type();
   (void)c;
-#if __cplusplus >= 201103L
+#if FMT_CPLUSPLUS >= 201103L
   auto s = std::string();
   auto lval = begin(s);
   (void)lval;

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -98,12 +98,12 @@ TEST(xchar_test, is_formattable) {
 }
 
 TEST(xchar_test, compile_time_string) {
-#if defined(FMT_USE_STRING_VIEW) && __cplusplus >= 201703L
+#if defined(FMT_USE_STRING_VIEW) && FMT_CPLUSPLUS >= 201703L
   EXPECT_EQ(L"42", fmt::format(FMT_STRING(std::wstring_view(L"{}")), 42));
 #endif
 }
 
-#if __cplusplus > 201103L
+#if FMT_CPLUSPLUS > 201103L
 struct custom_char {
   int value;
   custom_char() = default;


### PR DESCRIPTION
Fix for #2958 (On MSVC 2022 with ``/std:c++20``: ``FMT_CPLUSPLUS == 202002L``).

New CI tasks, Replace ``__cplusplus`` with ``FMT_CPLUSPLUS`` (for MSVC) and Add workaround for MSVC 2022 ICE.


Additional Information:
Internal compiler error message for commit "Workaround to Microsoft Visual Studio 2022 Internal compiler error.":

```
D:\a\fmt\fmt\test\compile-test.cc(362,3): fatal error C1001: Internal compiler error. [D:\a\fmt\build\test\compile-test.vcxproj]
  (compiler file 'D:\a\_work\1\s\src\vctools\Compiler\CxxFE\sl\p1\c\constexpr\constexpr.cpp', line 8635)
   To work around this problem, try simplifying or changing the program near the locations listed above.
  If possible please provide a repro here: https://developercommunity.visualstudio.com
  Please choose the Technical Support command on the Visual C++
   Help menu, or open the Technical Support help file for more information
```