### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # Necessary to update action hashs	
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Allow up to 3 opened pull requests for github-actions versions
+    open-pull-requests-limit: 3


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

#3449 

## Changes

I'm submiting a configuration file for dependabot (official from GitHub) to update only github workflows  and limited up to 3 PRs per week (let me know if you rather this to be greater of smaler)

I think it also has to enable `Dependabot version updated` at https://github/fmtlib/fmt/settings/security_analysis to actually works if merged.