### PR TITLE
Bugfix for fmt::printf on Power9 architecture with the XL compiler

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3580,19 +3580,19 @@ template <typename Char> struct arg_formatter {
   using context = buffer_context<Char>;
 
   iterator out;
-  const format_specs<Char>& specs;
+  const format_specs<Char>* specs;
   locale_ref locale;
 
-  arg_formatter(buffer_appender<Char> it, const format_specs<Char>& s)
+  arg_formatter(buffer_appender<Char> it, const format_specs<Char>* s)
       : out(it), specs(s) {}
 
-  arg_formatter(buffer_appender<Char> it, const format_specs<Char>& s,
+  arg_formatter(buffer_appender<Char> it, const format_specs<Char>* s,
                 locale_ref l)
       : out(it), specs(s), locale(l) {}
 
   template <typename T>
   FMT_CONSTEXPR FMT_INLINE auto operator()(T value) -> iterator {
-    return detail::write(out, value, specs, locale);
+    return detail::write(out, value, *specs, locale);
   }
   auto operator()(typename basic_format_arg<context>::handle) -> iterator {
     // User-defined types are handled separately because they require access
@@ -4220,7 +4220,7 @@ void vformat_to(buffer<Char>& buf, basic_string_view<Char> fmt,
           specs.precision, specs.precision_ref, context);
       if (begin == end || *begin != '}')
         on_error("missing '}' in format string");
-      auto f = arg_formatter<Char>{context.out(), specs, context.locale()};
+      auto f = arg_formatter<Char>{context.out(), &specs, context.locale()};
       context.advance_to(visit_format_arg(f, arg));
       return begin;
     }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3583,13 +3583,6 @@ template <typename Char> struct arg_formatter {
   const format_specs<Char>* specs;
   locale_ref locale;
 
-  arg_formatter(buffer_appender<Char> it, const format_specs<Char>* s)
-      : out(it), specs(s) {}
-
-  arg_formatter(buffer_appender<Char> it, const format_specs<Char>* s,
-                locale_ref l)
-      : out(it), specs(s), locale(l) {}
-
   template <typename T>
   FMT_CONSTEXPR FMT_INLINE auto operator()(T value) -> iterator {
     return detail::write(out, value, *specs, locale);

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3580,17 +3580,22 @@ template <typename Char> struct arg_formatter {
   using context = buffer_context<Char>;
 
   iterator out;
-  const format_specs<Char>* specs;
+  const format_specs<Char>& specs;
   locale_ref locale;
 
   template <typename T>
   FMT_CONSTEXPR FMT_INLINE auto operator()(T value) -> iterator {
-    return detail::write(out, value, *specs, locale);
+    return detail::write(out, value, specs, locale);
   }
   auto operator()(typename basic_format_arg<context>::handle) -> iterator {
     // User-defined types are handled separately because they require access
     // to the parse context.
     return out;
+  }
+
+  static auto make_arg_formatter(iterator iter, format_specs<Char>& s)
+      -> arg_formatter {
+    return {iter, s, locale_ref()};
   }
 };
 
@@ -4213,7 +4218,7 @@ void vformat_to(buffer<Char>& buf, basic_string_view<Char> fmt,
           specs.precision, specs.precision_ref, context);
       if (begin == end || *begin != '}')
         on_error("missing '}' in format string");
-      auto f = arg_formatter<Char>{context.out(), &specs, context.locale()};
+      auto f = arg_formatter<Char>{context.out(), specs, context.locale()};
       context.advance_to(visit_format_arg(f, arg));
       return begin;
     }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3583,6 +3583,10 @@ template <typename Char> struct arg_formatter {
   const format_specs<Char>& specs;
   locale_ref locale;
 
+  arg_formatter(buffer_appender<Char> it, const format_specs<Char>& s,
+                locale_ref l)
+      : out{it}, specs{s}, locale{l} {}
+
   template <typename T>
   FMT_CONSTEXPR FMT_INLINE auto operator()(T value) -> iterator {
     return detail::write(out, value, specs, locale);

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3592,11 +3592,6 @@ template <typename Char> struct arg_formatter {
     // to the parse context.
     return out;
   }
-
-  static auto make_arg_formatter(iterator iter, format_specs<Char>& s)
-      -> arg_formatter {
-    return {iter, s, locale_ref()};
-  }
 };
 
 template <typename Char> struct custom_formatter {

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3583,9 +3583,12 @@ template <typename Char> struct arg_formatter {
   const format_specs<Char>& specs;
   locale_ref locale;
 
+  arg_formatter(buffer_appender<Char> it, const format_specs<Char>& s)
+      : out(it), specs(s) {}
+
   arg_formatter(buffer_appender<Char> it, const format_specs<Char>& s,
                 locale_ref l)
-      : out{it}, specs{s}, locale{l} {}
+      : out(it), specs(s), locale(l) {}
 
   template <typename T>
   FMT_CONSTEXPR FMT_INLINE auto operator()(T value) -> iterator {

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -235,7 +235,13 @@ class printf_arg_formatter : public arg_formatter<Char> {
 
  public:
   printf_arg_formatter(OutputIt iter, format_specs<Char>* s, context_type& ctx)
-      : base{iter, s}, context_(ctx) {}
+      : base{iter, s, locale_ref()}, context_(ctx) {
+#if defined(__ibmxl__)
+    // Bugfix: XL compiler optimizes out initializer for base
+    this->out = iter;
+    this->specs = s;
+#endif
+  }
 
   OutputIt operator()(monostate value) { return base::operator()(value); }
 

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -228,13 +228,13 @@ class printf_arg_formatter : public arg_formatter<Char> {
   context_type& context_;
 
   OutputIt write_null_pointer(bool is_string = false) {
-    auto s = this->specs;
+    auto s = *this->specs;
     s.type = presentation_type::none;
     return write_bytes(this->out, is_string ? "(null)" : "(nil)", s);
   }
 
  public:
-  printf_arg_formatter(OutputIt iter, format_specs<Char>& s, context_type& ctx)
+  printf_arg_formatter(OutputIt iter, format_specs<Char>* s, context_type& ctx)
       : base{iter, s}, context_(ctx) {}
 
   OutputIt operator()(monostate value) { return base::operator()(value); }
@@ -244,7 +244,7 @@ class printf_arg_formatter : public arg_formatter<Char> {
     // MSVC2013 fails to compile separate overloads for bool and Char so use
     // std::is_same instead.
     if (std::is_same<T, Char>::value) {
-      format_specs<Char> fmt_specs = this->specs;
+      format_specs<Char> fmt_specs = *this->specs;
       if (fmt_specs.type != presentation_type::none &&
           fmt_specs.type != presentation_type::chr) {
         return (*this)(static_cast<int>(value));
@@ -269,13 +269,13 @@ class printf_arg_formatter : public arg_formatter<Char> {
   /** Formats a null-terminated C string. */
   OutputIt operator()(const char* value) {
     if (value) return base::operator()(value);
-    return write_null_pointer(this->specs.type != presentation_type::pointer);
+    return write_null_pointer(this->specs->type != presentation_type::pointer);
   }
 
   /** Formats a null-terminated wide C string. */
   OutputIt operator()(const wchar_t* value) {
     if (value) return base::operator()(value);
-    return write_null_pointer(this->specs.type != presentation_type::pointer);
+    return write_null_pointer(this->specs->type != presentation_type::pointer);
   }
 
   OutputIt operator()(basic_string_view<Char> value) {
@@ -545,7 +545,7 @@ void vprintf(buffer<Char>& buf, basic_string_view<Char> format,
 
     // Format argument.
     out = visit_format_arg(
-        printf_arg_formatter<iterator, Char>(out, specs, context), arg);
+        printf_arg_formatter<iterator, Char>(out, &specs, context), arg);
   }
   write(out, basic_string_view<Char>(start, to_unsigned(it - start)));
 }

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -218,6 +218,14 @@ template <typename Char> class printf_width_handler {
   }
 };
 
+// Workaround for a bug with the XL compiler when initializing
+// printf_arg_formatter's base class.
+template <typename Char>
+auto make_arg_formatter(buffer_appender<Char> iter, format_specs<Char>& s)
+    -> arg_formatter<Char> {
+  return {iter, s, locale_ref()};
+}
+
 // The ``printf`` argument formatter.
 template <typename OutputIt, typename Char>
 class printf_arg_formatter : public arg_formatter<Char> {
@@ -235,7 +243,7 @@ class printf_arg_formatter : public arg_formatter<Char> {
 
  public:
   printf_arg_formatter(OutputIt iter, format_specs<Char>& s, context_type& ctx)
-      : base(base::make_arg_formatter(iter, s)), context_(ctx) {}
+      : base(make_arg_formatter(iter, s)), context_(ctx) {}
 
   OutputIt operator()(monostate value) { return base::operator()(value); }
 

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -235,7 +235,7 @@ class printf_arg_formatter : public arg_formatter<Char> {
 
  public:
   printf_arg_formatter(OutputIt iter, format_specs<Char>& s, context_type& ctx)
-      : base{iter, s, locale_ref()}, context_(ctx) {}
+      : base{iter, s}, context_(ctx) {}
 
   OutputIt operator()(monostate value) { return base::operator()(value); }
 


### PR DESCRIPTION
_I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing._

This PR works around a bug encountered with the IBM xl compiler on the Power9 architecture (e.g. on the [Lassen supercomputer](https://www.top500.org/system/179567) ) with `fmt::printf()`.

The issue appears to be that XL is not copying the `format_specs` struct in the `printf_arg_formatter` constructor to the `arg_formatter` base class.
https://github.com/fmtlib/fmt/blob/a73a9b6a8443bb9bced066c94126b76f9c8f9b26/include/fmt/printf.h#L237-L238

This was causing the `printf` tests to segfault. E.g. https://github.com/fmtlib/fmt/blob/a73a9b6a8443bb9bced066c94126b76f9c8f9b26/test/printf-test.cc#L73

I resolved the problem by adding an explicit constructor to the `arg_formatter` base class.

This regression appears to have been introduced between `fmt@7.1.3` and `fmt@8.0.0`.

I tested this using the following compiler/config options
```cmake
set(CMAKE_C_COMPILER "/usr/tce/packages/xl/xl-2022.08.19/bin/xlc" CACHE PATH "")
set(CMAKE_CXX_COMPILER "/usr/tce/packages/xl/xl-2022.08.19/bin/xlC" CACHE PATH "")
set(CMAKE_C_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")
set(CMAKE_CXX_FLAGS "--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1" CACHE STRING "")

set(CMAKE_CXX_STANDARD "14" CACHE STRING "")
set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "")
set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath,/usr/tce/packages/xl/xl-2022.08.19/lib" CACHE STRING "Adds a missing rpath for libraries associated with the fortran compiler")

set(FMT_HEADER_ONLY ON CACHE BOOL "")
set(FMT_TEST ON CACHE BOOL "")
```

Note: There are a few other failing tests with this compiler. I will post separate issues for them.
