### PR TITLE
Pointless comparison warnings

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -203,7 +203,7 @@ To safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from,
     }
     const auto min1 =
         (std::numeric_limits<IntermediateRep>::min)() / Factor::num;
-    if (count < min1) {
+    if (std::is_unsigned<IntermediateRep>::value || count < min1) {
       ec = 1;
       return {};
     }

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1396,7 +1396,8 @@ inline bool isfinite(T) {
 // Converts value to Int and checks that it's in the range [0, upper).
 template <typename T, typename Int, FMT_ENABLE_IF(std::is_integral<T>::value)>
 inline Int to_nonnegative_int(T value, Int upper) {
-  FMT_ASSERT(value >= 0 && to_unsigned(value) <= to_unsigned(upper),
+  FMT_ASSERT(std::is_unsigned<Int>::value ||
+             (value >= 0 && to_unsigned(value) <= to_unsigned(upper)),
              "invalid value");
   (void)upper;
   return static_cast<Int>(value);

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -203,7 +203,7 @@ To safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from,
     }
     const auto min1 =
         (std::numeric_limits<IntermediateRep>::min)() / Factor::num;
-    if (std::is_unsigned<IntermediateRep>::value || count < min1) {
+    if (!std::is_unsigned<IntermediateRep>::value && count < min1) {
       ec = 1;
       return {};
     }

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -402,7 +402,7 @@ template <typename T> auto convert_for_visit(T) -> monostate { return {}; }
 template <typename Int>
 FMT_CONSTEXPR auto to_unsigned(Int value) ->
     typename std::make_unsigned<Int>::type {
-  FMT_ASSERT(value >= 0, "negative value");
+  FMT_ASSERT(std::is_unsigned<Int>::value || value >= 0, "negative value");
   return static_cast<typename std::make_unsigned<Int>::type>(value);
 }
 


### PR DESCRIPTION
The fix addresses the following errors/warnings in fmt-9.0.0 with MICROSOFT MSC 191125506/GCC-7.5.0
```
\fmt/chrono.h(1399): warning #186-D: pointless comparison of unsigned integer with zero
          detected during:
            instantiation of "Int fmt::v9::detail::to_nonnegative_int(T, Int) [with T=unsigned long long, Int=long long, <unnamed>=0]" 
(1688): here
```
```
fmt/chrono.h(206): warning #186-D: pointless comparison of unsigned integer with zero
          detected during:
            instantiation of "To fmt::v9::safe_duration_cast::safe_duration_cast<To,FromRep,FromPeriod,<unnamed>,<unnamed>>(std::chrono::duration<FromRep, FromPeriod>, int &) [with To=std::chrono::duration<unsigned long long, std::ratio<1LL, 1LL>>, FromRep=unsigned long long, FromPeriod=std::micro, <unnamed>=0, <unnamed>=0]" 
(1436): here
```
```
fmt/core.h(408): warning #186-D: pointless comparison of unsigned integer with zero
          detected during:
            instantiation of "auto fmt::v9::detail::to_unsigned(Int)->std::make_unsigned<Int>::type [with Int=size_t]"
fmt/include/fmt/format.h(555): here
```