### PR TITLE
Enable consteval for Xcode 14 and later

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -258,11 +258,13 @@
 #endif
 
 #ifndef FMT_CONSTEVAL
-#  if ((FMT_GCC_VERSION >= 1000 || FMT_CLANG_VERSION >= 1101) &&         \
-       FMT_CPLUSPLUS >= 202002L && !defined(__apple_build_version__)) || \
-      (defined(__cpp_consteval) &&                                       \
+#  if ((FMT_GCC_VERSION >= 1000 || FMT_CLANG_VERSION >= 1101) && \
+       (!defined(__apple_build_version__) ||                     \
+        __apple_build_version__ >= 14000029L) &&                 \
+       FMT_CPLUSPLUS >= 202002L) ||                              \
+      (defined(__cpp_consteval) &&                               \
        (!FMT_MSC_VERSION || _MSC_FULL_VER >= 193030704))
-// consteval is broken in MSVC before VS2022 and Apple clang 13.
+// consteval is broken in MSVC before VS2022 and Apple clang before 14.
 #    define FMT_CONSTEVAL consteval
 #    define FMT_HAS_CONSTEVAL
 #  else


### PR DESCRIPTION
The consteval problems that affected clang from Xcode 13 and earlier have been fixed in Xcode 14.  This patch just makes the Xcode exclusion a little more targeted.

Tested on an Apple Silicon Mac running macOS 13.2 with Xcode 14.0.1, Xcode 14.2.0, Xcode 14.3 beta, and some later internal builds.  I did actually also test with Xcode 13.4, and it was fine, but that's not a supported config so I'm not going to officially claim it works. 😄 

Build (including with `FMT_PEDANTIC`) and tests all pass, both in C++11 and C++20 modes.  (The default is C++98, so not setting `CMAKE_CXX_STANDARD` really isn't an option.)

C++11 (`make && make test`):
~~~
-- CMake version: 3.25.2
-- The CXX compiler identification is AppleClang 14.0.0.14000029
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode-14A.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Module support is disabled.
-- Version: 9.1.1
-- Build type: Release
-- Performing Test HAS_NULLPTR_WARNING
-- Performing Test HAS_NULLPTR_WARNING - Success
-- Target 'doc' disabled (requires doxygen)
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Looking for strptime
-- Looking for strptime - found
-- FMT_PEDANTIC: ON
-- Performing Test HAVE_FNO_EXCEPTIONS_FLAG
-- Performing Test HAVE_FNO_EXCEPTIONS_FLAG - Success
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/cloyce/src-ext/fmt-cds/b14A-11
[...]
Running tests...
Test project /Users/cloyce/src-ext/fmt-cds/b14A-11
      Start  1: args-test
 1/24 Test  #1: args-test ........................   Passed    0.00 sec
      Start  2: assert-test
 2/24 Test  #2: assert-test ......................   Passed    0.00 sec
      Start  3: chrono-test
 3/24 Test  #3: chrono-test ......................   Passed    0.03 sec
      Start  4: color-test
 4/24 Test  #4: color-test .......................   Passed    0.00 sec
      Start  5: core-test
 5/24 Test  #5: core-test ........................   Passed    0.00 sec
      Start  6: gtest-extra-test
 6/24 Test  #6: gtest-extra-test .................   Passed    0.00 sec
      Start  7: format-test
 7/24 Test  #7: format-test ......................   Passed    0.01 sec
      Start  8: format-impl-test
 8/24 Test  #8: format-impl-test .................   Passed    0.02 sec
      Start  9: ostream-test
 9/24 Test  #9: ostream-test .....................   Passed    0.01 sec
      Start 10: compile-test
10/24 Test #10: compile-test .....................   Passed    0.00 sec
      Start 11: compile-fp-test
11/24 Test #11: compile-fp-test ..................   Passed    0.00 sec
      Start 12: printf-test
12/24 Test #12: printf-test ......................   Passed    0.00 sec
      Start 13: ranges-test
13/24 Test #13: ranges-test ......................   Passed    0.01 sec
      Start 14: scan-test
14/24 Test #14: scan-test ........................   Passed    0.00 sec
      Start 15: std-test
15/24 Test #15: std-test .........................   Passed    0.00 sec
      Start 16: unicode-test
16/24 Test #16: unicode-test .....................   Passed    0.00 sec
      Start 17: xchar-test
17/24 Test #17: xchar-test .......................   Passed    0.00 sec
      Start 18: enforce-checks-test
18/24 Test #18: enforce-checks-test ..............   Passed    0.00 sec
      Start 19: posix-mock-test
19/24 Test #19: posix-mock-test ..................   Passed    0.00 sec
      Start 20: os-test
20/24 Test #20: os-test ..........................   Passed    0.00 sec
      Start 21: compile-error-test
21/24 Test #21: compile-error-test ...............   Passed    5.42 sec
      Start 22: find-package-test
22/24 Test #22: find-package-test ................   Passed    2.46 sec
      Start 23: add-subdirectory-test
23/24 Test #23: add-subdirectory-test ............   Passed    3.85 sec
      Start 24: static-export-test
24/24 Test #24: static-export-test ...............   Passed    7.25 sec

100% tests passed, 0 tests failed out of 24

Total Test time (real) =  19.13 sec
~~~



C++20 (`make && make test`):
~~~
-- CMake version: 3.25.2
-- The CXX compiler identification is AppleClang 14.0.0.14000029
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode-14A.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Version: 9.1.1
-- Build type: Release
-- Performing Test HAS_NULLPTR_WARNING
-- Performing Test HAS_NULLPTR_WARNING - Success
-- Target 'doc' disabled (requires doxygen)
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Looking for strptime
-- Looking for strptime - found
-- FMT_PEDANTIC: ON
-- Performing Test HAVE_FNO_EXCEPTIONS_FLAG
-- Performing Test HAVE_FNO_EXCEPTIONS_FLAG - Success
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/cloyce/src-ext/fmt-cds/b14A-20
[...]
Running tests...
Test project /Users/cloyce/src-ext/fmt-cds/b14A-20
      Start  1: args-test
 1/24 Test  #1: args-test ........................   Passed    0.01 sec
      Start  2: assert-test
 2/24 Test  #2: assert-test ......................   Passed    0.01 sec
      Start  3: chrono-test
 3/24 Test  #3: chrono-test ......................   Passed    0.06 sec
      Start  4: color-test
 4/24 Test  #4: color-test .......................   Passed    0.01 sec
      Start  5: core-test
 5/24 Test  #5: core-test ........................   Passed    0.02 sec
      Start  6: gtest-extra-test
 6/24 Test  #6: gtest-extra-test .................   Passed    0.01 sec
      Start  7: format-test
 7/24 Test  #7: format-test ......................   Passed    0.03 sec
      Start  8: format-impl-test
 8/24 Test  #8: format-impl-test .................   Passed    0.03 sec
      Start  9: ostream-test
 9/24 Test  #9: ostream-test .....................   Passed    0.01 sec
      Start 10: compile-test
10/24 Test #10: compile-test .....................   Passed    0.01 sec
      Start 11: compile-fp-test
11/24 Test #11: compile-fp-test ..................   Passed    0.01 sec
      Start 12: printf-test
12/24 Test #12: printf-test ......................   Passed    0.00 sec
      Start 13: ranges-test
13/24 Test #13: ranges-test ......................   Passed    0.01 sec
      Start 14: scan-test
14/24 Test #14: scan-test ........................   Passed    0.01 sec
      Start 15: std-test
15/24 Test #15: std-test .........................   Passed    0.01 sec
      Start 16: unicode-test
16/24 Test #16: unicode-test .....................   Passed    0.02 sec
      Start 17: xchar-test
17/24 Test #17: xchar-test .......................   Passed    0.01 sec
      Start 18: enforce-checks-test
18/24 Test #18: enforce-checks-test ..............   Passed    0.01 sec
      Start 19: posix-mock-test
19/24 Test #19: posix-mock-test ..................   Passed    0.01 sec
      Start 20: os-test
20/24 Test #20: os-test ..........................   Passed    0.01 sec
      Start 21: compile-error-test
21/24 Test #21: compile-error-test ...............   Passed   17.37 sec
      Start 22: find-package-test
22/24 Test #22: find-package-test ................   Passed    2.35 sec
      Start 23: add-subdirectory-test
23/24 Test #23: add-subdirectory-test ............   Passed    4.10 sec
      Start 24: static-export-test
24/24 Test #24: static-export-test ...............   Passed    2.98 sec

100% tests passed, 0 tests failed out of 24

Total Test time (real) =  27.16 sec
~~~

Building the fuzzers fails in C++20 mode, but I also observed that on LLVM 14 on Linux/x86, so I don't consider that a regression.