### PR TITLE
nvhpc/22.3: workaround for c++17 mode

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1557,7 +1557,10 @@ FMT_CONSTEXPR inline fp get_cached_power(int min_exponent,
   const int dec_exp_step = 8;
   index = (index - first_dec_exp - 1) / dec_exp_step + 1;
   pow10_exponent = first_dec_exp + index * dec_exp_step;
-  return {data::pow10_significands[index], data::pow10_exponents[index]};
+  // Using *(x + index) instead of x[index] avoids an issue with some compilers
+  // using the EDG frontend (e.g. nvhpc/22.3 in C++17 mode).
+  return {*(data::pow10_significands + index),
+          *(data::pow10_exponents + index)};
 }
 
 #ifndef _MSC_VER


### PR DESCRIPTION
https://github.com/fmtlib/fmt/issues/3028 discusses several issues with using fmt and the NVIDIA HPC compilers.

One issue leads to assertions failures and wrong results, even in simple examples. That issue seems to be a compiler but affecting version 22.3 of the compilers, specifically in C++17 mode. This workaround avoids the issue.

There are still other test failures with this patch, see https://github.com/fmtlib/fmt/issues/3028 for more information, but this seems sufficient to fix basic usage with 22.3 and C++17.

I assume it would also be fine to remove all of the macros and use the `*(foo + index)` style for all compilers (with an appropriate comment about nvhpc 22.3), if you prefer. 