### PR TITLE
Fixes IBM XLC behavior with uint128 fallback

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -49,14 +49,8 @@
 #  define FMT_ICC_VERSION 0
 #endif
 
-#ifdef __xlC_ver__
-#  define FMT_XLC_VERSION __xlC_ver__
-#elif defined(__xlC__)
-#  define FMT_XLC_VERSION __xlC__
-#elif defined(__IBMC__)
-#  define FMT_XLC_VERSION __IBMC__
-#elif defined(__IBMCPP__)
-#  define FMT_XLC_VERSION __IBMCPP__
+#ifdef __ibmxl__
+#  define FMT_XLC_VERSION __ibmxl_vrm__
 #else
 #  define FMT_XLC_VERSION 0
 #endif

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -49,6 +49,18 @@
 #  define FMT_ICC_VERSION 0
 #endif
 
+#ifdef __xlC_ver__
+#  define FMT_XLC_VERSION __xlC_ver__
+#elif defined(__xlC__)
+#  define FMT_XLC_VERSION __xlC__
+#elif defined(__IBMC__)
+#  define FMT_XLC_VERSION __IBMC__
+#elif defined(__IBMCPP__)
+#  define FMT_XLC_VERSION __IBMCPP__
+#else
+#  define FMT_XLC_VERSION 0
+#endif
+
 #ifdef _MSC_VER
 #  define FMT_MSC_VERSION _MSC_VER
 #  define FMT_MSC_WARNING(...) __pragma(warning(__VA_ARGS__))

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -49,12 +49,6 @@
 #  define FMT_ICC_VERSION 0
 #endif
 
-#ifdef __ibmxl__
-#  define FMT_XLC_VERSION __ibmxl_vrm__
-#else
-#  define FMT_XLC_VERSION 0
-#endif
-
 #ifdef _MSC_VER
 #  define FMT_MSC_VERSION _MSC_VER
 #  define FMT_MSC_WARNING(...) __pragma(warning(__VA_ARGS__))

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -391,14 +391,11 @@ class uint128_fallback {
       hi_ += (lo_ < n ? 1 : 0);
       return *this;
     }
-#if FMT_XLC_VERSION && defined(_ARCH_PWR9)
-    lo_ = __addex(lo_, n, 0, &carry);
-    hi_ += carry;
-#elif FMT_HAS_BUILTIN(__builtin_addcll) && !FMT_XLC_VERSION
+#if FMT_HAS_BUILTIN(__builtin_addcll) && !defined(__ibmxl__)
     unsigned long long carry;
     lo_ = __builtin_addcll(lo_, n, 0, &carry);
     hi_ += carry;
-#elif FMT_HAS_BUILTIN(__builtin_ia32_addcarryx_u64) && !FMT_XLC_VERSION
+#elif FMT_HAS_BUILTIN(__builtin_ia32_addcarryx_u64) && !defined(__ibmxl__)
     unsigned long long result;
     auto carry = __builtin_ia32_addcarryx_u64(0, lo_, n, &result);
     lo_ = result;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -391,7 +391,7 @@ class uint128_fallback {
       hi_ += (lo_ < n ? 1 : 0);
       return *this;
     }
-#if FMT_XLC_VERSION && defined(_ARCH_PWR9) && defined(_ARCH_PPC64)
+#if FMT_XLC_VERSION && defined(_ARCH_PWR9)
     lo_ = __addex(lo_, n, 0, &carry);
     hi_ += carry;
 #elif FMT_HAS_BUILTIN(__builtin_addcll) && !FMT_XLC_VERSION

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -391,11 +391,14 @@ class uint128_fallback {
       hi_ += (lo_ < n ? 1 : 0);
       return *this;
     }
-#if FMT_HAS_BUILTIN(__builtin_addcll)
+#if FMT_XLC_VERSION && defined(_ARCH_PWR9) && defined(_ARCH_PPC64)
+    lo_ = __addex(lo_, n, 0, &carry);
+    hi_ += carry;
+#elif FMT_HAS_BUILTIN(__builtin_addcll) && !FMT_XLC_VERSION
     unsigned long long carry;
     lo_ = __builtin_addcll(lo_, n, 0, &carry);
     hi_ += carry;
-#elif FMT_HAS_BUILTIN(__builtin_ia32_addcarryx_u64)
+#elif FMT_HAS_BUILTIN(__builtin_ia32_addcarryx_u64) && !FMT_XLC_VERSION
     unsigned long long result;
     auto carry = __builtin_ia32_addcarryx_u64(0, lo_, n, &result);
     lo_ = result;


### PR DESCRIPTION
IBM XLC compiler evaluates `#if FMT_HAS_BUILTIN(__builtin_addcll)` to true but `__builtin_addcll` is not supported and the compilation fails.