### PR TITLE
Fix testsuite on MinGW + MSVCRT

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,3 +67,26 @@ jobs:
       run: ctest -C ${{matrix.build_type}} -V
       env:
         CTEST_OUTPUT_ON_FAILURE: True
+
+  mingw:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    strategy:
+      matrix:
+        sys: [ mingw64, mingw32, ucrt64 ]
+    steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        release: false
+        msystem: ${{matrix.sys}}
+        pacboy: cc:p cmake:p ninja:p lld:p
+    - uses: actions/checkout@v2
+    - name: Configure
+      run: cmake -B ../build -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug
+      env: { LDFLAGS: -fuse-ld=lld }
+    - name: Build
+      run: cmake --build ../build
+    - name: Test
+      run: ctest -j `nproc` --test-dir ../build

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -121,6 +121,13 @@ TEST(chrono_test, format_tm) {
       make_tm(2000, 1, 2, 12, 14, 16),    // W52
       make_tm(2000, 1, 3, 12, 14, 16)     // W1
   };
+
+#if defined(__MINGW32__) && !defined(_UCRT)
+  GTEST_SKIP() << "Skip the rest of this test because it relies on strftime() "
+                  "conforming to C99, but on this platform, MINGW + MSVCRT, "
+                  "the function conforms only to C89.";
+#endif
+
   const std::string iso_week_spec = "%Y-%m-%d: %G %g %V";
   for (auto ctm : tm_list) {
     // Calculate tm_yday, tm_wday, etc.
@@ -261,12 +268,16 @@ TEST(chrono_test, time_point) {
       "%Oe", "%a",  "%A",  "%w",  "%Ow", "%u",  "%Ou", "%H",  "%OH",
       "%I",  "%OI", "%M",  "%OM", "%S",  "%OS", "%x",  "%Ex", "%X",
       "%EX", "%D",  "%F",  "%R",  "%T",  "%p",  "%z",  "%Z"};
-  spec_list.push_back("%Y-%m-%d %H:%M:%S");
 #ifndef _WIN32
   // Disabled on Windows because these formats are not consistent among
   // platforms.
   spec_list.insert(spec_list.end(), {"%c", "%Ec", "%r"});
+#elif defined(__MINGW32__) && !defined(_UCRT)
+  // Only C89 conversion specifiers when using MSVCRT instead of UCRT
+  spec_list = {"%%", "%Y", "%y", "%b", "%B", "%m", "%U", "%W", "%j", "%d", "%a",
+               "%A", "%w", "%H", "%I", "%M", "%S", "%x", "%X", "%p", "%Z"};
 #endif
+  spec_list.push_back("%Y-%m-%d %H:%M:%S");
 
   for (const auto& spec : spec_list) {
     auto t = std::chrono::system_clock::to_time_t(t1);

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -282,7 +282,7 @@ std::wstring system_wcsftime(const std::wstring& format, const std::tm* timeptr,
 #endif
 }
 
-TEST(chrono_test, time_point) {
+TEST(chrono_test_wchar, time_point) {
   auto t1 = std::chrono::system_clock::now();
 
   std::vector<std::wstring> spec_list = {
@@ -292,12 +292,17 @@ TEST(chrono_test, time_point) {
       L"%Oe", L"%a",  L"%A",  L"%w",  L"%Ow", L"%u",  L"%Ou", L"%H",  L"%OH",
       L"%I",  L"%OI", L"%M",  L"%OM", L"%S",  L"%OS", L"%x",  L"%Ex", L"%X",
       L"%EX", L"%D",  L"%F",  L"%R",  L"%T",  L"%p",  L"%z",  L"%Z"};
-  spec_list.push_back(L"%Y-%m-%d %H:%M:%S");
 #ifndef _WIN32
   // Disabled on Windows, because these formats is not consistent among
   // platforms.
   spec_list.insert(spec_list.end(), {L"%c", L"%Ec", L"%r"});
+#elif defined(__MINGW32__) && !defined(_UCRT)
+  // Only C89 conversion specifiers when using MSVCRT instead of UCRT
+  spec_list = {L"%%", L"%Y", L"%y", L"%b", L"%B", L"%m", L"%U",
+               L"%W", L"%j", L"%d", L"%a", L"%A", L"%w", L"%H",
+               L"%I", L"%M", L"%S", L"%x", L"%X", L"%p", L"%Z"};
 #endif
+  spec_list.push_back(L"%Y-%m-%d %H:%M:%S");
 
   for (const auto& spec : spec_list) {
     auto t = std::chrono::system_clock::to_time_t(t1);


### PR DESCRIPTION
Fixes #2952. The testsuite indirectly called `strftime()` with conversion specifiers defined only in C99. In MSVCRT this function conforms only to C89. Only in the updated UCRT this functon provides the functionality of C99.