### PR TITLE
Add support for CMake 3.28 C++ module features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8...3.26)
+cmake_minimum_required(VERSION 3.8...3.28)
 
 # Fallback for using newer policies on CMake <3.12.
 if(${CMAKE_VERSION} VERSION_LESS 3.12)
@@ -26,7 +26,7 @@ endfunction()
 
 # DEPRECATED! Should be merged into add_module_library.
 function(enable_module target)
-  if (MSVC)
+  if (MSVC AND CMAKE_VERSION VERSION_LESS 3.28)
     set(BMI ${CMAKE_CURRENT_BINARY_DIR}/${target}.ifc)
     target_compile_options(${target}
       PRIVATE /interface /ifcOutput ${BMI}
@@ -65,7 +65,7 @@ function(add_module_library name)
   # `std` is affected by CMake options and may be higher than C++20.
   get_target_property(std ${name} CXX_STANDARD)
 
-  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_VERSION VERSION_LESS 3.28)
     set(pcms)
     foreach (src ${sources})
       get_filename_component(pcm ${src} NAME_WE)
@@ -103,7 +103,11 @@ function(add_module_library name)
         DEPENDS ${pcm})
     endforeach ()
   endif ()
-  target_sources(${name} PRIVATE ${sources})
+  if(CMAKE_VERSION VERSION_LESS 3.28)
+    target_sources(${name} PRIVATE ${sources})
+  else()
+    target_sources(${name} PUBLIC FILE_SET fmt_module TYPE CXX_MODULES FILES ${sources})
+  endif()
 endfunction()
 
 include(CMakeParseArguments)
@@ -384,7 +388,13 @@ if (FMT_INSTALL)
           LIBRARY DESTINATION ${FMT_LIB_DIR}
           ARCHIVE DESTINATION ${FMT_LIB_DIR}
           PUBLIC_HEADER DESTINATION "${FMT_INC_DIR}/fmt"
+          FILE_SET fmt_module DESTINATION "${FMT_LIB_DIR}/cxx/miu"
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+  if(FMT_MODULE AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+    #Install format.cc and os.cc which are #included by the fmt.cc module interface file
+    install(FILES src/format.cc src/os.cc DESTINATION "${FMT_LIB_DIR}/cxx/miu/src")
+  endif()
 
   # Use a namespace because CMake provides better diagnostics for namespaced
   # imported targets.


### PR DESCRIPTION
CMake 3.28 ([rc1 announcement](https://www.kitware.com/cmake-3-28-0-rc1-is-ready-for-testing/)) adds support for C++ modules that is no longer experimental (so no need to add the experimental flags).

This PR adds support for this using the new features, when the build is configured with `FMT_MODULE` set to `ON` and the CMake version is 3.28 or higher.

Tested both building fmt, and then calling `cmake install` and using the fmt module from a different project. This works with:

* Linux, Clang 17, ninja 1.11.1
* Linux, gcc 13.1, ninja 1.11.1 (note that I'm using a patched version of gcc with dependency scanning support, and additional CMake variables since CMake expects gcc 14 for this, but gcc14 ICEs when building fmt as a module, I've reported this [here](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111785))
* Windows, msvc 19.37
  - Building fmt itself works with the Visual Studio generator or Ninja
  - Using the imported targets with  `find_package(fmt)` works with Ninja, but not with the Visual Studio generator - reported this [here](https://github.com/fmtlib/fmt/pull/3679#issue-1940145260).


Hopefully this is OK. For CMake versions earlier than 3.28, this should behave as it was previously.
