### PR TITLE
Fix compilation with FMT_ENFORCE_COMPILE_STRING and FMT_WERROR

### DIFF
--- a/src/os.cc
+++ b/src/os.cc
@@ -169,7 +169,8 @@ void detail::format_windows_error(detail::buffer<char>& out, int error_code,
     if (msg) {
       utf16_to_utf8 utf8_message;
       if (utf8_message.convert(msg) == ERROR_SUCCESS) {
-        fmt::format_to(buffer_appender<char>(out), "{}: {}", message, utf8_message);
+        fmt::format_to(buffer_appender<char>(out), "{}: {}", message,
+                       utf8_message);
         return;
       }
     }
@@ -192,19 +193,22 @@ buffered_file::buffered_file(cstring_view filename, cstring_view mode) {
   FMT_RETRY_VAL(file_, FMT_SYSTEM(fopen(filename.c_str(), mode.c_str())),
                 nullptr);
   if (!file_)
-    FMT_THROW(system_error(errno, "cannot open file {}", filename.c_str()));
+    FMT_THROW(system_error(errno, FMT_STRING("cannot open file {}"),
+                           filename.c_str()));
 }
 
 void buffered_file::close() {
   if (!file_) return;
   int result = FMT_SYSTEM(fclose(file_));
   file_ = nullptr;
-  if (result != 0) FMT_THROW(system_error(errno, "cannot close file"));
+  if (result != 0)
+    FMT_THROW(system_error(errno, FMT_STRING("cannot close file")));
 }
 
 int buffered_file::descriptor() const {
   int fd = FMT_POSIX_CALL(fileno(file_));
-  if (fd == -1) FMT_THROW(system_error(errno, "cannot get file descriptor"));
+  if (fd == -1)
+    FMT_THROW(system_error(errno, FMT_STRING("cannot get file descriptor")));
   return fd;
 }
 
@@ -222,7 +226,8 @@ file::file(cstring_view path, int oflag) {
   FMT_RETRY(fd_, FMT_POSIX_CALL(open(path.c_str(), oflag, mode)));
 #  endif
   if (fd_ == -1)
-    FMT_THROW(system_error(errno, "cannot open file {}", path.c_str()));
+    FMT_THROW(
+        system_error(errno, FMT_STRING("cannot open file {}"), path.c_str()));
 }
 
 file::~file() noexcept {
@@ -238,7 +243,8 @@ void file::close() {
   // See http://linux.derkeiler.com/Mailing-Lists/Kernel/2005-09/3000.html
   int result = FMT_POSIX_CALL(close(fd_));
   fd_ = -1;
-  if (result != 0) FMT_THROW(system_error(errno, "cannot close file"));
+  if (result != 0)
+    FMT_THROW(system_error(errno, FMT_STRING("cannot close file")));
 }
 
 long long file::size() const {
@@ -260,7 +266,7 @@ long long file::size() const {
   using Stat = struct stat;
   Stat file_stat = Stat();
   if (FMT_POSIX_CALL(fstat(fd_, &file_stat)) == -1)
-    FMT_THROW(system_error(errno, "cannot get file attributes"));
+    FMT_THROW(system_error(errno, FMT_STRING("cannot get file attributes")));
   static_assert(sizeof(long long) >= sizeof(file_stat.st_size),
                 "return type of file::size is not large enough");
   return file_stat.st_size;
@@ -270,14 +276,16 @@ long long file::size() const {
 std::size_t file::read(void* buffer, std::size_t count) {
   rwresult result = 0;
   FMT_RETRY(result, FMT_POSIX_CALL(read(fd_, buffer, convert_rwcount(count))));
-  if (result < 0) FMT_THROW(system_error(errno, "cannot read from file"));
+  if (result < 0)
+    FMT_THROW(system_error(errno, FMT_STRING("cannot read from file")));
   return detail::to_unsigned(result);
 }
 
 std::size_t file::write(const void* buffer, std::size_t count) {
   rwresult result = 0;
   FMT_RETRY(result, FMT_POSIX_CALL(write(fd_, buffer, convert_rwcount(count))));
-  if (result < 0) FMT_THROW(system_error(errno, "cannot write to file"));
+  if (result < 0)
+    FMT_THROW(system_error(errno, FMT_STRING("cannot write to file")));
   return detail::to_unsigned(result);
 }
 
@@ -286,7 +294,8 @@ file file::dup(int fd) {
   // http://pubs.opengroup.org/onlinepubs/009695399/functions/dup.html
   int new_fd = FMT_POSIX_CALL(dup(fd));
   if (new_fd == -1)
-    FMT_THROW(system_error(errno, "cannot duplicate file descriptor {}", fd));
+    FMT_THROW(system_error(
+        errno, FMT_STRING("cannot duplicate file descriptor {}"), fd));
   return file(new_fd);
 }
 
@@ -294,8 +303,9 @@ void file::dup2(int fd) {
   int result = 0;
   FMT_RETRY(result, FMT_POSIX_CALL(dup2(fd_, fd)));
   if (result == -1) {
-    FMT_THROW(system_error(errno, "cannot duplicate file descriptor {} to {}",
-                           fd_, fd));
+    FMT_THROW(system_error(
+        errno, FMT_STRING("cannot duplicate file descriptor {} to {}"), fd_,
+        fd));
   }
 }
 
@@ -320,7 +330,8 @@ void file::pipe(file& read_end, file& write_end) {
   // http://pubs.opengroup.org/onlinepubs/009696799/functions/pipe.html
   int result = FMT_POSIX_CALL(pipe(fds));
 #  endif
-  if (result != 0) FMT_THROW(system_error(errno, "cannot create pipe"));
+  if (result != 0)
+    FMT_THROW(system_error(errno, FMT_STRING("cannot create pipe")));
   // The following assignments don't throw because read_fd and write_fd
   // are closed.
   read_end = file(fds[0]);
@@ -335,8 +346,8 @@ buffered_file file::fdopen(const char* mode) {
   FILE* f = FMT_POSIX_CALL(fdopen(fd_, mode));
 #  endif
   if (!f)
-    FMT_THROW(
-        system_error(errno, "cannot associate stream with file descriptor"));
+    FMT_THROW(system_error(
+        errno, FMT_STRING("cannot associate stream with file descriptor")));
   buffered_file bf(f);
   fd_ = -1;
   return bf;
@@ -349,7 +360,8 @@ long getpagesize() {
   return si.dwPageSize;
 #  else
   long size = FMT_POSIX_CALL(sysconf(_SC_PAGESIZE));
-  if (size < 0) FMT_THROW(system_error(errno, "cannot get memory page size"));
+  if (size < 0)
+    FMT_THROW(system_error(errno, FMT_STRING("cannot get memory page size")));
   return size;
 #  endif
 }


### PR DESCRIPTION
With `Apple clang version 13.1.6 (clang-1316.0.21.2.5)`, turning on `FMT_ENFORCE_COMPILE_STRING` and `FMT_WERROR` fails to compile fmt itself.

This PR adds `FMT_STRING` around several strings in os.cc to fix it.

It also clang-formatted another line (172) which I left in this PR.