### PR TITLE
Remove workaround for GTest bug

### DIFF
--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -18,14 +18,6 @@ else ()
   target_compile_definitions(gtest PUBLIC GTEST_HAS_PTHREAD=0)
 endif ()
 
-# Workaround GTest bug https://github.com/google/googletest/issues/705
-if (NOT MSVC)
-  check_cxx_compiler_flag(-fno-delete-null-pointer-checks HAVE_FNO_DELETE_NULL_POINTER_CHECKS)
-endif ()
-if (HAVE_FNO_DELETE_NULL_POINTER_CHECKS)
-  target_compile_options(gtest PUBLIC -fno-delete-null-pointer-checks)
-endif ()
-
 if (MSVC)
   # Disable MSVC warnings of _CRT_INSECURE_DEPRECATE functions.
   target_compile_definitions(gtest PRIVATE _CRT_SECURE_NO_WARNINGS)


### PR DESCRIPTION
Gtest bug (https://github.com/google/googletest/issues/705) already fixed in used GTest version:

Upstream:
- https://github.com/google/googletest/issues/705#issuecomment-235067917
- https://github.com/google/googletest/commit/b5c81098a8ccc25e313ffca56c911200b3591ea0

FMT commit:
- https://github.com/fmtlib/fmt/commit/b4f9a058945a25d8a4af589d8e9168c70195077e
