### PR TITLE
Implement format_parse_context::starts_with()

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -681,12 +681,14 @@ template <typename Char> class basic_format_parse_context {
   constexpr bool starts_with(iterator prefix) const noexcept {
     auto first = begin();
     auto last = end();
+    bool mismatch_found = false;
     while (first != last && *prefix != '\0') {
       if (*prefix++ != *first++) {
-        return false;
+        mismatch_found = true;
+        break;
       }
     }
-    return *prefix == '\0';
+    return !mismatch_found && *prefix == '\0';
   }
 
   /** Advances the begin iterator to ``it``. */

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -679,11 +679,10 @@ template <typename Char> class basic_format_parse_context {
    * Checks whether the format string starts with the given prefix
    */
   constexpr bool starts_with(iterator prefix) const noexcept {
-    auto first = begin();
-    auto last = end();
+    std::ptrdiff_t i = 0;
     bool mismatch_found = false;
-    while (first != last && *prefix != '\0') {
-      if (*prefix++ != *first++) {
+    while (begin() + i != end() && *prefix != '\0') {
+      if (*prefix++ != *(begin() + i++)) {
         mismatch_found = true;
         break;
       }

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -675,6 +675,20 @@ template <typename Char> class basic_format_parse_context {
    */
   constexpr auto end() const noexcept -> iterator { return format_str_.end(); }
 
+  /**
+   * Checks whether the format string starts with the given prefix
+   */
+  constexpr bool starts_with(iterator prefix) const noexcept {
+    auto first = begin();
+    auto last = end();
+    while (first != last && *prefix != '\0') {
+      if (*prefix++ != *first++) {
+        return false;
+      }
+    }
+    return *prefix == '\0';
+  }
+
   /** Advances the begin iterator to ``it``. */
   FMT_CONSTEXPR void advance_to(iterator it) {
     format_str_.remove_prefix(detail::to_unsigned(it - begin()));


### PR DESCRIPTION
Add method to check whether the format string starts with a given prefix.

This simplifies specializing `fmt::formatter` for types like the following.

```c++
#include <fmt/format.h>
#include <cassert>


struct Record {
  int a;
  int b;
  int c;
};

template <>
struct fmt::formatter<Record> {
  enum Presentation { tsv, csv };
  Presentation presentation{Presentation::csv};

  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) {
    const auto *it = ctx.begin();
    const auto *end = ctx.end();

    if (ctx.starts_with(ctx, "tsv")) {
      this->presentation = Presentation::tsv;
      it += std::string_view{"tsv"}.size();
    } else if (ctx.starts_with(ctx, "csv")) {
      this->presentation = Presentation::csv;
      it += std::string_view{"csv"}.size();
    }

    if (it != end && *it != '}') {
      throw fmt::format_error("invalid format");
    }

    return it;
  }

  template <typename FormatContext>
  auto fmt::formatter<Record>::format(const Record &r, FormatContext &ctx) const  -> decltype(ctx.out()) {
    if (this->presentation == Presentation::tsv) {
      return fmt::format_to(ctx.out(), FMT_STRING("{}\t{}\t{}"), r.a, r.b, r.c);
    }

    assert(this->presentation == Presentation::csv);
    return fmt::format_to(ctx.out(), FMT_STRING("{},{},{}"), r.a, r.b, r.c);
  }
};
```