### PR TITLE
copying an object of non-trivial type error

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -287,7 +287,8 @@ FMT_CONSTEXPR20 auto bit_cast(const From& from) -> To {
   if (is_constant_evaluated()) return std::bit_cast<To>(from);
 #endif
   auto to = To();
-  std::memcpy(&to, &from, sizeof(to));
+  std::memcpy(static_cast<void*>(&to), static_cast<const void*>(&from),
+              sizeof(to));
   return to;
 }
 


### PR DESCRIPTION
The fix addresses the following error related to fmt-9.0.0 `uint128_fallback`, reproducible with GCC-8.3.0
```
fmt/format.h:290:12: error: 'void* memcpy(void*, const void*, size_t)' copying an object of non-trivial type 'class fmt::v9::detail::uint128_fallback' from an array of 'const long double' [-Werror=class-memaccess]
   std::memcpy(&to, &from, sizeof(to));
   ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
fmt/format.h:309:7: note: 'class fmt::v9::detail::uint128_fallback' declared here
 class uint128_fallback {
```