### PR TITLE
Improve fmt::print*

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -587,8 +587,25 @@ void print(std::FILE* f, const S& format_str, const Args&... args) {
 
 template <typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
+void println(std::FILE* f, const S& format_str, const Args&... args) {
+  memory_buffer buffer;
+  using Char = typename S::char_type;
+  Char suffix[] = {Char('\n'), 0};
+  fmt::format_to(std::back_inserter(buffer), format_str, args...);
+  buffer.append(suffix, suffix + 1);
+  detail::print(f, {buffer.data(), buffer.size()});
+}
+
+template <typename S, typename... Args,
+          FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
 void print(const S& format_str, const Args&... args) {
   print(stdout, format_str, args...);
+}
+
+template <typename S, typename... Args,
+          FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
+void println(const S& format_str, const Args&... args) {
+  println(stdout, format_str, args...);
 }
 
 #if FMT_USE_NONTYPE_TEMPLATE_ARGS

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2778,12 +2778,11 @@ void vformat_to(buffer<Char>& buf, basic_string_view<Char> fmt,
 
 FMT_API void vprint(std::FILE* f, string_view format_str, format_args args,
                     string_view suffix);
-FMT_API void vprint_mojibake(std::FILE*, string_view, format_args, string_view);
-FMT_API void vprint_mojibake(std::FILE*, string_view, format_args);
+FMT_API void vprint_mojibake(std::FILE*, string_view, format_args,
+                             string_view = {});
 #ifndef _WIN32
 inline void vprint_mojibake(std::FILE*, string_view, format_args, string_view) {
 }
-inline void vprint_mojibake(std::FILE*, string_view, format_args) {}
 #endif
 FMT_END_DETAIL_NAMESPACE
 
@@ -2983,8 +2982,12 @@ FMT_NODISCARD FMT_INLINE auto formatted_size(format_string<T...> fmt,
   return buf.count();
 }
 
-FMT_API void vprint(string_view fmt, format_args args);
-FMT_API void vprint(std::FILE* f, string_view fmt, format_args args);
+inline void vprint(std::FILE* f, string_view fmt, format_args args) {
+  detail::vprint(f, fmt, args, {});
+}
+inline void vprint(string_view fmt, format_args args) {
+  vprint(stdout, fmt, args);
+}
 
 /**
   \rst

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1482,22 +1482,34 @@ FMT_FUNC void print(std::FILE* f, string_view text) {
 #endif
   detail::fwrite_fully(text.data(), 1, text.size(), f);
 }
+
+FMT_FUNC void vprint(std::FILE* f, string_view format_str, format_args args,
+                     string_view suffix) {
+  memory_buffer buffer;
+  detail::vformat_to(buffer, format_str, args);
+  buffer.append(suffix);
+  detail::print(f, {buffer.data(), buffer.size()});
+}
+
 }  // namespace detail
 
 FMT_FUNC void vprint(std::FILE* f, string_view format_str, format_args args) {
-  memory_buffer buffer;
-  detail::vformat_to(buffer, format_str, args);
-  detail::print(f, {buffer.data(), buffer.size()});
+  detail::vprint(f, format_str, args, {});
 }
 
 #ifdef _WIN32
 // Print assuming legacy (non-Unicode) encoding.
 FMT_FUNC void detail::vprint_mojibake(std::FILE* f, string_view format_str,
-                                      format_args args) {
+                                      format_args args, string_view suffix) {
   memory_buffer buffer;
   detail::vformat_to(buffer, format_str,
                      basic_format_args<buffer_context<char>>(args));
+  buffer.append(suffix);
   fwrite_fully(buffer.data(), 1, buffer.size(), f);
+}
+FMT_FUNC void detail::vprint_mojibake(std::FILE* f, string_view format_str,
+                                      format_args args) {
+  vprint_mojibake(f, format_str, args, {});
 }
 #endif
 

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1490,12 +1490,7 @@ FMT_FUNC void vprint(std::FILE* f, string_view format_str, format_args args,
   buffer.append(suffix);
   detail::print(f, {buffer.data(), buffer.size()});
 }
-
 }  // namespace detail
-
-FMT_FUNC void vprint(std::FILE* f, string_view format_str, format_args args) {
-  detail::vprint(f, format_str, args, {});
-}
 
 #ifdef _WIN32
 // Print assuming legacy (non-Unicode) encoding.
@@ -1507,15 +1502,7 @@ FMT_FUNC void detail::vprint_mojibake(std::FILE* f, string_view format_str,
   buffer.append(suffix);
   fwrite_fully(buffer.data(), 1, buffer.size(), f);
 }
-FMT_FUNC void detail::vprint_mojibake(std::FILE* f, string_view format_str,
-                                      format_args args) {
-  vprint_mojibake(f, format_str, args, {});
-}
 #endif
-
-FMT_FUNC void vprint(string_view format_str, format_args args) {
-  vprint(stdout, format_str, args);
-}
 
 namespace detail {
 

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -284,8 +284,12 @@ TEST(compile_test, to_string_and_formatter) {
 TEST(compile_test, print) {
   EXPECT_WRITE(stdout, fmt::print(FMT_COMPILE("Don't {}!"), "panic"),
                "Don't panic!");
+  EXPECT_WRITE(stdout, fmt::print(FMT_COMPILE("Don't {}!\n"), "panic"),
+               "Don't panic!\n");
   EXPECT_WRITE(stderr, fmt::print(stderr, FMT_COMPILE("Don't {}!"), "panic"),
                "Don't panic!");
+  EXPECT_WRITE(stderr, fmt::print(stderr, FMT_COMPILE("Don't {}!\n"), "panic"),
+               "Don't panic!\n");
 }
 #endif
 


### PR DESCRIPTION
*) Reduce the memory allocations
*) Reduce symbols (with ABI break)
*) Add ``println`` for compiled format string