### PR TITLE
Force use a signed char (On ARM char is unsigned by default)

### DIFF
--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -820,9 +820,10 @@ TEST(chrono_test, cpp20_duration_subsecond_support) {
                         std::chrono::duration<long long, std::ratio<1, 7>>(1)),
             "00.142857");
 
-  EXPECT_EQ(fmt::format("{:%S}",
-                        std::chrono::duration<char, std::ratio<1, 100>>(0x80)),
-            "-01.28");
+  EXPECT_EQ(
+      fmt::format("{:%S}",
+                  std::chrono::duration<signed char, std::ratio<1, 100>>(0x80)),
+      "-01.28");
 
   EXPECT_EQ(
       fmt::format("{:%M:%S}",


### PR DESCRIPTION
Environment:
```
docker-desktop:/ # uname -a
Linux docker-desktop 5.15.49-linuxkit #1 SMP PREEMPT Tue Sep 13 07:51:32 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux
```

Error:
```
[ RUN      ] chrono_test.cpp20_duration_subsecond_support
/fmt/fmt-master/test/chrono-test.cc:823: Failure
Expected equality of these values:
  fmt::format("{:%S}", std::chrono::duration<char, std::ratio<1, 100>>(0x80))
    Which is: "01.28"
  "-01.28"
[  FAILED  ] chrono_test.cpp20_duration_subsecond_support (0 ms)
```

On ARM gcc char is unsigned:
https://developer.arm.com/documentation/den0013/d/Porting/Miscellaneous-C-porting-issues/unsigned-char-and-signed-char
https://trofi.github.io/posts/203-signed-char-or-unsigned-char.html