### PR TITLE
README.rst: fix broken LICENSE link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -521,7 +521,7 @@ License
 -------
 
 {fmt} is distributed under the MIT `license
-<https://github.com/fmtlib/fmt/blob/master/LICENSE.rst>`_.
+<https://github.com/fmtlib/fmt/blob/master/LICENSE>`_.
 
 Documentation License
 ---------------------


### PR DESCRIPTION
The `.rst` suffix was dropped for this file a while ago.