### PR TITLE
Add back legacy time_point interface

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -477,11 +477,14 @@ inline std::tm localtime(std::time_t time) {
   return lt.tm_;
 }
 
+inline std::tm localtime(std::chrono::system_clock::time_point time_point) {
+  return localtime(std::chrono::system_clock::to_time_t(time_point));
+}
+
 #if FMT_USE_LOCAL_TIME
 template <typename Duration>
 inline auto localtime(std::chrono::local_time<Duration> time) -> std::tm {
-  return localtime(std::chrono::system_clock::to_time_t(
-      std::chrono::current_zone()->to_sys(time)));
+  return localtime(std::chrono::current_zone()->to_sys(time));
 }
 #endif
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
The old interface of `fmt::localtime` for `std::chrono::system_clock::time_point` has been removed in 115001a3b165483563822645bb93fd9558908c50, but I think it is worth keeping it for legacy code. `std::chrono::local_time` was introduced in C++20 which is too new to most of the production applications.