### PR TITLE
Remove leftover usage of the __std_stream header

### DIFF
--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -63,8 +63,6 @@ module;
 #  if defined(__GLIBCXX__)
 #    include <ext/stdio_filebuf.h>
 #    include <ext/stdio_sync_filebuf.h>
-#  elif defined(_LIBCPP_VERSION)
-#    include <__std_stream>
 #  endif
 #  define WIN32_LEAN_AND_MEAN
 #  include <windows.h>


### PR DESCRIPTION
2dd4fa8742fdac36468f8d removed all usage of __std_stream because it is no longer available with clang v17. That commit missed one place where the header was still used (only used when building with -DFMT_MODULE=ON). Remove it there too.

See #3654
