### PR TITLE
Disable bogus -Wstringop-overflow on GCC 11

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,8 @@ function(add_fmt_executable name)
   #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95353
   if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND
       NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+    target_compile_options(${name} PRIVATE -Wno-stringop-overflow)
+    # The linker flag is needed for LTO.
     target_link_libraries(${name} -Wno-stringop-overflow)
   endif ()
 endfunction()


### PR DESCRIPTION
``gcc version 11.3.0 (SUSE Linux)``

Warning:

```
[ 43%] Building CXX object test/CMakeFiles/unicode-test.dir/test-main.cc.o
cd /home/phprus/devel/tmp/fmt/fmt-git/build/cxx20r-asan/test && /usr/bin/g++-11 -DFMT_HEADER_ONLY=1 -DGTEST_HAS_STD_WSTRING=1 -D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING=1 -I/home/phprus/devel/tmp/fmt/fmt-git/include -isystem /home/phprus/devel/tmp/fmt/fmt-git/test/gtest/. -fsanitize=address -O3 -DNDEBUG -fvisibility=hidden -fvisibility-inlines-hidden -pedantic-errors -Wall -Wextra -pedantic -Wold-style-cast -Wundef -Wredundant-decls -Wwrite-strings -Wpointer-arith -Wcast-qual -Wformat=2 -Wmissing-include-dirs -Wcast-align -Wctor-dtor-privacy -Wdisabled-optimization -Winvalid-pch -Woverloaded-virtual -Wconversion -Wno-ctor-dtor-privacy -Wno-format-nonliteral -Wno-dangling-else -Wno-unused-local-typedefs -Wdouble-promotion -Wtrampolines -Wzero-as-null-pointer-constant -Wuseless-cast -Wvector-operation-performance -Wsized-deallocation -Wshadow -Wshift-overflow=2 -Wnull-dereference -Wduplicated-cond -Werror -fno-delete-null-pointer-checks -std=gnu++20 -MD -MT test/CMakeFiles/unicode-test.dir/test-main.cc.o -MF CMakeFiles/unicode-test.dir/test-main.cc.o.d -o CMakeFiles/unicode-test.dir/test-main.cc.o -c /home/phprus/devel/tmp/fmt/fmt-git/test/test-main.cc
In file included from /home/phprus/devel/tmp/fmt/fmt-git/include/fmt/format.h:48,
                 from /home/phprus/devel/tmp/fmt/fmt-git/test/format-impl-test.cc:15:
In member function ‘constexpr void fmt::v9::detail::fill_t<Char>::operator=(fmt::v9::basic_string_view<Char>) [with Char = char]’,
    inlined from ‘constexpr void fmt::v9::detail::specs_setter<Char>::on_fill(fmt::v9::basic_string_view<Char>) [with Char = char]’ at /home/phprus/devel/tmp/fmt/fmt-git/include/fmt/core.h:2209:17,
    inlined from ‘constexpr const Char* fmt::v9::detail::parse_align(const Char*, const Char*, Handler&&) [with Char = char; Handler = fmt::v9::detail::specs_checker<fmt::v9::detail::specs_handler<char> >&]’ at /home/phprus/devel/tmp/fmt/fmt-git/include/fmt/core.h:2381:24,
    inlined from ‘constexpr const Char* fmt::v9::detail::parse_format_specs(const Char*, const Char*, SpecHandler&&) [with Char = char; SpecHandler = fmt::v9::detail::specs_checker<fmt::v9::detail::specs_handler<char> >&]’ at /home/phprus/devel/tmp/fmt/fmt-git/include/fmt/core.h:2572:22,
    inlined from ‘const Char* fmt::v9::detail::vformat_to(fmt::v9::detail::buffer<T>&, fmt::v9::basic_string_view<Char>, fmt::v9::basic_format_args<fmt::v9::basic_format_context<typename std::conditional<std::is_same<typename fmt::v9::type_identity<T>::type, char>::value, fmt::v9::appender, std::back_insert_iterator<fmt::v9::detail::buffer<typename fmt::v9::type_identity<T>::type> > >::type, typename fmt::v9::type_identity<T>::type> >, fmt::v9::detail::locale_ref)::format_handler::on_format_specs(int, const Char*, const Char*) [with Char = char]’ at /home/phprus/devel/tmp/fmt/fmt-git/include/fmt/format.h:4123:33:
/home/phprus/devel/tmp/fmt/fmt-git/include/fmt/core.h:2095:48: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
 2095 |     for (size_t i = 0; i < size; ++i) data_[i] = s[i];
      |                                       ~~~~~~~~~^~~~
/home/phprus/devel/tmp/fmt/fmt-git/include/fmt/core.h: In member function ‘const Char* fmt::v9::detail::vformat_to(fmt::v9::detail::buffer<T>&, fmt::v9::basic_string_view<Char>, fmt::v9::basic_format_args<fmt::v9::basic_format_context<typename std::conditional<std::is_same<typename fmt::v9::type_identity<T>::type, char>::value, fmt::v9::appender, std::back_insert_iterator<fmt::v9::detail::buffer<typename fmt::v9::type_identity<T>::type> > >::type, typename fmt::v9::type_identity<T>::type> >, fmt::v9::detail::locale_ref)::format_handler::on_format_specs(int, const Char*, const Char*) [with Char = char]’:
/home/phprus/devel/tmp/fmt/fmt-git/include/fmt/core.h:2088:8: note: at offset 4 into destination object ‘fmt::v9::detail::fill_t<char>::data_’ of size 4
 2088 |   Char data_[max_size] = {Char(' '), Char(0), Char(0), Char(0)};
      |        ^~~~~
```

Previous discussion in PR #2442.