### PR TITLE
Name `vfprintf` clashes with the identically named declaration in 'st…

### DIFF
--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -599,7 +599,7 @@ inline auto vsprintf(
     basic_format_args<basic_printf_context_t<type_identity_t<Char>>> args)
     -> std::basic_string<Char> {
   auto buf = basic_memory_buffer<Char>();
-  vprintf(buf, detail::to_string_view(fmt), args);
+  detail::vprintf(buf, detail::to_string_view(fmt), args);
   return to_string(buf);
 }
 
@@ -626,7 +626,7 @@ inline auto vfprintf(
     basic_format_args<basic_printf_context_t<type_identity_t<Char>>> args)
     -> int {
   auto buf = basic_memory_buffer<Char>();
-  vprintf(buf, detail::to_string_view(fmt), args);
+  detail::vprintf(buf, detail::to_string_view(fmt), args);
   size_t size = buf.size();
   return std::fwrite(buf.data(), sizeof(Char), size, f) < size
              ? -1


### PR DESCRIPTION
…dio.h' if that happens to be #included into the same TU. Fix this by using qualified name lookup instead of unqualified lookup that also enables ADL.
