### PR TITLE
Only use typeid() in std.h when it is available

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1786,7 +1786,7 @@ class format_arg_store
         basic_format_args<Context>(*this),
 #endif
         data_{detail::make_arg<is_packed, Context>(args)...} {
-    if (num_named_args != 0)
+    if (detail::const_check(num_named_args != 0))
       detail::init_named_args(data_.named_args(), 0, 0, args...);
   }
 };


### PR DESCRIPTION
This allows the std.h formatters to work when RTTI is disabed.

For issue #3464