### PR TITLE
The n specifier for ranges.

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -415,6 +415,7 @@ struct formatter<
       detail::range_formatter_type<Char, detail::uncvref_type<range_type>>;
   formatter_type underlying_;
   bool custom_specs_ = false;
+  bool use_brackets_ = true;
 
   template <typename ParseContext>
   FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
@@ -422,8 +423,13 @@ struct formatter<
     auto end = ctx.end();
     if (it == end || *it == '}') return it;
 
+    if (*it == 'n') {
+      use_brackets_ = false;
+      ++it;
+    }
+
     if (*it != ':')
-      FMT_THROW(format_error("no top-level range formatters supported"));
+      FMT_THROW(format_error("no other top-level range formatters supported"));
 
     custom_specs_ = true;
     ++it;
@@ -438,7 +444,7 @@ struct formatter<
     Char postfix = detail::is_set<R>::value ? '}' : ']';
     detail::range_mapper<buffer_context<Char>> mapper;
     auto out = ctx.out();
-    *out++ = prefix;
+    if (use_brackets_) *out++ = prefix;
     int i = 0;
     auto it = detail::range_begin(range);
     auto end = detail::range_end(range);
@@ -452,7 +458,7 @@ struct formatter<
       }
       ++i;
     }
-    *out++ = postfix;
+    if (use_brackets_) *out++ = postfix;
     return out;
   }
 };

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -47,12 +47,14 @@ TEST(ranges_test, format_vector) {
   auto v = std::vector<int>{1, 2, 3, 5, 7, 11};
   EXPECT_EQ(fmt::format("{}", v), "[1, 2, 3, 5, 7, 11]");
   EXPECT_EQ(fmt::format("{::#x}", v), "[0x1, 0x2, 0x3, 0x5, 0x7, 0xb]");
+  EXPECT_EQ(fmt::format("{:n:#x}", v), "0x1, 0x2, 0x3, 0x5, 0x7, 0xb");
 }
 
 TEST(ranges_test, format_vector2) {
   auto v = std::vector<std::vector<int>>{{1, 2}, {3, 5}, {7, 11}};
   EXPECT_EQ(fmt::format("{}", v), "[[1, 2], [3, 5], [7, 11]]");
   EXPECT_EQ(fmt::format("{:::#x}", v), "[[0x1, 0x2], [0x3, 0x5], [0x7, 0xb]]");
+  EXPECT_EQ(fmt::format("{:n:n:#x}", v), "0x1, 0x2, 0x3, 0x5, 0x7, 0xb");
 }
 
 TEST(ranges_test, format_map) {


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->

Figure I'd slowly continue this work. As per P2286, the `n` specifier formats without brackets. 