### PR TITLE
Improve calculation for the product of two uint64_t on x64 with gcc or clang

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1535,7 +1535,9 @@ inline int floor_log2_pow10(int e) noexcept {
 
 // Computes upper 64 bits of multiplication of two 64-bit unsigned integers.
 inline uint64_t umul128_upper64(uint64_t x, uint64_t y) noexcept {
-#if FMT_USE_INT128
+#if __x86_64__ && (__GNUC__ || __clang__)
+  return umul128(x, y).high();
+#elif FMT_USE_INT128
   auto p = static_cast<uint128_opt>(x) * static_cast<uint128_opt>(y);
   return static_cast<uint64_t>(p >> 64);
 #elif defined(_MSC_VER) && defined(_M_X64)

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1486,7 +1486,13 @@ template <typename WChar, typename Buffer = memory_buffer> class to_utf8 {
 
 // Computes 128-bit result of multiplication of two 64-bit unsigned integers.
 inline uint128_fallback umul128(uint64_t x, uint64_t y) noexcept {
-#if FMT_USE_INT128
+#if __x86_64__
+  uint64_t hi, lo;
+  __asm__(  "mulq %[y] \n" 
+          : "=a"(lo), "=d"(hi)                
+          : [y] "r"(y), "a"(x), "d"(0));
+  return {hi, lo};
+#elif FMT_USE_INT128
   auto p = static_cast<uint128_opt>(x) * static_cast<uint128_opt>(y);
   return {static_cast<uint64_t>(p >> 64), static_cast<uint64_t>(p)};
 #elif defined(_MSC_VER) && defined(_M_X64)

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1486,7 +1486,7 @@ template <typename WChar, typename Buffer = memory_buffer> class to_utf8 {
 
 // Computes 128-bit result of multiplication of two 64-bit unsigned integers.
 inline uint128_fallback umul128(uint64_t x, uint64_t y) noexcept {
-#if __x86_64__
+#if __x86_64__ && (__GNUC__ || __clang__)
   uint64_t hi, lo;
   __asm__(  "mulq %[y] \n" 
           : "=a"(lo), "=d"(hi)                


### PR DESCRIPTION
On x86_64, CPUs have an instruction to multiply two 64 integers and spread the result over two registers.
This allows to compute efficiently with a single operation the long multiplication.

https://www.agner.org/optimize/instruction_tables.pdf

https://www.felixcloutier.com/x86/mul
