### PR TITLE
[msvc] fix warning about non-inline variable

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -281,6 +281,12 @@
 #  endif
 #endif
 
+#if defined __cpp_inline_variables && __cpp_inline_variables >=  201606L
+#    define FMT_INLINE_VARIABLE inline
+#else
+#    define FMT_INLINE_VARIABLE
+#endif
+
 // Enable minimal optimizations for more compact code in debug mode.
 FMT_GCC_PRAGMA("GCC push_options")
 #if !defined(__OPTIMIZE__) && !defined(__NVCOMPILER) && !defined(__LCC__)
@@ -2662,7 +2668,7 @@ FMT_CONSTEXPR auto check_char_specs(const format_specs<Char>& specs) -> bool {
   return true;
 }
 
-constexpr int invalid_arg_index = -1;
+constexpr FMT_INLINE_VARIABLE int invalid_arg_index = -1;
 
 #if FMT_USE_NONTYPE_TEMPLATE_ARGS
 template <int N, typename T, typename... Args, typename Char>

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -281,7 +281,7 @@
 #  endif
 #endif
 
-#if defined __cpp_inline_variables && __cpp_inline_variables >=  201606L
+#if defined __cpp_inline_variables && __cpp_inline_variables >= 201606L
 #    define FMT_INLINE_VARIABLE inline
 #else
 #    define FMT_INLINE_VARIABLE

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -680,7 +680,7 @@ FMT_CONSTEXPR inline auto utf8_decode(const char* s, uint32_t* c, int* e)
   return next;
 }
 
-constexpr uint32_t invalid_code_point = ~uint32_t();
+constexpr uint32_t FMT_INLINE_VARIABLE invalid_code_point = ~uint32_t();
 
 // Invokes f(cp, sv) for every code point cp in s with sv being the string view
 // corresponding to the code point. cp is invalid_code_point on error.


### PR DESCRIPTION
With MSVC 17.4.4, I'm getting a warning originating from fmt headers:

```
fmt\core.h(2909,15): warning C5260: the constant variable 'fmt::v9::detail::invalid_arg_index' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit
fmt\core.h(2909,15): message : to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
fmt\core.h(413,58): warning C5260: the constant variable 'fmt::v9::detail::micro' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit
fmt\core.h(413,58): message : to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
fmt\format.h(639,20): warning C5260: the constant variable 'fmt::v9::detail::invalid_code_point' has internal linkage in an included header file context, but external linkage in imported header unit context; consider declaring it 'inline' as well if it will be shared across translation units, or 'static' to express intent to use it local to this translation unit
fmt\format.h(639,20): message : to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings
```

It seems to me `inline` is the proper linkage specifier here, as the definition won't vary from compilation unit to compilation unit. 

However, since it's only a C++17 feature, I've only enabled it when the feature is detected. 