### PR TITLE
Initialize member variable

### DIFF
--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -108,7 +108,7 @@ TEST(xchar_test, compile_time_string) {
 #if FMT_CPLUSPLUS > 201103L
 struct custom_char {
   int value;
-  custom_char() = default;
+  constexpr custom_char() : value(0) {}
 
   template <typename T>
   constexpr custom_char(T val) : value(static_cast<int>(val)) {}


### PR DESCRIPTION
as per N4861, 9.4/7.3 [dcl.init],

> A class type T is const-default-constructible if default-initialization of T would invoke a user-provided
> constructor of T (not inherited from a base class) or if
> each direct non-variant non-static data member M of T has a default member initializer or, if M is of
> class type X (or array thereof), X is const-default-constructible,

and a minimal reproducer is like:
```c++
struct C { int i; };
const C c;
```
so in this case, we have to initialize the member variable of `custom_char`, so that the class is const-default-constructible.

without this change, clang-15 complains like:
```
fmt/src/test/xchar-test.cc:108:8: note: ‘struct custom_char’ has no user-provided default constructor
  108 | struct custom_char {
      |        ^~~~~~~~~~~
fmt/src/test/xchar-test.cc:110:3: note: constructor is not user-provided because it is explicitly defaulted in the class body
  110 |   custom_char() = default;
      |   ^~~~~~~~~~~
fmt/src/test/xchar-test.cc:109:7: note: and the implicitly-defined constructor does not initialize ‘int custom_char::value’
  109 |   int value;
      |       ^~~~~
```
Signed-off-by: Kefu Chai <tchaikov@gmail.com>

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
