### PR TITLE
Add `FMT_STRING` for `format_to()` call with clang-cl

### DIFF
--- a/src/os.cc
+++ b/src/os.cc
@@ -169,8 +169,8 @@ void detail::format_windows_error(detail::buffer<char>& out, int error_code,
     if (msg) {
       auto utf8_message = utf16_to_utf8();
       if (utf8_message.convert(msg) == ERROR_SUCCESS) {
-        fmt::format_to(buffer_appender<char>(out), "{}: {}", message,
-                       string_view(utf8_message));
+        fmt::format_to(buffer_appender<char>(out), FMT_STRING("{}: {}"),
+                       message, string_view(utf8_message));
         return;
       }
     }


### PR DESCRIPTION
I get the following error when compiling `os.cc` on clang-cl 15.

```cpp
1>..\fmt\src\os.cc(172,52): error : call to consteval function 'fmt::basic_format_string<char, const char *&, fmt::detail::utf16_to_utf8 &>::basic_format_string<char[7], 0>' is not a constant expression
1>..\fmt\include\fmt/core.h(3165,62): message : non-constexpr constructor 'basic_string_view' cannot be used in a constant expression
1>..\fmt\src\os.cc(172,52): message : in call to 'basic_format_string("{}: {}")'
1>..\fmt\include\fmt/core.h(451,3): message : declared here
```

This pull request adds a `FMT_STRING` wrapper to resolve a format-string type and fixes the error.