### PR TITLE
fix case of variant which is valueless by exception

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.8...3.25)
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS YES)
-
 # Fallback for using newer policies on CMake <3.12.
 if(${CMAKE_VERSION} VERSION_LESS 3.12)
   cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.8...3.25)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS YES)
+
 # Fallback for using newer policies on CMake <3.12.
 if(${CMAKE_VERSION} VERSION_LESS 3.12)
   cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -218,11 +218,15 @@ struct formatter<
     auto out = ctx.out();
 
     out = detail::write<Char>(out, "variant(");
-    std::visit(
-        [&](const auto& v) {
-          out = detail::write_variant_alternative<Char>(out, v);
-        },
-        value);
+    try {
+      std::visit(
+          [&](const auto& v) {
+            out = detail::write_variant_alternative<Char>(out, v);
+          },
+          value);
+    } catch (const std::bad_variant_access&) {
+      detail::write<Char>(out, "valueless by exception");
+    }
     *out++ = ')';
     return out;
   }

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -96,24 +96,19 @@ TEST(std_test, optional) {
 #endif
 }
 
-// this struct exists only to force a variant to be
-// valueless by exception
-// NOLINTNEXTLINE
-struct throws_on_move_t {
-  throws_on_move_t() = default;
+struct throws_on_move {
+  throws_on_move() = default;
 
-  // NOLINTNEXTLINE
-  [[noreturn]] throws_on_move_t(throws_on_move_t&&) {
-    throw std::runtime_error{"Thrown by throws_on_move_t"};
+  [[noreturn]] throws_on_move(throws_on_move&&) {
+    throw std::runtime_error("Thrown by throws_on_move_t");
   }
 
-  throws_on_move_t(const throws_on_move_t&) = default;
+  throws_on_move(const throws_on_move&) = default;
 };
 
-template <> struct fmt::formatter<throws_on_move_t> : formatter<string_view> {
-  template <typename FormatContext>
-  auto format(const throws_on_move_t&, FormatContext& ctx) const {
-    string_view str{"<throws_on_move_t>"};
+template <> struct fmt::formatter<throws_on_move> : formatter<string_view> {
+  auto format(const throws_on_move&, format_context& ctx) const {
+    string_view str("<throws_on_move_t>");
     return formatter<string_view>::format(str, ctx);
   }
 };
@@ -150,13 +145,11 @@ TEST(std_test, variant) {
   volatile int i = 42;  // Test compile error before GCC 11 described in #3068.
   EXPECT_EQ(fmt::format("{}", i), "42");
 
-  using V2 = std::variant<std::monostate, throws_on_move_t>;
-
-  V2 v6{};
+  std::variant<std::monostate, throws_on_move> v6;
 
   try {
-    throws_on_move_t thrower{};
-    v6.emplace<throws_on_move_t>(std::move(thrower));
+    throws_on_move thrower;
+    v6.emplace<throws_on_move>(std::move(thrower));
   } catch (const std::runtime_error&) {
   }
   // v6 is now valueless by exception

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -107,7 +107,8 @@ struct throws_on_move {
 };
 
 template <> struct fmt::formatter<throws_on_move> : formatter<string_view> {
-  auto format(const throws_on_move&, format_context& ctx) const {
+  auto format(const throws_on_move&, format_context& ctx) const
+      -> decltype(ctx.out()) {
     string_view str("<throws_on_move>");
     return formatter<string_view>::format(str, ctx);
   }

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -106,13 +106,15 @@ struct throws_on_move {
   throws_on_move(const throws_on_move&) = default;
 };
 
-template <> struct fmt::formatter<throws_on_move> : formatter<string_view> {
+namespace fmt {
+template <> struct formatter<throws_on_move> : formatter<string_view> {
   auto format(const throws_on_move&, format_context& ctx) const
       -> decltype(ctx.out()) {
     string_view str("<throws_on_move>");
     return formatter<string_view>::format(str, ctx);
   }
 };
+}  // namespace fmt
 
 TEST(std_test, variant) {
 #ifdef __cpp_lib_variant

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -100,7 +100,7 @@ struct throws_on_move {
   throws_on_move() = default;
 
   [[noreturn]] throws_on_move(throws_on_move&&) {
-    throw std::runtime_error("Thrown by throws_on_move_t");
+    throw std::runtime_error("Thrown by throws_on_move");
   }
 
   throws_on_move(const throws_on_move&) = default;
@@ -108,7 +108,7 @@ struct throws_on_move {
 
 template <> struct fmt::formatter<throws_on_move> : formatter<string_view> {
   auto format(const throws_on_move&, format_context& ctx) const {
-    string_view str("<throws_on_move_t>");
+    string_view str("<throws_on_move>");
     return formatter<string_view>::format(str, ctx);
   }
 };


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

[This](https://github.com/TheOmegaCarrot/breaking-fmt) tiny repository contains a small bit of code which forces an `std::variant` to be valueless by exception, and demonstrates that upstream fmtlib does not handle that case.

My small change simply handles this case.