### PR TITLE
Wrap Char in array to avoid pointer arithmetic

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1958,11 +1958,12 @@ auto write_escaped_string(OutputIt out, basic_string_view<Char> str)
 
 template <typename Char, typename OutputIt>
 auto write_escaped_char(OutputIt out, Char v) -> OutputIt {
+  Char v_array[1] = {v};
   *out++ = static_cast<Char>('\'');
   if ((needs_escape(static_cast<uint32_t>(v)) && v != static_cast<Char>('"')) ||
       v == static_cast<Char>('\'')) {
     out = write_escaped_cp(
-        out, find_escape_result<Char>{&v, &v + 1, static_cast<uint32_t>(v)});
+        out, find_escape_result<Char>{v_array, v_array + 1, static_cast<uint32_t>(v)});
   } else {
     *out++ = v;
   }


### PR DESCRIPTION
This resolves the following finding reported by Coverity Static Analysis v2023.6.1 on [include/fmt/format.h#L1959](https://github.com/fmtlib/fmt/blob/19276d73254f2b06e5d466f45c7390f1ccf0354e/include/fmt/format.h#L1959):

* ptr_arith: Using &v as an array. This might corrupt or misinterpret adjacent memory locations. 

Resolves  #3694.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
