### PR TITLE
`atomic_flag` formatting

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -451,8 +451,7 @@ struct formatter<std::atomic<T>, Char,
 #if defined(__cpp_lib_atomic_flag_test) && __cpp_lib_atomic_flag_test >= 201907L
 FMT_EXPORT
 template <typename Char>
-struct formatter<std::atomic_flag, Char,
-                 enable_if_t<is_formattable<bool, Char>::value>>
+struct formatter<std::atomic_flag, Char>
     : formatter<bool, Char> {
   template <typename FormatContext>
   auto format(const std::atomic_flag& v, FormatContext& ctx) const

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -448,5 +448,19 @@ struct formatter<std::atomic<T>, Char,
   }
 };
 
+#if defined(__cpp_lib_atomic_flag_test) && __cpp_lib_atomic_flag_test >= 201907L
+FMT_EXPORT
+template <typename Char>
+struct formatter<std::atomic_flag, Char,
+                 enable_if_t<is_formattable<bool, Char>::value>>
+    : formatter<bool, Char> {
+  template <typename FormatContext>
+  auto format(const std::atomic_flag& v, FormatContext& ctx) const
+      -> decltype(ctx.out()) {
+    return formatter<bool, Char>::format(v.test(), ctx);
+  }
+};
+#endif // defined(__cpp_lib_atomic_flag_test) && __cpp_lib_atomic_flag_test >= 201907L
+
 FMT_END_NAMESPACE
 #endif  // FMT_STD_H_

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -448,7 +448,7 @@ struct formatter<std::atomic<T>, Char,
   }
 };
 
-#if defined(__cpp_lib_atomic_flag_test) && __cpp_lib_atomic_flag_test >= 201907L
+#ifdef __cpp_lib_atomic_flag_test
 FMT_EXPORT
 template <typename Char>
 struct formatter<std::atomic_flag, Char>
@@ -459,7 +459,7 @@ struct formatter<std::atomic_flag, Char>
     return formatter<bool, Char>::format(v.test(), ctx);
   }
 };
-#endif // defined(__cpp_lib_atomic_flag_test) && __cpp_lib_atomic_flag_test >= 201907L
+#endif // __cpp_lib_atomic_flag_test
 
 FMT_END_NAMESPACE
 #endif  // FMT_STD_H_

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -244,3 +244,14 @@ TEST(std_test, format_atomic) {
   const std::atomic<bool> cb(true);
   EXPECT_EQ(fmt::format("{}", cb), "true");
 }
+
+#if defined(__cpp_lib_atomic_flag_test) && __cpp_lib_atomic_flag_test >= 201907L
+TEST(std_test, format_atomic_flag) {
+  std::atomic_flag f = ATOMIC_FLAG_INIT;
+  (void) f.test_and_set();
+  EXPECT_EQ(fmt::format("{}", f), "true");
+
+  const std::atomic<bool> cf = ATOMIC_FLAG_INIT;
+  EXPECT_EQ(fmt::format("{}", cf), "false");
+}
+#endif // defined(__cpp_lib_atomic_flag_test) && __cpp_lib_atomic_flag_test >= 201907L

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -245,7 +245,7 @@ TEST(std_test, format_atomic) {
   EXPECT_EQ(fmt::format("{}", cb), "true");
 }
 
-#if defined(__cpp_lib_atomic_flag_test) && __cpp_lib_atomic_flag_test >= 201907L
+#ifdef __cpp_lib_atomic_flag_test
 TEST(std_test, format_atomic_flag) {
   std::atomic_flag f = ATOMIC_FLAG_INIT;
   (void) f.test_and_set();
@@ -254,4 +254,4 @@ TEST(std_test, format_atomic_flag) {
   const std::atomic_flag cf = ATOMIC_FLAG_INIT;
   EXPECT_EQ(fmt::format("{}", cf), "false");
 }
-#endif // defined(__cpp_lib_atomic_flag_test) && __cpp_lib_atomic_flag_test >= 201907L
+#endif // __cpp_lib_atomic_flag_test

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -251,7 +251,7 @@ TEST(std_test, format_atomic_flag) {
   (void) f.test_and_set();
   EXPECT_EQ(fmt::format("{}", f), "true");
 
-  const std::atomic<bool> cf = ATOMIC_FLAG_INIT;
+  const std::atomic_flag cf = ATOMIC_FLAG_INIT;
   EXPECT_EQ(fmt::format("{}", cf), "false");
 }
 #endif // defined(__cpp_lib_atomic_flag_test) && __cpp_lib_atomic_flag_test >= 201907L


### PR DESCRIPTION
To have complete atomic support