### PR TITLE
Fix options for C++20 experimental module in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,10 +84,8 @@ option(FMT_MODULE "Build a module instead of a traditional library." OFF)
 option(FMT_SYSTEM_HEADERS "Expose headers with marking them as system." OFF)
 
 set(FMT_CAN_MODULE OFF)
-if (CMAKE_CXX_STANDARD GREATER 17 AND
-    # msvc 16.10-pre4
-    MSVC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 19.29.30035)
-  set(FMT_CAN_MODULE OFF)
+if (CMAKE_CXX_STANDARD GREATER 17 AND NOT MSVC)
+  set(FMT_CAN_MODULE ON)
 endif ()
 if (NOT FMT_CAN_MODULE)
   set(FMT_MODULE OFF)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,7 +94,7 @@ add_fmt_test(enforce-checks-test)
 target_compile_definitions(enforce-checks-test PRIVATE
                            -DFMT_ENFORCE_COMPILE_STRING)
 
-if (FMT_CAN_MODULE)
+if (FMT_MODULE)
   # The tests need {fmt} to be compiled as traditional library
   # because of visibility of implementation details.
   # If module support is present the module tests require a


### PR DESCRIPTION
This PR, as discussed previously under commit 3def950b8479cdd5769b4d4e7794d94648ebdbd6, is to fix a mistake introduced in #2432 which disabled option for building the module with the new C++20 module system completely (even for compatible compiler).