### PR TITLE
Added format_as for std::vector<bool>::reference

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -15,6 +15,7 @@
 #include <type_traits>
 #include <typeinfo>
 #include <utility>
+#include <vector>
 
 #include "format.h"
 #include "ostream.h"
@@ -390,5 +391,13 @@ struct formatter<
   }
 };
 FMT_END_NAMESPACE
+
+namespace std
+{
+template <typename T, FMT_ENABLE_IF(std::is_same<T, std::vector<bool>::reference>::value)>
+inline auto format_as(T b) -> bool {
+  return static_cast<bool>(b);
+}
+}
 
 #endif  // FMT_STD_H_

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -221,3 +221,8 @@ TEST(std_test, exception) {
   }
 #endif
 }
+
+TEST(std_test, format_vector_bool_specialization) {
+  std::vector<bool> v = {true, false};
+  EXPECT_EQ(fmt::format("{} {}", v[0], v[1]), "true false");
+}


### PR DESCRIPTION
Added a format_as entry to support std::vector\<bool\>::reference.

closes #3567 