### PR TITLE
Added format_string forwarding tests to color-test, Fixed #3536

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -536,6 +536,12 @@ constexpr auto to_string_view(const S& s)
     -> basic_string_view<typename S::char_type> {
   return basic_string_view<typename S::char_type>(s);
 }
+// Catch basic_format_string for any char type.
+template <typename S, FMT_ENABLE_IF(!is_compile_string<S>::value)>
+constexpr auto to_string_view(const S& s)
+    -> decltype(s.get()) {
+  return s.get();
+}
 void to_string_view(...);
 
 // Specifies whether S is a string type convertible to fmt::basic_string_view.

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -538,8 +538,7 @@ constexpr auto to_string_view(const S& s)
 }
 // Catch basic_format_string for any char type.
 template <typename S, FMT_ENABLE_IF(!is_compile_string<S>::value)>
-constexpr auto to_string_view(const S& s)
-    -> decltype(s.get()) {
+constexpr auto to_string_view(const S& s) -> decltype(s.get()) {
   return s.get();
 }
 void to_string_view(...);

--- a/test/color-test.cc
+++ b/test/color-test.cc
@@ -58,6 +58,13 @@ TEST(color_test, format) {
             "\x1b[4m\x1b[38;2;000;000;255mbar\x1b[0m");
 }
 
+TEST(color_test, format_forwarding) {
+  const fmt::format_string<int,int,int> format_str_int = "rgb(255,20,30){}{}{}";
+  auto sv = fmt::detail::to_string_view(format_str_int);
+  EXPECT_EQ(fmt::format(fg(fmt::rgb(255, 20, 30)), format_str_int, 1, 2, 3),
+            "\x1b[38;2;255;020;030mrgb(255,20,30)123\x1b[0m");
+}
+
 TEST(color_test, format_to) {
   auto out = std::string();
   fmt::format_to(std::back_inserter(out), fg(fmt::rgb(255, 20, 30)),
@@ -66,7 +73,24 @@ TEST(color_test, format_to) {
             "\x1b[38;2;255;020;030mrgb(255,20,30)123\x1b[0m");
 }
 
+TEST(color_test, format_to_forwarding) {
+  auto out = std::string();
+  const fmt::format_string<int,int,int> format_str_int = "rgb(255,20,30){}{}{}";
+  fmt::format_to(std::back_inserter(out), fg(fmt::rgb(255, 20, 30)),
+                 format_str_int, 1, 2, 3);
+  EXPECT_EQ(fmt::to_string(out),
+            "\x1b[38;2;255;020;030mrgb(255,20,30)123\x1b[0m");
+}
+
 TEST(color_test, print) {
   EXPECT_WRITE(stdout, fmt::print(fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30)"),
                "\x1b[38;2;255;020;030mrgb(255,20,30)\x1b[0m");
+}
+
+TEST(color_test, print_forwarding) {
+  const fmt::format_string<int,int,int> format_str_int = "rgb(255,20,30){}{}{}";
+  EXPECT_WRITE(stdout, fmt::print(fg(fmt::rgb(255, 20, 30)), format_str_int, 1, 2, 3),
+               "\x1b[38;2;255;020;030mrgb(255,20,30)123\x1b[0m");
+  EXPECT_WRITE(stdout, fmt::print(stdout, fg(fmt::rgb(255, 20, 30)), format_str_int, 1, 2, 3),
+               "\x1b[38;2;255;020;030mrgb(255,20,30)123\x1b[0m");
 }


### PR DESCRIPTION
Referring to #3536

I was not able to make the suggested change because the color functions must preserve the Char type of the basic_format_string, and this cannot be plumbed through all the way down those overloads due to how ubiquitous the `is_string`, `to_string_view` and `char_t` meta-functions are.

The only viable solution appeared to fix those meta-functions to work with basic_format_string, as it they were clearly intended to. The solution to that particular riddle (without casting too broad of an implicit conversion net) was to Sfinae-switch on the existence of the `.get()` function that `basic_format_string` has to retrieve the underlying `string_view`.

This PR does that and adds the tests for the color function. The added tests fail without this fix. And all other tests pass to.