### PR TITLE
Trying to improve errors in the unformattable case.

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1550,11 +1550,6 @@ FMT_CONSTEXPR FMT_INLINE auto make_arg(T& val) -> value<Context> {
 
   constexpr bool formattable_char =
       !std::is_same<arg_type, unformattable_char>::value;
-#if defined(__cpp_if_constexpr)
-  if constexpr (!formattable_char) {
-    type_is_unformattable_for<T, typename Context::char_type> _;
-  }
-#endif
   static_assert(formattable_char, "Mixing character types is disallowed.");
 
   // Formatting of arbitrary pointers is disallowed. If you want to format a
@@ -1562,11 +1557,6 @@ FMT_CONSTEXPR FMT_INLINE auto make_arg(T& val) -> value<Context> {
   // formatting of `[const] volatile char*` printed as bool by iostreams.
   constexpr bool formattable_pointer =
       !std::is_same<arg_type, unformattable_pointer>::value;
-#if defined(__cpp_if_constexpr)
-  if constexpr (!formattable_pointer) {
-    type_is_unformattable_for<T, typename Context::char_type> _;
-  }
-#endif
   static_assert(formattable_pointer,
                 "Formatting of non-void pointers is disallowed.");
 

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1539,8 +1539,10 @@ constexpr auto encode_types() -> unsigned long long {
          (encode_types<Context, Args...>() << packed_arg_bits);
 }
 
+#if defined(__cpp_if_constexpr)
 // This type is intentionally undefined, only used for errors
 template <typename T, typename Char> struct type_is_unformattable_for;
+#endif
 
 template <bool PACKED, typename Context, typename T, FMT_ENABLE_IF(PACKED)>
 FMT_CONSTEXPR FMT_INLINE auto make_arg(T& val) -> value<Context> {
@@ -1548,9 +1550,11 @@ FMT_CONSTEXPR FMT_INLINE auto make_arg(T& val) -> value<Context> {
 
   constexpr bool formattable_char =
       !std::is_same<arg_type, unformattable_char>::value;
+#if defined(__cpp_if_constexpr)
   if constexpr (not formattable_char) {
     type_is_unformattable_for<T, typename Context::char_type> _;
   }
+#endif
   static_assert(formattable_char, "Mixing character types is disallowed.");
 
   // Formatting of arbitrary pointers is disallowed. If you want to format a
@@ -1558,16 +1562,20 @@ FMT_CONSTEXPR FMT_INLINE auto make_arg(T& val) -> value<Context> {
   // formatting of `[const] volatile char*` printed as bool by iostreams.
   constexpr bool formattable_pointer =
       !std::is_same<arg_type, unformattable_pointer>::value;
+#if defined(__cpp_if_constexpr)
   if constexpr (not formattable_pointer) {
     type_is_unformattable_for<T, typename Context::char_type> _;
   }
+#endif
   static_assert(formattable_pointer,
                 "Formatting of non-void pointers is disallowed.");
 
   constexpr bool formattable = !std::is_same<arg_type, unformattable>::value;
+#if defined(__cpp_if_constexpr)
   if constexpr (not formattable) {
     type_is_unformattable_for<T, typename Context::char_type> _;
   }
+#endif
   static_assert(
       formattable,
       "Cannot format an argument. To make type T formattable provide a "
@@ -2532,6 +2540,7 @@ FMT_CONSTEXPR auto parse_format_specs(ParseContext& ctx)
       mapped_type_constant<T, context>::value != type::custom_type,
       decltype(arg_mapper<context>().map(std::declval<const T&>())),
       typename strip_named_arg<T>::type>;
+#if defined(__cpp_if_constexpr)
   if constexpr (std::is_default_constructible_v<
                     formatter<mapped_type, char_type>>) {
     return formatter<mapped_type, char_type>().parse(ctx);
@@ -2539,6 +2548,9 @@ FMT_CONSTEXPR auto parse_format_specs(ParseContext& ctx)
     type_is_unformattable_for<T, char_type> _;
     return ctx.begin();
   }
+#else
+  return formatter<mapped_type, char_type>().parse(ctx);
+#endif
 }
 
 // Checks char specs and returns true iff the presentation type is char-like.

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1563,7 +1563,7 @@ FMT_CONSTEXPR FMT_INLINE auto make_arg(T& val) -> value<Context> {
   constexpr bool formattable_pointer =
       !std::is_same<arg_type, unformattable_pointer>::value;
 #if defined(__cpp_if_constexpr)
-  if constexpr (not formattable_pointer) {
+  if constexpr (!formattable_pointer) {
     type_is_unformattable_for<T, typename Context::char_type> _;
   }
 #endif
@@ -1572,7 +1572,7 @@ FMT_CONSTEXPR FMT_INLINE auto make_arg(T& val) -> value<Context> {
 
   constexpr bool formattable = !std::is_same<arg_type, unformattable>::value;
 #if defined(__cpp_if_constexpr)
-  if constexpr (not formattable) {
+  if constexpr (!formattable) {
     type_is_unformattable_for<T, typename Context::char_type> _;
   }
 #endif

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1551,7 +1551,7 @@ FMT_CONSTEXPR FMT_INLINE auto make_arg(T& val) -> value<Context> {
   constexpr bool formattable_char =
       !std::is_same<arg_type, unformattable_char>::value;
 #if defined(__cpp_if_constexpr)
-  if constexpr (not formattable_char) {
+  if constexpr (!formattable_char) {
     type_is_unformattable_for<T, typename Context::char_type> _;
   }
 #endif


### PR DESCRIPTION
This is my attempt to improve some some of the compile errors that we get when types aren't formattable at all. 

[Example 1](https://godbolt.org/z/3Pjhanv6s):

```cpp
void test(X x, Y y, Z z) {
    fmt::vprint("{} {} {}\n", fmt::make_format_args(x, y, z));
}
```

Before - you know _something_ is unformattable, but you don't know which one: is it the `X`, the `Y`, or the `Z`?

```
<source>: In instantiation of 'constexpr fmt::v10::detail::value<Context> fmt::v10::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; T = Y; typename std::enable_if<PACKED, int>::type <anonymous> = 0]':
<source>:1805:51:   required from 'constexpr fmt::v10::format_arg_store<Context, Args>::format_arg_store(T& ...) [with T = {X, Y, Z}; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; Args = {X, Y, Z}]'
<source>:1823:18:   required from 'constexpr fmt::v10::format_arg_store<Context, typename std::remove_cv<typename std::remove_reference<T>::type>::type ...> fmt::v10::make_format_args(T& ...) [with Context = basic_format_context<appender, char>; T = {X, Y, Z}]'
<source>:2936:52:   required from here
<source>:1577:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1577 |       formattable,
      |       ^~~~~~~~~~~
<source>:1577:7: note: 'formattable' evaluates to false
ASM generation compiler returned: 1
<source>: In instantiation of 'constexpr fmt::v10::detail::value<Context> fmt::v10::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; T = Y; typename std::enable_if<PACKED, int>::type <anonymous> = 0]':
<source>:1805:51:   required from 'constexpr fmt::v10::format_arg_store<Context, Args>::format_arg_store(T& ...) [with T = {X, Y, Z}; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; Args = {X, Y, Z}]'
<source>:1823:18:   required from 'constexpr fmt::v10::format_arg_store<Context, typename std::remove_cv<typename std::remove_reference<T>::type>::type ...> fmt::v10::make_format_args(T& ...) [with Context = basic_format_context<appender, char>; T = {X, Y, Z}]'
<source>:2936:52:   required from here
<source>:1577:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1577 |       formattable,
      |       ^~~~~~~~~~~
<source>:1577:7: note: 'formattable' evaluates to false
```

After: obviously the `Y`:

```
<source>: In instantiation of 'constexpr fmt::v10::detail::value<Context> fmt::v10::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; T = Y; typename std::enable_if<PACKED, int>::type <anonymous> = 0]':
<source>:1805:51:   required from 'constexpr fmt::v10::format_arg_store<Context, Args>::format_arg_store(T& ...) [with T = {X, Y, Z}; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; Args = {X, Y, Z}]'
<source>:1823:18:   required from 'constexpr fmt::v10::format_arg_store<Context, typename std::remove_cv<typename std::remove_reference<T>::type>::type ...> fmt::v10::make_format_args(T& ...) [with Context = basic_format_context<appender, char>; T = {X, Y, Z}]'
<source>:2936:52:   required from here
<source>:1573:63: error: 'fmt::v10::detail::type_is_unformattable_for<Y, char> _' has incomplete type
 1573 |     type_is_unformattable_for<T, typename Context::char_type> _;
      |                                                               ^
<source>:1577:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1577 |       formattable,
      |       ^~~~~~~~~~~
<source>:1577:7: note: 'formattable' evaluates to false
ASM generation compiler returned: 1
<source>: In instantiation of 'constexpr fmt::v10::detail::value<Context> fmt::v10::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; T = Y; typename std::enable_if<PACKED, int>::type <anonymous> = 0]':
<source>:1805:51:   required from 'constexpr fmt::v10::format_arg_store<Context, Args>::format_arg_store(T& ...) [with T = {X, Y, Z}; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; Args = {X, Y, Z}]'
<source>:1823:18:   required from 'constexpr fmt::v10::format_arg_store<Context, typename std::remove_cv<typename std::remove_reference<T>::type>::type ...> fmt::v10::make_format_args(T& ...) [with Context = basic_format_context<appender, char>; T = {X, Y, Z}]'
<source>:2936:52:   required from here
<source>:1573:63: error: 'fmt::v10::detail::type_is_unformattable_for<Y, char> _' has incomplete type
 1573 |     type_is_unformattable_for<T, typename Context::char_type> _;
      |                                                               ^
<source>:1577:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1577 |       formattable,
      |       ^~~~~~~~~~~
<source>:1577:7: note: 'formattable' evaluates to false
```

[Example 2](https://godbolt.org/z/KqzPvv6Ea), which is the more typical way people run into this:

```cpp
void test(X x, Y y, Z z) {
    fmt::print("{} {} {}\n", x, y, z);
}
```

Before (just copying the first error). Here, you can tell that `Y` isn't formattable, but the message is about something not being default constructible, which is a little cryptic?

```
<source>: In instantiation of 'constexpr decltype (ctx.begin()) fmt::v10::detail::parse_format_specs(ParseContext&) [with T = Y; ParseContext = compile_parse_context<char>; decltype (ctx.begin()) = const char*]':
<source>:2607:22:   required from 'constexpr fmt::v10::detail::format_string_checker<Char, Args>::format_string_checker(fmt::v10::basic_string_view<Char>) [with Char = char; Args = {X, Y, Z}]'
<source>:2937:15:   required from here
<source>:2549:10: error: use of deleted function 'fmt::v10::formatter<T, Char, Enable>::formatter() [with T = Y; Char = char; Enable = void]'
 2549 |   return formatter<mapped_type, char_type>().parse(ctx);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<source>:1066:3: note: declared here
 1066 |   formatter() = delete;
      |   ^~~~~~~~~
```

After: clearly `Y` is unformattable:

```cpp
<source>: In instantiation of 'constexpr decltype (ctx.begin()) fmt::v10::detail::parse_format_specs(ParseContext&) [with T = Y; ParseContext = compile_parse_context<char>; decltype (ctx.begin()) = const char*]':
<source>:2607:22:   required from 'constexpr fmt::v10::detail::format_string_checker<Char, Args>::format_string_checker(fmt::v10::basic_string_view<Char>) [with Char = char; Args = {X, Y, Z}]'
<source>:2937:15:   required from here
<source>:2545:45: error: 'fmt::v10::detail::type_is_unformattable_for<Y, char> _' has incomplete type
 2545 |     type_is_unformattable_for<T, char_type> _;
      |                                             ^
<source>: In instantiation of 'constexpr fmt::v10::detail::value<Context> fmt::v10::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; T = Y; typename std::enable_if<PACKED, int>::type <anonymous> = 0]':
<source>:1805:51:   required from 'constexpr fmt::v10::format_arg_store<Context, Args>::format_arg_store(T& ...) [with T = {X, Y, Z}; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; Args = {X, Y, Z}]'
<source>:1823:18:   required from 'constexpr fmt::v10::format_arg_store<Context, typename std::remove_cv<typename std::remove_reference<T>::type>::type ...> fmt::v10::make_format_args(T& ...) [with Context = basic_format_context<appender, char>; T = {X, Y, Z}]'
<source>:2870:44:   required from 'void fmt::v10::print(format_string<T ...>, T&& ...) [with T = {X&, Y&, Z&}; format_string<T ...> = basic_format_string<char, X&, Y&, Z&>]'
<source>:2937:15:   required from here
<source>:1573:63: error: 'fmt::v10::detail::type_is_unformattable_for<Y, char> _' has incomplete type
 1573 |     type_is_unformattable_for<T, typename Context::char_type> _;
      |                                                               ^
```

Maybe it's possible to do better than this, I'm not sure, but this is the best I've been able to come up with so far at least. 