### PR TITLE
Fix parameter type of formatter<char*>

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2693,7 +2693,7 @@ struct formatter<T, Char,
   template <typename Char>                                               \
   struct formatter<Type, Char> : formatter<Base, Char> {                 \
     template <typename FormatContext>                                    \
-    auto format(const Type& val, FormatContext& ctx) const               \
+    auto format(Type const& val, FormatContext& ctx) const               \
         -> decltype(ctx.out()) {                                         \
       return formatter<Base, Char>::format(static_cast<Base>(val), ctx); \
     }                                                                    \

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2251,3 +2251,19 @@ TEST(format_test, format_named_arg_with_locale) {
 }
 
 #endif  // FMT_STATIC_THOUSANDS_SEPARATOR
+
+struct convertible_to_nonconst_cstring {
+    operator char*() const {
+        static char c[]="bar";
+        return c;
+    }
+};
+
+FMT_BEGIN_NAMESPACE
+template <> struct formatter<convertible_to_nonconst_cstring> : formatter<char*> {
+};
+FMT_END_NAMESPACE
+
+TEST(format_test, formatter_nonconst_char) {
+  EXPECT_EQ(fmt::format("{}", convertible_to_nonconst_cstring()), "bar");
+}


### PR DESCRIPTION
Since this is macro expansion, `const Type&` expands to `const Char*&` instead of the desired `Char* const&`.
