### PR TITLE
Prepare for deprecating FindPythonInterp module.

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -6,9 +6,9 @@ if (NOT DOXYGEN)
   return ()
 endif ()
 
-# Find the python interpreter, set the PYTHON_EXECUTABLE variable
+# Find the Python interpreter and set the PYTHON_EXECUTABLE variable.
 if (CMAKE_VERSION VERSION_LESS 3.12)
-  # This logic is deprecated in CMake after 3.12
+  # This logic is deprecated in CMake after 3.12.
   find_package(PythonInterp QUIET REQUIRED)
 else ()
   find_package(Python QUIET REQUIRED)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -6,7 +6,14 @@ if (NOT DOXYGEN)
   return ()
 endif ()
 
-find_package(PythonInterp QUIET REQUIRED)
+# Find the python interpreter, set the PYTHON_EXECUTABLE variable
+if (CMAKE_VERSION VERSION_LESS 3.12)
+  # This logic is deprecated in CMake after 3.12
+  find_package(PythonInterp QUIET REQUIRED)
+else ()
+  find_package(Python QUIET REQUIRED)
+  set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+endif ()
 
 add_custom_target(doc
   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/build.py


### PR DESCRIPTION
Since FindPythonInterp module is deprecated after CMake 3.12, it is better to start using the new FindPython module.

I take the following codes for reference.

- https://github.com/Dav1dde/glad/blob/ea756f7cc5e11dcef3cafdab87d45b3b528c875d/CMakeLists.txt#L26-L34
- https://github.com/CLIUtils/CLI11/blob/c57000e582fae45b01cd8074c79c81897379cbe5/CMakeLists.txt#L243-L253
- https://github.com/isl-org/Open3D/blob/da98405c476410cacb7028fd806bc1291b69b091/CMakeLists.txt#L317-L320

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
