### PR TITLE
Normalization of stdlib inline namespace names

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -214,32 +214,38 @@ struct formatter<
     std::size_t size = 0;
     std::unique_ptr<char, decltype(&std::free)> demangled_name_ptr(
         abi::__cxa_demangle(ti.name(), nullptr, &size, &status), &std::free);
-    string_view demangled_name_view(
-        demangled_name_ptr ? demangled_name_ptr.get() : ti.name());
 
-    // Normalization of stdlib inline namespace names.
-    if (demangled_name_view.starts_with("std::")) {
-      // Separation of user's and system exception classes.
-      demangled_name_view.remove_prefix(5);
-      out = detail::write_bytes(out, string_view("std::"), spec);
+    string_view demangled_name_view;
+    if (demangled_name_ptr) {
+      demangled_name_view = demangled_name_ptr.get();
 
+      // Normalization of stdlib inline namespace names.
       // libc++ inline namespaces.
-      // std::__1::*       -> std::*
-      // std::__1::__fs::* -> std::*
-      if (demangled_name_view.starts_with("__1::")) {
-        demangled_name_view.remove_prefix(5);
-        if (demangled_name_view.starts_with("__fs::"))
-          demangled_name_view.remove_prefix(6);
-      }
+      //  std::__1::*       -> std::*
+      //  std::__1::__fs::* -> std::*
       // libstdc++ inline namespaces.
-      // std::__cxx11::*             -> std::*
-      // std::filesystem::__cxx11::* -> std::filesystem::*
-      else if (demangled_name_view.starts_with("__cxx11::")) {
-        demangled_name_view.remove_prefix(9);
-      } else if (demangled_name_view.starts_with("filesystem::__cxx11::")) {
-        demangled_name_view.remove_prefix(21);
-        out = detail::write_bytes(out, string_view("filesystem::"), spec);
+      //  std::__cxx11::*             -> std::*
+      //  std::filesystem::__cxx11::* -> std::filesystem::*
+      if (demangled_name_view.starts_with("std::")) {
+        char* begin = demangled_name_ptr.get();
+        char* to = begin + 5;  // std::
+        for (char *from = to, *end = begin + demangled_name_view.size();
+             from < end;) {
+          // This is safe, because demangled_name is NUL-terminated.
+          if (from[0] == '_' && from[1] == '_') {
+            char* next = from + 1;
+            while (next < end && *next != ':') next++;
+            if (next[0] == ':' && next[1] == ':') {
+              from = next + 2;
+              continue;
+            }
+          }
+          *to++ = *from++;
+        }
+        demangled_name_view = {begin, detail::to_unsigned(to - begin)};
       }
+    } else {
+      demangled_name_view = string_view(ti.name());
     }
     out = detail::write_bytes(out, demangled_name_view, spec);
 #elif FMT_MSC_VERSION

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -11,7 +11,9 @@
 #include <vector>
 
 #include "fmt/ranges.h"
-#include "gtest/gtest.h"
+#include "gtest-extra.h"  // StartsWith
+
+using testing::StartsWith;
 
 TEST(std_test, path) {
 #ifdef __cpp_lib_filesystem
@@ -116,4 +118,19 @@ TEST(std_test, exception) {
               fmt::format("{:t}", ex));
     EXPECT_EQ("My Exception", fmt::format("{:}", ex));
   }
+
+  try {
+    throw std::system_error(std::error_code(), "message");
+  } catch (const std::system_error& ex) {
+    EXPECT_THAT(fmt::format("{:t}", ex), StartsWith("std::system_error: "));
+  }
+
+#ifdef __cpp_lib_filesystem
+  try {
+    throw std::filesystem::filesystem_error("message", std::error_code());
+  } catch (const std::filesystem::filesystem_error& ex) {
+    EXPECT_THAT(fmt::format("{:t}", ex),
+                StartsWith("std::filesystem::filesystem_error: "));
+  }
+#endif
 }


### PR DESCRIPTION
``libc++`` inline namespace:
```
std::__1::system_error                        ->  std::system_error
std::__1::__fs::filesystem::filesystem_error  ->  std::filesystem::filesystem_error
```

``libstdc++`` inline namespace:
```
std::__cxx11::system_error                 ->  std::system_error
std::filesystem::__cxx11::filesystem_error ->  std::filesystem::filesystem_error
```