### PR TITLE
Cleanup dead variable

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -437,7 +437,6 @@ struct range_formatter<
                     detail::has_fallback_formatter<T, Char>>>::value>> {
  private:
   detail::range_formatter_type<Char, T> underlying_;
-  bool custom_specs_ = false;
   basic_string_view<Char> separator_ = detail::string_literal<Char, ',', ' '>{};
   basic_string_view<Char> opening_bracket_ =
       detail::string_literal<Char, '['>{};
@@ -473,7 +472,6 @@ struct range_formatter<
 
     if (it != end && *it != '}') {
       if (*it != ':') FMT_THROW(format_error("invalid format specifier"));
-      custom_specs_ = true;
       ++it;
     } else {
       detail::maybe_set_debug_format(underlying_, true);


### PR DESCRIPTION
`custom_specs_` is introduced in https://github.com/fmtlib/fmt/pull/2673/files#diff-6ac6e767e83158d3347137b8f2ca90a37cb361e79c27fc3ba6a935074c26a342R646

The variable is unused after the removal of `if (custom_specs_)` in https://github.com/fmtlib/fmt/pull/2983/files#diff-6ac6e767e83158d3347137b8f2ca90a37cb361e79c27fc3ba6a935074c26a342L466 