### PR TITLE
Fix compilation error with gcc-7.2.0

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1238,7 +1238,7 @@ template <typename Char, typename UInt, typename Iterator,
 FMT_CONSTEXPR inline auto format_decimal(Iterator out, UInt value, int size)
     -> format_decimal_result<Iterator> {
   // Buffer is large enough to hold all digits (digits10 + 1).
-  Char buffer[digits10<UInt>() + 1];
+  Char buffer[digits10<UInt>() + 1] = {};
   auto end = format_decimal(buffer, value, size).end;
   return {out, detail::copy_str_noinline<Char>(buffer, end, out)};
 }


### PR DESCRIPTION
Without the added line, the gcc-7.2.0 compiler will give the following error:
```
/opt/compiler-explorer/libs/fmt/trunk/include/fmt/format.h:1240:8: error: uninitialized variable 'buffer' in 'constexpr' function
   Char buffer[digits10<UInt>() + 1];
        ^~~~~~
```
See https://godbolt.org/z/fh7TMs9qs

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
