### PR TITLE
fix #3105 - Compile-time error when mixing named argument with automatic indexing

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2984,7 +2984,7 @@ class format_string_checker {
 #if FMT_USE_NONTYPE_TEMPLATE_ARGS
     auto index = get_arg_index_by_name<Args...>(id);
     if (index == invalid_arg_index) on_error("named argument is not found");
-    return context_.check_arg_id(index), index;
+    return index;
 #else
     (void)id;
     on_error("compile-time checks for named arguments require C++20 support");

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1907,6 +1907,7 @@ TEST(format_test, compile_time_string) {
   EXPECT_EQ("", fmt::format(FMT_STRING("")));
   EXPECT_EQ("", fmt::format(FMT_STRING(""), "arg"_a = 42));
   EXPECT_EQ("42", fmt::format(FMT_STRING("{answer}"), "answer"_a = Answer()));
+  EXPECT_EQ("1 2", fmt::format(FMT_STRING("{} {two}"), 1, "two"_a = 2));
 #endif
 
   (void)static_with_null;


### PR DESCRIPTION
Fixes #3105

Looks like this is enough to fix the issue.

I compared the runtime checking with compile-time checking and adjusted the compile-time version to mirror the runtime one.

The runtime check is this (second function for named args):
```
    FMT_CONSTEXPR auto on_arg_id(int id) -> int {
      return parse_context.check_arg_id(id), id;
    }
    FMT_CONSTEXPR auto on_arg_id(basic_string_view<Char> id) -> int {
      int arg_id = context.arg_id(id);
      if (arg_id < 0) on_error("argument not found");
      return arg_id;
    }
```
It returns the arg index directly without running it through the `check_arg_id`, unlike the indexed arg check.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
