### PR TITLE
Added workaround for old xcode compiler bug

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -59,7 +59,7 @@
 #  endif
 #endif
 
-#ifdef __cpp_lib_filesystem
+#if !defined(FMT_DISABLE_STD_FILESYSTEM) && defined(__cpp_lib_filesystem)
 FMT_BEGIN_NAMESPACE
 
 namespace detail {
@@ -211,7 +211,7 @@ struct formatter<std::optional<T>, Char,
 FMT_END_NAMESPACE
 #endif  // __cpp_lib_optional
 
-#ifdef __cpp_lib_variant
+#if !defined(FMT_DISABLE_STD_VARIANT) && defined(__cpp_lib_variant)
 FMT_BEGIN_NAMESPACE
 namespace detail {
 

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -59,7 +59,24 @@
 #  endif
 #endif
 
-#if !defined(FMT_DISABLE_STD_FILESYSTEM) && defined(__cpp_lib_filesystem)
+// For older Xcode versions, __cpp_lib_xxx flags are inaccurately defined.
+#ifndef FMT_CPP_LIB_FILESYSTEM
+#  ifdef __cpp_lib_filesystem
+#    define FMT_CPP_LIB_FILESYSTEM __cpp_lib_filesystem
+#  else
+#    define FMT_CPP_LIB_FILESYSTEM 0
+# endif
+#endif
+
+#ifndef FMT_CPP_LIB_VARIANT
+#  ifdef __cpp_lib_variant
+#    define FMT_CPP_LIB_VARIANT __cpp_lib_variant
+#  else
+#    define FMT_CPP_LIB_VARIANT 0
+#  endif
+#endif
+
+#if FMT_CPP_LIB_FILESYSTEM
 FMT_BEGIN_NAMESPACE
 
 namespace detail {
@@ -133,7 +150,7 @@ template <typename Char> struct formatter<std::filesystem::path, Char> {
   }
 };
 FMT_END_NAMESPACE
-#endif
+#endif // FMT_CPP_LIB_FILESYSTEM
 
 FMT_BEGIN_NAMESPACE
 FMT_EXPORT
@@ -211,7 +228,7 @@ struct formatter<std::optional<T>, Char,
 FMT_END_NAMESPACE
 #endif  // __cpp_lib_optional
 
-#if !defined(FMT_DISABLE_STD_VARIANT) && defined(__cpp_lib_variant)
+#if FMT_CPP_LIB_VARIANT
 FMT_BEGIN_NAMESPACE
 namespace detail {
 
@@ -302,7 +319,7 @@ struct formatter<
   }
 };
 FMT_END_NAMESPACE
-#endif  // __cpp_lib_variant
+#endif  // FMT_CPP_LIB_VARIANT
 
 FMT_BEGIN_NAMESPACE
 FMT_EXPORT


### PR DESCRIPTION
Older xcode (at least xcode12) had a bug that defined macros for `__cpp_lib_filesystem` and `__cpp_lib_variant` even if the target did not support it.
When building for a target lower than macOS 10.15 with c++17, fmtlib compilation failed. (https://developer.apple.com/xcode/cpp/#c++17)

As a workaround, I would like to add a flag to disable std::filesystem and std::variant.

This problem seems to have been fixed in the latest xcode15, but I don't think version checking is practical.

Similar issues in other projects: https://github.com/ToruNiina/toml11/issues/150