### PR TITLE
Add Optional Support

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -508,6 +508,7 @@ Standard Library Types Formatting
 * `std::thread::id <https://en.cppreference.com/w/cpp/thread/thread/id>`_
 * `std::monostate <https://en.cppreference.com/w/cpp/utility/variant/monostate>`_
 * `std::variant <https://en.cppreference.com/w/cpp/utility/variant/variant>`_
+* `std::optional <https://en.cppreference.com/w/cpp/utility/optional>`_
 
 Formatting Variants
 -------------------

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -29,6 +29,9 @@
 #  if FMT_HAS_INCLUDE(<variant>)
 #    include <variant>
 #  endif
+#  if FMT_HAS_INCLUDE(<optional>)
+#    include <optional>
+#  endif
 #endif
 
 // GCC 4 does not support FMT_HAS_INCLUDE.
@@ -90,6 +93,49 @@ FMT_BEGIN_NAMESPACE
 template <typename Char>
 struct formatter<std::thread::id, Char> : basic_ostream_formatter<Char> {};
 FMT_END_NAMESPACE
+
+#ifdef __cpp_lib_optional
+FMT_BEGIN_NAMESPACE
+template <typename T, typename Char>
+struct formatter<std::optional<T>, Char,
+                 std::enable_if_t<is_formattable<T>::value>> {
+ private:
+  formatter<T, Char> underlying_;
+  static constexpr basic_string_view<Char> optional =
+      detail::string_literal<Char, 'o', 'p', 't', 'i', 'o', 'n', 'a', 'l',
+                             '('>{};
+  static constexpr basic_string_view<Char> none =
+      detail::string_literal<Char, 'n', 'o', 'n', 'e'>{};
+
+  template <class U>
+  FMT_CONSTEXPR static auto maybe_set_debug_format(U& u, bool set)
+      -> decltype(u.set_debug_format(set)) {
+    u.set_debug_format(set);
+  }
+
+  template <class U>
+  FMT_CONSTEXPR static void maybe_set_debug_format(U&, ...) {}
+
+ public:
+  template <typename ParseContext> FMT_CONSTEXPR auto parse(ParseContext& ctx) {
+    maybe_set_debug_format(underlying_, true);
+    return underlying_.parse(ctx);
+  }
+
+  template <typename FormatContext>
+  auto format(std::optional<T> const& opt, FormatContext& ctx) const
+      -> decltype(ctx.out()) {
+    if (not opt) return detail::write<Char>(ctx.out(), none);
+
+    auto out = ctx.out();
+    out = detail::write<Char>(out, optional);
+    ctx.advance_to(out);
+    out = underlying_.format(*opt, ctx);
+    return detail::write(out, ')');
+  }
+};
+FMT_END_NAMESPACE
+#endif  // __cpp_lib_optional
 
 #ifdef __cpp_lib_variant
 FMT_BEGIN_NAMESPACE

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -98,7 +98,7 @@ FMT_END_NAMESPACE
 FMT_BEGIN_NAMESPACE
 template <typename T, typename Char>
 struct formatter<std::optional<T>, Char,
-                 std::enable_if_t<is_formattable<T>::value>> {
+                 std::enable_if_t<is_formattable<T, Char>::value>> {
  private:
   formatter<T, Char> underlying_;
   static constexpr basic_string_view<Char> optional =

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -125,7 +125,7 @@ struct formatter<std::optional<T>, Char,
   template <typename FormatContext>
   auto format(std::optional<T> const& opt, FormatContext& ctx) const
       -> decltype(ctx.out()) {
-    if (not opt) return detail::write<Char>(ctx.out(), none);
+    if (!opt) return detail::write<Char>(ctx.out(), none);
 
     auto out = ctx.out();
     out = detail::write<Char>(out, optional);

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -59,8 +59,7 @@ TEST(std_test, optional) {
                                           std::optional{3}}),
             "[optional(1), optional(2), optional(3)]");
   EXPECT_EQ(
-      fmt::format("{}", std::optional<std::optional<const char*>>{std::optional{
-                            "nested"}}),
+      fmt::format("{}", std::optional<std::optional<const char*>>{{"nested"}}),
       "optional(optional(\"nested\"))");
   EXPECT_EQ(
       fmt::format("{:<{}}", std::optional{std::string{"left aligned"}}, 30),

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -12,6 +12,7 @@
 
 #include "fmt/os.h"  // fmt::system_category
 #include "fmt/ranges.h"
+#include "fmt/xchar.h"
 #include "gtest-extra.h"  // StartsWith
 
 using testing::StartsWith;
@@ -48,6 +49,35 @@ TEST(ranges_std_test, format_vector_path) {
 
 TEST(std_test, thread_id) {
   EXPECT_FALSE(fmt::format("{}", std::this_thread::get_id()).empty());
+}
+
+TEST(std_test, optional) {
+#ifdef __cpp_lib_optional
+  EXPECT_EQ(fmt::format(L"{}", std::optional<int>{}), L"none");
+  EXPECT_EQ(fmt::format("{}", std::pair{1, "second"}), "(1, \"second\")");
+  EXPECT_EQ(fmt::format("{}", std::vector{std::optional{1}, std::optional{2},
+                                          std::optional{3}}),
+            "[optional(1), optional(2), optional(3)]");
+  EXPECT_EQ(
+      fmt::format("{}", std::optional<std::optional<const char*>>{std::optional{
+                            "nested"}}),
+      "optional(optional(\"nested\"))");
+  EXPECT_EQ(
+      fmt::format("{:<{}}", std::optional{std::string{"left aligned"}}, 30),
+      "optional(\"left aligned\"                )");
+  EXPECT_EQ(
+      fmt::format("{::d}", std::optional{std::vector{'h', 'e', 'l', 'l', 'o'}}),
+      "optional([104, 101, 108, 108, 111])");
+  EXPECT_EQ(fmt::format("{}", std::optional{std::string{"string"}}),
+            "optional(\"string\")");
+  EXPECT_EQ(fmt::format("{}", std::optional{'C'}), "optional(\'C\')");
+  EXPECT_EQ(fmt::format("{:.{}f}", std::optional{3.14}, 1), "optional(3.1)");
+
+  struct unformattable {};
+  EXPECT_FALSE((fmt::is_formattable<unformattable>::value));
+  EXPECT_FALSE((fmt::is_formattable<std::optional<unformattable>>::value));
+  EXPECT_TRUE((fmt::is_formattable<std::optional<int>>::value));
+#endif
 }
 
 TEST(std_test, variant) {

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -12,7 +12,6 @@
 
 #include "fmt/os.h"  // fmt::system_category
 #include "fmt/ranges.h"
-#include "fmt/xchar.h"
 #include "gtest-extra.h"  // StartsWith
 
 using testing::StartsWith;
@@ -53,7 +52,7 @@ TEST(std_test, thread_id) {
 
 TEST(std_test, optional) {
 #ifdef __cpp_lib_optional
-  EXPECT_EQ(fmt::format(L"{}", std::optional<int>{}), L"none");
+  EXPECT_EQ(fmt::format("{}", std::optional<int>{}), "none");
   EXPECT_EQ(fmt::format("{}", std::pair{1, "second"}), "(1, \"second\")");
   EXPECT_EQ(fmt::format("{}", std::vector{std::optional{1}, std::optional{2},
                                           std::optional{3}}),

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -16,6 +16,7 @@
 #include "fmt/color.h"
 #include "fmt/ostream.h"
 #include "fmt/ranges.h"
+#include "fmt/std.h"
 #include "gtest-extra.h"  // Contains
 #include "util.h"         // get_locale
 
@@ -586,6 +587,14 @@ TEST(locale_test, chrono_weekday) {
 
 TEST(locale_test, sign) {
   EXPECT_EQ(fmt::format(std::locale(), L"{:L}", -50), L"-50");
+}
+
+TEST(std_test_xchar, optional) {
+#  ifdef __cpp_lib_optional
+  EXPECT_EQ(fmt::format(L"{}", std::optional{L'C'}), L"optional(\'C\')");
+  EXPECT_EQ(fmt::format(L"{}", std::optional{std::wstring{L"wide string"}}),
+            L"optional(\"wide string\")");
+#  endif
 }
 
 #endif  // FMT_STATIC_THOUSANDS_SEPARATOR


### PR DESCRIPTION
A formatter for `std::optional` as per https://github.com/fmtlib/fmt/issues/1367#issuecomment-1171254031

The code is just copied from barry's [slideware](https://www.youtube.com/watch?v=EQELdyecZlU) where the specifier just get parsed through to the formatter of the underling type.

As such there is no customization of printing of the optional's container for which I originally went with the opinionated `Some(...)` and `None`, but then changed to `Option(...)` and `Empty`. I'm not very convinced about `nullopt` when you're trying to study complicated output:
> {(50258, 0, None), (50364, 0, None), (538, 0, Some(" by")), (428, 42, Some(" your")), (9827, 100, Some(" spell")), (11, 100, Some(",")), (457, 121, Some(" but")), (4374, 100, Some(" release")), (385, 142, Some(" me")), (490, 156, Some(" from")), (452, 168, Some(" my")), (13543, 177, Some(" bands")), (11, 260, Some(",")), (365, 264, Some(" with")), (264, 268, Some(" the")), (854, 270, Some(" help")), (295, 282, Some(" of")), (428, 290, Some(" your")), (665, 300, Some(" good")), (2377, 312, Some(" hands")), (13, 350, Some(".")), (26214, 374, Some(" Gentle")), (6045, 442, Some(" breath")), (50816, 452, None), (50816, 452, None), (295, 1223, Some(" of")), (6342, 487, Some(" yours")), ...

>{(50258, 0, Empty), (50364, 0, Empty), (538, 0, Option(" by")), (428, 42, Option(" your")), (9827, 100, Option(" spell")), (11, 100, Option(",")), (457, 121, Option(" but")), (4374, 100, Option(" release")), (385, 142, Option(" me")), (490, 156, Option(" from")), (452, 168, Option(" my")), (13543, 177, Option(" bands")), (11, 260, Option(",")), (365, 264, Option(" with")), (264, 268, Option(" the")), (854, 270, Option(" help")), (295, 282, Option(" of")), (428, 290, Option(" your")), (665, 300, Option(" good")), (2377, 312, Option(" hands")), (13, 350, Option(".")), (26214, 374, Option(" Gentle")), (6045, 442, Option(" breath")), (50816, 452, Empty), (50816, 452, Empty), (295, 1223, Option(" of")), ...