### PR TITLE
Fix warnings for compilers with EDG frontend

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2117,12 +2117,10 @@ template <typename Char = char> struct loc_writer {
     return true;
   }
 
-  template <typename T, FMT_ENABLE_IF(is_floating_point<T>::value)>
+  template <typename T, FMT_ENABLE_IF(!is_integer<T>::value)>
   auto operator()(T) -> bool {
     return false;
   }
-
-  auto operator()(...) -> bool { return false; }
 };
 
 template <typename Char, typename OutputIt, typename T>

--- a/test/gtest/gmock-gtest-all.cc
+++ b/test/gtest/gmock-gtest-all.cc
@@ -13778,7 +13778,7 @@ UntypedActionResultHolderBase* UntypedFunctionMockerBase::UntypedInvokeWith(
 
   UntypedActionResultHolderBase* result = nullptr;
 
-  auto perform_action = [&] {
+  auto perform_action = [&, this] {
     return untyped_action == nullptr
                ? this->UntypedPerformDefaultAction(untyped_args, ss.str())
                : this->UntypedPerformAction(untyped_action, untyped_args);


### PR DESCRIPTION
**1) warning: a class type that is not trivially copyable passed through ellipsis (EDG frontend)**
```
lcc: "/export/home/phprus/fmt/fmt-hexfloat-1/include/fmt/core.h", line 1670: warning #1290:
          a class type that is not trivially copyable passed through ellipsis
      return vis(sv(arg.value_.string.data, arg.value_.string.size));
                 ^
          detected during:
            instantiation of
                      "auto fmt::v9::visit_format_arg(Visitor &&, const fmt::v9::basic_format_arg<Context> &)->decltype((<expression>)) [with Visitor=fmt::v9::detail::loc_writer<char> &, Context=fmt::v9::format_context]"
                      at line 1022 of
                      "/export/home/phprus/fmt/fmt-hexfloat-1/include/fmt/format.h"
            instantiation of
                      "auto fmt::v9::loc_value::visit(Visitor &&)->decltype((<expression>)) [with Visitor=fmt::v9::detail::loc_writer<char>]"
                      at line 146 of
                      "/export/home/phprus/fmt/fmt-hexfloat-1/include/fmt/format-inl.h"

lcc: "/export/home/phprus/fmt/fmt-hexfloat-1/include/fmt/core.h", line 1674: warning #1290:
          a class type that is not trivially copyable passed through ellipsis
      return vis(typename basic_format_arg<Context>::handle(arg.value_.custom));
                 ^
          detected during:
            instantiation of
                      "auto fmt::v9::visit_format_arg(Visitor &&, const fmt::v9::basic_format_arg<Context> &)->decltype((<expression>)) [with Visitor=fmt::v9::detail::loc_writer<char> &, Context=fmt::v9::format_context]"
                      at line 1022 of
                      "/export/home/phprus/fmt/fmt-hexfloat-1/include/fmt/format.h"
            instantiation of
                      "auto fmt::v9::loc_value::visit(Visitor &&)->decltype((<expression>)) [with Visitor=fmt::v9::detail::loc_writer<char>]"
                      at line 146 of
                      "/export/home/phprus/fmt/fmt-hexfloat-1/include/fmt/format-inl.h"

lcc: "/export/home/phprus/fmt/fmt-hexfloat-1/include/fmt/core.h", line 1676: warning #1290:
          a class type that is not trivially copyable passed through ellipsis
    return vis(monostate());
               ^
          detected during:
            instantiation of
                      "auto fmt::v9::visit_format_arg(Visitor &&, const fmt::v9::basic_format_arg<Context> &)->decltype((<expression>)) [with Visitor=fmt::v9::detail::loc_writer<char> &, Context=fmt::v9::format_context]"
                      at line 1022 of
                      "/export/home/phprus/fmt/fmt-hexfloat-1/include/fmt/format.h"
            instantiation of
                      "auto fmt::v9::loc_value::visit(Visitor &&)->decltype((<expression>)) [with Visitor=fmt::v9::detail::loc_writer<char>]"
                      at line 146 of
                      "/export/home/phprus/fmt/fmt-hexfloat-1/include/fmt/format-inl.h"
```
Passing a non-trivially copyable class via ``...`` is not allowed:

> Only arithmetic, enumeration, pointer, pointer to member, and class type arguments (after conversion) are allowed. However, non-POD class types (until C++11)class types with an eligible non-trivial copy constructor, an eligible non-trivial move constructor, or a non-trivial destructor, together with scoped enumerations (since C++11), are conditionally-supported in potentially-evaluated calls with implementation-defined semantics (these types are always supported in [unevaluated calls](https://en.cppreference.com/w/cpp/language/expressions#Unevaluated_expressions)).

See: https://en.cppreference.com/w/cpp/language/variadic_arguments

**2) warning: the implicit by-copy capture of "this" is deprecated (EDG frontend)**
```
lcc: "/export/home/phprus/fmt/fmt-hexfloat-1/test/gtest/gmock-gtest-all.cc", line 13783: warning #2908:
          the implicit by-copy capture of "this" is deprecated
                 ? this->UntypedPerformDefaultAction(untyped_args, ss.str())
                   ^
```

I think it's a bug in the compiler or EDG frontend.