### PR TITLE
Add missing inline specifier

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -73,7 +73,7 @@ void write_escaped_path(basic_memory_buffer<Char>& quoted,
 
 #  ifdef _WIN32
 template <>
-auto get_path_string<char>(const std::filesystem::path& p) {
+inline auto get_path_string<char>(const std::filesystem::path& p) {
   return to_utf8<wchar_t>(p.native(), to_utf8_error_policy::replace);
 }
 


### PR DESCRIPTION
Add missing inline specifier for `auto get_path_string<char>(const std::filesystem::path& p)`, causing duplicate symbol build errors on windows