### PR TITLE
Implement `%j` specifier for `std::chrono::duration`

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1622,6 +1622,7 @@ struct chrono_format_checker : null_chrono_spec_handler<chrono_format_checker> {
 
   template <typename Char>
   FMT_CONSTEXPR void on_text(const Char*, const Char*) {}
+  FMT_CONSTEXPR void on_day_of_year() {}
   FMT_CONSTEXPR void on_24_hour(numeric_system, pad_type) {}
   FMT_CONSTEXPR void on_12_hour(numeric_system, pad_type) {}
   FMT_CONSTEXPR void on_minute(numeric_system, pad_type) {}
@@ -1806,6 +1807,7 @@ struct chrono_formatter {
     return true;
   }
 
+  Rep days() const { return static_cast<Rep>(s.count() / 86400); }
   Rep hour() const { return static_cast<Rep>(mod((s.count() / 3600), 24)); }
 
   Rep hour12() const {
@@ -1884,9 +1886,13 @@ struct chrono_formatter {
   void on_dec0_week_of_year(numeric_system) {}
   void on_dec1_week_of_year(numeric_system) {}
   void on_iso_week_of_year(numeric_system) {}
-  void on_day_of_year() {}
   void on_day_of_month(numeric_system) {}
   void on_day_of_month_space(numeric_system) {}
+
+  void on_day_of_year() {
+    if (handle_nan_inf()) return;
+    write(days(), 0);
+  }
 
   void on_24_hour(numeric_system ns, pad_type pad) {
     if (handle_nan_inf()) return;

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -462,9 +462,7 @@ TEST(chrono_test, format_default) {
             fmt::format("{}", std::chrono::duration<int, std::exa>(42)));
   EXPECT_EQ("42min", fmt::format("{}", std::chrono::minutes(42)));
   EXPECT_EQ("42h", fmt::format("{}", std::chrono::hours(42)));
-#  if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 201907L
-  EXPECT_EQ("42d", fmt::format("{}", std::chrono::days(42)));
-#  endif
+  EXPECT_EQ("42d", fmt::format("{}", days(42)));
   EXPECT_EQ(
       "42[15]s",
       fmt::format("{}", std::chrono::duration<int, std::ratio<15, 1>>(42)));

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -537,6 +537,8 @@ TEST(chrono_test, format_specs) {
   EXPECT_EQ("12", fmt::format("{:%I}", std::chrono::hours(24)));
   EXPECT_EQ("04", fmt::format("{:%I}", std::chrono::hours(4)));
   EXPECT_EQ("02", fmt::format("{:%I}", std::chrono::hours(14)));
+  EXPECT_EQ("12345", fmt::format("{:%j}", days(12345)));
+  EXPECT_EQ("12345", fmt::format("{:%j}", std::chrono::hours(12345 * 24 + 12)));
   EXPECT_EQ("03:25:45",
             fmt::format("{:%H:%M:%S}", std::chrono::seconds(12345)));
   EXPECT_EQ("03:25", fmt::format("{:%R}", std::chrono::seconds(12345)));

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -24,6 +24,12 @@ using testing::Contains;
 #  define FMT_HAS_C99_STRFTIME 1
 #endif
 
+#if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 201907L
+using days = std::chrono::days;
+#else
+using days = std::chrono::duration<std::chrono::hours::rep, std::ratio<86400>>;
+#endif
+
 auto make_tm() -> std::tm {
   auto time = std::tm();
   time.tm_mday = 1;


### PR DESCRIPTION
This adds support for `%j` presentation type for duration types:

> "If the type being formatted is a specialization of duration, the decimal number of days without padding."

Fixes #3643.

---

I assume it isn't needed to handle padding or alternative numeric systems here as neither is mentioned in the specification, thus the implementation is basically one line. (Please correct me if I'm wrong.)

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
