### PR TITLE
Fix flushing C++ iostreams before calling write_console()

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1038,7 +1038,7 @@ struct is_contiguous<basic_memory_buffer<T, SIZE, Allocator>> : std::true_type {
 
 FMT_END_EXPORT
 namespace detail {
-FMT_API bool write_console(std::FILE* f, string_view text);
+FMT_API bool write_console(int fd, string_view text);
 FMT_API void print(std::FILE*, string_view);
 }  // namespace detail
 


### PR DESCRIPTION
This change correctly implements https://wg21.link/P2539/ for both C streams and C++ iostreams.

Fixes #3688.