### PR TITLE
Add precision modifier for seconds in chrono format

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1415,7 +1415,7 @@ struct chrono_format_checker : null_chrono_spec_handler<chrono_format_checker> {
   FMT_CONSTEXPR void on_minute(numeric_system) {}
   FMT_CONSTEXPR void on_second(numeric_system) {}
   FMT_CONSTEXPR void on_second_with_fractions(numeric_system, int precision) {
-    static constexpr int allowed_precisions[6] = {3, 6, 9, 12, 15, 18};
+    constexpr int allowed_precisions[6] = {3, 6, 9, 12, 15, 18};
     check_allowed_precision(precision, allowed_precisions);
   }
   FMT_CONSTEXPR void on_12_hour_time() {}

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1701,7 +1701,7 @@ struct chrono_formatter {
     }
   }
 
-  template <typename Duration> void write_fractional_seconds(Duration d, int precision) {
+  template <typename Duration> void write_fractional_seconds_p(Duration d) {
     constexpr auto num_fractional_digits =
         count_fractional_digits<Duration::period::num,
                                 Duration::period::den>::value;
@@ -1728,7 +1728,7 @@ struct chrono_formatter {
         out = std::fill_n(out, zeroes, '0');
       int remaining = precision - (zeroes > 0 ? zeroes : 0);
       if (remaining < num_digits) {
-        n /= detail::pow10(num_digits - remaining);
+        n /= to_unsigned(detail::pow10(to_unsigned(num_digits - remaining)));
         out = format_decimal<char_type>(out, n, remaining).end;
         return;
       }
@@ -1831,7 +1831,7 @@ struct chrono_formatter {
       } else {
         write(second(), 2);
         if (precision >= 0) {
-          write_fractional_seconds(std::chrono::duration<rep, Period>(val), precision);
+          write_fractional_seconds_p(std::chrono::duration<rep, Period>(val));
         } else {
           write_fractional_seconds(std::chrono::duration<rep, Period>(val));
         }

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1415,7 +1415,8 @@ struct chrono_format_checker : null_chrono_spec_handler<chrono_format_checker> {
   FMT_CONSTEXPR void on_minute(numeric_system) {}
   FMT_CONSTEXPR void on_second(numeric_system) {}
   FMT_CONSTEXPR void on_second_with_fractions(numeric_system, int precision) {
-    check_allowed_precision(precision, {3, 6, 9, 12, 15, 18});
+    static constexpr int allowed_precisions[6] = {3, 6, 9, 12, 15, 18};
+    check_allowed_precision(precision, allowed_precisions);
   }
   FMT_CONSTEXPR void on_12_hour_time() {}
   FMT_CONSTEXPR void on_24_hour_time() {}

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -465,7 +465,7 @@ TEST(chrono_test, format_default_fp) {
 
 TEST(chrono_test, format_precision) {
   EXPECT_THROW_MSG(
-      (void)fmt::format(runtime("{:.2}"), std::chrono::seconds(42)),
+      (void)fmt::format(runtime("{:.2%Q}"), std::chrono::seconds(42)),
       fmt::format_error, "precision not allowed for this argument type");
   EXPECT_EQ("1ms", fmt::format("{:.0}", dms(1.234)));
   EXPECT_EQ("1.2ms", fmt::format("{:.1}", dms(1.234)));
@@ -611,24 +611,22 @@ TEST(chrono_test, cpp20_duration_subsecond_support) {
             "-13.420148734");
   EXPECT_EQ(fmt::format("{:%S}", std::chrono::milliseconds{1234}), "01.234");
   // Check subsecond presision modifier.
-  EXPECT_EQ(fmt::format("{:%.6S}", std::chrono::nanoseconds{1234}), "00.000001");
-  EXPECT_EQ(fmt::format("{:%.18S}", std::chrono::nanoseconds{1234}), "00.000001234000000000");
-  EXPECT_EQ(fmt::format("{:%.3S}", std::chrono::microseconds{1234}), "00.001");
-  EXPECT_EQ(fmt::format("{:%.9S}", std::chrono::microseconds{1234}), "00.001234000");
-  EXPECT_EQ(fmt::format("{:%.6S}", std::chrono::milliseconds{1234}), "01.234000");
-  EXPECT_EQ(fmt::format("{:%.6S}", std::chrono::milliseconds{-1234}), "-01.234000");
-  EXPECT_EQ(fmt::format("{:%.3S}", std::chrono::seconds{1234}), "34.000");
-  EXPECT_EQ(fmt::format("{:%.9S}", std::chrono::minutes{1234}), "00.000000000");
-  EXPECT_EQ(fmt::format("{:%.3S}", std::chrono::hours{1234}), "00.000");
-  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%.5S}"), std::chrono::microseconds{1234}), fmt::format_error,
-                   "invalid precision");
+  EXPECT_EQ(fmt::format("{:.6%S}", std::chrono::nanoseconds{1234}), "00.000001");
+  EXPECT_EQ(fmt::format("{:.18%S}", std::chrono::nanoseconds{1234}), "00.000001234000000000");
+  EXPECT_EQ(fmt::format("{:.{}%S}", std::chrono::nanoseconds{1234}, 6), "00.000001");
+  EXPECT_EQ(fmt::format("{:.6%S}", std::chrono::milliseconds{1234}), "01.234000");
+  EXPECT_EQ(fmt::format("{:.6%S}", std::chrono::milliseconds{-1234}), "-01.234000");
+  EXPECT_EQ(fmt::format("{:.3%S}", std::chrono::seconds{1234}), "34.000");
+  EXPECT_EQ(fmt::format("{:.3%S}", std::chrono::hours{1234}), "00.000");
+  EXPECT_EQ(fmt::format("{:.5%S}", dms(1.234)), "00.00123");
+  EXPECT_EQ(fmt::format("{:.8%S}", dms(1.234)), "00.00123400");
   {
     // Check that {:%H:%M:%S} is equivalent to {:%T}.
     auto dur = std::chrono::milliseconds{3601234};
     auto formatted_dur = fmt::format("{:%T}", dur);
     EXPECT_EQ(formatted_dur, "01:00:01.234");
     EXPECT_EQ(fmt::format("{:%H:%M:%S}", dur), formatted_dur);
-    EXPECT_EQ(fmt::format("{:%H:%M:%.6S}", dur), "01:00:01.234000");
+    EXPECT_EQ(fmt::format("{:.6%H:%M:%S}", dur), "01:00:01.234000");
   }
   using nanoseconds_dbl = std::chrono::duration<double, std::nano>;
   EXPECT_EQ(fmt::format("{:%S}", nanoseconds_dbl{-123456789}), "-00.123456789");
@@ -642,7 +640,7 @@ TEST(chrono_test, cpp20_duration_subsecond_support) {
     auto formatted_dur = fmt::format("{:%T}", dur);
     EXPECT_EQ(formatted_dur, "-00:01:39.123456789");
     EXPECT_EQ(fmt::format("{:%H:%M:%S}", dur), formatted_dur);
-    EXPECT_EQ(fmt::format("{:%H:%M:%.3S}", dur), "-00:01:39.123");
+    EXPECT_EQ(fmt::format("{:.3%H:%M:%S}", dur), "-00:01:39.123");
   }
   // Check that durations with precision greater than std::chrono::seconds have
   // fixed precision, and print zeros even if there is no fractional part.

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -610,12 +610,25 @@ TEST(chrono_test, cpp20_duration_subsecond_support) {
   EXPECT_EQ(fmt::format("{:%S}", std::chrono::nanoseconds{-13420148734}),
             "-13.420148734");
   EXPECT_EQ(fmt::format("{:%S}", std::chrono::milliseconds{1234}), "01.234");
+  // Check subsecond presision modifier.
+  EXPECT_EQ(fmt::format("{:%.6S}", std::chrono::nanoseconds{1234}), "00.000001");
+  EXPECT_EQ(fmt::format("{:%.18S}", std::chrono::nanoseconds{1234}), "00.000001234000000000");
+  EXPECT_EQ(fmt::format("{:%.3S}", std::chrono::microseconds{1234}), "00.001");
+  EXPECT_EQ(fmt::format("{:%.9S}", std::chrono::microseconds{1234}), "00.001234000");
+  EXPECT_EQ(fmt::format("{:%.6S}", std::chrono::milliseconds{1234}), "01.234000");
+  EXPECT_EQ(fmt::format("{:%.6S}", std::chrono::milliseconds{-1234}), "-01.234000");
+  EXPECT_EQ(fmt::format("{:%.3S}", std::chrono::seconds{1234}), "34.000");
+  EXPECT_EQ(fmt::format("{:%.9S}", std::chrono::minutes{1234}), "00.000000000");
+  EXPECT_EQ(fmt::format("{:%.3S}", std::chrono::hours{1234}), "00.000");
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:%.5S}"), std::chrono::microseconds{1234}), fmt::format_error,
+                   "invalid precision");
   {
     // Check that {:%H:%M:%S} is equivalent to {:%T}.
     auto dur = std::chrono::milliseconds{3601234};
     auto formatted_dur = fmt::format("{:%T}", dur);
     EXPECT_EQ(formatted_dur, "01:00:01.234");
     EXPECT_EQ(fmt::format("{:%H:%M:%S}", dur), formatted_dur);
+    EXPECT_EQ(fmt::format("{:%H:%M:%.6S}", dur), "01:00:01.234000");
   }
   using nanoseconds_dbl = std::chrono::duration<double, std::nano>;
   EXPECT_EQ(fmt::format("{:%S}", nanoseconds_dbl{-123456789}), "-00.123456789");
@@ -629,6 +642,7 @@ TEST(chrono_test, cpp20_duration_subsecond_support) {
     auto formatted_dur = fmt::format("{:%T}", dur);
     EXPECT_EQ(formatted_dur, "-00:01:39.123456789");
     EXPECT_EQ(fmt::format("{:%H:%M:%S}", dur), formatted_dur);
+    EXPECT_EQ(fmt::format("{:%H:%M:%.3S}", dur), "-00:01:39.123");
   }
   // Check that durations with precision greater than std::chrono::seconds have
   // fixed precision, and print zeros even if there is no fractional part.


### PR DESCRIPTION
Add precision modifier for seconds in chrono format and test for it.

It's became important for custom datetime types that store date, time and subseconds. I want to use chrono format for those types, but I have no way to control subsecond precision.

Use case:
```
EXPECT_EQ(fmt::format("{:%Y-%m-%d %H:%M:%.6S %Z}", datetime), "2022-09-28 12:14:25.123456 MSK");
```