### PR TITLE
Fix code causing spurious Wstringop-overflow warning

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2218,7 +2218,7 @@ FMT_CONSTEXPR inline auto code_point_length_impl(char c) -> int {
 // This is useful because it allows the compiler to check that the
 // length is within the range [1, 4]
 FMT_CONSTEXPR inline auto code_point_length_impl_2(char c) -> int {
-  return ((0x3a55000000000000ull >> (2 * (static_cast<unsigned char>(c) >> 3))) & 0x3) + 1;
+  return static_cast<int>((0x3a55000000000000ull >> (2 * (static_cast<unsigned char>(c) >> 3))) & 0x3) + 1;
 }
 
 template <typename Char>

--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -898,3 +898,18 @@ TEST(core_test, has_const_formatter) {
 TEST(core_test, format_nonconst) {
   EXPECT_EQ(fmt::format("{}", nonconst_formattable()), "test");
 }
+
+TEST(core_test, code_point_length_impl) {
+  // code_point_length_impl_2 is a bit-shifted version of code_point_length_impl
+  // that returns 1 for invalid codepoints, so that length is always in [1..4]
+  int min = CHAR_MIN;
+  int max = CHAR_MAX;
+
+  for(int ch = min; ch <= max; ch++) {
+    char c = static_cast<char>(ch);
+    int len1 = fmt::detail::code_point_length_impl(c);
+    int len2 = fmt::detail::code_point_length_impl_2(c);
+
+    ASSERT_EQ(len1 + !len1, len2);
+  }
+}


### PR DESCRIPTION
Despite attempts to disable `-Wstringop-overflow` for tests, building the library from source still results in spurious Wstringop-overflow warnings. This occurs both for downstream consumers (eg, those using CMake Package Manager), and for people building the library from scratch.

Rather than attempting to disable the warning, I've modified the code such that the compiler is able to "figure out" that `fmt::detail::code_point_length` returns a value between 1 and 4, inclusive. The change also allows using bitshifts to calculate the codepoint length, which avoids a second array access.

While the `Wstringop-overflow` warning *was* spurious in this case, the new code should be more performant, and downstream consumers will no longer have the headache of dealing with a spurious warning when compiling their code. 

See Issue #2989, as well as #3054.