### PR TITLE
CMake: Do not fail on unknown compiler features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,7 +297,11 @@ if (FMT_PEDANTIC)
   target_compile_options(fmt PRIVATE ${PEDANTIC_COMPILE_FLAGS})
 endif ()
 
-target_compile_features(fmt PUBLIC cxx_std_11)
+if (cxx_std_11 IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+  target_compile_features(fmt PUBLIC cxx_std_11)
+else ()
+  message(WARNING "Feature cxx_std_11 is unknown for the CXX compiler")
+endif ()
 
 target_include_directories(fmt ${FMT_SYSTEM_HEADERS_ATTRIBUTE} PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>


### PR DESCRIPTION
If CMake does not know much about a compiler, `target_compile_features` will fail. Issue a warning instead.
