### PR TITLE
Fix intellisense on Windows

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -69,9 +69,7 @@
 #  define FMT_HAS_FEATURE(x) 0
 #endif
 
-#if (defined(__has_include) || FMT_ICC_VERSION >= 1600 || \
-     FMT_MSC_VERSION > 1900) &&                           \
-    !defined(__INTELLISENSE__)
+#if defined(__has_include) || FMT_ICC_VERSION >= 1600 || FMT_MSC_VERSION > 1900
 #  define FMT_HAS_INCLUDE(x) __has_include(x)
 #else
 #  define FMT_HAS_INCLUDE(x) 0


### PR DESCRIPTION
`__INTELLISENSE__` is **1** on vs2022 and clang, causing FMT_HAS_INCLUDE, FMT_USE_FCNTL, etc to be 0.
That results in VS and VSCode having a lot of linter errors while code compiles just fine.

Removing `&& !defined(__INTELLISENSE__)` fixes these problems.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
