### PR TITLE
Simplify and improve chrono formatting

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2006,11 +2006,6 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
                    default_specs + sizeof(default_specs) / sizeof(Char));
   }
 
-  template <typename ParseContext>
-  FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
-    return this->do_parse(ctx.begin(), ctx.end());
-  }
-
   template <typename FormatContext>
   auto format(std::chrono::time_point<std::chrono::system_clock> val,
               FormatContext& ctx) const -> decltype(ctx.out()) {

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2008,7 +2008,7 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
 
   template <typename ParseContext>
   FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
-    return this->do_parse(ctx.begin(), ctx.end(), true);
+    return this->do_parse(ctx.begin(), ctx.end());
   }
 
   template <typename FormatContext>
@@ -2039,13 +2039,10 @@ template <typename Char> struct formatter<std::tm, Char> {
   basic_string_view<Char> specs;
 
  protected:
-  template <typename It>
-  FMT_CONSTEXPR auto do_parse(It begin, It end, bool with_default = false)
-      -> It {
+  template <typename It> FMT_CONSTEXPR auto do_parse(It begin, It end) -> It {
     if (begin != end && *begin == ':') ++begin;
     end = detail::parse_chrono_format(begin, end, detail::tm_format_checker());
-    if (!with_default || end != begin)
-      specs = {begin, detail::to_unsigned(end - begin)};
+    if (end != begin) specs = {begin, detail::to_unsigned(end - begin)};
     // basic_string_view<>::compare isn't constexpr before C++17.
     if (specs.size() == 2 && specs[0] == Char('%')) {
       if (specs[1] == Char('F'))

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2049,8 +2049,8 @@ template <typename Char> struct formatter<std::tm, Char> {
   }
 
  public:
-  template <typename ParseContext>
-  FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+  FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
+      -> decltype(ctx.begin()) {
     return this->do_parse(ctx.begin(), ctx.end());
   }
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2030,6 +2030,13 @@ template <typename Char> struct formatter<std::tm, Char> {
     end = detail::parse_chrono_format(begin, end, detail::tm_format_checker());
     // Replace default spec only if the new spec is not empty.
     if (end != begin) specs = {begin, detail::to_unsigned(end - begin)};
+    return end;
+  }
+
+ public:
+  FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
+      -> decltype(ctx.begin()) {
+    auto end = this->do_parse(ctx.begin(), ctx.end());
     // basic_string_view<>::compare isn't constexpr before C++17.
     if (specs.size() == 2 && specs[0] == Char('%')) {
       if (specs[1] == Char('F'))
@@ -2038,12 +2045,6 @@ template <typename Char> struct formatter<std::tm, Char> {
         spec_ = spec::hh_mm_ss;
     }
     return end;
-  }
-
- public:
-  FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
-      -> decltype(ctx.begin()) {
-    return this->do_parse(ctx.begin(), ctx.end());
   }
 
   template <typename FormatContext>

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2028,6 +2028,7 @@ template <typename Char> struct formatter<std::tm, Char> {
   template <typename It> FMT_CONSTEXPR auto do_parse(It begin, It end) -> It {
     if (begin != end && *begin == ':') ++begin;
     end = detail::parse_chrono_format(begin, end, detail::tm_format_checker());
+    // Replace default spec only if the new spec is not empty.
     if (end != begin) specs = {begin, detail::to_unsigned(end - begin)};
     // basic_string_view<>::compare isn't constexpr before C++17.
     if (specs.size() == 2 && specs[0] == Char('%')) {

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2002,8 +2002,9 @@ template <typename Char, typename Duration>
 struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
                  Char> : formatter<std::tm, Char> {
   FMT_CONSTEXPR formatter() {
-    this->do_parse(default_specs,
-                   default_specs + sizeof(default_specs) / sizeof(Char));
+    basic_string_view<Char> default_specs =
+        detail::string_literal<Char, '%', 'F', ' ', '%', 'T'>{};
+    this->do_parse(default_specs.begin(), default_specs.end());
   }
 
   template <typename FormatContext>
@@ -2011,17 +2012,7 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
               FormatContext& ctx) const -> decltype(ctx.out()) {
     return formatter<std::tm, Char>::format(localtime(val), ctx);
   }
-
-  // EDG frontend (Intel, NVHPC compilers) can't determine array length.
-  static constexpr const Char default_specs[5] = {'%', 'F', ' ', '%', 'T'};
 };
-
-#if FMT_CPLUSPLUS < 201703L
-template <typename Char, typename Duration>
-constexpr const Char
-    formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
-              Char>::default_specs[];
-#endif
 
 template <typename Char> struct formatter<std::tm, Char> {
  private:

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -249,6 +249,18 @@ FMT_CONSTEXPR inline void abort_fuzzing_if(bool condition) {
 #endif
 }
 
+template <typename CharT, CharT... C> struct string_literal {
+  static constexpr CharT value[sizeof...(C)] = {C...};
+  constexpr operator basic_string_view<CharT>() const {
+    return {value, sizeof...(C)};
+  }
+};
+
+#if FMT_CPLUSPLUS < 201703L
+template <typename CharT, CharT... C>
+constexpr CharT string_literal<CharT, C...>::value[sizeof...(C)];
+#endif
+
 template <typename Streambuf> class formatbuf : public Streambuf {
  private:
   using char_type = typename Streambuf::char_type;

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -309,16 +309,6 @@ OutputIt write_range_entry(OutputIt out, const Arg& v) {
   return write<Char>(out, v);
 }
 
-template <typename CharT, CharT... C> struct string_literal {
-  static constexpr CharT value[sizeof...(C)] = {C...};
-  constexpr operator basic_string_view<CharT>() const {
-    return {value, sizeof...(C)};
-  }
-};
-
-template <typename CharT, CharT... C>
-constexpr CharT string_literal<CharT, C...>::value[sizeof...(C)];
-
 }  // namespace detail
 
 template <typename T> struct is_tuple_like {


### PR DESCRIPTION
1) Reused ``detail::string_literal``
2) Removed unneeded code.
3) Improve performance (prevented double code execution, because formatter<>::parse() is always called and for empty format spec too).