### PR TITLE
Simplify is_variant_like_ check, fix compile error before GCC 11

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -100,14 +100,12 @@ template <typename T>
 using variant_index_sequence =
     std::make_index_sequence<std::variant_size<T>::value>;
 
-// variant_size and variant_alternative check.
-template <typename T, typename U = void>
+template <typename>
 struct is_variant_like_ : std::false_type {};
-template <typename T>
-struct is_variant_like_<T, std::void_t<decltype(std::variant_size<T>::value)>>
-    : std::true_type {};
+template <typename... Types>
+struct is_variant_like_<std::variant<Types...>> : std::true_type {};
 
-// formattable element check
+// formattable element check.
 template <typename T, typename C> class is_variant_formattable_ {
   template <std::size_t... I>
   static std::conjunction<

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -75,5 +75,8 @@ TEST(std_test, variant) {
 
   EXPECT_EQ(fmt::format("{}", v4), "variant(monostate)");
   EXPECT_EQ(fmt::format("{}", v5), "variant(\"yes, this is variant\")");
+
+  volatile int i = 42;  // Test compile error before GCC 11 described in #3068.
+  EXPECT_EQ(fmt::format("{}", i), "42");
 #endif
 }


### PR DESCRIPTION
Fixes #3068.

Co-authored-by: Vladislav Shchapov <vladislav@shchapov.ru>