### PR TITLE
Added workarounds for compilers with EDG frontend (LCC and Nvidia)

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -755,8 +755,11 @@ class compile_parse_context
   using base::check_arg_id;
 
   FMT_CONSTEXPR void check_dynamic_spec(int arg_id) {
+    detail::ignore_unused(arg_id);
+#if !defined(__LCC__)
     if (arg_id < num_args_ && types_ && !is_integral_type(types_[arg_id]))
       this->on_error("width/precision is not integer");
+#endif
   }
 };
 FMT_END_DETAIL_NAMESPACE

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -286,7 +286,7 @@
 
 // Enable minimal optimizations for more compact code in debug mode.
 FMT_GCC_PRAGMA("GCC push_options")
-#if !defined(__OPTIMIZE__) && !defined(__NVCOMPILER)
+#if !defined(__OPTIMIZE__) && !defined(__NVCOMPILER) && !defined(__LCC__)
 FMT_GCC_PRAGMA("GCC optimize(\"Og\")")
 #endif
 

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -277,7 +277,7 @@
 #  if defined(__cpp_nontype_template_args) &&                  \
       ((FMT_GCC_VERSION >= 903 && FMT_CPLUSPLUS >= 201709L) || \
        __cpp_nontype_template_args >= 201911L) &&              \
-      !defined(__NVCOMPILER)
+      !defined(__NVCOMPILER) && !defined(__LCC__)
 #    define FMT_USE_NONTYPE_TEMPLATE_ARGS 1
 #  else
 #    define FMT_USE_NONTYPE_TEMPLATE_ARGS 0

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -304,8 +304,9 @@ TEST(compile_test, compile_format_string_literal) {
 //  (compiler file
 //  'D:\a\_work\1\s\src\vctools\Compiler\CxxFE\sl\p1\c\constexpr\constexpr.cpp',
 //  line 8635)
-#if ((FMT_CPLUSPLUS >= 202002L) &&                    \
-     (!FMT_MSC_VERSION || FMT_MSC_VERSION < 1930)) || \
+#if ((FMT_CPLUSPLUS >= 202002L) &&                           \
+     (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE > 9) && \
+     (!FMT_MSC_VERSION || FMT_MSC_VERSION < 1930)) ||        \
     (FMT_CPLUSPLUS >= 201709L && FMT_GCC_VERSION >= 1002)
 template <size_t max_string_length, typename Char = char> struct test_string {
   template <typename T> constexpr bool operator==(const T& rhs) const noexcept {

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2178,7 +2178,9 @@ TEST(format_test, format_string_errors) {
   EXPECT_ERROR("{: }", "format specifier requires signed argument", unsigned);
   EXPECT_ERROR("{:{}}", "argument not found", int);
   EXPECT_ERROR("{:.{}}", "argument not found", double);
+#    if defined(__cpp_lib_is_constant_evaluated) && !defined(__LCC__)
   EXPECT_ERROR("{:{}}", "width/precision is not integer", int, double);
+#    endif
   EXPECT_ERROR("{:.2}", "precision not allowed for this argument type", int);
   EXPECT_ERROR("{:s}", "invalid type specifier", int);
   EXPECT_ERROR("{:s}", "invalid type specifier", char);


### PR DESCRIPTION
Added workarounds for compilers with EDG frontend (LCC and Nvidia) that emulate GCC.
