### PR TITLE
Remove type cast as mxe(mingw32) compiler complains about useless-cast

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1446,7 +1446,7 @@ FMT_FUNC bool write_console(std::FILE* f, string_view text) {
 FMT_FUNC void vprint_mojibake(std::FILE* f, string_view fmt, format_args args) {
   auto buffer = memory_buffer();
   detail::vformat_to(buffer, fmt,
-                     basic_format_args<buffer_context<char>>(args));
+                     args);
   fwrite_fully(buffer.data(), 1, buffer.size(), f);
 }
 #endif

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1445,8 +1445,7 @@ FMT_FUNC bool write_console(std::FILE* f, string_view text) {
 // Print assuming legacy (non-Unicode) encoding.
 FMT_FUNC void vprint_mojibake(std::FILE* f, string_view fmt, format_args args) {
   auto buffer = memory_buffer();
-  detail::vformat_to(buffer, fmt,
-                     args);
+  detail::vformat_to(buffer, fmt, args);
   fwrite_fully(buffer.data(), 1, buffer.size(), f);
 }
 #endif


### PR DESCRIPTION
Remove type cast as mxe(mingw32) compiler complains about useless-cast
when FMT_PEDANTIC && FMT_WERROR options are enabled """
error: useless cast to type 'class fmt::v10::basic_format_args<fmt::v10::basic_format_context<fmt::v10::appender, char> >' [-Werror=useless-cast]
 1449 |                      basic_format_args<buffer_context<char>>(args));
"""

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
