### PR TITLE
Fix error C2668 on Windows with option /std:c++latest

### DIFF
--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1788,7 +1788,8 @@ FMT_BEGIN_NAMESPACE
 template <> struct formatter<point> : nested_formatter<double> {
   auto format(point p, format_context& ctx) const -> decltype(ctx.out()) {
     return write_padded(ctx, [this, p](auto out) -> decltype(out) {
-      return format_to(out, "({}, {})", nested(p.x), nested(p.y));
+      // Namespace-qualify to avoid ambiguity with std::format_to
+      return fmt::format_to(out, "({}, {})", nested(p.x), nested(p.y));
     });
   }
 };

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1788,7 +1788,6 @@ FMT_BEGIN_NAMESPACE
 template <> struct formatter<point> : nested_formatter<double> {
   auto format(point p, format_context& ctx) const -> decltype(ctx.out()) {
     return write_padded(ctx, [this, p](auto out) -> decltype(out) {
-      // Namespace-qualify to avoid ambiguity with std::format_to
       return fmt::format_to(out, "({}, {})", nested(p.x), nested(p.y));
     });
   }


### PR DESCRIPTION
When build fmt with MSVC under option /std:c++latest, it failed due to `error 2668: 'std::format_to': ambiguous call to overloaded function`, so add namespace to qualify the call to format_to to avoid this issue. Could you please review and approval it? Thanks.

It is the same issue as https://github.com/fmtlib/fmt/issues/3377.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
