### PR TITLE
Add formatter for std::exception

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -8,6 +8,7 @@
 #ifndef FMT_STD_H_
 #define FMT_STD_H_
 
+#include <exception>
 #include <thread>
 #include <type_traits>
 #include <utility>
@@ -166,6 +167,20 @@ struct formatter<
   }
 };
 FMT_END_NAMESPACE
-#endif
+#endif  // __cpp_lib_variant
+
+FMT_BEGIN_NAMESPACE
+template <typename T, typename Char>
+struct formatter<
+    T, Char,
+    typename std::enable_if<std::is_base_of<std::exception, T>::value>::type>
+    : formatter<string_view> {
+  template <typename FormatContext>
+  auto format(const std::exception& ex, FormatContext& ctx) const ->
+      typename FormatContext::iterator {
+    return fmt::formatter<string_view>::format(ex.what(), ctx);
+  }
+};
+FMT_END_NAMESPACE
 
 #endif  // FMT_STD_H_

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -6,11 +6,11 @@
 // For the license information refer to format.h.
 
 #include "fmt/std.h"
-#include "fmt/ranges.h"
 
 #include <string>
 #include <vector>
 
+#include "fmt/ranges.h"
 #include "gtest/gtest.h"
 
 TEST(std_test, path) {
@@ -76,4 +76,23 @@ TEST(std_test, variant) {
   EXPECT_EQ(fmt::format("{}", v4), "variant(monostate)");
   EXPECT_EQ(fmt::format("{}", v5), "variant(\"yes, this is variant\")");
 #endif
+}
+
+TEST(std_test, exception) {
+  std::string str("Test Exception");
+  std::string escstr = fmt::format("\"{}\"", str);
+
+  try {
+    throw std::runtime_error(str);
+  } catch (const std::exception& ex) {
+    EXPECT_EQ(fmt::format("{}", ex), str);
+    EXPECT_EQ(fmt::format("{:?}", ex), escstr);
+  }
+
+  try {
+    throw std::runtime_error(str);
+  } catch (const std::runtime_error& ex) {
+    EXPECT_EQ(fmt::format("{}", ex), str);
+    EXPECT_EQ(fmt::format("{:?}", ex), escstr);
+  }
 }


### PR DESCRIPTION
Adds a single simple formatter for `std::exception` and accompanying test.

Reference:
https://github.com/fmtlib/fmt/issues/2977
https://github.com/fmtlib/fmt/issues/3012

Closes https://github.com/fmtlib/fmt/issues/2977