### PR TITLE
Fix MSVC C4365 warning (signed/unsigned mismatch) on 32-bit Windows

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -225,7 +225,7 @@ inline auto clzll(uint64_t x) -> int {
   _BitScanReverse64(&r, x);
 #  else
   // Scan the high 32 bits.
-  if (_BitScanReverse(&r, static_cast<uint32_t>(x >> 32))) return 63 ^ (r + 32);
+  if (_BitScanReverse(&r, static_cast<uint32_t>(x >> 32))) return 63 ^ static_cast<int>(r + 32);
   // Scan the low 32 bits.
   _BitScanReverse(&r, static_cast<uint32_t>(x));
 #  endif


### PR DESCRIPTION
Just needs a cast to `int` similar to the cast a few lines later.