### PR TITLE
Disable non-type template args for nvhpc

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -276,7 +276,8 @@
 #ifndef FMT_USE_NONTYPE_TEMPLATE_ARGS
 #  if defined(__cpp_nontype_template_args) &&                  \
       ((FMT_GCC_VERSION >= 903 && FMT_CPLUSPLUS >= 201709L) || \
-       __cpp_nontype_template_args >= 201911L)
+       __cpp_nontype_template_args >= 201911L) &&              \
+      !defined(__NVCOMPILER)
 #    define FMT_USE_NONTYPE_TEMPLATE_ARGS 1
 #  else
 #    define FMT_USE_NONTYPE_TEMPLATE_ARGS 0


### PR DESCRIPTION
Hi!

When I use `fmt` in a project with `nvhpc` as compiler in C++20 mode, I get the following error:
```bash
"/usr/local/share/vcpkg/installed/x64-linux/include/fmt/format.h", line 4138: error: a literal operator template must have a template parameter list equivalent to "<char ...>"
  template <detail_exported::fixed_string Str> constexpr auto operator""_a() {
                                                              ^
```

In spirit of #742, the use of non-type template paramters could also be disabled for nvhpc. This is what this PR proposes.

Workaround for now: I can specify `-DFMT_USE_NONTYPE_TEMPLATE_ARGS=0` in my project.