### PR TITLE
Fix errors setting of FMT_USE_FLOAT128

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -786,12 +786,24 @@ using is_integer =
                   !std::is_same<T, wchar_t>::value>;
 
 #ifndef FMT_USE_FLOAT128
-#  ifdef __SIZEOF_FLOAT128__
-#    define FMT_USE_FLOAT128 1
-#  else
+#  ifdef __clang__
+// Clang C++ emulates GCC, so it has to appear early.
+#    if defined(__has_include)
+#      if __has_include(<quadmath.h>)
+#        define FMT_USE_FLOAT128 1
+#      endif
+#    endif
+#  elif defined(__GNUC__)
+// GNU C++:
+#    if defined(_GLIBCXX_USE_FLOAT128) && !defined(__STRICT_ANSI__)
+#      define FMT_USE_FLOAT128 1
+#    endif
+#  endif
+#  ifndef FMT_USE_FLOAT128
 #    define FMT_USE_FLOAT128 0
 #  endif
 #endif
+
 #if FMT_USE_FLOAT128
 using float128 = __float128;
 #else


### PR DESCRIPTION
Target=x86_64-linux-gnu
```
ld.lld: error: undefined symbol: __extenddftf2
>>> referenced by format-test.cc:89 (.../contrib/libs/fmt/test/format-test.cc:89)
>>>               /home/romankoshelev/.ya/build/build_root/zb02/000035/contrib/libs/fmt/test/format-test/__/format-test.cc.o:(void check_isfinite<__float128>())
>>> referenced by format-test.cc:94 (.../contrib/libs/fmt/test/format-test.cc:94)
>>>               /home/romankoshelev/.ya/build/build_root/zb02/000035/contrib/libs/fmt/test/format-test/__/format-test.cc.o:(void check_isfinite<__float128>())
>>> referenced by format-test.cc:95 (.../contrib/libs/fmt/test/format-test.cc:95)
>>>               /home/romankoshelev/.ya/build/build_root/zb02/000035/contrib/libs/fmt/test/format-test/__/format-test.cc.o:(void check_isfinite<__float128>())
>>> referenced 8 more times

ld.lld: error: undefined symbol: __eqtf2
>>> referenced by format.h:2491 (.../contrib/libs/fmt/include/fmt/format.h:2491)
>>>               /home/romankoshelev/.ya/build/build_root/zb02/000035/contrib/libs/fmt/test/format-test/__/format-test.cc.o:(bool fmt::v9::detail::isfinite<__float128, 0>(__float128))

ld.lld: error: undefined symbol: __netf2
>>> referenced by format.h:2491 (.../contrib/libs/fmt/include/fmt/format.h:2491)
>>>               /home/romankoshelev/.ya/build/build_root/zb02/000035/contrib/libs/fmt/test/format-test/__/format-test.cc.o:(bool fmt::v9::detail::isfinite<__float128, 0>(__float128))

ld.lld: error: undefined symbol: __unordtf2
>>> referenced by format.h:2469 (.../contrib/libs/fmt/include/fmt/format.h:2469)
>>>               /home/romankoshelev/.ya/build/build_root/zb02/000035/contrib/libs/fmt/test/format-test/__/format-test.cc.o:(bool fmt::v9::detail::isnan<__float128>(__float128))

ld.lld: error: undefined symbol: __trunctfdf2
>>> referenced by format.h:2504 (.../contrib/libs/fmt/include/fmt/format.h:2504)
>>>               /home/romankoshelev/.ya/build/build_root/zb02/000035/contrib/libs/fmt/test/format-test/__/format-test.cc.o:(std::__y1::back_insert_iterator<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > > fmt::v9::detail::write<char, std::__y1::back_insert_iterator<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, __float128, 0>(std::__y1::back_insert_iterator<std::__y1::basic_string<char, std::__y1::char_traits<char>, std::__y1::allocator<char> > >, __float128, fmt::v9::basic_format_specs<char>, fmt::v9::detail::locale_ref))

ld.lld: error: undefined symbol: __getf2
>>> referenced by format.h:3077 (.../contrib/libs/fmt/include/fmt/format.h:3077)
>>>               /home/romankoshelev/.ya/build/build_root/zb02/000035/contrib/libs/fmt/test/format-test/__/format-test.cc.o:(int fmt::v9::detail::format_float<__float128>(__float128, int, fmt::v9::detail::float_specs, fmt::v9::detail::buffer<char>&))

ld.lld: error: undefined symbol: __letf2
>>> referenced by format.h:3081 (.../contrib/libs/fmt/include/fmt/format.h:3081)
>>>               /home/romankoshelev/.ya/build/build_root/zb02/000035/contrib/libs/fmt/test/format-test/__/format-test.cc.o:(int fmt::v9::detail::format_float<__float128>(__float128, int, fmt::v9::detail::float_specs, fmt::v9::detail::buffer<char>&))

ld.lld: error: undefined symbol: __trunctfsf2
>>> referenced by format.h:3138 (.../contrib/libs/fmt/include/fmt/format.h:3138)
>>>               /home/romankoshelev/.ya/build/build_root/zb02/000035/contrib/libs/fmt/test/format-test/__/format-test.cc.o:(int fmt::v9::detail::format_float<__float128>(__float128, int, fmt::v9::detail::float_specs, fmt::v9::detail::buffer<char>&))
clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
Failed
```