### PR TITLE
suffixes for helper chrono types added in C++  20

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -582,12 +582,9 @@ template <typename Period> FMT_CONSTEXPR inline const char* get_units() {
   if (std::is_same<Period, std::tera>::value) return "Ts";
   if (std::is_same<Period, std::peta>::value) return "Ps";
   if (std::is_same<Period, std::exa>::value) return "Es";
-  if (std::is_same<Period, std::ratio<60>>::value) return "m";
+  if (std::is_same<Period, std::ratio<60>>::value) return "min";
   if (std::is_same<Period, std::ratio<3600>>::value) return "h";
   if (std::is_same<Period, std::ratio<86400>>::value) return "d";
-  if (std::is_same<Period, std::ratio<604800>>::value) return "wk";
-  if (std::is_same<Period, std::ratio<2629746>>::value) return "mo";
-  if (std::is_same<Period, std::ratio<31556952>>::value) return "a";
   return nullptr;
 }
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -584,6 +584,10 @@ template <typename Period> FMT_CONSTEXPR inline const char* get_units() {
   if (std::is_same<Period, std::exa>::value) return "Es";
   if (std::is_same<Period, std::ratio<60>>::value) return "m";
   if (std::is_same<Period, std::ratio<3600>>::value) return "h";
+  if (std::is_same<Period, std::ratio<86400>>::value) return "d";
+  if (std::is_same<Period, std::ratio<604800>>::value) return "wk";
+  if (std::is_same<Period, std::ratio<2629746>>::value) return "mo";
+  if (std::is_same<Period, std::ratio<31556952>>::value) return "a";
   return nullptr;
 }
 

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -456,7 +456,7 @@ TEST(chrono_test, format_default) {
             fmt::format("{}", std::chrono::duration<int, std::exa>(42)));
   EXPECT_EQ("42min", fmt::format("{}", std::chrono::minutes(42)));
   EXPECT_EQ("42h", fmt::format("{}", std::chrono::hours(42)));
-#  if __cpp_lib_chrono >= 201907L
+#  if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 201907L
   EXPECT_EQ("42d", fmt::format("{}", std::chrono::days(42)));
 #  endif
   EXPECT_EQ(

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -454,8 +454,11 @@ TEST(chrono_test, format_default) {
             fmt::format("{}", std::chrono::duration<int, std::peta>(42)));
   EXPECT_EQ("42Es",
             fmt::format("{}", std::chrono::duration<int, std::exa>(42)));
-  EXPECT_EQ("42m", fmt::format("{}", std::chrono::minutes(42)));
+  EXPECT_EQ("42min", fmt::format("{}", std::chrono::minutes(42)));
   EXPECT_EQ("42h", fmt::format("{}", std::chrono::hours(42)));
+#  if __cpp_lib_chrono >= 201907L
+  EXPECT_EQ("42d", fmt::format("{}", std::chrono::days(42)));
+#  endif
   EXPECT_EQ(
       "42[15]s",
       fmt::format("{}", std::chrono::duration<int, std::ratio<15, 1>>(42)));


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
C++ 20 added
`std::chrono::days`
`std::chrono::weeks`
`std::chrono::months`
`std::chrono::years`

This adds suffixes for them.

The standard only specifies `d` for days, but it also specifies `min` for minutes, while fmt uses `m` so I am not sure how far you want to deviate from there.