### PR TITLE
Fix negative subsec for time_point

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2115,7 +2115,6 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
         val -= std::chrono::seconds(1);
       }
 
-
       return formatter<std::tm, Char>::do_format(
           gmtime(std::chrono::time_point_cast<std::chrono::seconds>(val)), ctx,
           &subsecs);

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1046,26 +1046,6 @@ inline Int to_nonnegative_int(T value, Int upper) {
   return static_cast<Int>(value);
 }
 
-template <typename Rep, typename Period,
-          FMT_ENABLE_IF(std::numeric_limits<Rep>::is_signed)>
-constexpr std::chrono::duration<Rep, Period> abs(
-    std::chrono::duration<Rep, Period> d) {
-  // We need to compare the duration using the count() method directly
-  // due to a compiler bug in clang-11 regarding the spaceship operator,
-  // when -Wzero-as-null-pointer-constant is enabled.
-  // In clang-12 the bug has been fixed. See
-  // https://bugs.llvm.org/show_bug.cgi?id=46235 and the reproducible example:
-  // https://www.godbolt.org/z/Knbb5joYx.
-  return d.count() >= d.zero().count() ? d : -d;
-}
-
-template <typename Rep, typename Period,
-          FMT_ENABLE_IF(!std::numeric_limits<Rep>::is_signed)>
-constexpr std::chrono::duration<Rep, Period> abs(
-    std::chrono::duration<Rep, Period> d) {
-  return d;
-}
-
 constexpr long long pow10(std::uint32_t n) {
   return n == 0 ? 1 : 10 * pow10(n - 1);
 }
@@ -1101,7 +1081,7 @@ void write_fractional_seconds(OutputIt& out, Duration d, int precision = -1) {
       std::ratio<1, detail::pow10(num_fractional_digits)>>;
 
   const auto fractional =
-      detail::abs(d) - std::chrono::duration_cast<std::chrono::seconds>(d);
+      d - std::chrono::duration_cast<std::chrono::seconds>(d);
   const auto subseconds =
       std::chrono::treat_as_floating_point<
           typename subsecond_precision::rep>::value
@@ -2127,8 +2107,14 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
     if (period::num != 1 || period::den != 1 ||
         std::is_floating_point<typename Duration::rep>::value) {
       const auto epoch = val.time_since_epoch();
-      const auto subsecs = std::chrono::duration_cast<Duration>(
+      auto subsecs = std::chrono::duration_cast<Duration>(
           epoch - std::chrono::duration_cast<std::chrono::seconds>(epoch));
+
+      if (subsecs.count() < 0) {
+        subsecs += std::chrono::seconds(1);
+        val -= std::chrono::seconds(1);
+      }
+
 
       return formatter<std::tm, Char>::do_format(
           gmtime(std::chrono::time_point_cast<std::chrono::seconds>(val)), ctx,

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -879,4 +879,12 @@ TEST(chrono_test, timestamps_sub_seconds) {
       t10(std::chrono::milliseconds(2000));
 
   EXPECT_EQ(fmt::format("{:%S}", t10), "02.000");
+
+  const auto tp11 = std::chrono::system_clock::from_time_t(0) +
+                    std::chrono::milliseconds(250);
+  EXPECT_EQ(fmt::format("{:%S}", tp11), "00.250000");
+
+  const auto tp12 = std::chrono::system_clock::from_time_t(0) -
+                    std::chrono::milliseconds(250);
+  EXPECT_EQ(fmt::format("{:%S}", tp12), "59.750000");
 }

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -883,10 +883,10 @@ TEST(chrono_test, timestamps_sub_seconds) {
   const auto tp11 = std::chrono::time_point_cast<std::chrono::milliseconds>(
       std::chrono::system_clock::from_time_t(0) +
       std::chrono::milliseconds(250));
-  EXPECT_EQ(fmt::format("{:%S}", tp11), "00.250000");
+  EXPECT_EQ(fmt::format("{:%S}", tp11), "00.250");
 
   const auto tp12 = std::chrono::time_point_cast<std::chrono::milliseconds>(
       std::chrono::system_clock::from_time_t(0) -
       std::chrono::milliseconds(250));
-  EXPECT_EQ(fmt::format("{:%S}", tp12), "59.750000");
+  EXPECT_EQ(fmt::format("{:%S}", tp12), "59.750");
 }

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -885,8 +885,8 @@ TEST(chrono_test, timestamps_sub_seconds) {
                                                std::chrono::milliseconds>();
     const auto d = std::chrono::milliseconds(250);
 
-    EXPECT_EQ("59.750", fmt::format("{:%S}", epoch - 1 * d));
+    EXPECT_EQ("59.750", fmt::format("{:%S}", epoch - d));
     EXPECT_EQ("00.000", fmt::format("{:%S}", epoch));
-    EXPECT_EQ("00.250", fmt::format("{:%S}", epoch + 1 * d));
+    EXPECT_EQ("00.250", fmt::format("{:%S}", epoch + d));
   }
 }

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -880,11 +880,13 @@ TEST(chrono_test, timestamps_sub_seconds) {
 
   EXPECT_EQ(fmt::format("{:%S}", t10), "02.000");
 
-  const auto tp11 = std::chrono::system_clock::from_time_t(0) +
-                    std::chrono::milliseconds(250);
+  const auto tp11 = std::chrono::time_point_cast<std::chrono::milliseconds>(
+      std::chrono::system_clock::from_time_t(0) +
+      std::chrono::milliseconds(250));
   EXPECT_EQ(fmt::format("{:%S}", tp11), "00.250000");
 
-  const auto tp12 = std::chrono::system_clock::from_time_t(0) -
-                    std::chrono::milliseconds(250);
+  const auto tp12 = std::chrono::time_point_cast<std::chrono::milliseconds>(
+      std::chrono::system_clock::from_time_t(0) -
+      std::chrono::milliseconds(250));
   EXPECT_EQ(fmt::format("{:%S}", tp12), "59.750000");
 }

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -885,14 +885,8 @@ TEST(chrono_test, timestamps_sub_seconds) {
                                                std::chrono::milliseconds>();
     const auto d = std::chrono::milliseconds(250);
 
-    EXPECT_EQ("59.000", fmt::format("{:%S}", epoch - 4 * d));
-    EXPECT_EQ("59.250", fmt::format("{:%S}", epoch - 3 * d));
-    EXPECT_EQ("59.500", fmt::format("{:%S}", epoch - 2 * d));
     EXPECT_EQ("59.750", fmt::format("{:%S}", epoch - 1 * d));
     EXPECT_EQ("00.000", fmt::format("{:%S}", epoch));
     EXPECT_EQ("00.250", fmt::format("{:%S}", epoch + 1 * d));
-    EXPECT_EQ("00.500", fmt::format("{:%S}", epoch + 2 * d));
-    EXPECT_EQ("00.750", fmt::format("{:%S}", epoch + 3 * d));
-    EXPECT_EQ("01.000", fmt::format("{:%S}", epoch + 4 * d));
   }
 }

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -880,13 +880,19 @@ TEST(chrono_test, timestamps_sub_seconds) {
 
   EXPECT_EQ(fmt::format("{:%S}", t10), "02.000");
 
-  const auto tp11 = std::chrono::time_point_cast<std::chrono::milliseconds>(
-      std::chrono::system_clock::from_time_t(0) +
-      std::chrono::milliseconds(250));
-  EXPECT_EQ(fmt::format("{:%S}", tp11), "00.250");
+  {
+    const auto epoch = std::chrono::time_point<std::chrono::system_clock,
+                                               std::chrono::milliseconds>();
+    const auto d = std::chrono::milliseconds(250);
 
-  const auto tp12 = std::chrono::time_point_cast<std::chrono::milliseconds>(
-      std::chrono::system_clock::from_time_t(0) -
-      std::chrono::milliseconds(250));
-  EXPECT_EQ(fmt::format("{:%S}", tp12), "59.750");
+    EXPECT_EQ("59.000", fmt::format("{:%S}", epoch - 4 * d));
+    EXPECT_EQ("59.250", fmt::format("{:%S}", epoch - 3 * d));
+    EXPECT_EQ("59.500", fmt::format("{:%S}", epoch - 2 * d));
+    EXPECT_EQ("59.750", fmt::format("{:%S}", epoch - 1 * d));
+    EXPECT_EQ("00.000", fmt::format("{:%S}", epoch));
+    EXPECT_EQ("00.250", fmt::format("{:%S}", epoch + 1 * d));
+    EXPECT_EQ("00.500", fmt::format("{:%S}", epoch + 2 * d));
+    EXPECT_EQ("00.750", fmt::format("{:%S}", epoch + 3 * d));
+    EXPECT_EQ("01.000", fmt::format("{:%S}", epoch + 4 * d));
+  }
 }


### PR DESCRIPTION
Fix #3117

The following piece of code (https://godbolt.org/z/4qr5389ns) used to print `59.000 00.750 00.500 00.250 00.000 00.250 00.500 00.750 01.000`, which is wrong. After this PR, it now correctly prints `59.000 59.250 59.500 59.750 00.000 00.250 00.500 00.750 01.000`

```cpp
const auto epoch = std::chrono::time_point<std::chrono::system_clock,
                                           std::chrono::milliseconds>();
const auto d = std::chrono::milliseconds(250);
for (int i = -4; i <= 4; i++) {
  fmt::print("{:%S} ", epoch + i * d);
}
```