### PR TITLE
Fix spec "{:}" for time point

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2180,7 +2180,7 @@ template <typename Char> struct formatter<std::tm, Char> {
   FMT_CONSTEXPR auto do_parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
     auto begin = ctx.begin(), end = ctx.end();
-    if (begin == end || *begin == '}') return end;
+    if (begin == end || *begin == '}') return begin;
 
     begin = detail::parse_align(begin, end, specs);
     if (begin == end) return end;

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -259,6 +259,7 @@ TEST(chrono_test, system_clock_time_point) {
       std::chrono::system_clock::now());
   EXPECT_EQ(strftime_full_utc(t1), fmt::format("{:%Y-%m-%d %H:%M:%S}", t1));
   EXPECT_EQ(strftime_full_utc(t1), fmt::format("{}", t1));
+  EXPECT_EQ(strftime_full_utc(t1), fmt::format("{:}", t1));
   using time_point =
       std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>;
   auto t2 = time_point(std::chrono::seconds(42));
@@ -365,6 +366,7 @@ TEST(chrono_test, local_system_clock_time_point) {
       std::chrono::current_zone()->to_local(std::chrono::system_clock::now()));
   EXPECT_EQ(strftime_full_local(t1), fmt::format("{:%Y-%m-%d %H:%M:%S}", t1));
   EXPECT_EQ(strftime_full_local(t1), fmt::format("{}", t1));
+  EXPECT_EQ(strftime_full_local(t1), fmt::format("{:}", t1));
   using time_point = std::chrono::local_time<std::chrono::seconds>;
   auto t2 = time_point(std::chrono::seconds(86400 + 42));
   EXPECT_EQ(strftime_full_local(t2), fmt::format("{:%Y-%m-%d %H:%M:%S}", t2));


### PR DESCRIPTION
My PR https://github.com/fmtlib/fmt/pull/3260 results in a `format_error` when formatting a timepoint with spec `{:}` due to a typo in parsing. This PR fixes the issue.  