### PR TITLE
Fix standard default installation target presence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ option(FMT_WERROR "Halt the compilation with an error on compiler warnings."
 
 # Options that control generation of various targets.
 option(FMT_DOC "Generate the doc target." ${FMT_MASTER_PROJECT})
-option(FMT_INSTALL "Generate the install target." ${FMT_MASTER_PROJECT})
+option(FMT_INSTALL "Generate the install target." ON)
 option(FMT_TEST "Generate the test target." ${FMT_MASTER_PROJECT})
 option(FMT_FUZZ "Generate the fuzz target." OFF)
 option(FMT_CUDA_TEST "Generate the cuda-test target." OFF)


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
Presently, for usage, installation, and packaging of the `fmt` library as transient dependency from third party CMake project, the extraneous `FMT_INSTALL` option needs to be set, this option is unexpected, needs to be discovered by users. 
```cmake
FetchContent_Declare(
  fmt
  GIT_REPOSITORY "https://github.com/fmtlib/fmt"
  FIND_PACKAGE_ARGS NAMES fmt)

# Note the non-standard required configuration option setting for installing, packaging the dependency:
option(FMT_INSTALL "Enable installation for the {fmt} project." ON)

FetchContent_MakeAvailable(fmt)
```
The CMake installation target for the `fmt` library should be present by default to conform to CMake defaults. Standard installation support simplifies usage in projects. The presence of the target, by default, allows standard CMake transient usage, installation, and packaging of the `fmt` library in other projects.

The extraneous configuration option can now be removed from projects using the library. Transient usage, packaging, installation follows. It simplifies usage. Users need not discover this option anymore. The library works like others. It would not override pre-installed, or pinned `fmt` library versions by downstream projects from CMake's _"first to record, wins" approach which is what allows hierarchical projects to have parent projects override content details of child projects._ Now, regular usage just works: 
```cmake
FetchContent_Declare(
  fmt
  GIT_REPOSITORY "https://github.com/fmtlib/fmt"
  FIND_PACKAGE_ARGS NAMES fmt)
FetchContent_MakeAvailable(fmt)
```
Reference: https://cmake.org/cmake/help/latest/module/FetchContent.html