### PR TITLE
Support %P (lowercase am/pm) glibc extension

### DIFF
--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -315,8 +315,8 @@ Format specifications for chrono duration and time point types as well as
    modifier: "E" | "O"
    chrono_type: "a" | "A" | "b" | "B" | "c" | "C" | "d" | "D" | "e" | "F" |
               : "g" | "G" | "h" | "H" | "I" | "j" | "m" | "M" | "n" | "p" |
-              : "q" | "Q" | "r" | "R" | "S" | "t" | "T" | "u" | "U" | "V" |
-              : "w" | "W" | "x" | "X" | "y" | "Y" | "z" | "Z" | "%"
+              : "P" | "q" | "Q" | "r" | "R" | "S" | "t" | "T" | "u" | "U" |
+              : "V" | "w" | "W" | "x" | "X" | "y" | "Y" | "z" | "Z" | "%"
 
 Literal chars are copied unchanged to the output. Precision is valid only for
 ``std::chrono::duration`` types with a floating-point representation type.
@@ -395,6 +395,8 @@ The available presentation types (*chrono_type*) are:
 | ``'n'`` | A new-line character.                                              |
 +---------+--------------------------------------------------------------------+
 | ``'p'`` | The AM/PM designations associated with a 12-hour clock.            |
++---------+--------------------------------------------------------------------+
+| ``'P'`` | ``%p``, but lowercase (am/pm). (GNU/glibc extension.)              |
 +---------+--------------------------------------------------------------------+
 | ``'q'`` | The duration's unit suffix.                                        |
 +---------+--------------------------------------------------------------------+

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -973,4 +973,12 @@ TEST(chrono_test, glibc_extensions) {
     EXPECT_EQ(fmt::format("{:%_S}", d), " 3.140000");
     EXPECT_EQ(fmt::format("{:%-S}", d), "3.140000");
   }
+
+  {
+    // %p is standard, %P is glibc
+    const auto tm_am = make_tm(1970, 1, 1, 0, 0, 0);
+    const auto tm_pm = make_tm(1970, 1, 1, 12, 0, 0);
+    EXPECT_EQ(fmt::format("{:%p,%P}", tm_am), "AM,am");
+    EXPECT_EQ(fmt::format("{:%p,%P}", tm_pm), "PM,pm");
+  }
 }


### PR DESCRIPTION
Fun fact: in glibc you can also spell %P %#p, # meaning “swap case”. I haven’t implemented glibc’s ^ or # flags (and don’t think there’s any particularly urgent need for it, so long as %P is around).

----

When #2544 broke this functionality for me and many other users of Waybar, I gathered from the response in #2811 that there was *actively* no interest in supporting glibc extensions. But now that #3271 has added the other important glibc extension (unpadded hours), I figured it might be worth making and trying submitting this patch after all.

The naming is arbitrary, and the code order for a quite possibly misguided form of consistency. I’m not fussed about it, feel free to amend it as you desire.