### PR TITLE
Fix error C2668 on msvc

### DIFF
--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -193,7 +193,7 @@ void print(std::wostream& os,
 
 FMT_MODULE_EXPORT template <typename... T>
 void println(std::ostream& os, format_string<T...> fmt, T&&... args) {
-  print(os, "{}\n", fmt::format(fmt, std::forward<T>(args)...));
+  fmt::print(os, "{}\n", fmt::format(fmt, std::forward<T>(args)...));
 }
 
 FMT_MODULE_EXPORT

--- a/test/args-test.cc
+++ b/test/args-test.cc
@@ -44,7 +44,7 @@ template <> struct formatter<custom_type> {
 
   template <typename FormatContext>
   auto format(const custom_type& p, FormatContext& ctx) -> decltype(ctx.out()) {
-    return format_to(ctx.out(), "cust={}", p.i);
+    return fmt::format_to(ctx.out(), "cust={}", p.i);
   }
 };
 FMT_END_NAMESPACE

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -301,7 +301,7 @@ TEST(format_impl_test, format_error_code) {
   std::string msg = "error 42", sep = ": ";
   {
     auto buffer = fmt::memory_buffer();
-    format_to(fmt::appender(buffer), "garbage");
+    fmt::format_to(fmt::appender(buffer), "garbage");
     fmt::detail::format_error_code(buffer, 42, "test");
     EXPECT_EQ(to_string(buffer), "test: " + msg);
   }

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1638,7 +1638,7 @@ struct fmt::formatter<explicitly_convertible_to_std_string_view>
     : formatter<std::string_view> {
   auto format(explicitly_convertible_to_std_string_view v, format_context& ctx)
       -> decltype(ctx.out()) {
-    return format_to(ctx.out(), "'{}'", std::string_view(v));
+    return fmt::format_to(ctx.out(), "'{}'", std::string_view(v));
   }
 };
 
@@ -1702,7 +1702,7 @@ TEST(format_test, format_examples) {
   EXPECT_EQ("42", fmt::format("{}", 42));
 
   memory_buffer out;
-  format_to(std::back_inserter(out), "The answer is {}.", 42);
+  fmt::format_to(std::back_inserter(out), "The answer is {}.", 42);
   EXPECT_EQ("The answer is 42.", to_string(out));
 
   const char* filename = "nonexistent";
@@ -1837,7 +1837,7 @@ TEST(format_test, join_bytes) {
 
 std::string vformat_message(int id, const char* format, fmt::format_args args) {
   auto buffer = fmt::memory_buffer();
-  format_to(fmt::appender(buffer), "[{}] ", id);
+  fmt::format_to(fmt::appender(buffer), "[{}] ", id);
   vformat_to(fmt::appender(buffer), format, args);
   return to_string(buffer);
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

Fmt built failed due to `error C2668: 'std::format_to': ambiguous call to overloaded function ` on MSVC, add namespace to qualify the call to format_to to solve this issue.

The related issue is: #3377 
