### PR TITLE
Workaround intel bug

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3258,14 +3258,11 @@ FMT_CONSTEXPR20 void format_hexfloat(Float value, int precision,
   format_hexfloat(static_cast<double>(value), precision, specs, buf);
 }
 
-template <typename Float>
-FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs,
-                                  buffer<char>& buf) -> int {
-  
+FMT_CONSTEXPR uint32_t fractional_part_rounding_threshold(int index) {
   // For checking rounding thresholds.
   // The kth entry is chosen to be the smallest integer such that the
   // upper 32-bits of 10^(k+1) times it is strictly bigger than 5 * 10^k.
-  static constexpr uint32_t fractional_part_rounding_thresholds[8] = {
+  constexpr uint32_t thresholds[8] = {
       2576980378U,  // ceil(2^31 + 2^32/10^1)
       2190433321U,  // ceil(2^31 + 2^32/10^2)
       2151778616U,  // ceil(2^31 + 2^32/10^3)
@@ -3275,7 +3272,13 @@ FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs,
       2147484078U,  // ceil(2^31 + 2^32/10^7)
       2147483691U   // ceil(2^31 + 2^32/10^8)
   };
+  return thresholds[index];
+}
 
+template <typename Float>
+FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs,
+                                  buffer<char>& buf) -> int {
+  
   // float is passed as double to reduce the number of instantiations.
   static_assert(!std::is_same<Float, float>::value, "");
   FMT_ASSERT(value >= 0, "value is negative");
@@ -3479,7 +3482,7 @@ FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs,
             uint32_t fractional_part = static_cast<uint32_t>(prod);
             should_round_up = fractional_part >=
                                   fractional_part_rounding_thresholds
-                                      [8 - number_of_digits_to_print] ||
+                                      (8 - number_of_digits_to_print) ||
                               ((fractional_part >> 31) &
                                ((digits & 1) | (second_third_subsegments != 0) |
                                 has_more_segments)) != 0;
@@ -3519,7 +3522,7 @@ FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs,
             uint32_t fractional_part = static_cast<uint32_t>(prod);
             should_round_up = fractional_part >=
                                   fractional_part_rounding_thresholds
-                                      [8 - number_of_digits_to_print] ||
+                                      (8 - number_of_digits_to_print) ||
                               ((fractional_part >> 31) &
                                ((digits & 1) | (third_subsegment != 0) |
                                 has_more_segments)) != 0;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3258,7 +3258,7 @@ FMT_CONSTEXPR20 void format_hexfloat(Float value, int precision,
   format_hexfloat(static_cast<double>(value), precision, specs, buf);
 }
 
-FMT_CONSTEXPR uint32_t fractional_part_rounding_thresholds(int index) {
+FMT_CONSTEXPR inline uint32_t fractional_part_rounding_thresholds(int index) {
   // For checking rounding thresholds.
   // The kth entry is chosen to be the smallest integer such that the
   // upper 32-bits of 10^(k+1) times it is strictly bigger than 5 * 10^k.

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1740,28 +1740,6 @@ FMT_CONSTEXPR inline fp operator*(fp x, fp y) {
   return {multiply(x.f, y.f), x.e + y.e + 64};
 }
 
-template <typename T = void> struct basic_data {
-  // For checking rounding thresholds.
-  // The kth entry is chosen to be the smallest integer such that the
-  // upper 32-bits of 10^(k+1) times it is strictly bigger than 5 * 10^k.
-  static constexpr uint32_t fractional_part_rounding_thresholds[8] = {
-      2576980378U,  // ceil(2^31 + 2^32/10^1)
-      2190433321U,  // ceil(2^31 + 2^32/10^2)
-      2151778616U,  // ceil(2^31 + 2^32/10^3)
-      2147913145U,  // ceil(2^31 + 2^32/10^4)
-      2147526598U,  // ceil(2^31 + 2^32/10^5)
-      2147487943U,  // ceil(2^31 + 2^32/10^6)
-      2147484078U,  // ceil(2^31 + 2^32/10^7)
-      2147483691U   // ceil(2^31 + 2^32/10^8)
-  };
-};
-// This is a struct rather than an alias to avoid shadowing warnings in gcc.
-struct data : basic_data<> {};
-
-#if FMT_CPLUSPLUS < 201703L
-template <typename T>
-constexpr uint32_t basic_data<T>::fractional_part_rounding_thresholds[];
-#endif
 
 template <typename T, bool doublish = num_bits<T>() == num_bits<double>()>
 using convert_float_result =
@@ -3283,6 +3261,21 @@ FMT_CONSTEXPR20 void format_hexfloat(Float value, int precision,
 template <typename Float>
 FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs,
                                   buffer<char>& buf) -> int {
+  
+  // For checking rounding thresholds.
+  // The kth entry is chosen to be the smallest integer such that the
+  // upper 32-bits of 10^(k+1) times it is strictly bigger than 5 * 10^k.
+  static constexpr uint32_t fractional_part_rounding_thresholds[8] = {
+      2576980378U,  // ceil(2^31 + 2^32/10^1)
+      2190433321U,  // ceil(2^31 + 2^32/10^2)
+      2151778616U,  // ceil(2^31 + 2^32/10^3)
+      2147913145U,  // ceil(2^31 + 2^32/10^4)
+      2147526598U,  // ceil(2^31 + 2^32/10^5)
+      2147487943U,  // ceil(2^31 + 2^32/10^6)
+      2147484078U,  // ceil(2^31 + 2^32/10^7)
+      2147483691U   // ceil(2^31 + 2^32/10^8)
+  };
+
   // float is passed as double to reduce the number of instantiations.
   static_assert(!std::is_same<Float, float>::value, "");
   FMT_ASSERT(value >= 0, "value is negative");

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3258,7 +3258,7 @@ FMT_CONSTEXPR20 void format_hexfloat(Float value, int precision,
   format_hexfloat(static_cast<double>(value), precision, specs, buf);
 }
 
-FMT_CONSTEXPR uint32_t fractional_part_rounding_threshold(int index) {
+FMT_CONSTEXPR uint32_t fractional_part_rounding_thresholds(int index) {
   // For checking rounding thresholds.
   // The kth entry is chosen to be the smallest integer such that the
   // upper 32-bits of 10^(k+1) times it is strictly bigger than 5 * 10^k.

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3478,7 +3478,7 @@ FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs,
           if (precision < 9) {
             uint32_t fractional_part = static_cast<uint32_t>(prod);
             should_round_up = fractional_part >=
-                                  data::fractional_part_rounding_thresholds
+                                  fractional_part_rounding_thresholds
                                       [8 - number_of_digits_to_print] ||
                               ((fractional_part >> 31) &
                                ((digits & 1) | (second_third_subsegments != 0) |
@@ -3518,7 +3518,7 @@ FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs,
             // consisting of a genuine digit from the input.
             uint32_t fractional_part = static_cast<uint32_t>(prod);
             should_round_up = fractional_part >=
-                                  data::fractional_part_rounding_thresholds
+                                  fractional_part_rounding_thresholds
                                       [8 - number_of_digits_to_print] ||
                               ((fractional_part >> 31) &
                                ((digits & 1) | (third_subsegment != 0) |


### PR DESCRIPTION
Potential workaround / restructure for the intel bug that is the cause of #3645.

Make the variable in the external struct instead an embedded static constexpr variable in the only function that uses the variable.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
