### PR TITLE
Fix build with MSVC C++20 modules

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -395,9 +395,9 @@ FMT_CONSTEXPR auto to_unsigned(Int value) ->
   return static_cast<typename std::make_unsigned<Int>::type>(value);
 }
 
-FMT_MSC_WARNING(suppress : 4566) constexpr unsigned char section[] = "\u00A7";
+FMT_CONSTEXPR auto is_utf8() -> bool {
+  FMT_MSC_WARNING(suppress : 4566) constexpr unsigned char section[] = "\u00A7";
 
-constexpr auto is_utf8() -> bool {
   // Avoid buggy sign extensions in MSVC's constant evaluation mode (#2297).
   using uchar = unsigned char;
   return FMT_UNICODE || (sizeof(section) == 3 && uchar(section[0]) == 0xC2 &&

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -395,7 +395,7 @@ FMT_CONSTEXPR auto to_unsigned(Int value) ->
   return static_cast<typename std::make_unsigned<Int>::type>(value);
 }
 
-FMT_CONSTEXPR auto is_utf8() -> bool {
+FMT_CONSTEXPR inline auto is_utf8() -> bool {
   FMT_MSC_WARNING(suppress : 4566) constexpr unsigned char section[] = "\u00A7";
 
   // Avoid buggy sign extensions in MSVC's constant evaluation mode (#2297).


### PR DESCRIPTION
When using fmt with C++20 modules under MSVC, it can end up requiring certain things to have storage that would not otherwise have needed to. Since I didn't see anything that was already doing detection for `inline constexpr` variable support, I've just moved the entire thing into the only function where it's used. I've also swapped the function from `constexpr` to `FMT_CONSTEXPR` since it's no longer a simple C++11 constexpr function.