### PR TITLE
minor fix to README.rst security policy link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -547,6 +547,6 @@ we'll make it right.
 Security Policy
 ---------------
 
-To report a security issue, please disclose it at [security advisory](https://github.com/fmtlib/fmt/security/advisories/new).
+To report a security issue, please disclose it at `security advisory <https://github.com/fmtlib/fmt/security/advisories/new>`_.
 
 This project is maintained by a team of volunteers on a reasonable-effort basis. As such, please give us at least 90 days to work on a fix before public exposure.


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

Sorry, I didn't noticed that the README was a rst file (I'm not used to this type of file actually)

I've fixed using the same format it is used on other links in the file and verified in the preview to be sure:

<img width="858" alt="image" src="https://github.com/fmtlib/fmt/assets/22223372/a772cc98-b07b-49d6-b8c4-f1fc2f368f71">

Sorry about that.
