### PR TITLE
Remove this-> from decltype

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1439,7 +1439,7 @@ template <typename Context> struct arg_mapper {
   // Only map owning types because mapping views can be unsafe.
   template <typename T, typename U = format_as_t<T>,
             FMT_ENABLE_IF(std::is_arithmetic<U>::value)>
-  FMT_CONSTEXPR FMT_INLINE auto map(const T& val) -> decltype(this->map(U())) {
+  FMT_CONSTEXPR FMT_INLINE auto map(const T& val) -> decltype(map(U())) {
     return map(format_as(val));
   }
 
@@ -1463,13 +1463,13 @@ template <typename Context> struct arg_mapper {
                           !is_string<U>::value && !is_char<U>::value &&
                           !is_named_arg<U>::value &&
                           !std::is_arithmetic<format_as_t<U>>::value)>
-  FMT_CONSTEXPR FMT_INLINE auto map(T& val) -> decltype(this->do_map(val)) {
+  FMT_CONSTEXPR FMT_INLINE auto map(T& val) -> decltype(do_map(val)) {
     return do_map(val);
   }
 
   template <typename T, FMT_ENABLE_IF(is_named_arg<T>::value)>
   FMT_CONSTEXPR FMT_INLINE auto map(const T& named_arg)
-      -> decltype(this->map(named_arg.value)) {
+      -> decltype(map(named_arg.value)) {
     return map(named_arg.value);
   }
 

--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -244,6 +244,15 @@
 #  endif
 #endif
 
+// GCC < 5 requires this-> in decltype
+#ifndef FMT_DECLTYPE_THIS
+#  if FMT_GCC_VERSION && FMT_GCC_VERSION < 500
+#    define FMT_DECLTYPE_THIS this->
+#  else
+#    define FMT_DECLTYPE_THIS
+#  endif
+#endif
+
 // Enable minimal optimizations for more compact code in debug mode.
 FMT_GCC_PRAGMA("GCC push_options")
 #if !defined(__OPTIMIZE__) && !defined(__NVCOMPILER) && !defined(__LCC__) && \
@@ -1439,7 +1448,7 @@ template <typename Context> struct arg_mapper {
   // Only map owning types because mapping views can be unsafe.
   template <typename T, typename U = format_as_t<T>,
             FMT_ENABLE_IF(std::is_arithmetic<U>::value)>
-  FMT_CONSTEXPR FMT_INLINE auto map(const T& val) -> decltype(map(U())) {
+  FMT_CONSTEXPR FMT_INLINE auto map(const T& val) -> decltype(FMT_DECLTYPE_THIS map(U())) {
     return map(format_as(val));
   }
 
@@ -1463,13 +1472,13 @@ template <typename Context> struct arg_mapper {
                           !is_string<U>::value && !is_char<U>::value &&
                           !is_named_arg<U>::value &&
                           !std::is_arithmetic<format_as_t<U>>::value)>
-  FMT_CONSTEXPR FMT_INLINE auto map(T& val) -> decltype(do_map(val)) {
+  FMT_CONSTEXPR FMT_INLINE auto map(T& val) -> decltype(FMT_DECLTYPE_THIS do_map(val)) {
     return do_map(val);
   }
 
   template <typename T, FMT_ENABLE_IF(is_named_arg<T>::value)>
   FMT_CONSTEXPR FMT_INLINE auto map(const T& named_arg)
-      -> decltype(map(named_arg.value)) {
+      -> decltype(FMT_DECLTYPE_THIS map(named_arg.value)) {
     return map(named_arg.value);
   }
 


### PR DESCRIPTION
The latest version of MSVC doesn't like the use of `this->` in decltype, and removing it from the decltype doesn't seem to harm anything.  It's unclear whether this is a bug in MSVC, or a standards-compliant change, given that other compilers don't reject either variant.  It feels like this might be a bug in the compiler, as the error messages make it look like MSVC is trying to look up the function in the class where it's being *used*, rather than the class where it's being *defined* (e.g. the `this` pointer maybe isn't properly tracked/associated)?

An identical patch (https://github.com/wpilibsuite/allwpilib/pull/5948) fixes the build failures we are seeing with current HEAD.

Rough code (full code is https://github.com/calcmogul/allwpilib/blob/6e23e70a8c48266ca25fbb818ce8357dce80ac32/wpilibc/src/main/native/cpp/Preferences.cpp):
```c++
std::string_view GetPath();
namespace { struct Instance {
std::string path = fmt::format("{}/", GetPath());
}; }
```

On MSVC 19.38.33129 or similar (e.g. using the latest GitHub Windows-2022 image), this errors with the following (full build log at https://github.com/wpilibsuite/allwpilib/actions/runs/6937548373/job/18871818708?pr=5945):

```
C:\work\wpiutil\src\main\native\thirdparty\fmtlib\include\fmt\core.h(1438): error C2039: 'map': is not a member of '`anonymous-namespace'::Instance'
C:\work\wpilibc\src\main\native\cpp\Preferences.cpp(23): note: see declaration of '`anonymous-namespace'::Instance'
C:\work\wpiutil\src\main\native\thirdparty\fmtlib\include\fmt\core.h(1438): note: the template instantiation context (the oldest one first) is
C:\work\wpilibc\src\main\native\cpp\Preferences.cpp(33): note: see reference to function template instantiation 'fmt::v10::basic_format_string<char,std::basic_string_view<char,std::char_traits<char>>>::basic_format_string<char[4],0>(const S (&))' being compiled
        with
        [
            S=char [4]
        ]
C:\work\wpiutil\src\main\native\thirdparty\fmtlib\include\fmt\core.h(2740): note: see reference to class template instantiation 'fmt::v10::detail::format_string_checker<Char,std::basic_string_view<char,std::char_traits<char>>>' being compiled
        with
        [
            Char=char
        ]
C:\work\wpiutil\src\main\native\thirdparty\fmtlib\include\fmt\core.h(2608): note: while compiling class template member function 'fmt::v10::detail::format_string_checker<Char,std::basic_string_view<char,std::char_traits<char>>>::format_string_checker(fmt::v10::basic_string_view<Char>)'
        with
        [
            Char=char
        ]
C:\work\wpiutil\src\main\native\thirdparty\fmtlib\include\fmt\core.h(2609): note: see reference to alias template instantiation 'fmt::v10::detail::mapped_type_constant<std::basic_string_view<char,std::char_traits<char>>,fmt::v10::basic_format_context<fmt::v10::appender,char>>' being compiled
C:\work\wpiutil\src\main\native\thirdparty\fmtlib\include\fmt\core.h(1478): note: see reference to class template instantiation 'fmt::v10::detail::arg_mapper<fmt::v10::basic_format_context<fmt::v10::appender,char>>' being compiled
C:\work\wpiutil\src\main\native\thirdparty\fmtlib\include\fmt\core.h(1462): error C2039: 'do_map': is not a member of '`anonymous-namespace'::Instance'
C:\work\wpilibc\src\main\native\cpp\Preferences.cpp(23): note: see declaration of '`anonymous-namespace'::Instance'
C:\work\wpiutil\src\main\native\thirdparty\fmtlib\include\fmt\core.h(1468): error C2039: 'map': is not a member of '`anonymous-namespace'::Instance'
C:\work\wpilibc\src\main\native\cpp\Preferences.cpp(23): note: see declaration of '`anonymous-namespace'::Instance'
C:\work\wpiutil\src\main\native\thirdparty\fmtlib\include\fmt\core.h(2609): error C2062: type 'unknown-type' unexpected
```