### PR TITLE
Fix MSVC warning in std::chrono::time_point formatter

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2135,8 +2135,9 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
   auto format(std::chrono::time_point<std::chrono::system_clock, Duration> val,
               FormatContext& ctx) const -> decltype(ctx.out()) {
     using period = typename Duration::period;
-    if constexpr (period::num != 1 || period::den != 1 ||
-                  std::is_floating_point<typename Duration::rep>::value) {
+    if (detail::const_check(
+            period::num != 1 || period::den != 1 ||
+            std::is_floating_point<typename Duration::rep>::value)) {
       const auto epoch = val.time_since_epoch();
       auto subsecs = std::chrono::duration_cast<Duration>(
           epoch - std::chrono::duration_cast<std::chrono::seconds>(epoch));

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2135,8 +2135,8 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
   auto format(std::chrono::time_point<std::chrono::system_clock, Duration> val,
               FormatContext& ctx) const -> decltype(ctx.out()) {
     using period = typename Duration::period;
-    if (period::num != 1 || period::den != 1 ||
-        std::is_floating_point<typename Duration::rep>::value) {
+    if constexpr (period::num != 1 || period::den != 1 ||
+                  std::is_floating_point<typename Duration::rep>::value) {
       const auto epoch = val.time_since_epoch();
       auto subsecs = std::chrono::duration_cast<Duration>(
           epoch - std::chrono::duration_cast<std::chrono::seconds>(epoch));
@@ -2153,10 +2153,10 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
       return formatter<std::tm, Char>::do_format(
           gmtime(std::chrono::time_point_cast<std::chrono::seconds>(val)), ctx,
           &subsecs);
+    } else {
+      return formatter<std::tm, Char>::format(
+          gmtime(std::chrono::time_point_cast<std::chrono::seconds>(val)), ctx);
     }
-
-    return formatter<std::tm, Char>::format(
-        gmtime(std::chrono::time_point_cast<std::chrono::seconds>(val)), ctx);
   }
 };
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2154,10 +2154,10 @@ struct formatter<std::chrono::time_point<std::chrono::system_clock, Duration>,
       return formatter<std::tm, Char>::do_format(
           gmtime(std::chrono::time_point_cast<std::chrono::seconds>(val)), ctx,
           &subsecs);
-    } else {
-      return formatter<std::tm, Char>::format(
-          gmtime(std::chrono::time_point_cast<std::chrono::seconds>(val)), ctx);
     }
+
+    return formatter<std::tm, Char>::format(
+        gmtime(std::chrono::time_point_cast<std::chrono::seconds>(val)), ctx);
   }
 };
 


### PR DESCRIPTION
The condition is constexpr causing MSVC level 4 warning:
    warning C4127: conditional expression is constant

Made condition constexpr to eliminate the warning.

Code to reproduce the issue:
```
#include <fmt/chrono.h>
#include <fmt/xchar.h>
int main()
{
    fmt::format(L"{}", std::chrono::system_clock::time_point());
}
```

CMakeLists.txt:
```
cmake_minimum_required(VERSION 3.14)
project(mytest LANGUAGES CXX)

include(FetchContent)
FetchContent_Declare(fmt
  GIT_REPOSITORY  https://github.com/fmtlib/fmt.git
  GIT_TAG         10.0.0
)
FetchContent_MakeAvailable(fmt)

add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/W4>")
add_executable(mytest main.cpp)
target_compile_features(mytest PRIVATE cxx_std_17)
target_link_libraries(mytest PRIVATE fmt::fmt-header-only)
```
