### PR TITLE
Disallow presentation_type `c` in combination with `bool` arg 

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -2429,6 +2429,7 @@ FMT_CONSTEXPR FMT_INLINE auto parse_format_specs(
     case 'G':
       return parse_presentation_type(pres::general_upper, float_set);
     case 'c':
+      if (arg_type == type::bool_type) throw_format_error("invalid format specifier");
       return parse_presentation_type(pres::chr, integral_set);
     case 's':
       return parse_presentation_type(pres::string,

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1159,6 +1159,8 @@ TEST(format_test, format_bool) {
   EXPECT_EQ("true", fmt::format("{:s}", true));
   EXPECT_EQ("false", fmt::format("{:s}", false));
   EXPECT_EQ("false ", fmt::format("{:6s}", false));
+  EXPECT_THROW_MSG((void)fmt::format(runtime("{:c}"), false), format_error,
+                   "invalid format specifier");
 }
 
 TEST(format_test, format_short) {


### PR DESCRIPTION
This fixes #3726 by throwing an error in the case that std::format is used with an arg type of `bool` and presentation type of `c`/character format. Added a test as well.