### PR TITLE
Remove std::copy usage.

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2896,7 +2896,7 @@ class bigint {
     auto size = other.bigits_.size();
     bigits_.resize(size);
     auto data = other.bigits_.data();
-    std::copy(data, data + size, bigits_.data());
+    std::uninitialized_copy(data, data + size, bigits_.data());
     exp_ = other.exp_;
   }
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2896,7 +2896,7 @@ class bigint {
     auto size = other.bigits_.size();
     bigits_.resize(size);
     auto data = other.bigits_.data();
-    std::uninitialized_copy(data, data + size, bigits_.data());
+    copy_str<bigit>(data, data + size, bigits_.data());
     exp_ = other.exp_;
   }
 


### PR DESCRIPTION
Fixes missing `<algorithm>` include error.