### PR TITLE
expose detail::throw_format_error

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -124,7 +124,7 @@ parsing and formatting. To use this method specialize the ``formatter`` struct
 template for your type and implement ``parse`` and ``format`` methods.
 For example::
 
-  #include <fmt/format.h>
+  #include <fmt/core.h>
 
   struct point {
     double x, y;
@@ -156,7 +156,7 @@ For example::
       if (it != end && (*it == 'f' || *it == 'e')) presentation = *it++;
 
       // Check if reached the end of the range:
-      if (it != end && *it != '}') throw format_error("invalid format");
+      if (it != end && *it != '}') throw_format_error("invalid format");
 
       // Return an iterator past the end of the parsed range:
       return it;

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -638,6 +638,9 @@ struct error_handler {
 };
 }  // namespace detail
 
+/** Helper function to throw an error from a custom formatter. */
+using detail::throw_format_error;
+
 /** String's character type. */
 template <typename S> using char_t = typename detail::char_t_impl<S>::type;
 


### PR DESCRIPTION
This enables to only #include <fmt/core.h> when defining formatters.

Addresses https://github.com/fmtlib/fmt/issues/3529.
