### PR TITLE
Fix `FMT_NO_UNIQUE_ADDRESS` warning with clang-cl.

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -83,7 +83,8 @@
 #  if FMT_CPLUSPLUS >= 202002L
 #    if FMT_HAS_CPP_ATTRIBUTE(no_unique_address)
 #      define FMT_NO_UNIQUE_ADDRESS [[no_unique_address]]
-#    elif FMT_MSC_VERSION >= 1929  // VS2019 v16.10 and later
+// VS2019 v16.10 and later except clang-cl (https://reviews.llvm.org/D110485)
+#    elif (FMT_MSC_VERSION >= 1929) && !FMT_CLANG_VERSION
 #      define FMT_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
 #    endif
 #  endif


### PR DESCRIPTION
Hi

clang-cl is generating a warning with the `no_unique_address` change from c86fe0b8d3aa6553160ad04aed608c2e694e9136: `warning : unknown attribute 'no_unique_address' ignored [-Wunknown-attributes]`

Thread on clang-cl and no_unique_address: https://reviews.llvm.org/D110485

Here's an additional check check for clang-cl (plus use `__has_cpp_attribute(msvc::no_unique_address)` to cope in case clang-cl adds support; cl returns true since 19.31).

Thanks

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
