### PR TITLE
Add formatter for std::atomic

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -8,6 +8,7 @@
 #ifndef FMT_STD_H_
 #define FMT_STD_H_
 
+#include <atomic>
 #include <bitset>
 #include <cstdlib>
 #include <exception>
@@ -435,6 +436,17 @@ struct formatter<BitRef, Char,
   }
 };
 
-FMT_END_NAMESPACE
+FMT_EXPORT
+template <typename T, typename Char>
+struct formatter<std::atomic<T>, Char,
+                 enable_if_t<is_formattable<T, Char>::value>>
+    : formatter<T, Char> {
+  template <typename FormatContext>
+  auto format(const std::atomic<T>& v, FormatContext& ctx) const
+      -> decltype(ctx.out()) {
+    return formatter<T, Char>::format(v.load(), ctx);
+  }
+};
 
+FMT_END_NAMESPACE
 #endif  // FMT_STD_H_

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -236,3 +236,11 @@ TEST(std_test, format_const_bit_reference) {
   const std::vector<bool> v = {true, false};
   EXPECT_EQ(fmt::format("{} {}", v[0], v[1]), "true false");
 }
+
+TEST(std_test, format_atomic) {
+  std::atomic<bool> b(false);
+  EXPECT_EQ(fmt::format("{}", b), "false");
+
+  const std::atomic<bool> cb(true);
+  EXPECT_EQ(fmt::format("{}", cb), "true");
+}


### PR DESCRIPTION
There is no formatter for `std::atomic` and `std:errc` and inject `format_as` in `std` namespace is not a good idea.

This patch implement formatter for above types.
