### PR TITLE
Revert ae25f79 to restore capability to `cmake --install` when included as a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,6 @@ set(FMT_DEBUG_POSTFIX d CACHE STRING "Debug library postfix.")
 
 set_target_properties(fmt PROPERTIES
   VERSION ${FMT_VERSION} SOVERSION ${CPACK_PACKAGE_VERSION_MAJOR}
-  PUBLIC_HEADER "${FMT_HEADERS}"
   DEBUG_POSTFIX "${FMT_DEBUG_POSTFIX}")
 
 # Set FMT_LIB_NAME for pkg-config fmt.pc. We cannot use the OUTPUT_NAME target
@@ -384,7 +383,6 @@ if (FMT_INSTALL)
           LIBRARY DESTINATION ${FMT_LIB_DIR}
           ARCHIVE DESTINATION ${FMT_LIB_DIR}
           PUBLIC_HEADER DESTINATION "${FMT_INC_DIR}/fmt"
-          FRAMEWORK DESTINATION "."
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   # Use a namespace because CMake provides better diagnostics for namespaced


### PR DESCRIPTION
Following the discussion in #3489, this PR reverts commit ae25f7968efca30a6483ad7802ccfa5419f6330a.

This commit introduces a relative path dependency to public header files, which does not hold when fmtlib is included as non-root project in more complex directory tree. At a later point during a call to `cmake --install` this relative path is resolved w.r.t. the path of the root project rather than the fmtlib project, causing a failure.

Since this PR does not add anything new, compliance with coding conventions is trivially satisfied. Furthermore, the submitter hereby agrees to fmtlib's license conditions.
