### PR TITLE
README: Add link to merged clang-tidy check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -295,9 +295,12 @@ or the bloat test::
 Migrating code
 --------------
 
-`clang-tidy-fmt <https://github.com/mikecrowe/clang-tidy-fmt>`_ provides clang
-tidy checks for converting occurrences of ``printf`` and ``fprintf`` to
-``fmt::print``.
+`clang-tidy <https://clang.llvm.org/extra/clang-tidy/>`_ v17 (not yet
+released) provides the `modernize-use-std-print
+<https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-print.html>`_
+check that is capable of converting occurrences of ``printf`` and
+``fprintf`` to ``fmt::print`` if configured to do so. (By default it
+converts to ``std::print``.)
 
 Projects using this library
 ---------------------------


### PR DESCRIPTION
A much-improved version of the main clang-tidy-fmt check for converting printf and fprintf has landed in upstream LLVM. It converts to std::print by default, but can be configured to convert to fmt::print instead. It makes more sense for the README to point to that version instead now.

