### PR TITLE
Add an option to disable file descriptors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,13 @@ target_include_directories(fmt-header-only ${FMT_SYSTEM_HEADERS_ATTRIBUTE} INTER
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${FMT_INC_DIR}>)
 
+option(FMT_FILE_DESCRIPTORS "Disable this if your system does not provide numeric file descriptors" ON)
+mark_as_advanced(FMT_FILE_DESCRIPTORS)
+if (NOT FMT_FILE_DESCRIPTORS)
+  target_compile_definitions(fmt PUBLIC FMT_HAS_FILE_DESCRIPTORS=0)
+  target_compile_definitions(fmt-header-only INTERFACE FMT_HAS_FILE_DESCRIPTORS=0)
+endif ()
+
 # Install targets.
 if (FMT_INSTALL)
   include(CMakePackageConfigHelpers)

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -19,6 +19,17 @@
 
 #include "format.h"
 
+// Some operating systems do not implement numeric file descriptors.
+// If set to 0, functions that rely on file descriptors will not be defined.
+#ifndef FMT_HAS_FILE_DESCRIPTORS
+#  define FMT_HAS_FILE_DESCRIPTORS 1
+#endif
+
+// FCNTL requires file descriptors.
+#if FMT_HAS_FILE_DESCRIPTORS == 0
+#  define FMT_USE_FCNTL 0
+#endif
+
 #ifndef FMT_USE_FCNTL
 // UWP doesn't provide _pipe.
 #  if FMT_HAS_INCLUDE("winapifamily.h")
@@ -222,7 +233,9 @@ class buffered_file {
   // Returns the pointer to a FILE object representing this file.
   FILE* get() const noexcept { return file_; }
 
+#if FMT_HAS_FILE_DESCRIPTORS
   FMT_API int descriptor() const;
+#endif
 
   void vprint(string_view format_str, format_args args) {
     fmt::vprint(file_, format_str, args);

--- a/src/os.cc
+++ b/src/os.cc
@@ -181,6 +181,7 @@ void buffered_file::close() {
     FMT_THROW(system_error(errno, FMT_STRING("cannot close file")));
 }
 
+#if FMT_HAS_FILE_DESCRIPTORS
 int buffered_file::descriptor() const {
 #ifdef fileno  // fileno is a macro on OpenBSD so we cannot use FMT_POSIX_CALL.
   int fd = fileno(file_);
@@ -191,6 +192,7 @@ int buffered_file::descriptor() const {
     FMT_THROW(system_error(errno, FMT_STRING("cannot get file descriptor")));
   return fd;
 }
+#endif  // FMT_HAS_FILE_DESCRIPTORS
 
 #if FMT_USE_FCNTL
 #  ifdef _WIN32


### PR DESCRIPTION
Systems such as Win98 and the original Xbox do not provide file numeric file descriptors.

Allows the user to selectively disable the functionality that relies on numeric file descriptors.

---

Not sure if this is the right way to go about it, advice appreciated.
I'm trying to extract the changes needed to build for NXDK and Win98 into separate options.

Here are all the changes needed for NXDK: https://github.com/diasurgical/fmt/commit/e421e854efcb21ee641349bab604d91b34af26b8