### PR TITLE
allow format_as() to format reference

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -1332,7 +1332,7 @@ using ulong_type = conditional_t<long_short, unsigned, unsigned long long>;
 template <typename T> struct format_as_result {
   template <typename U,
             FMT_ENABLE_IF(std::is_enum<U>::value || std::is_class<U>::value)>
-  static auto map(U*) -> decltype(format_as(std::declval<U>()));
+  static auto map(U*) -> remove_cvref_t<decltype(format_as(std::declval<U>()))>;
   static auto map(...) -> void;
 
   using type = decltype(map(static_cast<T*>(nullptr)));

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2173,6 +2173,13 @@ auto format_as(scoped_enum_as_string) -> std::string { return "foo"; }
 
 struct struct_as_int {};
 auto format_as(struct_as_int) -> int { return 42; }
+
+struct struct_as_const_reference {
+  const std::string name = "foo";
+};
+auto format_as(const struct_as_const_reference& s) -> const std::string& {
+  return s.name;
+}
 }  // namespace test
 
 TEST(format_test, format_as) {
@@ -2180,6 +2187,7 @@ TEST(format_test, format_as) {
   EXPECT_EQ(fmt::format("{}", test::scoped_enum_as_string_view()), "foo");
   EXPECT_EQ(fmt::format("{}", test::scoped_enum_as_string()), "foo");
   EXPECT_EQ(fmt::format("{}", test::struct_as_int()), "42");
+  EXPECT_EQ(fmt::format("{}", test::struct_as_const_reference()), "foo");
 }
 
 TEST(format_test, format_as_to_string) {


### PR DESCRIPTION
before this change, format_as() is unable to format a type which has `auto format_as() -> const another_type&`, and `another_type` is formattable. because `format_as_result` maps the result type as it is, and the compiler refuses to compile
`static_cast<T*>(nullptr)`, where T is a reference type. but it would be handy if we could use `format_as()` to format types which, for instance, owns / inherit from a formattable type, and delegate the formatter to these variables instead without creating a copy of them.

in this change:

* instruct `format_as_result` to map the result type to the decayed type, so that `type` can be the decayed type of result type, and this also enables `type` to be formattable, as long as the decayed type is formattable.
* corresponding test is added to format-test.cc

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
