### PR TITLE
Make constexpr ceil

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,19 +7,29 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-11
     strategy:
       matrix:
+        os: [macos-11, macos-13]
         build_type: [Debug, Release]
-        std: [11, 17]
+        std: [11, 17, 20]
+        exclude:
+          - { os: macos-11, std: 20 }
+          - { os: macos-13, std: 11 }
+          - { os: macos-13, std: 17 }
         include:
           - shared: -DBUILD_SHARED_LIBS=ON
+
+    runs-on: '${{ matrix.os }}'
 
     steps:
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
     - name: Set timezone
       run: sudo systemsetup -settimezone 'Asia/Yekaterinburg'
+
+    - name: Select Xcode 14.3 (macOS 13)
+      run: sudo xcode-select -s "/Applications/Xcode_14.3.app"
+      if: ${{ matrix.os == 'macos-13' }}
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3322,19 +3322,16 @@ template <typename Float> FMT_CONSTEXPR auto iceil(Float value) -> int {
   auto max = (std::numeric_limits<int>::max)();
   ignore_unused(min, max);
   FMT_ASSERT(value >= min && value <= max, "value not in int range");
-  if (is_constant_evaluated()) {
-    do {
-      auto mid = min + static_cast<int>((static_cast<unsigned>(max) -
-                                         static_cast<unsigned>(min)) /
-                                        2);
-      if (mid < value)
-        min = mid;
-      else
-        max = mid;
-    } while (min + 1 != max);
-    return max;
-  }
-  return static_cast<int>(std::ceil(value));
+  do {
+    auto mid = min + static_cast<int>((static_cast<unsigned>(max) -
+                                       static_cast<unsigned>(min)) /
+                                      2);
+    if (mid < value)
+      min = mid;
+    else
+      max = mid;
+  } while (min + 1 != max);
+  return max;
 }
 
 template <typename Float>

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -524,22 +524,6 @@ TEST(format_impl_test, to_utf8) {
   EXPECT_EQ(s.size(), u.size());
 }
 
-FMT_CONSTEXPR20 bool constexpr_iceil() {
-  for (double v : std::initializer_list<double>{
-           ((std::numeric_limits<int>::min)() + 0.5),
-           -1.2,
-           -0.2,
-           0.0,
-           0.2,
-           1.2,
-           4.0,
-           ((std::numeric_limits<int>::max)() - 0.5),
-       }) {
-    auto r = fmt::detail::iceil(v);
-    fmt::detail::ignore_unused(r);
-  }
-  return true;
-}
 TEST(format_impl_test, iceil) {
   for (double v : std::initializer_list<double>{
            ((std::numeric_limits<int>::min)() + 0.5),
@@ -553,7 +537,4 @@ TEST(format_impl_test, iceil) {
        }) {
     EXPECT_EQ(fmt::detail::iceil(v), static_cast<int>(std::ceil(v)));
   }
-
-  FMT_CONSTEXPR20 auto result = constexpr_iceil();
-  EXPECT_TRUE(result);
 }

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -523,3 +523,37 @@ TEST(format_impl_test, to_utf8) {
   EXPECT_EQ(s, u.str());
   EXPECT_EQ(s.size(), u.size());
 }
+
+FMT_CONSTEXPR20 bool constexpr_iceil() {
+  for (double v : std::initializer_list<double>{
+           ((std::numeric_limits<int>::min)() + 0.5),
+           -1.2,
+           -0.2,
+           0.0,
+           0.2,
+           1.2,
+           4.0,
+           ((std::numeric_limits<int>::max)() - 0.5),
+       }) {
+    auto r = fmt::detail::iceil(v);
+    fmt::detail::ignore_unused(r);
+  }
+  return true;
+}
+TEST(format_impl_test, iceil) {
+  for (double v : std::initializer_list<double>{
+           ((std::numeric_limits<int>::min)() + 0.5),
+           -1.2,
+           -0.2,
+           0.0,
+           0.2,
+           1.2,
+           4.0,
+           ((std::numeric_limits<int>::max)() - 0.5),
+       }) {
+    EXPECT_EQ(fmt::detail::iceil(v), static_cast<int>(std::ceil(v)));
+  }
+
+  FMT_CONSTEXPR20 auto result = constexpr_iceil();
+  EXPECT_TRUE(result);
+}


### PR DESCRIPTION
Fix for https://github.com/fmtlib/fmt/commit/858e528abd2be97cf11f9a9c1c180d6ad1a4d255#r114625556


Broken on macOS 13.3.1
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
C++20.
```
/.../fmt/test/compile-fp-test.cc:32: error: call to consteval function 'test_format<11UL, char, float, FMT_COMPILE_STRING>' is not a constant expression
/.../fmt/test/compile-fp-test.cc:32:27: error: call to consteval function 'test_format<11UL, char, float, FMT_COMPILE_STRING>' is not a constant expression
  EXPECT_EQ("392.500000", test_format<11>(FMT_COMPILE("{0:f}"), 392.5f));
                          ^
/.../fmt/include/fmt/format.h:3351:9: note: non-constexpr function 'ceil' cannot be used in a constant expression
        std::ceil((f.e + count_digits<1>(f.f) - 1) * inv_log2_10 - 1e-10));
```

``std::ceil`` is constexpr since C++23 (https://en.cppreference.com/w/cpp/numeric/math/ceil)

This is not a compiler bug. This is unimplemented feature in clang and msvs. Only gcc support it.
https://en.cppreference.com/w/cpp/compiler_support