### PR TITLE
Bump tested CMake version to 3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8...3.18)
+cmake_minimum_required(VERSION 3.8...3.25)
 
 # Fallback for using newer policies on CMake <3.12.
 if(${CMAKE_VERSION} VERSION_LESS 3.12)

--- a/test/add-subdirectory-test/CMakeLists.txt
+++ b/test/add-subdirectory-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8...3.18)
+cmake_minimum_required(VERSION 3.8...3.25)
 
 project(fmt-test CXX)
 

--- a/test/compile-error-test/CMakeLists.txt
+++ b/test/compile-error-test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Test if compile errors are produced where necessary.
 
-cmake_minimum_required(VERSION 3.8...3.18)
+cmake_minimum_required(VERSION 3.8...3.25)
 project(compile-error-test CXX)
 
 set(fmt_headers "
@@ -64,7 +64,7 @@ function (run_tests)
   ")
 
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/test/CMakeLists.txt" "
-    cmake_minimum_required(VERSION 3.8...3.18)
+    cmake_minimum_required(VERSION 3.8...3.25)
     project(tests CXX)
     add_subdirectory(${FMT_DIR} fmt)
     ${cmake_targets}

--- a/test/find-package-test/CMakeLists.txt
+++ b/test/find-package-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8...3.18)
+cmake_minimum_required(VERSION 3.8...3.25)
 
 project(fmt-test)
 

--- a/test/static-export-test/CMakeLists.txt
+++ b/test/static-export-test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8...3.18)
+cmake_minimum_required(VERSION 3.8...3.25)
 
 project(fmt-link CXX)
 


### PR DESCRIPTION
Version update will allow new cmake policies to be used.