### PR TITLE
Make fmt::println support text style

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -460,10 +460,11 @@ void vformat_to(buffer<Char>& buf, const text_style& ts,
 FMT_END_DETAIL_NAMESPACE
 
 inline void vprint(std::FILE* f, const text_style& ts, string_view fmt,
-                   format_args args) {
+                   bool new_line, format_args args) {
   // Legacy wide streams are not supported.
   auto buf = memory_buffer();
   detail::vformat_to(buf, ts, fmt, args);
+  if (new_line) buf.push_back('\n');
   if (detail::is_utf8()) {
     detail::print(f, string_view(buf.begin(), buf.size()));
     return;
@@ -489,7 +490,26 @@ template <typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_string<S>::value)>
 void print(std::FILE* f, const text_style& ts, const S& format_str,
            const Args&... args) {
-  vprint(f, ts, format_str,
+  vprint(f, ts, format_str, false,
+         fmt::make_format_args<buffer_context<char_t<S>>>(args...));
+}
+
+/**
+  \rst
+  Formats a string and prints it to the specified file stream using ANSI
+  escape sequences to specify text formatting followed by a newline.
+
+  **Example**::
+
+    fmt::println(fmt::emphasis::bold | fg(fmt::color::red),
+               "Elapsed time: {0:.2f} seconds", 1.23);
+  \endrst
+ */
+template <typename S, typename... Args,
+          FMT_ENABLE_IF(detail::is_string<S>::value)>
+void println(std::FILE* f, const text_style& ts, const S& format_str,
+             const Args&... args) {
+  vprint(f, ts, format_str, true,
          fmt::make_format_args<buffer_context<char_t<S>>>(args...));
 }
 
@@ -508,6 +528,23 @@ template <typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_string<S>::value)>
 void print(const text_style& ts, const S& format_str, const Args&... args) {
   return print(stdout, ts, format_str, args...);
+}
+
+/**
+  \rst
+  Formats a string and prints it to stdout using ANSI escape sequences to
+  specify text formatting followed by a newline.
+
+  **Example**::
+
+    fmt::println(fmt::emphasis::bold | fg(fmt::color::red),
+               "Elapsed time: {0:.2f} seconds", 1.23);
+  \endrst
+ */
+template <typename S, typename... Args,
+          FMT_ENABLE_IF(detail::is_string<S>::value)>
+void println(const text_style& ts, const S& format_str, const Args&... args) {
+  return println(stdout, ts, format_str, args...);
 }
 
 template <typename S, typename Char = char_t<S>>

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -460,11 +460,10 @@ void vformat_to(buffer<Char>& buf, const text_style& ts,
 FMT_END_DETAIL_NAMESPACE
 
 inline void vprint(std::FILE* f, const text_style& ts, string_view fmt,
-                   bool new_line, format_args args) {
+                   format_args args) {
   // Legacy wide streams are not supported.
   auto buf = memory_buffer();
   detail::vformat_to(buf, ts, fmt, args);
-  if (new_line) buf.push_back('\n');
   if (detail::is_utf8()) {
     detail::print(f, string_view(buf.begin(), buf.size()));
     return;
@@ -490,7 +489,7 @@ template <typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_string<S>::value)>
 void print(std::FILE* f, const text_style& ts, const S& format_str,
            const Args&... args) {
-  vprint(f, ts, format_str, false,
+  vprint(f, ts, format_str,
          fmt::make_format_args<buffer_context<char_t<S>>>(args...));
 }
 
@@ -509,8 +508,7 @@ template <typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_string<S>::value)>
 void println(std::FILE* f, const text_style& ts, const S& format_str,
              const Args&... args) {
-  vprint(f, ts, format_str, true,
-         fmt::make_format_args<buffer_context<char_t<S>>>(args...));
+  print(f, ts, "{}\n", fmt::format(format_str, std::forward<Args>(args)...));
 }
 
 /**

--- a/test/color-test.cc
+++ b/test/color-test.cc
@@ -69,4 +69,6 @@ TEST(color_test, format_to) {
 TEST(color_test, print) {
   EXPECT_WRITE(stdout, fmt::print(fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30)"),
                "\x1b[38;2;255;020;030mrgb(255,20,30)\x1b[0m");
+  EXPECT_WRITE(stdout, fmt::println(fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30)"),
+               "\x1b[38;2;255;020;030mrgb(255,20,30)\x1b[0m\n");
 }

--- a/test/color-test.cc
+++ b/test/color-test.cc
@@ -70,5 +70,5 @@ TEST(color_test, print) {
   EXPECT_WRITE(stdout, fmt::print(fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30)"),
                "\x1b[38;2;255;020;030mrgb(255,20,30)\x1b[0m");
   EXPECT_WRITE(stdout, fmt::println(fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30)"),
-               "\x1b[38;2;255;020;030mrgb(255,20,30)\x1b[0m\n");
+               "\x1b[38;2;255;020;030mrgb(255,20,30)\n\x1b[0m");
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/89713806/230750462-f73bbe3e-8bf2-4fe8-a877-55396b504bd3.png)
Supports all text style