### PR TITLE
Fix for EDG frontend (Intel, NVHPC compilers)

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2016,13 +2016,16 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
     return formatter<std::tm, Char>::format(localtime(val), ctx);
   }
 
-  static constexpr const Char default_specs[] = {'%', 'F', ' ', '%', 'T'};
+  // EDG frontend (Intel, NVHPC compilers) can't determine array length.
+  static constexpr const Char default_specs[5] = {'%', 'F', ' ', '%', 'T'};
 };
 
+#if FMT_CPLUSPLUS < 201703L
 template <typename Char, typename Duration>
 constexpr const Char
     formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
               Char>::default_specs[];
+#endif
 
 template <typename Char> struct formatter<std::tm, Char> {
  private:


### PR DESCRIPTION
EDG frontend (Intel, NVHPC compilers) can't determine static constexpr array length.

Test:
```c++
#include <iostream>
#include <fmt/chrono.h>

int main()
{
    auto t1 = std::chrono::system_clock::now();
    std::cerr << fmt::format("!{:%F %T}!", t1) << std::endl;
    std::cerr << fmt::format("!{}!", t1) << std::endl;

    return 0;
}
```

C++17:
https://godbolt.org/z/WWW3v8eWs

```
!2022-07-11 13:27:10!
!!
```

C++14:
https://godbolt.org/z/qxfnYTz4G

```
!2022-07-11 13:34:17!
!2022-07-11 13:34:17!
```

C++17 with fix:
https://godbolt.org/z/7MKjY9oE1
```
!2022-07-11 13:44:10!
!2022-07-11 13:44:10!
```
