### PR TITLE
Silence NVCC warning in has_isfinite

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2802,7 +2802,7 @@ template <typename T, typename Enable = void>
 struct has_isfinite : std::false_type {};
 
 template <typename T>
-struct has_isfinite<T, enable_if_t<sizeof(std::isfinite(T())) != 0>>
+struct has_isfinite<T, void_t<decltype(std::isfinite(T()))>>
     : std::true_type {};
 
 template <typename T, FMT_ENABLE_IF(std::is_floating_point<T>::value&&


### PR DESCRIPTION
This avoids warnings like:
```
: warning: pointless comparison of unsigned integer with zero
          detected during:
            instantiation of "auto fmt::v9::detail::to_unsigned(Int)->std::make_unsigned<Int>::type [with Int=size_t]" 
```
It also has the benefit of being a little clearer in its intent.