### PR TITLE
Fix time_point formatting for durations with certain ratios

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2142,7 +2142,8 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
           epoch - std::chrono::duration_cast<std::chrono::seconds>(epoch));
 
       if (subsecs.count() < 0) {
-        auto second = std::chrono::seconds(1);
+        auto second = std::chrono::duration_cast<Duration>(
+            std::chrono::seconds(1));
         if (epoch.count() < ((Duration::min)() + second).count())
           FMT_THROW(format_error("duration is too small"));
         subsecs += second;

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -850,6 +850,30 @@ TEST(chrono_test, utc_clock) {
 }
 #endif
 
+TEST(chrono_test, timestamps_ratios) {
+  std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>
+      t1(std::chrono::milliseconds(67890));
+
+  EXPECT_EQ(fmt::format("{:%M:%S}", t1), "01:07.890");
+
+  std::chrono::time_point<std::chrono::system_clock, std::chrono::minutes>
+      t2(std::chrono::minutes(7));
+
+  EXPECT_EQ(fmt::format("{:%M:%S}", t2), "07:00");
+
+  std::chrono::time_point<std::chrono::system_clock, 
+                          std::chrono::duration<int, std::ratio<9>>>
+      t3(std::chrono::duration<int, std::ratio<9>>(7));
+
+  EXPECT_EQ(fmt::format("{:%M:%S}", t3), "01:03");
+
+  std::chrono::time_point<std::chrono::system_clock, 
+                          std::chrono::duration<int, std::ratio<63>>>
+      t4(std::chrono::duration<int, std::ratio<63>>(1));
+
+  EXPECT_EQ(fmt::format("{:%M:%S}", t4), "01:03");
+}
+
 TEST(chrono_test, timestamps_sub_seconds) {
   std::chrono::time_point<std::chrono::system_clock,
                           std::chrono::duration<long long, std::ratio<1, 3>>>


### PR DESCRIPTION
#3261 unfortunately broke formatting for `std::chrono::time_point`s with durations with certain ratios, since `std::chrono::seconds` is not implicitly convertible to these durations. 

This PR fixes this by explicitly `duration_cast`-ing back to the `time_point`'s `Duration`.

Repro: The following worked in 9.1.0, but doesn't compile in 10.0.0:
```cpp
#include <fmt/chrono.h>

int main() {
    fmt::print("{}\n", std::chrono::time_point_cast<std::chrono::minutes>(std::chrono::system_clock::now()));
}
```