### PR TITLE
Explicitly export buffer<char> for MSVC

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -960,6 +960,14 @@ template <typename T> class buffer {
   }
 };
 
+#if defined(FMT_MSC_VERSION)
+#  ifdef FMT_EXPORT
+extern template class buffer<char>;
+#  else
+template class FMT_API buffer<char>;
+#  endif
+#endif
+
 struct buffer_traits {
   explicit buffer_traits(size_t) {}
   auto count() const -> size_t { return 0; }

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -960,7 +960,7 @@ template <typename T> class buffer {
   }
 };
 
-#if defined(FMT_MSC_VERSION)
+#if FMT_MSC_VERSION
 #  ifdef FMT_EXPORT
 extern template class buffer<char>;
 #  else

--- a/src/format.cc
+++ b/src/format.cc
@@ -23,9 +23,9 @@ template FMT_API auto locale_ref::get<std::locale>() const -> std::locale;
 // Explicit instantiations for char.
 
 #if FMT_MSC_VERSION
-// ostream does it implicitly, so we need make it explicitly
-// otherwise we get ODR violation when {fmt} is built as a shared library
-// and fmt/os.h is not included by the user
+// fmt::ostream does it implicitly, so we need make it explicitly.
+// Otherwise we get ODR violation when {fmt} is built as a shared library
+// and fmt/os.h is not included by the user.
 template class FMT_API buffer<char>;
 #endif
 

--- a/src/format.cc
+++ b/src/format.cc
@@ -22,6 +22,13 @@ template FMT_API auto locale_ref::get<std::locale>() const -> std::locale;
 
 // Explicit instantiations for char.
 
+#if defined(FMT_MSC_VERSION)
+// ostream does it implicitly, so we need make it explicitly
+// otherwise we get ODR violation when {fmt} is built as a shared library
+// and fmt/os.h is not included by the user
+template class FMT_API buffer<char>;
+#endif
+
 template FMT_API auto thousands_sep_impl(locale_ref)
     -> thousands_sep_result<char>;
 template FMT_API auto decimal_point_impl(locale_ref) -> char;

--- a/src/format.cc
+++ b/src/format.cc
@@ -22,7 +22,7 @@ template FMT_API auto locale_ref::get<std::locale>() const -> std::locale;
 
 // Explicit instantiations for char.
 
-#if defined(FMT_MSC_VERSION)
+#if FMT_MSC_VERSION
 // ostream does it implicitly, so we need make it explicitly
 // otherwise we get ODR violation when {fmt} is built as a shared library
 // and fmt/os.h is not included by the user


### PR DESCRIPTION
Some MSVC-specific behavior:

Class ostream by inheriting detail::buffer<char> implicitly exports it when fmt is built as a shared library. Unless os.h is included, the compiler assumes detail::buffer<char> is not externally exported and instantiets a local copy of it, which causes ODR violation.