### PR TITLE
Use correct Char type in std::filesystem::path formatter

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -89,9 +89,9 @@ inline void write_escaped_path<std::filesystem::path::value_type>(
 FMT_EXPORT
 template <typename Char>
 struct formatter<std::filesystem::path, Char>
-    : formatter<basic_string_view<Char>> {
+    : formatter<basic_string_view<Char>, Char> {
   template <typename ParseContext> FMT_CONSTEXPR auto parse(ParseContext& ctx) {
-    auto out = formatter<basic_string_view<Char>>::parse(ctx);
+    auto out = formatter<basic_string_view<Char>, Char>::parse(ctx);
     this->set_debug_format(false);
     return out;
   }
@@ -100,7 +100,7 @@ struct formatter<std::filesystem::path, Char>
       typename FormatContext::iterator {
     auto quoted = basic_memory_buffer<Char>();
     detail::write_escaped_path(quoted, p);
-    return formatter<basic_string_view<Char>>::format(
+    return formatter<basic_string_view<Char>, Char>::format(
         basic_string_view<Char>(quoted.data(), quoted.size()), ctx);
   }
 };


### PR DESCRIPTION
Fixed template specialization for std::filesystem::path formatter.

Godbolt repro:
https://godbolt.org/z/o4bjG6ddo

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
