### PR TITLE
Add formatters for container adapters

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -671,36 +671,29 @@ template <typename T> class is_container_adaptor_like {
   static constexpr const bool value =
       !std::is_void<decltype(check<T>(nullptr))>::value;
 };
-
-template <class T>
-auto get_container(T& t) ->
-    typename std::add_const<typename T::container_type>::type& {
-  struct getter : T {
-    static auto get(const T& t) ->
-        typename std::add_const<typename T::container_type>::type& {
-      return t.*(&getter::c); // Access c through the derived class.
-    }
-  };
-  return getter::get(t);
-}
-
 }  // namespace detail
 
 template <typename T, typename Char>
 struct formatter<T, Char,
                  enable_if_t<detail::is_container_adaptor_like<T>::value>> {
-  struct formatter<decltype(detail::get_container(std::declval<T&>())), Char>
-      container_formatter;
+ private:
+    struct formatter<typename T::container_type, Char> container_formatter;
 
+ public:
   template <typename ParseContext>
   FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
     return container_formatter.parse(ctx);
   }
 
   template <typename FormatContext>
-  auto format(const T& value, FormatContext& ctx) const ->
+  auto format(const T& t, FormatContext& ctx) const ->
       typename FormatContext::iterator {
-    return container_formatter.format(detail::get_container(value), ctx);
+    struct getter : T {
+      static auto get(const T& t) -> decltype(t.*(&getter::c)) {
+        return t.*(&getter::c);  // Access c through the derived class.
+      }
+    };
+    return container_formatter.format(getter::get(t), ctx);
   }
 };
 

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -675,25 +675,16 @@ template <typename T> class is_container_adaptor_like {
 
 template <typename T, typename Char>
 struct formatter<T, Char,
-                 enable_if_t<detail::is_container_adaptor_like<T>::value>> {
- private:
-    struct formatter<typename T::container_type, Char> container_formatter;
-
- public:
-  template <typename ParseContext>
-  FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
-    return container_formatter.parse(ctx);
-  }
-
+                 enable_if_t<detail::is_container_adaptor_like<T>::value>>
+    : formatter<typename T::container_type, Char> {
   template <typename FormatContext>
-  auto format(T& t, FormatContext& ctx) const ->
-      typename FormatContext::iterator {
+  auto format(T& t, FormatContext& ctx) const -> decltype(ctx.out()) {
     struct getter : T {
       static auto get(T& t) -> typename T::container_type& {
         return t.*(&getter::c);  // Access c through the derived class.
       }
     };
-    return container_formatter.format(getter::get(t), ctx);
+    return formatter<typename T::container_type>::format(getter::get(t), ctx);
   }
 };
 

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -686,10 +686,10 @@ struct formatter<T, Char,
   }
 
   template <typename FormatContext>
-  auto format(const T& t, FormatContext& ctx) const ->
+  auto format(T& t, FormatContext& ctx) const ->
       typename FormatContext::iterator {
     struct getter : T {
-      static auto get(const T& t) -> decltype(t.*(&getter::c)) {
+      static auto get(T& t) -> typename T::container_type& {
         return t.*(&getter::c);  // Access c through the derived class.
       }
     };

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -678,9 +678,9 @@ struct formatter<T, Char,
                  enable_if_t<detail::is_container_adaptor_like<T>::value>>
     : formatter<typename T::container_type, Char> {
   template <typename FormatContext>
-  auto format(T& t, FormatContext& ctx) const -> decltype(ctx.out()) {
+  auto format(const T& t, FormatContext& ctx) const -> decltype(ctx.out()) {
     struct getter : T {
-      static auto get(T& t) -> typename T::container_type& {
+      static auto get(const T& t) -> const typename T::container_type& {
         return t.*(&getter::c);  // Access c through the derived class.
       }
     };

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -427,13 +427,6 @@ TEST(ranges_test, container_adaptor) {
   }
 
   {
-    std::stack<int, std::vector<int>> s;
-    s.push(1);
-    s.push(2);
-    EXPECT_EQ(fmt::format("{}", s), "[1, 2]");
-  }
-
-  {
     std::queue<int> q;
     q.push(1);
     q.push(2);
@@ -447,6 +440,16 @@ TEST(ranges_test, container_adaptor) {
     q.push(2);
     q.push(4);
     EXPECT_EQ(fmt::format("{}", q), "[4, 3, 2, 1]");
+  }
+
+  {
+    std::stack<char, std::string> s;
+    s.push('a');
+    s.push('b');
+    // Note: The output is formatted as a string because the underlying
+    // container is a string. This behavior is conforming to the standard
+    // [container.adaptors.format].
+    EXPECT_EQ(fmt::format("{}", s), "ab");
   }
 
   {

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -424,6 +424,7 @@ TEST(ranges_test, container_adaptor) {
     s.push(1);
     s.push(2);
     EXPECT_EQ(fmt::format("{}", s), "[1, 2]");
+    EXPECT_EQ(fmt::format("{}", const_cast<const decltype(s)&>(s)), "[1, 2]");
   }
 
   {


### PR DESCRIPTION
Close #3215. 

https://eel.is/c++draft/container.adaptors.format specifies formatting for container adapters (`std::stack`, `std::queue`, and `std::priority_queue` in particular).

Not sure if the implementation should go into `ranges.h` or `std.h`. I'm putting it in `ranges.h` for now because I don't want to make `std.h` depend on `ranges.h`.

Container adapters have a protected member `Container c`, which can be exposed by defining a derived class. 