### PR TITLE
fmt::ostream - aggregate buffer instead of inheriting it

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -385,7 +385,7 @@ class file_buffer final : public detail::buffer<char> {
   FMT_API void grow(size_t) override;
 
  public:
-  FMT_API file_buffer(cstring_view path, const detail::ostream_params& params);
+  FMT_API file_buffer(cstring_view path, const ostream_params& params);
   FMT_API file_buffer(file_buffer&& other);
   FMT_API ~file_buffer();
 
@@ -408,7 +408,7 @@ FMT_END_DETAIL_NAMESPACE
 constexpr detail::buffer_size buffer_size{};
 
 /** A fast output stream which is not thread-safe. */
-class FMT_API ostream final {
+class FMT_API ostream {
  private:
   FMT_MSC_WARNING(suppress : 4251)
   detail::file_buffer buffer_;

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -379,7 +379,7 @@ struct ostream_params {
 #  endif
 };
 
-class file_buffer final : public detail::buffer<char> {
+class file_buffer final : public buffer<char> {
   file file_;
 
   FMT_API void grow(size_t) override;

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -382,7 +382,9 @@ struct ostream_params {
 class ostream_buffer final : public detail::buffer<char> {
   file file_;
 
-  FMT_API void grow(size_t) override;
+  void grow(size_t) override {
+    if (this->size() == this->capacity()) flush();
+  }
 
  public:
   ostream_buffer(cstring_view path, const detail::ostream_params& params)

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -379,35 +379,20 @@ struct ostream_params {
 #  endif
 };
 
-template <typename Char> class file_buffer final : public detail::buffer<Char> {
+class file_buffer final : public detail::buffer<char> {
   file file_;
 
-  void grow(size_t) override {
-    if (this->size() == this->capacity()) flush();
-  }
+  FMT_API void grow(size_t) override;
 
  public:
-  file_buffer(cstring_view path, const detail::ostream_params& params)
-      : file_(path, params.oflag) {
-    detail::buffer<Char>::set(new Char[params.buffer_size], params.buffer_size);
-  }
-  file_buffer(file_buffer&& other)
-      : detail::buffer<Char>(other.data(), other.size(), other.capacity()),
-        file_(std::move(other.file_)) {
-    other.clear();
-    other.set(nullptr, 0);
-  }
-  ~file_buffer() {
-    flush();
-    delete[] detail::buffer<Char>::data();
-  }
+  FMT_API file_buffer(cstring_view path, const detail::ostream_params& params);
+  FMT_API file_buffer(file_buffer&& other);
+  FMT_API ~file_buffer();
 
   void flush() {
-    if (detail::buffer<Char>::size() == 0) return;
-    file_.write(
-        detail::buffer<Char>::data(),
-        detail::buffer<Char>::size() * sizeof(detail::buffer<Char>::data()[0]));
-    detail::buffer<Char>::clear();
+    if (size() == 0) return;
+    file_.write(data(), size() * sizeof(data()[0]));
+    clear();
   }
 
   void close() {
@@ -426,7 +411,7 @@ constexpr detail::buffer_size buffer_size{};
 class FMT_API ostream final {
  private:
   FMT_MSC_WARNING(suppress : 4251)
-  detail::file_buffer<char> buffer_;
+  detail::file_buffer buffer_;
 
   ostream(cstring_view path, const detail::ostream_params& params)
       : buffer_(path, params) {}

--- a/src/os.cc
+++ b/src/os.cc
@@ -366,8 +366,10 @@ long getpagesize() {
 #  endif
 }
 
-FMT_API void ostream::grow(size_t) {
+FMT_API void detail::ostream_buffer::grow(size_t) {
   if (this->size() == this->capacity()) flush();
 }
+
+ostream::~ostream() = default;
 #endif  // FMT_USE_FCNTL
 FMT_END_NAMESPACE

--- a/src/os.cc
+++ b/src/os.cc
@@ -366,10 +366,6 @@ long getpagesize() {
 #  endif
 }
 
-FMT_API void detail::ostream_buffer::grow(size_t) {
-  if (this->size() == this->capacity()) flush();
-}
-
 ostream::~ostream() = default;
 #endif  // FMT_USE_FCNTL
 FMT_END_NAMESPACE

--- a/src/os.cc
+++ b/src/os.cc
@@ -366,6 +366,32 @@ long getpagesize() {
 #  endif
 }
 
+FMT_BEGIN_DETAIL_NAMESPACE
+
+void file_buffer::grow(size_t) {
+  if (this->size() == this->capacity()) flush();
+}
+
+file_buffer::file_buffer(cstring_view path,
+                         const detail::ostream_params& params)
+    : file_(path, params.oflag) {
+  set(new char[params.buffer_size], params.buffer_size);
+}
+
+file_buffer::file_buffer(file_buffer&& other)
+    : detail::buffer<char>(other.data(), other.size(), other.capacity()),
+      file_(std::move(other.file_)) {
+  other.clear();
+  other.set(nullptr, 0);
+}
+
+file_buffer::~file_buffer() {
+  flush();
+  delete[] data();
+}
+
+FMT_END_DETAIL_NAMESPACE
+
 ostream::~ostream() = default;
 #endif  // FMT_USE_FCNTL
 FMT_END_NAMESPACE


### PR DESCRIPTION
Some MSVC-specific behavior:
When class fmt::ostream inherits detail::buffer - the last gets implicitly exported when fmt is built as a shared library.
Unless os.h is included, the compiler assumes detail::buffer is not externally exported and instantiets a local copy of it, which causes ODR violation.
With aggregation - there is no compiler assumptions that could cause an ODR violation.

Closes: #3132