### PR TITLE
Fix include xlocale

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -13,8 +13,10 @@
 #include <cstdio>
 #include <system_error>  // std::system_error
 
-#if (defined __APPLE__ || defined(__FreeBSD__)) && __has_include(<xlocale.h>)
-#  include <xlocale.h>  // for LC_NUMERIC_MASK on OS X
+#if defined __APPLE__ || defined(__FreeBSD__)
+#  if (__cplusplus < 201703L) || __has_include(<xlocale.h>)
+#    include <xlocale.h>  // for LC_NUMERIC_MASK on OS X
+#  endif
 #endif
 
 #include "format.h"

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -13,7 +13,7 @@
 #include <cstdio>
 #include <system_error>  // std::system_error
 
-#if defined __APPLE__ || defined(__FreeBSD__)
+#if (defined __APPLE__ || defined(__FreeBSD__)) && __has_include(<xlocale.h>)
 #  include <xlocale.h>  // for LC_NUMERIC_MASK on OS X
 #endif
 

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -13,8 +13,10 @@
 #include <cstdio>
 #include <system_error>  // std::system_error
 
+#include "core.h"
+
 #if defined __APPLE__ || defined(__FreeBSD__)
-#  if (__cplusplus < 201703L) || __has_include(<xlocale.h>)
+#  if FMT_HAS_INCLUDE(<xlocale.h>)
 #    include <xlocale.h>  // for LC_NUMERIC_MASK on OS X
 #  endif
 #endif


### PR DESCRIPTION
I use fmtlib's fmt on some console game development environment, but os.h doesn't compile because of missing of xlocale.h.

Therefore I added `__has_include()` check before including xlocale.h.

Thanks.