### PR TITLE
%T is %H:%M:%S

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1624,10 +1624,9 @@ class tm_writer {
     write2(tm_min());
   }
   void on_iso_time() {
-    char buf[8];
-    write_digit2_separated(buf, to_unsigned(tm_hour()), to_unsigned(tm_min()),
-                           to_unsigned(tm_sec()), ':');
-    out_ = copy_str<Char>(std::begin(buf), std::end(buf), out_);
+    on_24_hour_time();
+    *out_++ = ':';
+    on_second(numeric_system::standard, pad_type::unspecified);
   }
 
   void on_am_pm() {

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -904,6 +904,8 @@ TEST(chrono_test, timestamps_sub_seconds) {
 
   EXPECT_EQ(fmt::format("{}.{}", strftime_full_utc(t9_sec), t9_sub_sec_part),
             fmt::format("{:%Y-%m-%d %H:%M:%S}", t9));
+  EXPECT_EQ(fmt::format("{}.{}", strftime_full_utc(t9_sec), t9_sub_sec_part),
+            fmt::format("{:%Y-%m-%d %T}", t9));
 
   const std::chrono::time_point<std::chrono::system_clock,
                                 std::chrono::milliseconds>


### PR DESCRIPTION
`%S` was fixed to print sub-second resolutions, but `%T` still only formats seconds. 