### PR TITLE
Use FMT_TRY and FMT_CATCH in std.h

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -16,6 +16,7 @@
 #include <typeinfo>
 #include <utility>
 
+#include "format.h"
 #include "ostream.h"
 
 #if FMT_HAS_INCLUDE(<version>)
@@ -234,13 +235,14 @@ struct formatter<
     auto out = ctx.out();
 
     out = detail::write<Char>(out, "variant(");
-    try {
+    FMT_TRY {
       std::visit(
           [&](const auto& v) {
             out = detail::write_variant_alternative<Char>(out, v);
           },
           value);
-    } catch (const std::bad_variant_access&) {
+    }
+    FMT_CATCH(const std::bad_variant_access&) {
       detail::write<Char>(out, "valueless by exception");
     }
     *out++ = ')';


### PR DESCRIPTION
This naked try-catch block prevents compilation when exceptions are disabled.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
