### PR TITLE
modules missing pieces

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1039,10 +1039,12 @@ template <typename T, size_t SIZE, typename Allocator>
 struct is_contiguous<basic_memory_buffer<T, SIZE, Allocator>> : std::true_type {
 };
 
+FMT_END_EXPORT
 namespace detail {
 FMT_API bool write_console(std::FILE* f, string_view text);
 FMT_API void print(std::FILE*, string_view);
 }  // namespace detail
+FMT_BEGIN_EXPORT
 
 // Suppress a misleading warning in older versions of clang.
 #if FMT_CLANG_VERSION

--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -29,12 +29,16 @@ module;
 #include <system_error>
 #include <thread>
 #include <type_traits>
+#include <typeinfo>
 #include <utility>
 #include <variant>
 #include <vector>
 #include <version>
 
-#if _MSC_VER
+#if __has_include(<cxxabi.h>)
+#  include <cxxabi.h>
+#endif
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #  include <intrin.h>
 #endif
 #if defined __APPLE__ || defined(__FreeBSD__)
@@ -56,6 +60,12 @@ module;
 #  endif
 #endif
 #ifdef _WIN32
+#  if defined(__GLIBCXX__)
+#    include <ext/stdio_filebuf.h>
+#    include <ext/stdio_sync_filebuf.h>
+#  elif defined(_LIBCPP_VERSION)
+#    include <__std_stream>
+#  endif
 #  define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
 #endif


### PR DESCRIPTION
- don't export names from `detail`
- put more headers into the global module fragment
- support MSYS2 and Clang
