### PR TITLE
fix: support `optional<T>` with `format_as(T)` (#3712)

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -4053,6 +4053,7 @@ struct formatter<T, Char, enable_if_t<detail::has_format_as<T>::value>>
     : private formatter<detail::format_as_t<T>, Char> {
   using base = formatter<detail::format_as_t<T>, Char>;
   using base::parse;
+  using base::set_debug_format;
 
   template <typename FormatContext>
   auto format(const T& value, FormatContext& ctx) const -> decltype(ctx.out()) {

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -90,6 +90,36 @@ TEST(std_test, optional) {
 #endif
 }
 
+namespace my_nso {
+enum class my_number {
+  one,
+  two,
+};
+auto format_as(my_number number) -> fmt::string_view {
+  return number == my_number::one ? "first" : "second";
+}
+
+class my_class {
+ public:
+  int av;
+
+ private:
+  friend auto format_as(const my_class& elm) -> std::string {
+    return fmt::to_string(elm.av);
+  }
+};
+}  // namespace my_nso
+TEST(std_test, optional_format_as) {
+#ifdef __cpp_lib_optional
+  EXPECT_EQ(fmt::format("{}", std::optional<my_nso::my_number>{}), "none");
+  EXPECT_EQ(fmt::format("{}", std::optional{my_nso::my_number::one}),
+            "optional(\"first\")");
+  EXPECT_EQ(fmt::format("{}", std::optional<my_nso::my_class>{}), "none");
+  EXPECT_EQ(fmt::format("{}", std::optional{my_nso::my_class{7}}),
+            "optional(\"7\")");
+#endif
+}
+
 struct throws_on_move {
   throws_on_move() = default;
 


### PR DESCRIPTION
Formatting a `std::optional<T>` where T had a custom `format_as(T)` function failed to compile with clang, due to `set_debug_format` being hidden by private inheritance. This fix makes the function available through a using clause.

This fixes #3712 

