### PR TITLE
cmake: respect semantic versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,7 +363,7 @@ if (FMT_INSTALL)
   write_basic_package_version_file(
     ${version_config}
     VERSION ${FMT_VERSION}
-    COMPATIBILITY AnyNewerVersion)
+    COMPATIBILITY SameMajorVersion)
 
   join_paths(libdir_for_pc_file "\${exec_prefix}" "${FMT_LIB_DIR}")
   join_paths(includedir_for_pc_file "\${prefix}" "${FMT_INC_DIR}")


### PR DESCRIPTION
`fmt` is [clearly incompatible between different major versions ](https://github.com/fmtlib/fmt/issues/3560).
This will allow `find_package(fmt 9 REQUIRED)` to reject version 10.