### PR TITLE
revert non-working workaround for issue #3163

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1131,11 +1131,8 @@ bool is_left_endpoint_integer_shorter_interval(int exponent) noexcept {
 FMT_INLINE int remove_trailing_zeros(uint32_t& n, int s = 0) noexcept {
   FMT_ASSERT(n != 0, "");
   // Modular inverse of 5 (mod 2^32): (mod_inv_5 * 5) mod 2^32 = 1.
-  // See https://github.com/fmtlib/fmt/issues/3163 for more details.
-  const uint32_t mod_inv_5 = 0xcccccccd;
-  // Casts are needed to workaround a bug in MSVC 19.22 and older.
-  const uint32_t mod_inv_25 =
-      static_cast<uint32_t>(uint64_t(mod_inv_5) * mod_inv_5);
+  constexpr uint32_t mod_inv_5 = 0xcccccccd;
+  constexpr uint32_t mod_inv_25 = 0xc28f5c29; // = mod_inv_5 * mod_inv_5
 
   while (true) {
     auto q = rotr(n * mod_inv_25, 2);
@@ -1170,8 +1167,8 @@ FMT_INLINE int remove_trailing_zeros(uint64_t& n) noexcept {
   }
 
   // If n is not divisible by 10^8, work with n itself.
-  const uint64_t mod_inv_5 = 0xcccccccccccccccd;
-  const uint64_t mod_inv_25 = mod_inv_5 * mod_inv_5;
+  constexpr uint64_t mod_inv_5 = 0xcccccccccccccccd;
+  constexpr uint64_t mod_inv_25 = 0x8f5c28f5c28f5c29; // = mod_inv_5 * mod_inv_5
 
   int s = 0;
   while (true) {


### PR DESCRIPTION
revert non-working workaround for issue #3163

This fix for warning C4307: '*': integral constant overflow leads to warning C4309: 'static_cast': truncation of constant value, which is not better (both are level 3 VS warnings). Revert to the original code that is clearer and also present further in this source code.

Alternatively, to avoid any VS warning, one could follow the third suggestion of https://github.com/fmtlib/fmt/issues/3163#issuecomment-1332608091 and write the explicit value of mod_inv_25 which is 0xc28f5c29 and replace the lines with:
`const uint32_t mod_inv_25 = 0xc28f5c29 // = mod_inv_5 * mod_inv_5;`