### PR TITLE
Replace use of newer C++ library feature with older equivalent

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2541,8 +2541,8 @@ FMT_CONSTEXPR auto parse_format_specs(ParseContext& ctx)
       decltype(arg_mapper<context>().map(std::declval<const T&>())),
       typename strip_named_arg<T>::type>;
 #if defined(__cpp_if_constexpr)
-  if constexpr (std::is_default_constructible_v<
-                    formatter<mapped_type, char_type>>) {
+  if constexpr (std::is_default_constructible<
+                    formatter<mapped_type, char_type>>::value) {
     return formatter<mapped_type, char_type>().parse(ctx);
   } else {
     type_is_unformattable_for<T, char_type> _;


### PR DESCRIPTION
When compiling something like the following bit of code:
```c++
#include <fmt/core.h>
#include <fmt/format.h>

int main() {
  fmt::format(FMT_STRING("hi {}\n"), 44);
  return 0;
}
```
on an environment that uses the older C++11 standard library with C++17 language features enabled, you get this error (significantly shortened):
```c++
.../include/fmt/core.h:2544:22: error: no template named 'is_default_constructible_v' in namespace 'std'; did you mean 'is_default_constructible'? [clang-diagnostic-error]
  if constexpr (std::is_default_constructible_v<
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
                     is_default_constructible
.../include/type_traits:848:12: note: 'is_default_constructible' declared here
    struct is_default_constructible
           ^
```

The error comes from the usage of `std::is_default_constructible_v`, a template that was not added until C++17. This usage is gated by a check for `__cpp_if_constexpr`, another C++17 feature, but the compiler I am using does have support for `if constexpr` and defines the macro.  
Unfortunately, having modern C++ features like `if constexpr` does not imply that a modern C++ standard library is available.

This replacement fixes the error for me and has equivalent behavior to the previous code. Judging by the surrounding bits of code, a standard library version of at least C++11 was already assumed so this is hopefully all good.