### PR TITLE
Add fmt::println without args

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2912,6 +2912,13 @@ FMT_INLINE void println(format_string<T...> fmt, T&&... args) {
   return fmt::println(stdout, fmt, std::forward<T>(args)...);
 }
 
+/**
+  Writes a newline to ``stdout``.
+ */
+FMT_INLINE void println() {
+  return fmt::println(stdout, "");
+}
+
 FMT_END_EXPORT
 FMT_GCC_PRAGMA("GCC pop_options")
 FMT_END_NAMESPACE

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2915,9 +2915,7 @@ FMT_INLINE void println(format_string<T...> fmt, T&&... args) {
 /**
   Writes a newline to ``stdout``.
  */
-FMT_INLINE void println() {
-  return fmt::println(stdout, "");
-}
+FMT_INLINE void println() { return fmt::println(""); }
 
 FMT_END_EXPORT
 FMT_GCC_PRAGMA("GCC pop_options")


### PR DESCRIPTION
Hi there!

I added a println function with no arguments. This function allows you to output an empty string to the console, which can be useful for output formatting.

It is just a short way to write this:
```cpp
fmt::println("");
```

The Java language also has a println function with no arguments, which prints only a newline to the console. This println function in the fmt library will work similarly.