### PR TITLE
small typo in syntax.rst

### DIFF
--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -497,7 +497,7 @@ Examples::
   fmt::format("{}", std::vector{10, 20, 30});
   // Result: [10, 20, 30]
   fmt::format("{::#x}", std::vector{10, 20, 30});
-  // Result: [0xa, 0x14, 0x13]
+  // Result: [0xa, 0x14, 0x1e]
   fmt::format("{}", vector{'h', 'e', 'l', 'l', 'o'});
   // Result: ['h', 'e', 'l', 'l', 'o']
   fmt::format("{::}", vector{'h', 'e', 'l', 'l', 'o'});


### PR DESCRIPTION
0x1e was misread as 0x13, it looks like

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
