### PR TITLE
Improve timezone tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -59,6 +59,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Set timezone
+      run: sudo timedatectl set-timezone 'Asia/Yekaterinburg'
+
     - name: Add repositories for older GCC
       run: |
         # Bellow two repos provide GCC 4.8, 5.5 and 6.4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Set timezone
+      run: sudo systemsetup -settimezone 'Asia/Yekaterinburg'
+
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,6 +43,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Set timezone
+      run: tzutil /s "Ekaterinburg Standard Time"
+
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build
 
@@ -77,6 +80,9 @@ jobs:
       matrix:
         sys: [ mingw64, ucrt64 ]
     steps:
+    - name: Set timezone
+      run: tzutil /s "Ekaterinburg Standard Time"
+      shell: cmd
     - uses: msys2/setup-msys2@v2
       with:
         release: false

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -294,7 +294,7 @@ TEST(chrono_test_wchar, time_point) {
       L"%OU", L"%W",  L"%OW", L"%V",  L"%OV", L"%j",  L"%d",  L"%Od", L"%e",
       L"%Oe", L"%a",  L"%A",  L"%w",  L"%Ow", L"%u",  L"%Ou", L"%H",  L"%OH",
       L"%I",  L"%OI", L"%M",  L"%OM", L"%S",  L"%OS", L"%x",  L"%Ex", L"%X",
-      L"%EX", L"%D",  L"%F",  L"%R",  L"%T",  L"%p",  L"%z",  L"%Z"};
+      L"%EX", L"%D",  L"%F",  L"%R",  L"%T",  L"%p"};
 #ifndef _WIN32
   // Disabled on Windows, because these formats is not consistent among
   // platforms.
@@ -303,7 +303,7 @@ TEST(chrono_test_wchar, time_point) {
   // Only C89 conversion specifiers when using MSVCRT instead of UCRT
   spec_list = {L"%%", L"%Y", L"%y", L"%b", L"%B", L"%m", L"%U",
                L"%W", L"%j", L"%d", L"%a", L"%A", L"%w", L"%H",
-               L"%I", L"%M", L"%S", L"%x", L"%X", L"%p", L"%Z"};
+               L"%I", L"%M", L"%S", L"%x", L"%X", L"%p"};
 #endif
   spec_list.push_back(L"%Y-%m-%d %H:%M:%S");
 
@@ -316,6 +316,53 @@ TEST(chrono_test_wchar, time_point) {
     auto fmt_spec = fmt::format(L"{{:{}}}", spec);
     EXPECT_EQ(sys_output, fmt::format(fmt::runtime(fmt_spec), t1));
     EXPECT_EQ(sys_output, fmt::format(fmt::runtime(fmt_spec), tm));
+  }
+
+  // Timezone formatters tests makes sense for localtime.
+#if defined(__MINGW32__) && !defined(_UCRT)
+  spec_list = {L"%Z"};
+#else
+  spec_list = {L"%z", L"%Z"};
+#endif
+  for (const auto& spec : spec_list) {
+    auto t = std::chrono::system_clock::to_time_t(t1);
+    auto tm = *std::localtime(&t);
+
+    auto sys_output = system_wcsftime(spec, &tm);
+
+    auto fmt_spec = fmt::format(L"{{:{}}}", spec);
+    EXPECT_EQ(sys_output, fmt::format(fmt::runtime(fmt_spec), tm));
+
+    if (spec == L"%z") {
+      sys_output.insert(sys_output.end() - 2, 1, L':');
+      EXPECT_EQ(sys_output, fmt::format(L"{:%Ez}", tm));
+      EXPECT_EQ(sys_output, fmt::format(L"{:%Oz}", tm));
+    }
+  }
+
+  // Separate tests for UTC, since std::time_put can use local time and ignoring
+  // the timezone in std::tm (if it presents on platform).
+  if (fmt::detail::has_member_data_tm_zone<std::tm>::value) {
+    auto t = std::chrono::system_clock::to_time_t(t1);
+    auto tm = *std::gmtime(&t);
+
+    std::vector<std::wstring> tz_names = {L"GMT", L"UTC"};
+    EXPECT_THAT(tz_names, Contains(fmt::format(L"{:%Z}", t1)));
+    EXPECT_THAT(tz_names, Contains(fmt::format(L"{:%Z}", tm)));
+  }
+
+  if (fmt::detail::has_member_data_tm_gmtoff<std::tm>::value) {
+    auto t = std::chrono::system_clock::to_time_t(t1);
+    auto tm = *std::gmtime(&t);
+
+    EXPECT_EQ(L"+0000", fmt::format(L"{:%z}", t1));
+    EXPECT_EQ(L"+0000", fmt::format(L"{:%z}", tm));
+
+    EXPECT_EQ(L"+00:00", fmt::format(L"{:%Ez}", t1));
+    EXPECT_EQ(L"+00:00", fmt::format(L"{:%Ez}", tm));
+
+    EXPECT_EQ(L"+00:00", fmt::format(L"{:%Oz}", t1));
+    EXPECT_EQ(L"+00:00", fmt::format(L"{:%Oz}", tm));
   }
 }
 

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -22,6 +22,13 @@
 using fmt::detail::max_value;
 using testing::Contains;
 
+#if defined(__MINGW32__) && !defined(_UCRT)
+// Only C89 conversion specifiers when using MSVCRT instead of UCRT
+#  define FMT_HAS_C99_STRFTIME 0
+#else
+#  define FMT_HAS_C99_STRFTIME 1
+#endif
+
 namespace test_ns {
 template <typename Char> class test_string {
  private:
@@ -299,7 +306,7 @@ TEST(chrono_test_wchar, time_point) {
   // Disabled on Windows, because these formats is not consistent among
   // platforms.
   spec_list.insert(spec_list.end(), {L"%c", L"%Ec", L"%r"});
-#elif defined(__MINGW32__) && !defined(_UCRT)
+#elif !FMT_HAS_C99_STRFTIME
   // Only C89 conversion specifiers when using MSVCRT instead of UCRT
   spec_list = {L"%%", L"%Y", L"%y", L"%b", L"%B", L"%m", L"%U",
                L"%W", L"%j", L"%d", L"%a", L"%A", L"%w", L"%H",
@@ -319,10 +326,10 @@ TEST(chrono_test_wchar, time_point) {
   }
 
   // Timezone formatters tests makes sense for localtime.
-#if defined(__MINGW32__) && !defined(_UCRT)
-  spec_list = {L"%Z"};
-#else
+#if FMT_HAS_C99_STRFTIME
   spec_list = {L"%z", L"%Z"};
+#else
+  spec_list = {L"%Z"};
 #endif
   for (const auto& spec : spec_list) {
     auto t = std::chrono::system_clock::to_time_t(t1);


### PR DESCRIPTION
Issues present after commit 115001a3b165483563822645bb93fd9558908c50


1) macOS has broken std::time_put:
```
[ RUN      ] chrono_test.system_clock_time_point
/Users/phprus/Devel/fmt/test/chrono-test.cc:287: Failure
Expected equality of these values:
  sys_output
    Which is: "+0500"
  fmt::format(fmt::runtime(fmt_spec), t1)
    Which is: "+0000"
/Users/phprus/Devel/fmt/test/chrono-test.cc:288: Failure
Expected equality of these values:
  sys_output
    Which is: "+0500"
  fmt::format(fmt::runtime(fmt_spec), tm)
    Which is: "+0000"
/Users/phprus/Devel/fmt/test/chrono-test.cc:299: Failure
Expected equality of these values:
  sys_output
    Which is: "+05:00"
  fmt::format("{:%Ez}", t1)
    Which is: "+00:00"
/Users/phprus/Devel/fmt/test/chrono-test.cc:300: Failure
Expected equality of these values:
  sys_output
    Which is: "+05:00"
  fmt::format("{:%Ez}", tm)
    Which is: "+00:00"
/Users/phprus/Devel/fmt/test/chrono-test.cc:302: Failure
Expected equality of these values:
  sys_output
    Which is: "+05:00"
  fmt::format("{:%Oz}", t1)
    Which is: "+00:00"
/Users/phprus/Devel/fmt/test/chrono-test.cc:303: Failure
Expected equality of these values:
  sys_output
    Which is: "+05:00"
  fmt::format("{:%Oz}", tm)
    Which is: "+00:00"
[  FAILED  ] chrono_test.system_clock_time_point (0 ms)
```

2) Windows has not normal support UTC timezone for ``std::tm``.
We need to use ``std::chrono`` to format time with timezone.

