### PR TITLE
constexpr-ed a 'shift', of constexpr variables

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2821,7 +2821,7 @@ class bigint {
   FMT_CONSTEXPR20 void multiply(UInt value) {
     using half_uint =
         conditional_t<std::is_same<UInt, uint128_t>::value, uint64_t, uint32_t>;
-    const int shift = num_bits<half_uint>() - bigit_bits;
+    constexpr int shift = num_bits<half_uint>() - bigit_bits;
     const UInt lower = static_cast<half_uint>(value);
     const UInt upper = value >> num_bits<half_uint>();
     UInt carry = 0;


### PR DESCRIPTION
Credits to, **Code Analyzer of Visual Studio 2022 (MSVC 17.6.4)**.

<!-- ✅
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
