### PR TITLE
fix ambiguous formatter lookup for flat_set

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -668,8 +668,11 @@ template <typename Container> struct all {
 }  // namespace detail
 
 template <typename T, typename Char>
-struct formatter<T, Char,
-                 enable_if_t<detail::is_container_adaptor_like<T>::value>>
+struct formatter<
+    T, Char,
+    enable_if_t<conjunction<detail::is_container_adaptor_like<T>,
+                            bool_constant<range_format_kind<T, Char>::value ==
+                                          range_format::disabled>>::value>>
     : formatter<detail::all<typename T::container_type>, Char> {
   using all = detail::all<typename T::container_type>;
   template <typename FormatContext>

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -15,6 +15,7 @@
 #include <queue>
 #include <stack>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -77,6 +78,32 @@ TEST(ranges_test, format_map) {
 
 TEST(ranges_test, format_set) {
   EXPECT_EQ(fmt::format("{}", std::set<std::string>{"one", "two"}),
+            "{\"one\", \"two\"}");
+}
+
+// Models std::flat_set close enough to test if no ambiguous lookup of a
+// formatter happens due to the flat_set type matching is_set and
+// is_container_adaptor_like
+template <typename T> class flat_set {
+ public:
+  using key_type = T;
+  using container_type = std::vector<T>;
+
+  template <typename... Ts>
+  explicit flat_set(Ts&&... args) : c{std::forward<Ts>(args)...} {}
+
+  auto begin() -> decltype(auto) { return c.begin(); }
+  auto begin() const -> decltype(auto) { return c.begin(); }
+
+  auto end() -> decltype(auto) { return c.end(); }
+  auto end() const -> decltype(auto) { return c.end(); }
+
+ private:
+  std::vector<T> c;
+};
+
+TEST(ranges_test, format_flat_set) {
+  EXPECT_EQ(fmt::format("{}", flat_set<std::string>{"one", "two"}),
             "{\"one\", \"two\"}");
 }
 

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -89,14 +89,17 @@ template <typename T> class flat_set {
   using key_type = T;
   using container_type = std::vector<T>;
 
+  using iterator = typename std::vector<T>::iterator;
+  using const_iterator = typename std::vector<T>::const_iterator;
+
   template <typename... Ts>
   explicit flat_set(Ts&&... args) : c{std::forward<Ts>(args)...} {}
 
-  auto begin() -> decltype(auto) { return c.begin(); }
-  auto begin() const -> decltype(auto) { return c.begin(); }
+  iterator begin() { return c.begin(); }
+  const_iterator begin() const { return c.begin(); }
 
-  auto end() -> decltype(auto) { return c.end(); }
-  auto end() const -> decltype(auto) { return c.end(); }
+  iterator end() { return c.end(); }
+  const_iterator end() const { return c.end(); }
 
  private:
   std::vector<T> c;


### PR DESCRIPTION
Fixes #3556

The underlying issue was that the `flat_set` of boost (and in theory of std), could match `is_set` and `is_container_adaptor_like` at the same time. This resulted in an ambiguous lookup of the formatters for ranges and range adaptors.

I added the change that @vitaut suggested in the issue and tested the change with a minimal reproducer of the original issue (a range that matches `is_set` and `is_container_adaptor_like`).