### PR TITLE
Add locale getter in tm_writer

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1263,7 +1263,7 @@ class tm_writer {
 
   OutputIt out() const { return out_; }
 
-  const std::locale & locale() const { return loc_; }
+  const std::locale& locale() const { return loc_; }
 
   FMT_CONSTEXPR void on_text(const Char* begin, const Char* end) {
     out_ = copy_str<Char>(begin, end, out_);

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1263,6 +1263,8 @@ class tm_writer {
 
   OutputIt out() const { return out_; }
 
+  const std::locale & locale() const { return loc_; }
+
   FMT_CONSTEXPR void on_text(const Char* begin, const Char* end) {
     out_ = copy_str<Char>(begin, end, out_);
   }


### PR DESCRIPTION
Why not?

Example of usage in custom DateTime writer:

```cpp
template <typename OutputIt, typename Char>
class DateTimeWriter : public fmt::detail::tm_writer<OutputIt, Char>
{
    using super = fmt::detail::tm_writer<OutputIt, Char>;

public:
    DateTimeWriter(const std::locale & loc,
                   OutputIt out,
                   const std::tm & tm,
                   const int32_t usec,
                   const char * zone)
        : super(loc, out, tm)
        , m_usec(usec)
        , m_zone(zone)
    {
    }

    void on_tz_name()
    {
        super::out() = detail::write_tm_str<Char>(
                super::out(), m_zone, super::locale());    // <----- tm_writer::locale()
    }
```