### PR TITLE
Add precision modifier for seconds in chrono format

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1038,7 +1038,7 @@ void write_fractional_seconds(OutputIt& out, Duration d, int precision = -1) {
 
   const auto fractional =
       detail::abs(d) - std::chrono::duration_cast<std::chrono::seconds>(d);
-  const auto& subseconds =
+  const auto subseconds =
       std::chrono::treat_as_floating_point<
           typename subsecond_precision::rep>::value
           ? fractional.count()
@@ -1860,13 +1860,8 @@ struct chrono_formatter {
         out = std::copy(buf.begin(), buf.end(), out);
       } else {
         write(second(), 2);
-        if (precision >= 0) {
-          write_fractional_seconds<char_type>(
-              out, std::chrono::duration<rep, Period>(val), precision);
-        } else {
-          write_fractional_seconds<char_type>(
-              out, std::chrono::duration<rep, Period>(val));
-        }
+        write_fractional_seconds<char_type>(
+            out, std::chrono::duration<rep, Period>(val), precision);
       }
       return;
     }

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1119,7 +1119,8 @@ void write_floating_seconds(memory_buffer& buf, Duration duration) {
 }
 
 template <typename Duration>
-void write_floating_seconds(memory_buffer& buf, Duration duration, int precision) {
+void write_floating_seconds(memory_buffer& buf, Duration duration,
+                            int precision) {
   if (precision < 0) {
     write_floating_seconds(buf, duration);
     return;
@@ -1894,16 +1895,19 @@ struct chrono_formatter {
     if (ns == numeric_system::standard) {
       if (std::is_floating_point<rep>::value) {
         auto buf = memory_buffer();
-        write_floating_seconds(buf, std::chrono::duration<rep, Period>(val), precision);
+        write_floating_seconds(buf, std::chrono::duration<rep, Period>(val),
+                               precision);
         if (negative) *out++ = '-';
         if (buf.size() < 2 || buf[1] == '.') *out++ = '0';
         out = std::copy(buf.begin(), buf.end(), out);
       } else {
         write(second(), 2);
         if (precision >= 0) {
-          write_fractional_seconds<char_type>(out, std::chrono::duration<rep, Period>(val), precision);
+          write_fractional_seconds<char_type>(
+              out, std::chrono::duration<rep, Period>(val), precision);
         } else {
-          write_fractional_seconds<char_type>(out, std::chrono::duration<rep, Period>(val));
+          write_fractional_seconds<char_type>(
+              out, std::chrono::duration<rep, Period>(val));
         }
       }
       return;

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1099,7 +1099,8 @@ void write_fractional_seconds(OutputIt& out, Duration d, int precision) {
 // pass the Rep value in the chrono_formatter.
 template <typename Duration>
 void write_floating_seconds(memory_buffer& buf, Duration duration) {
-  FMT_ASSERT(std::is_floating_point<typename Duration::rep>::value, "");
+  using Rep =  typename Duration::rep;
+  FMT_ASSERT(std::is_floating_point<Rep>::value, "");
   auto num_fractional_digits =
       count_fractional_digits<Duration::period::num,
                               Duration::period::den>::value;
@@ -1107,35 +1108,36 @@ void write_floating_seconds(memory_buffer& buf, Duration duration) {
   // precision.
   auto val = duration.count();
   if (num_fractional_digits < 6 &&
-      static_cast<typename Duration::rep>(std::round(val)) != val)
+      static_cast<Rep>(std::round(val)) != val)
     num_fractional_digits = 6;
 
   format_to(
       std::back_inserter(buf), runtime("{:.{}f}"),
       std::fmod(val *
-                    static_cast<typename Duration::rep>(Duration::period::num) /
-                    static_cast<typename Duration::rep>(Duration::period::den),
-                static_cast<typename Duration::rep>(60)),
+                    static_cast<Rep>(Duration::period::num) /
+                    static_cast<Rep>(Duration::period::den),
+                static_cast<Rep>(60)),
       num_fractional_digits);
 }
 
 template <typename Duration>
 void write_floating_seconds(memory_buffer& buf, Duration duration,
                             int precision) {
+  using Rep =  typename Duration::rep;
   if (precision < 0) {
     write_floating_seconds(buf, duration);
     return;
   }
 
-  FMT_ASSERT(std::is_floating_point<typename Duration::rep>::value, "");
+  FMT_ASSERT(std::is_floating_point<Rep>::value, "");
   auto val = duration.count();
 
   format_to(
       std::back_inserter(buf), runtime("{:.{}f}"),
       std::fmod(val *
-                    static_cast<typename Duration::rep>(Duration::period::num) /
-                    static_cast<typename Duration::rep>(Duration::period::den),
-                static_cast<typename Duration::rep>(60)),
+                    static_cast<Rep>(Duration::period::num) /
+                    static_cast<Rep>(Duration::period::den),
+                static_cast<Rep>(60)),
       precision);
 }
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1079,9 +1079,10 @@ void write_fractional_seconds(OutputIt& out, Duration d, int precision) {
     uint32_or_64_or_128_t<long long> n =
         to_unsigned(to_nonnegative_int(subseconds, max_value<long long>()));
     int num_digits = detail::count_digits(n);
-    int zeroes = std::min(num_fractional_digits - num_digits, precision);
+    int zeroes =
+        std::min(std::max(0, num_fractional_digits - num_digits), precision);
     if (num_fractional_digits > num_digits) out = std::fill_n(out, zeroes, '0');
-    int remaining = precision - (zeroes > 0 ? zeroes : 0);
+    int remaining = precision - zeroes;
     if (remaining < num_digits) {
       n /= to_unsigned(detail::pow10(to_unsigned(num_digits - remaining)));
       out = format_decimal<Char>(out, n, remaining).end;

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -466,7 +466,7 @@ TEST(chrono_test, format_default_fp) {
 
 TEST(chrono_test, format_precision) {
   EXPECT_THROW_MSG(
-      (void)fmt::format(runtime("{:.2}"), std::chrono::seconds(42)),
+      (void)fmt::format(runtime("{:.2%Q}"), std::chrono::seconds(42)),
       fmt::format_error, "precision not allowed for this argument type");
   EXPECT_EQ("1ms", fmt::format("{:.0}", dms(1.234)));
   EXPECT_EQ("1.2ms", fmt::format("{:.1}", dms(1.234)));
@@ -611,12 +611,23 @@ TEST(chrono_test, cpp20_duration_subsecond_support) {
   EXPECT_EQ(fmt::format("{:%S}", std::chrono::nanoseconds{-13420148734}),
             "-13.420148734");
   EXPECT_EQ(fmt::format("{:%S}", std::chrono::milliseconds{1234}), "01.234");
+  // Check subsecond presision modifier.
+  EXPECT_EQ(fmt::format("{:.6%S}", std::chrono::nanoseconds{1234}), "00.000001");
+  EXPECT_EQ(fmt::format("{:.18%S}", std::chrono::nanoseconds{1234}), "00.000001234000000000");
+  EXPECT_EQ(fmt::format("{:.{}%S}", std::chrono::nanoseconds{1234}, 6), "00.000001");
+  EXPECT_EQ(fmt::format("{:.6%S}", std::chrono::milliseconds{1234}), "01.234000");
+  EXPECT_EQ(fmt::format("{:.6%S}", std::chrono::milliseconds{-1234}), "-01.234000");
+  EXPECT_EQ(fmt::format("{:.3%S}", std::chrono::seconds{1234}), "34.000");
+  EXPECT_EQ(fmt::format("{:.3%S}", std::chrono::hours{1234}), "00.000");
+  EXPECT_EQ(fmt::format("{:.5%S}", dms(1.234)), "00.00123");
+  EXPECT_EQ(fmt::format("{:.8%S}", dms(1.234)), "00.00123400");
   {
     // Check that {:%H:%M:%S} is equivalent to {:%T}.
     auto dur = std::chrono::milliseconds{3601234};
     auto formatted_dur = fmt::format("{:%T}", dur);
     EXPECT_EQ(formatted_dur, "01:00:01.234");
     EXPECT_EQ(fmt::format("{:%H:%M:%S}", dur), formatted_dur);
+    EXPECT_EQ(fmt::format("{:.6%H:%M:%S}", dur), "01:00:01.234000");
   }
   using nanoseconds_dbl = std::chrono::duration<double, std::nano>;
   EXPECT_EQ(fmt::format("{:%S}", nanoseconds_dbl{-123456789}), "-00.123456789");
@@ -630,6 +641,7 @@ TEST(chrono_test, cpp20_duration_subsecond_support) {
     auto formatted_dur = fmt::format("{:%T}", dur);
     EXPECT_EQ(formatted_dur, "-00:01:39.123456789");
     EXPECT_EQ(fmt::format("{:%H:%M:%S}", dur), formatted_dur);
+    EXPECT_EQ(fmt::format("{:.3%H:%M:%S}", dur), "-00:01:39.123");
   }
   // Check that durations with precision greater than std::chrono::seconds have
   // fixed precision, and print zeros even if there is no fractional part.

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -612,11 +612,16 @@ TEST(chrono_test, cpp20_duration_subsecond_support) {
             "-13.420148734");
   EXPECT_EQ(fmt::format("{:%S}", std::chrono::milliseconds{1234}), "01.234");
   // Check subsecond presision modifier.
-  EXPECT_EQ(fmt::format("{:.6%S}", std::chrono::nanoseconds{1234}), "00.000001");
-  EXPECT_EQ(fmt::format("{:.18%S}", std::chrono::nanoseconds{1234}), "00.000001234000000000");
-  EXPECT_EQ(fmt::format("{:.{}%S}", std::chrono::nanoseconds{1234}, 6), "00.000001");
-  EXPECT_EQ(fmt::format("{:.6%S}", std::chrono::milliseconds{1234}), "01.234000");
-  EXPECT_EQ(fmt::format("{:.6%S}", std::chrono::milliseconds{-1234}), "-01.234000");
+  EXPECT_EQ(fmt::format("{:.6%S}", std::chrono::nanoseconds{1234}),
+            "00.000001");
+  EXPECT_EQ(fmt::format("{:.18%S}", std::chrono::nanoseconds{1234}),
+            "00.000001234000000000");
+  EXPECT_EQ(fmt::format("{:.{}%S}", std::chrono::nanoseconds{1234}, 6),
+            "00.000001");
+  EXPECT_EQ(fmt::format("{:.6%S}", std::chrono::milliseconds{1234}),
+            "01.234000");
+  EXPECT_EQ(fmt::format("{:.6%S}", std::chrono::milliseconds{-1234}),
+            "-01.234000");
   EXPECT_EQ(fmt::format("{:.3%S}", std::chrono::seconds{1234}), "34.000");
   EXPECT_EQ(fmt::format("{:.3%S}", std::chrono::hours{1234}), "00.000");
   EXPECT_EQ(fmt::format("{:.5%S}", dms(1.234)), "00.00123");


### PR DESCRIPTION
Continuation of #3122

Add precision modifier for seconds in chrono format and test for it.

It's became important for custom datetime types that store date, time and subseconds. I want to use chrono format for those types, but I have no way to control subsecond precision.

Use case:

```
EXPECT_EQ(fmt::format("{:.6%Y-%m-%d %H:%M:%S %Z}", datetime), "2022-09-28 12:14:25.123456 MSK");
```

So precision can be applied not only for %Q spec, but for %S too.