### PR TITLE
Fix `formatted_size` with `FMT_COMPILE` and format specs

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1387,8 +1387,8 @@ FMT_CONSTEXPR auto format_uint(Char* buffer, UInt value, int num_digits,
 }
 
 template <unsigned BASE_BITS, typename Char, typename It, typename UInt>
-inline auto format_uint(It out, UInt value, int num_digits, bool upper = false)
-    -> It {
+FMT_CONSTEXPR inline auto format_uint(It out, UInt value, int num_digits,
+                                      bool upper = false) -> It {
   if (auto ptr = to_pointer<Char>(out, to_unsigned(num_digits))) {
     format_uint<BASE_BITS>(ptr, value, num_digits, upper);
     return out;

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -199,6 +199,21 @@ TEST(compile_test, format_to_n) {
 TEST(compile_test, constexpr_formatted_size) {
   FMT_CONSTEXPR20 size_t size = fmt::formatted_size(FMT_COMPILE("{}"), 42);
   EXPECT_EQ(size, 2);
+  FMT_CONSTEXPR20 size_t hex_size =
+      fmt::formatted_size(FMT_COMPILE("{:x}"), 15);
+  EXPECT_EQ(hex_size, 1);
+  FMT_CONSTEXPR20 size_t binary_size =
+      fmt::formatted_size(FMT_COMPILE("{:b}"), 15);
+  EXPECT_EQ(binary_size, 4);
+  FMT_CONSTEXPR20 size_t padded_size =
+      fmt::formatted_size(FMT_COMPILE("{:*^6}"), 42);
+  EXPECT_EQ(padded_size, 6);
+  FMT_CONSTEXPR20 size_t float_size =
+      fmt::formatted_size(FMT_COMPILE("{:.3}"), 12.345);
+  EXPECT_EQ(float_size, 4);
+  FMT_CONSTEXPR20 size_t str_size =
+      fmt::formatted_size(FMT_COMPILE("{:s}"), "abc");
+  EXPECT_EQ(str_size, 3);
 }
 #  endif
 


### PR DESCRIPTION
Addresses issue #3586
