### PR TITLE
Hash pin Github Workflows

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -23,7 +23,7 @@ jobs:
         dry-run: false
         language: c++
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
     - name: Add ubuntu mirrors
       run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,7 +57,7 @@ jobs:
           - shared: -DBUILD_SHARED_LIBS=ON
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
     - name: Set timezone
       run: sudo timedatectl set-timezone 'Asia/Yekaterinburg'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
           - shared: -DBUILD_SHARED_LIBS=ON
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
     - name: Set timezone
       run: sudo systemsetup -settimezone 'Asia/Yekaterinburg'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,7 +41,7 @@ jobs:
             standard: 20
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
     - name: Set timezone
       run: tzutil /s "Ekaterinburg Standard Time"
@@ -83,12 +83,12 @@ jobs:
     - name: Set timezone
       run: tzutil /s "Ekaterinburg Standard Time"
       shell: cmd
-    - uses: msys2/setup-msys2@v2
+    - uses: msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff # v2
       with:
         release: false
         msystem: ${{matrix.sys}}
         pacboy: cc:p cmake:p ninja:p lld:p
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
     - name: Configure
       run: cmake -B ../build -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug
       env: { LDFLAGS: -fuse-ld=lld }


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

#3449 

## Changes
- Hash pin actions used on the github workflows. 
- cifuzz workflow not pinned since it only works on master (pinning it would cause too much notifications from dependabot/renovatebot without need)