### PR TITLE
Improve Unicode handling when writing to an ostream on Windows

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1473,17 +1473,13 @@ FMT_FUNC std::string vformat(string_view fmt, format_args args) {
   return to_string(buffer);
 }
 
-#ifdef _WIN32
 namespace detail {
+#ifdef _WIN32
 using dword = conditional_t<sizeof(long) == 4, unsigned long, unsigned>;
 extern "C" __declspec(dllimport) int __stdcall WriteConsoleW(  //
     void*, const void*, dword, dword*, void*);
-}  // namespace detail
-#endif
 
-namespace detail {
-FMT_FUNC void print(std::FILE* f, string_view text) {
-#ifdef _WIN32
+FMT_FUNC bool write_console_on_windows(std::FILE* f, string_view text) {
   auto fd = _fileno(f);
   if (_isatty(fd)) {
     detail::utf8_to_utf16 u16(string_view(text.data(), text.size()));
@@ -1491,11 +1487,20 @@ FMT_FUNC void print(std::FILE* f, string_view text) {
     if (detail::WriteConsoleW(reinterpret_cast<void*>(_get_osfhandle(fd)),
                               u16.c_str(), static_cast<uint32_t>(u16.size()),
                               &written, nullptr)) {
-      return;
+      return true;
     }
-    // Fallback to fwrite on failure. It can happen if the output has been
-    // redirected to NUL.
   }
+  // We return false if the file descriptor was not TTY, or it was but
+  // SetConsoleW failed which can happen if the output has been redirected to
+  // NUL. In both cases when we return false, we should attempt to do regular
+  // write via fwrite or std::ostream::write.
+  return false;
+}
+#endif
+
+FMT_FUNC void print(std::FILE* f, string_view text) {
+#ifdef _WIN32
+  if (write_console_on_windows(f, text)) return;
 #endif
   detail::fwrite_fully(text.data(), 1, text.size(), f);
 }

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1479,7 +1479,7 @@ using dword = conditional_t<sizeof(long) == 4, unsigned long, unsigned>;
 extern "C" __declspec(dllimport) int __stdcall WriteConsoleW(  //
     void*, const void*, dword, dword*, void*);
 
-FMT_FUNC bool write_console_on_windows(std::FILE* f, string_view text) {
+FMT_FUNC bool write_console(std::FILE* f, string_view text) {
   auto fd = _fileno(f);
   if (_isatty(fd)) {
     detail::utf8_to_utf16 u16(string_view(text.data(), text.size()));
@@ -1500,7 +1500,7 @@ FMT_FUNC bool write_console_on_windows(std::FILE* f, string_view text) {
 
 FMT_FUNC void print(std::FILE* f, string_view text) {
 #ifdef _WIN32
-  if (write_console_on_windows(f, text)) return;
+  if (write_console(f, text)) return;
 #endif
   detail::fwrite_fully(text.data(), 1, text.size(), f);
 }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -921,6 +921,7 @@ struct is_contiguous<basic_memory_buffer<T, SIZE, Allocator>> : std::true_type {
 };
 
 namespace detail {
+bool write_console_on_windows(std::FILE* f, string_view text);
 FMT_API void print(std::FILE*, string_view);
 }
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -922,7 +922,7 @@ struct is_contiguous<basic_memory_buffer<T, SIZE, Allocator>> : std::true_type {
 
 namespace detail {
 #ifdef _WIN32
-FMT_API bool write_console_on_windows(std::FILE* f, string_view text);
+FMT_API bool write_console(std::FILE* f, string_view text);
 #endif
 FMT_API void print(std::FILE*, string_view);
 }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -922,7 +922,7 @@ struct is_contiguous<basic_memory_buffer<T, SIZE, Allocator>> : std::true_type {
 
 namespace detail {
 #ifdef _WIN32
-bool write_console_on_windows(std::FILE* f, string_view text);
+FMT_API bool write_console_on_windows(std::FILE* f, string_view text);
 #endif
 FMT_API void print(std::FILE*, string_view);
 }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -921,7 +921,9 @@ struct is_contiguous<basic_memory_buffer<T, SIZE, Allocator>> : std::true_type {
 };
 
 namespace detail {
+#ifdef _WIN32
 bool write_console_on_windows(std::FILE* f, string_view text);
+#endif
 FMT_API void print(std::FILE*, string_view);
 }
 

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -87,8 +87,10 @@ template class filebuf_access<filebuf_access_tag,
 
 inline bool write_ostream_msvc_unicode(std::ostream& os,
                                        fmt::string_view data) {
+#ifdef _WIN32
   if (auto* buf = dynamic_cast<std::filebuf*>(os.rdbuf()))
     if (FILE* f = get_file(*buf)) return write_console_on_windows(f, data);
+#endif
   return false;
 }
 inline bool write_ostream_msvc_unicode(std::wostream&,

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -121,6 +121,7 @@ inline bool write_ostream_gcc_mingw_unicode(std::wostream&,
 // It is a separate function rather than a part of vprint to simplify testing.
 template <typename Char>
 void write_buffer(std::basic_ostream<Char>& os, buffer<Char>& buf) {
+  // TODO: check detail::is_utf8(). Here or bellow in print or in vprint?
 #if FMT_MSC_VERSION
   if (write_ostream_msvc_unicode(os, {buf.data(), buf.size()})) return;
 #elif _WIN32 && __GLIBCXX__

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -100,8 +100,8 @@ inline bool write_ostream_unicode(std::ostream& os, fmt::string_view data) {
     return false;
   if (c_file) return write_console(c_file, data);
 #else
-  (void)os;  // suppress warning
-  (void)data;
+  ignore_unused(os);
+  ignore_unused(data);
 #endif
   return false;
 }

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -10,7 +10,7 @@
 
 #include <fstream>
 #include <ostream>
-#if _WIN32 && __GLIBCXX__
+#if defined(_WIN32) && defined(__GLIBCXX__)
 #  include <ext/stdio_filebuf.h>
 #  include <ext/stdio_sync_filebuf.h>
 #endif
@@ -96,7 +96,7 @@ inline bool write_ostream_msvc_unicode(std::wostream&,
   return false;
 }
 
-#if _WIN32 && __GLIBCXX__
+#if defined(_WIN32) && defined(__GLIBCXX__)
 inline bool write_ostream_gcc_mingw_unicode(std::ostream& os,
                                             fmt::string_view data) {
   auto* rdbuf = os.rdbuf();
@@ -124,7 +124,7 @@ void write_buffer(std::basic_ostream<Char>& os, buffer<Char>& buf) {
   // TODO: check detail::is_utf8(). Here or bellow in print or in vprint?
 #if FMT_MSC_VERSION
   if (write_ostream_msvc_unicode(os, {buf.data(), buf.size()})) return;
-#elif _WIN32 && __GLIBCXX__
+#elif defined(_WIN32) && defined(__GLIBCXX__)
   if (write_ostream_gcc_mingw_unicode(os, {buf.data(), buf.size()})) return;
 #endif
   const Char* buf_data = buf.data();


### PR DESCRIPTION
See also #2875. I split the whole patch into 4 commits so reviewing is easier.
