### PR TITLE
Add locale overload for formatted_size (#3084)

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -4270,6 +4270,18 @@ FMT_INLINE auto format_to(OutputIt out, const Locale& loc,
   return vformat_to(out, loc, fmt, fmt::make_format_args(args...));
 }
 
+template <typename Locale, typename... T,
+          FMT_ENABLE_IF(detail::is_locale<Locale>::value)>
+FMT_NODISCARD FMT_INLINE auto formatted_size(const Locale& loc,
+                                             format_string<T...> fmt,
+                                             T&&... args) -> size_t {
+  auto buf = detail::counting_buffer<>();
+  detail::vformat_to(buf, string_view(fmt),
+                     format_args(fmt::make_format_args(args...)),
+                     detail::locale_ref(loc));
+  return buf.count();
+}
+
 FMT_MODULE_EXPORT_END
 FMT_END_NAMESPACE
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2006,6 +2006,7 @@ TEST(format_test, output_iterators) {
 
 TEST(format_test, formatted_size) {
   EXPECT_EQ(2u, fmt::formatted_size("{}", 42));
+  EXPECT_EQ(2u, fmt::formatted_size(std::locale(), "{}", 42));
 }
 
 TEST(format_test, format_to_no_args) {


### PR DESCRIPTION
Fix for issue #3084. Adds an overload to `formatted_size` which takes a `locale`, as [`std::formatted_size`](https://en.cppreference.com/w/cpp/utility/format/formatted_size) does.

The unit test is more of a "does it compile" test than actually testing locale-dependent behaviour. Is that ok? My thought was that `vformat_to` is already tested, so no need to repeat that here...