### PR TITLE
Fix CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ if (FMT_OS)
 endif ()
 
 add_module_library(fmt src/fmt.cc FALLBACK
-                   ${FMT_SOURCES} ${FMT_HEADERS} README.rst ChangeLog.md
+                   ${FMT_SOURCES} ${FMT_HEADERS} README.md ChangeLog.md
                    IF FMT_MODULE)
 add_library(fmt::fmt ALIAS fmt)
 if (FMT_MODULE)


### PR DESCRIPTION
After the change in https://github.com/fmtlib/fmt/commit/81629e425c6baf90dff71eda574fd883817fb9bd, seems like it broke CMake builds when using CPM, this pull request fixes that.

```
1> [CMake] CMake Error at out/build/x64-Debug/_deps/fmt-src/CMakeLists.txt:55 (target_sources):
1> [CMake]   Cannot find source file:
1> [CMake] 
1> [CMake]     README.rst
1> [CMake] Call Stack (most recent call first):
1> [CMake]   out/build/x64-Debug/_deps/fmt-src/CMakeLists.txt:285 (add_module_library)
1> [CMake] CMake Error at out/build/x64-Debug/_deps/fmt-src/CMakeLists.txt:50 (add_library):
1> [CMake]   No SOURCES given to target: fmt
1> [CMake] Call Stack (most recent call first):
1> [CMake]   out/build/x64-Debug/_deps/fmt-src/CMakeLists.txt:285 (add_module_library)
1> [CMake] CMake Generate step failed.  Build files cannot be regenerated correctly.
```