### PR TITLE
Skip only strptime dependent test in scan-test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -78,11 +78,10 @@ endif()
 add_fmt_test(printf-test)
 add_fmt_test(ranges-test ranges-odr-test.cc)
 
+add_fmt_test(scan-test)
 check_symbol_exists(strptime "time.h" HAVE_STRPTIME)
 if (HAVE_STRPTIME)
-  add_fmt_test(scan-test)
-else()
-  message(WARNING "Skipping scan-test due to missing strptime dependency.")
+  target_compile_definitions(scan-test PRIVATE FMT_HAVE_STRPTIME)
 endif ()
 
 add_fmt_test(std-test)

--- a/test/scan-test.cc
+++ b/test/scan-test.cc
@@ -65,7 +65,7 @@ TEST(scan_test, read_string_view) {
   EXPECT_EQ(s, "foo");
 }
 
-#ifndef _WIN32
+#ifdef FMT_HAVE_STRPTIME
 namespace fmt {
 template <> struct scanner<tm> {
   std::string format;


### PR DESCRIPTION
Skip only strptime dependent test in scan-test and fix cmake warning on windows.

Improve #3184
cc @thesmurph 