### PR TITLE
Fix localized format for float-point numbers

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2547,7 +2547,7 @@ FMT_CONSTEXPR20 auto do_write_float(OutputIt out, const DecimalFP& f,
     int num_zeros = fspecs.showpoint ? fspecs.precision - significand_size : 0;
     size += 1 + to_unsigned(num_zeros > 0 ? num_zeros : 0);
     auto grouping = Grouping(loc, fspecs.locale);
-    size += to_unsigned(grouping.count_separators(significand_size));
+    size += to_unsigned(grouping.count_separators(exp));
     return write_padded<align::right>(out, specs, size, [&](iterator it) {
       if (sign) *it++ = detail::sign<Char>(sign);
       it = write_significand(it, significand, significand_size, exp,

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -438,6 +438,9 @@ TEST(locale_test, localized_double) {
   EXPECT_EQ(fmt::format(loc, "{:L}", 1234.5), "1~234?5");
   EXPECT_EQ(fmt::format(loc, "{:L}", 12000.0), "12~000");
   EXPECT_EQ(fmt::format(loc, "{:8L}", 1230.0), "   1~230");
+  EXPECT_EQ(fmt::format(loc, "{:15.6Lf}", 0.1), "       0?100000");
+  EXPECT_EQ(fmt::format(loc, "{:15.6Lf}", 1.0), "       1?000000");
+  EXPECT_EQ(fmt::format(loc, "{:15.6Lf}", 1e3), "   1~000?000000");
 }
 
 TEST(locale_test, format) {


### PR DESCRIPTION
Fix #3263

The following [piece of code](https://godbolt.org/z/53YjTMf6x) used to print `15, 9, 14`, which should be `15, 15, 15`. This PR fixes this issue. 
```cpp
#include <locale>
#include <fmt/format.h>

template <typename Char> struct numpunct : std::numpunct<Char> {
 protected:
  Char do_decimal_point() const override { return '.'; }
  std::string do_grouping() const override { return "\1"; }
  Char do_thousands_sep() const override { return ','; }
};

int main() {
  auto loc = std::locale(std::locale(), new numpunct<char>());
  auto i = fmt::format(loc, "{:15.6Lf}", 0.1).size();
  auto j = fmt::format(loc, "{:15.6Lf}", 1.0).size();
  auto k = fmt::format(loc, "{:15.6Lf}", 1e3).size();
  fmt::print("{}, {}, {}", i, j, k);
}
```

