### PR TITLE
Added formatter for std::source_location

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -235,9 +235,8 @@ FMT_END_NAMESPACE
 #ifdef __cpp_lib_source_location
 FMT_BEGIN_NAMESPACE
 FMT_EXPORT
-template <typename Char>
-struct formatter<std::source_location, Char,
-                 std::enable_if_t<is_formattable<Char>::value>> {
+template<>
+struct formatter<std::source_location> {
   template <typename ParseContext> FMT_CONSTEXPR auto parse(ParseContext& ctx) {
     return ctx.begin();
   }
@@ -246,13 +245,13 @@ struct formatter<std::source_location, Char,
   auto format(const std::source_location& loc, FormatContext& ctx) const
       -> decltype(ctx.out()) {
     auto out = ctx.out();
-    out = detail::write_bytes(out, loc.file_name(), format_specs<Char>());
-    out = detail::write<Char>(out, Char(':'));
-    out = detail::write<Char>(out, loc.line());
-    out = detail::write<Char>(out, Char(':'));
-    out = detail::write<Char>(out, loc.column());
-    out = detail::write<Char>(out, ": ");
-    out = detail::write<Char>(out, loc.function_name());
+    out = detail::write_bytes(out, loc.file_name(), format_specs<char>());
+    out = detail::write(out, ':');
+    out = detail::write<char>(out, loc.line());
+    out = detail::write(out, ':');
+    out = detail::write<char>(out, loc.column());
+    out = detail::write(out, ": ");
+    out = detail::write(out, loc.function_name());
     return out;
   }
 };

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -38,6 +38,10 @@
 #  endif
 #endif
 
+#if FMT_CPLUSPLUS > 201703L && FMT_HAS_INCLUDE(<source_location>)
+#  include <source_location>
+#endif
+
 // GCC 4 does not support FMT_HAS_INCLUDE.
 #if FMT_HAS_INCLUDE(<cxxabi.h>) || defined(__GLIBCXX__)
 #  include <cxxabi.h>
@@ -227,6 +231,33 @@ struct formatter<std::optional<T>, Char,
 };
 FMT_END_NAMESPACE
 #endif  // __cpp_lib_optional
+
+#ifdef __cpp_lib_source_location
+FMT_BEGIN_NAMESPACE
+FMT_EXPORT
+template <typename Char>
+struct formatter<std::source_location, Char,
+                 std::enable_if_t<is_formattable<Char>::value>> {
+  template <typename ParseContext> FMT_CONSTEXPR auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(const std::source_location& loc, FormatContext& ctx) const
+      -> decltype(ctx.out()) {
+    auto out = ctx.out();
+    out = detail::write_bytes(out, loc.file_name(), format_specs<Char>());
+    out = detail::write<Char>(out, Char(':'));
+    out = detail::write<Char>(out, loc.line());
+    out = detail::write<Char>(out, Char(':'));
+    out = detail::write<Char>(out, loc.column());
+    out = detail::write<Char>(out, ": ");
+    out = detail::write<Char>(out, loc.function_name());
+    return out;
+  }
+};
+FMT_END_NAMESPACE
+#endif
 
 #if FMT_CPP_LIB_VARIANT
 FMT_BEGIN_NAMESPACE

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -245,7 +245,7 @@ struct formatter<std::source_location> {
   auto format(const std::source_location& loc, FormatContext& ctx) const
       -> decltype(ctx.out()) {
     auto out = ctx.out();
-    out = detail::write_bytes(out, loc.file_name(), format_specs<char>());
+    out = detail::write(out, loc.file_name());
     out = detail::write(out, ':');
     out = detail::write<char>(out, loc.line());
     out = detail::write(out, ':');

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -62,6 +62,16 @@ TEST(std_test, thread_id) {
   EXPECT_FALSE(fmt::format("{}", std::this_thread::get_id()).empty());
 }
 
+#ifdef __cpp_lib_source_location
+TEST(std_test, source_location) {
+  std::source_location loc = std::source_location::current();
+  EXPECT_EQ(fmt::format("{}", loc), std::string(loc.file_name()) + ":" +
+                                        std::to_string(loc.line()) + ":" +
+                                        std::to_string(loc.column()) + ": " +
+                                        loc.function_name());
+}
+#endif
+
 TEST(std_test, optional) {
 #ifdef __cpp_lib_optional
   EXPECT_EQ(fmt::format("{}", std::optional<int>{}), "none");


### PR DESCRIPTION
Added custom formatter for std::source_location to support this type of code :

`fmt::print("{}\n", std::source_location::current());`

The format was taken from the following discussion : https://github.com/fmtlib/fmt/issues/3012#issuecomment-1206515140
Let me know if there is a better format that could be implemented. 