### PR TITLE
Fix various typos

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -64,10 +64,10 @@ jobs:
 
     - name: Add repositories for older GCC
       run: |
-        # Bellow two repos provide GCC 4.8, 5.5 and 6.4
+        # Below two repos provide GCC 4.8, 5.5 and 6.4
         sudo apt-add-repository 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic main'
         sudo apt-add-repository 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic universe'
-        # Bellow two repos additionally update GCC 6 to 6.5
+        # Below two repos additionally update GCC 6 to 6.5
         # sudo apt-add-repository 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic-updates main'
         # sudo apt-add-repository 'deb http://azure.archive.ubuntu.com/ubuntu/ bionic-updates universe'
       if: ${{ matrix.cxx == 'g++-4.8' }}

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2260,7 +2260,7 @@
   <https://github.com/kwesolowski>`_.
 
 * Replaced ``FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`` with the ``FMT_FUZZ``
-  macro to prevent interferring with fuzzing of projects using {fmt}
+  macro to prevent interfering with fuzzing of projects using {fmt}
   (`#1650 <https://github.com/fmtlib/fmt/pull/1650>`_).
   Thanks `@asraa (Asra Ali) <https://github.com/asraa>`_.
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1156,7 +1156,7 @@ void write_fractional_seconds(OutputIt& out, Duration d, int precision = -1) {
   }
 }
 
-// Format subseconds which are given as a floating point type with an appropiate
+// Format subseconds which are given as a floating point type with an appropriate
 // number of digits. We cannot pass the Duration here, as we explicitly need to
 // pass the Rep value in the chrono_formatter.
 template <typename Duration>

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -34,7 +34,7 @@
 // GCC 4 does not support FMT_HAS_INCLUDE.
 #if FMT_HAS_INCLUDE(<cxxabi.h>) || defined(__GLIBCXX__)
 #  include <cxxabi.h>
-// Android NDK with gabi++ library on some archtectures does not implement
+// Android NDK with gabi++ library on some architectures does not implement
 // abi::__cxa_demangle().
 #  ifndef __GABIXX_CXXABI_H__
 #    define FMT_HAS_ABI_CXA_DEMANGLE

--- a/test/module-test.cc
+++ b/test/module-test.cc
@@ -111,7 +111,7 @@ TEST(module_test, macros) {
 // but rather visibility of all client-facing overloads, reachability of
 // non-exported entities, name lookup and overload resolution within
 // template instantitions.
-// Excercise all exported entities of the API at least once.
+// Exercise all exported entities of the API at least once.
 // Instantiate as many code paths as possible.
 
 TEST(module_test, to_string) {

--- a/test/util.h
+++ b/test/util.h
@@ -81,5 +81,5 @@ class date {
   int day() const { return day_; }
 };
 
-// Returns a locale with the given name if available or classic locale othewise.
+// Returns a locale with the given name if available or classic locale otherwise.
 std::locale get_locale(const char* name, const char* alt_name = nullptr);


### PR DESCRIPTION
Found via `codespell -q 3 -S ./test/gtest -L "fo,pres,seh,wronly"`

By submitting this pull request, I agree that my contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
