### PR TITLE
Add additional search paths for doxygen on Windows

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,4 +1,6 @@
-find_program(DOXYGEN doxygen)
+find_program(DOXYGEN doxygen
+  PATHS "$ENV{ProgramFiles}/doxygen/bin"
+        "$ENV{ProgramFiles\(x86\)}/doxygen/bin")
 if (NOT DOXYGEN)
   message(STATUS "Target 'doc' disabled (requires doxygen)")
   return ()


### PR DESCRIPTION
`find_program(DOXYGEN doxygen)` didn't find the executable automatically even if I installed Doxygen on Windows. Therefore, I added some additional search paths.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
