### PR TITLE
Remove whitespace in `operator"" _a`

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -4428,7 +4428,7 @@ template <detail_exported::fixed_string Str> constexpr auto operator""_a() {
   return detail::udl_arg<char_t, sizeof(Str.data) / sizeof(char_t), Str>();
 }
 #  else
-constexpr auto operator"" _a(const char* s, size_t) -> detail::udl_arg<char> {
+constexpr auto operator""_a(const char* s, size_t) -> detail::udl_arg<char> {
   return {s};
 }
 #  endif


### PR DESCRIPTION
Clang 18 warns about this whitespace.

```
third_party/fmt/include/fmt/format.h:4417:27: warning: identifier '_a' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
 4417 | constexpr auto operator"" _a(const char* s, size_t) -> detail::udl_arg<char> {
      |                ~~~~~~~~~~~^~
      |                operator""_a
1 warning generated.
```

Resolves #3607
