### PR TITLE
Add fmt:: namespace to doc

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -39,7 +39,7 @@ The ``fmt::format`` function returns a string "The answer is 42.". You can use
 .. code:: c++
 
   auto out = fmt::memory_buffer();
-  format_to(std::back_inserter(out),
+  fmt::format_to(std::back_inserter(out),
             "For a moment, {} happened.", "nothing");
   auto data = out.data(); // pointer to the formatted data
   auto size = out.size(); // size of the formatted data


### PR DESCRIPTION
Otherwise as-is the example does not compile on Visual Studio due to the conflict with std::format_to: 
https://gcc.godbolt.org/z/qe4jEvvqY

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
