### PR TITLE
Reduce filesize of the tests on MinGW

### DIFF
--- a/support/appveyor-build.py
+++ b/support/appveyor-build.py
@@ -11,32 +11,23 @@ path = os.environ['PATH']
 image = os.environ['APPVEYOR_BUILD_WORKER_IMAGE']
 jobid = os.environ['APPVEYOR_JOB_ID']
 cmake_command = ['cmake', '-DFMT_PEDANTIC=ON', '-DCMAKE_BUILD_TYPE=' + config, '..']
-if build == 'mingw':
-    cmake_command.append('-GMinGW Makefiles')
-    build_command = ['mingw32-make', '-j4']
-    test_command = ['mingw32-make', 'test']
-    # Remove the path to Git bin directory from $PATH because it breaks
-    # MinGW config.
-    path = path.replace(r'C:\Program Files (x86)\Git\bin', '')
-    os.environ['PATH'] = r'C:\MinGW\bin;' + path
+# Add MSBuild 14.0 to PATH as described in
+# http://help.appveyor.com/discussions/problems/2229-v140-not-found-on-vs2105rc.
+os.environ['PATH'] = r'C:\Program Files (x86)\MSBuild\15.0\Bin;' + path
+if image == 'Visual Studio 2019':
+    generator = 'Visual Studio 16 2019'
+    if platform == 'x64':
+        cmake_command.extend(['-A', 'x64'])
 else:
-    # Add MSBuild 14.0 to PATH as described in
-    # http://help.appveyor.com/discussions/problems/2229-v140-not-found-on-vs2105rc.
-    os.environ['PATH'] = r'C:\Program Files (x86)\MSBuild\15.0\Bin;' + path
-    if image == 'Visual Studio 2019':
-        generator = 'Visual Studio 16 2019'
-        if platform == 'x64':
-            cmake_command.extend(['-A', 'x64'])
-    else:
-        if image == 'Visual Studio 2015':
-            generator = 'Visual Studio 14 2015'
-        elif image == 'Visual Studio 2017':
-            generator = 'Visual Studio 15 2017'
-        if platform == 'x64':
-            generator += ' Win64'
-    cmake_command.append('-G' + generator)
-    build_command = ['cmake', '--build', '.', '--config', config, '--', '/m:4']
-    test_command = ['ctest', '-C', config]
+    if image == 'Visual Studio 2015':
+        generator = 'Visual Studio 14 2015'
+    elif image == 'Visual Studio 2017':
+        generator = 'Visual Studio 15 2017'
+    if platform == 'x64':
+        generator += ' Win64'
+cmake_command.append('-G' + generator)
+build_command = ['cmake', '--build', '.', '--config', config, '--', '/m:4']
+test_command = ['ctest', '-C', config]
 
 check_call(cmake_command)
 check_call(build_command)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,9 +8,6 @@ target_link_libraries(test-main gtest fmt)
 
 function(add_fmt_executable name)
   add_executable(${name} ${ARGN})
-  if (MINGW)
-    target_link_libraries(${name} -static-libgcc -static-libstdc++)
-  endif ()
   # (Wstringop-overflow) - [meta-bug] bogus/missing -Wstringop-overflow warnings
   #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88443
   # Bogus -Wstringop-overflow warning


### PR DESCRIPTION
This patch removes the workaround applied here 1acfd07f1ed9d4055833a70d9195e57aee7bbe77. MinGW is not tested on Appveyor anymore. If its added in the future it should be added in Github Actions.