### PR TITLE
Pass correct Char to base format_as formatter

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -4103,8 +4103,8 @@ class format_int {
 
 template <typename T, typename Char>
 struct formatter<T, Char, enable_if_t<detail::has_format_as<T>::value>>
-    : private formatter<detail::format_as_t<T>> {
-  using base = formatter<detail::format_as_t<T>>;
+    : private formatter<detail::format_as_t<T>, Char> {
+  using base = formatter<detail::format_as_t<T>, Char>;
   using base::parse;
 
   template <typename FormatContext>

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -152,6 +152,15 @@ TEST(xchar_test, vformat_to) {
   EXPECT_EQ(L"42", w);
 }
 
+namespace test {
+struct struct_as_wstring_view {};
+auto format_as(struct_as_wstring_view) -> fmt::wstring_view { return L"foo"; }
+}  // namespace test
+
+TEST(xchar_test, format_as) {
+  EXPECT_EQ(fmt::format(L"{}", test::struct_as_wstring_view()), L"foo");
+}
+
 TEST(format_test, wide_format_to_n) {
   wchar_t buffer[4];
   buffer[3] = L'x';


### PR DESCRIPTION
Returning a non-`char` `string_view` from `format_as` fails to compile since the base formatter always uses `char`.