### PR TITLE
Fix GCC6 compilation error in `count_digits`

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1107,7 +1107,7 @@ FMT_CONSTEXPR auto count_digits(UInt n) -> int {
     return (FMT_BUILTIN_CLZ(static_cast<uint32_t>(n) | 1) ^ 31) / BITS + 1;
 #endif
   // Lambda avoids unreachable code warnings from NVHPC.
-  return [](UInt m) {
+  return [](UInt m) -> int {
     int num_digits = 0;
     do {
       ++num_digits;


### PR DESCRIPTION
GCC6 appears to need the explicit return type there.

Otherwise, it fails with:

> error: use of 'fmt::v9::detail::count_digits(UInt)::<lambda(UInt)> [with int BITS = 4; UInt = long long unsigned int]' before deduction of 'auto'

Fixes #3339 