### PR TITLE
Unification utf16/utf32 to utf8 conversion

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1416,6 +1416,68 @@ class utf8_to_utf16 {
   auto str() const -> std::wstring { return {&buffer_[0], size()}; }
 };
 
+// A converter from UTF-16/UTF-32 (host endian) to UTF-8.
+template <typename WChar, typename Buffer = memory_buffer>
+class unicode_to_utf8 {
+ private:
+  Buffer buffer_;
+
+ public:
+  unicode_to_utf8() {}
+  explicit unicode_to_utf8(basic_string_view<WChar> s) {
+    static_assert(sizeof(WChar) == 2 || sizeof(WChar) == 4,
+                  "Expect utf16 or utf32");
+
+    if (!convert(s))
+      FMT_THROW(std::runtime_error(sizeof(WChar) == 2 ? "invalid utf16"
+                                                      : "invalid utf32"));
+  }
+  operator string_view() const { return string_view(&buffer_[0], size()); }
+  size_t size() const { return buffer_.size() - 1; }
+  const char* c_str() const { return &buffer_[0]; }
+  std::string str() const { return std::string(&buffer_[0], size()); }
+
+  // Performs conversion returning a bool instead of throwing exception on
+  // conversion error. This method may still throw in case of memory allocation
+  // error.
+  bool convert(basic_string_view<WChar> s) {
+    if (!convert(buffer_, s)) return false;
+    buffer_.push_back(0);
+    return true;
+  }
+  static bool convert(Buffer& buf, basic_string_view<WChar> s) {
+    for (auto p = s.begin(); p != s.end(); ++p) {
+      uint32_t c = static_cast<uint32_t>(*p);
+      if (sizeof(WChar) == 2 && c >= 0xd800 && c <= 0xdfff) {
+        // surrogate pair
+        ++p;
+        if (p == s.end() || (c & 0xfc00) != 0xd800 || (*p & 0xfc00) != 0xdc00) {
+          return false;
+        }
+        c = (c << 10) + static_cast<uint32_t>(*p) - 0x35fdc00;
+      }
+      if (c < 0x80) {
+        buf.push_back(static_cast<char>(c));
+      } else if (c < 0x800) {
+        buf.push_back(static_cast<char>(0xc0 | (c >> 6)));
+        buf.push_back(static_cast<char>(0x80 | (c & 0x3f)));
+      } else if ((c >= 0x800 && c <= 0xd7ff) || (c >= 0xe000 && c <= 0xffff)) {
+        buf.push_back(static_cast<char>(0xe0 | (c >> 12)));
+        buf.push_back(static_cast<char>(0x80 | ((c & 0xfff) >> 6)));
+        buf.push_back(static_cast<char>(0x80 | (c & 0x3f)));
+      } else if (c >= 0x10000 && c <= 0x10ffff) {
+        buf.push_back(static_cast<char>(0xf0 | (c >> 18)));
+        buf.push_back(static_cast<char>(0x80 | ((c & 0x3ffff) >> 12)));
+        buf.push_back(static_cast<char>(0x80 | ((c & 0xfff) >> 6)));
+        buf.push_back(static_cast<char>(0x80 | (c & 0x3f)));
+      } else {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
 // Computes 128-bit result of multiplication of two 64-bit unsigned integers.
 inline uint128_fallback umul128(uint64_t x, uint64_t y) noexcept {
 #if FMT_USE_INT128

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -124,26 +124,6 @@ using wcstring_view = basic_cstring_view<wchar_t>;
 FMT_API const std::error_category& system_category() noexcept;
 
 FMT_BEGIN_DETAIL_NAMESPACE
-// A converter from UTF-16 to UTF-8.
-// It is only provided for Windows since other systems support UTF-8 natively.
-class utf16_to_utf8 {
- private:
-  memory_buffer buffer_;
-
- public:
-  utf16_to_utf8() {}
-  FMT_API explicit utf16_to_utf8(basic_string_view<wchar_t> s);
-  operator string_view() const { return string_view(&buffer_[0], size()); }
-  size_t size() const { return buffer_.size() - 1; }
-  const char* c_str() const { return &buffer_[0]; }
-  std::string str() const { return std::string(&buffer_[0], size()); }
-
-  // Performs conversion returning a system error code instead of
-  // throwing exception on conversion error. This method may still throw
-  // in case of memory allocation error.
-  FMT_API int convert(basic_string_view<wchar_t> s);
-};
-
 FMT_API void format_windows_error(buffer<char>& out, int error_code,
                                   const char* message) noexcept;
 FMT_END_DETAIL_NAMESPACE

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -60,19 +60,9 @@ inline void write_escaped_path<char>(memory_buffer& quoted,
                                      const std::filesystem::path& p) {
   auto buf = basic_memory_buffer<wchar_t>();
   write_escaped_string<wchar_t>(std::back_inserter(buf), p.native());
-  for (unsigned c : buf) {
-    // Convert UTF-16 to UTF-8.
-    if (c < 0x80) {
-      quoted.push_back(static_cast<unsigned char>(c));
-    } else if (c < 0x800) {
-      quoted.push_back(0b1100'0000 | ((c >> 6) & 0b01'1111));
-      quoted.push_back(0b1000'0000 | (c & 0b11'1111));
-    } else {
-      quoted.push_back(0b1110'0000 | ((c >> 12) & 0b01'1111));
-      quoted.push_back(0b1000'0000 | ((c >> 6) & 0b11'1111));
-      quoted.push_back(0b1000'0000 | (c & 0b11'1111));
-    }
-  }
+  // Convert UTF-16 to UTF-8.
+  if (!unicode_to_utf8<wchar_t>::convert(quoted, {buf.data(), buf.size()}))
+    FMT_THROW(std::runtime_error("invalid utf16"));
 }
 #  endif
 template <>

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -559,3 +559,10 @@ TEST(format_impl_test, utf8_decode_bogus_byte_sequences) {
   EXPECT_NE(e, 0);    // "bogus [c0 0a] 0x%02x U+%04lx", e, (unsigned long)c
   EXPECT_EQ(len, 2);  // "bogus [c0 0a] recovery %d", len);
 }
+
+TEST(format_impl_test, unicode_to_utf8) {
+  auto s = std::string("ёжик");
+  fmt::detail::unicode_to_utf8<wchar_t> u(L"\x0451\x0436\x0438\x043A");
+  EXPECT_EQ(s, u.str());
+  EXPECT_EQ(s.size(), u.size());
+}

--- a/test/gtest-extra-test.cc
+++ b/test/gtest-extra-test.cc
@@ -201,6 +201,7 @@ TEST(gtest_extra_test, expect_write_streaming) {
 // EXPECT_THROW_MSG macro.
 TEST(gtest_extra_test, expect_throw_no_unreachable_code_warning) {
   int n = 0;
+  (void)n;
   using std::runtime_error;
   EXPECT_THROW_MSG(throw runtime_error(""), runtime_error, "");
   EXPECT_NONFATAL_FAILURE(EXPECT_THROW_MSG(n++, runtime_error, ""), "");
@@ -213,6 +214,7 @@ TEST(gtest_extra_test, expect_throw_no_unreachable_code_warning) {
 // EXPECT_SYSTEM_ERROR macro.
 TEST(gtest_extra_test, expect_system_error_no_unreachable_code_warning) {
   int n = 0;
+  (void)n;
   EXPECT_SYSTEM_ERROR(throw fmt::system_error(EDOM, "test"), EDOM, "test");
   EXPECT_NONFATAL_FAILURE(EXPECT_SYSTEM_ERROR(n++, EDOM, ""), "");
   EXPECT_NONFATAL_FAILURE(EXPECT_SYSTEM_ERROR(throw 1, EDOM, ""), "");


### PR DESCRIPTION
Discussion: https://github.com/fmtlib/fmt/commit/02cae7e48ac9b1d90acb0ee07c76fbde2462a99e#r111229765

XCode 14.3 error (fix in first commit):

```
cd /Users/phprus/Devel/fmt/build/cxx17/test && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DGTEST_HAS_STD_WSTRING=1 -D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING=1 -I/Users/phprus/Devel/fmt/include -isystem /Users/phprus/Devel/fmt/test/gtest/. -O2 -g -DNDEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.3.sdk -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -pedantic -Wconversion -Wundef -Wdeprecated -Wweak-vtables -Wshadow -Wno-gnu-zero-variadic-macro-arguments -Wzero-as-null-pointer-constant -Werror -std=gnu++17 -MD -MT test/CMakeFiles/gtest-extra-test.dir/gtest-extra-test.cc.o -MF CMakeFiles/gtest-extra-test.dir/gtest-extra-test.cc.o.d -o CMakeFiles/gtest-extra-test.dir/gtest-extra-test.cc.o -c /Users/phprus/Devel/fmt/test/gtest-extra-test.cc
/Users/phprus/Devel/fmt/test/gtest-extra-test.cc:203:7: error: variable 'n' set but not used [-Werror,-Wunused-but-set-variable]
  int n = 0;
      ^
/Users/phprus/Devel/fmt/test/gtest-extra-test.cc:215:7: error: variable 'n' set but not used [-Werror,-Wunused-but-set-variable]
  int n = 0;
      ^
2 errors generated.
```