### PR TITLE
fix: mark fmt::streamed() as constexpr

### DIFF
--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -140,7 +140,7 @@ struct formatter<detail::streamed_view<T>, Char>
   \endrst
  */
 template <typename T>
-auto streamed(const T& value) -> detail::streamed_view<T> {
+constexpr auto streamed(const T& value) -> detail::streamed_view<T> {
   return {value};
 }
 


### PR DESCRIPTION
Because it's just performing a very basic type conversion that can be done at constexpr time.

My use case simultaneously creates a
`fmt::basic_format_string<some_type_conversion<Args...>>` instance and performs `maybe_stream<Args>(args)...`. `maybe_stream` optionally applies `fmt::streamed(arg)` to a subset of types. This needs to be `constexpr` because `basic_format_string`'s constructor is `consteval`.

Reduced example below. Note that I could make both those functions `consteval` *if and only if* `fmt::streamed` is `constexpr`.
```cpp
template <typename T>
constexpr decltype(auto) maybe_stream(const T& value) {
  if constexpr (some_condition_v<T>) {
    return fmt::streamed(value);
    // NOTE: currently doing this instead as a workaround:
    return decltype(fmt::streamed(value)){value};
  } else {
    return value;
  }
}

template <
    typename S
  , typename... Args
  , std::enable_if_t<std::is_convertible<const S&, fmt::string_view>::value>* = nullptr
  >
constexpr auto make_log_record(
    ExtraArgs            extra_args
  , const S&             format
  , Args&&...            args
) noexcept {
  using record_t         = log_record_impl<decltype(maybe_stream(std::forward<Args>(args)))...>;
  using format_string_t = typename record_t::format_string_t;
  using args_t          = typename record_t::args_t;

  return record_t{
      extra_args,
      format_string_t(format), // <-- requires std::is_constant_evaluated()==true but won't (always) be if 'maybe_stream' below isn't
      args_t{maybe_stream(std::forward<Args>(args))...},
  };
}
```
