### PR TITLE
Update tests to use recommended MOCK_METHOD

### DIFF
--- a/test/core-test.cc
+++ b/test/core-test.cc
@@ -141,7 +141,7 @@ TEST(buffer_test, indestructible) {
 }
 
 template <typename T> struct mock_buffer final : buffer<T> {
-  MOCK_METHOD1(do_grow, size_t(size_t capacity));
+  MOCK_METHOD(size_t, do_grow, (size_t));
 
   void grow(size_t capacity) override {
     this->set(this->data(), do_grow(capacity));
@@ -327,8 +327,8 @@ template <typename T> struct mock_visitor {
     ON_CALL(*this, visit(_)).WillByDefault(Return(test_result()));
   }
 
-  MOCK_METHOD1_T(visit, test_result(T value));
-  MOCK_METHOD0_T(unexpected, void());
+  MOCK_METHOD(test_result, visit, (T));
+  MOCK_METHOD(void, unexpected, ());
 
   auto operator()(T value) -> test_result { return visit(value); }
 

--- a/test/mock-allocator.h
+++ b/test/mock-allocator.h
@@ -20,8 +20,8 @@ template <typename T> class mock_allocator {
   mock_allocator() {}
   mock_allocator(const mock_allocator&) {}
   using value_type = T;
-  MOCK_METHOD1_T(allocate, T*(size_t n));
-  MOCK_METHOD2_T(deallocate, void(T* p, size_t n));
+  MOCK_METHOD(T*, allocate, (size_t));
+  MOCK_METHOD(void, deallocate, (T*, size_t));
 };
 
 template <typename Allocator> class allocator_ref {

--- a/test/ostream-test.cc
+++ b/test/ostream-test.cc
@@ -140,7 +140,7 @@ TEST(ostream_test, write_to_ostream_max_size) {
   } buffer(max_size);
 
   struct mock_streambuf : std::streambuf {
-    MOCK_METHOD2(xsputn, std::streamsize(const void* s, std::streamsize n));
+    MOCK_METHOD(std::streamsize, xsputn, (const void*, std::streamsize));
     auto xsputn(const char* s, std::streamsize n) -> std::streamsize override {
       const void* v = s;
       return xsputn(v, n);


### PR DESCRIPTION
`MOCK_METHODn()` has been deprecated.

See https://google.github.io/googletest/gmock_cook_book.html#old-style-mock_methodn-macros.
