### PR TITLE
Fix datatype of underlying data to avoid signed/unsigned compiler warning with MSVC

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3033,7 +3033,7 @@ class bigint {
     bigits_.resize(to_unsigned(num_bigits + exp_difference));
     for (int i = num_bigits - 1, j = i + exp_difference; i >= 0; --i, --j)
       bigits_[j] = bigits_[i];
-    std::uninitialized_fill_n(bigits_.data(), exp_difference, 0);
+    std::uninitialized_fill_n(bigits_.data(), exp_difference, 0u);
     exp_ -= exp_difference;
   }
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

The following line leads to a signed/unsigned error on newer MSVC compilers (14.36.32532).

https://github.com/fmtlib/fmt/blame/f6ca4ea1990af67e00358cfe83c19f5aa4df5f19/include/fmt/format.h#L3036

Casting the value to the underlying datatype uint32_t solves the compiler issue.

std::uninitialized_fill_n(bigits_.data(), exp_difference, **static_cast<uint32_t>(0)**);
