### PR TITLE
Avoid using `uint` as a type name

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1405,8 +1405,8 @@ template <typename Float> constexpr int num_significand_bits() {
 template <typename Float>
 constexpr auto exponent_mask() ->
     typename dragonbox::float_info<Float>::carrier_uint {
-  using uint = typename dragonbox::float_info<Float>::carrier_uint;
-  return ((uint(1) << dragonbox::float_info<Float>::exponent_bits) - 1)
+  using float_uint = typename dragonbox::float_info<Float>::carrier_uint;
+  return ((float_uint(1) << dragonbox::float_info<Float>::exponent_bits) - 1)
          << num_significand_bits<Float>();
 }
 template <typename Float> constexpr auto exponent_bias() -> int {
@@ -3333,9 +3333,9 @@ FMT_CONSTEXPR20 auto write(OutputIt out, T value) -> OutputIt {
 
   constexpr auto specs = basic_format_specs<Char>();
   using floaty = conditional_t<std::is_same<T, long double>::value, double, T>;
-  using uint = typename dragonbox::float_info<floaty>::carrier_uint;
-  uint mask = exponent_mask<floaty>();
-  if ((bit_cast<uint>(value) & mask) == mask)
+  using floaty_uint = typename dragonbox::float_info<floaty>::carrier_uint;
+  floaty_uint mask = exponent_mask<floaty>();
+  if ((bit_cast<floaty_uint>(value) & mask) == mask)
     return write_nonfinite(out, std::isnan(value), specs, fspecs);
 
   auto dec = dragonbox::to_decimal(static_cast<floaty>(value));


### PR DESCRIPTION
Sometime `uint` is defined as a global type by the project's code directly or by some 3rdparty libraries (e.g. Qt or OpenCV). Some versions of MSVC (e.g. v16.11.15) gives a type shadowing warning:
```
3rdparty\fmtlib\fmt\include\fmt/format.h(3251): warning C4459: declaration of 'uint' hides global declaration
opencv2/core/hal/interface.h(45): note: see declaration of 'uint'
```
This also causes a compilation failure when `/WX` is used.