### PR TITLE
Fix typo in assert message.

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3300,7 +3300,7 @@ FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs,
       significand <<= 1;
     } else {
       // Normalize subnormal inputs.
-      FMT_ASSERT(significand != 0, "zeros should not appear hear");
+      FMT_ASSERT(significand != 0, "zeros should not appear here");
       int shift = countl_zero(significand);
       FMT_ASSERT(shift >= num_bits<uint64_t>() - num_significand_bits<double>(),
                  "");


### PR DESCRIPTION
I noticed this one while looking at the compiler output in godbolt. I reviewed all strings in the file but this was the only typo I found.

oh, and sorry about the typo in the commit message :( 

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
