### PR TITLE
Fix for FMT_MODULE not compiling on GCC

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -376,9 +376,6 @@ class uint128_fallback {
   constexpr uint64_t high() const noexcept { return hi_; }
   constexpr uint64_t low() const noexcept { return lo_; }
 
-  uint64_t& high() { return hi_; }
-  uint64_t& low() { return lo_; }
-
   template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
   constexpr explicit operator T() const {
     return static_cast<T>(lo_);
@@ -1489,9 +1486,9 @@ inline uint128_fallback umul128(uint64_t x, uint64_t y) noexcept {
   auto p = static_cast<uint128_opt>(x) * static_cast<uint128_opt>(y);
   return {static_cast<uint64_t>(p >> 64), static_cast<uint64_t>(p)};
 #elif defined(_MSC_VER) && defined(_M_X64)
-  auto result = uint128_fallback();
-  result.low() = _umul128(x, y, &result.high());
-  return result;
+  auto hi = uint64_t{};
+  auto lo = _umul128(x, y, &hi);
+  return {hi, lo};
 #else
   const uint64_t mask = static_cast<uint64_t>(max_value<uint32_t>());
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -369,6 +369,10 @@ class uint128_fallback {
  private:
   uint64_t lo_, hi_;
 
+#ifdef _WIN32
+  friend uint128_fallback umul128(uint64_t x, uint64_t y) noexcept;
+#endif
+
  public:
   constexpr uint128_fallback(uint64_t hi, uint64_t lo) : lo_(lo), hi_(hi) {}
   constexpr uint128_fallback(uint64_t value = 0) : lo_(value), hi_(0) {}

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -369,8 +369,6 @@ class uint128_fallback {
  private:
   uint64_t lo_, hi_;
 
-  friend uint128_fallback umul128(uint64_t x, uint64_t y) noexcept;
-
  public:
   constexpr uint128_fallback(uint64_t hi, uint64_t lo) : lo_(lo), hi_(hi) {}
   constexpr uint128_fallback(uint64_t value = 0) : lo_(value), hi_(0) {}

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -369,16 +369,15 @@ class uint128_fallback {
  private:
   uint64_t lo_, hi_;
 
-#ifdef _WIN32
-  friend uint128_fallback umul128(uint64_t x, uint64_t y) noexcept;
-#endif
-
  public:
   constexpr uint128_fallback(uint64_t hi, uint64_t lo) : lo_(lo), hi_(hi) {}
   constexpr uint128_fallback(uint64_t value = 0) : lo_(value), hi_(0) {}
 
   constexpr uint64_t high() const noexcept { return hi_; }
   constexpr uint64_t low() const noexcept { return lo_; }
+
+  uint64_t& high() { return hi_; }
+  uint64_t& low() { return lo_; }
 
   template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
   constexpr explicit operator T() const {
@@ -1491,7 +1490,7 @@ inline uint128_fallback umul128(uint64_t x, uint64_t y) noexcept {
   return {static_cast<uint64_t>(p >> 64), static_cast<uint64_t>(p)};
 #elif defined(_MSC_VER) && defined(_M_X64)
   auto result = uint128_fallback();
-  result.lo_ = _umul128(x, y, &result.hi_);
+  result.low() = _umul128(x, y, &result.high());
   return result;
 #else
   const uint64_t mask = static_cast<uint64_t>(max_value<uint32_t>());


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
Removing the friend function declaration has made compilation with FMT_MODULE succeed on GCC on linux. Also Tested with clang on linux.

However I have noted some failed checks with windows.

Perhaps a macro could now fix #3587
