### PR TITLE
Update isfinite declaration to be constexpr for c++23 only

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2752,7 +2752,7 @@ template <typename T, FMT_ENABLE_IF(std::is_floating_point<T>::value&&
                                         has_isfinite<T>::value)>
 FMT_CONSTEXPR20 bool isfinite(T value) {
   constexpr T inf = T(std::numeric_limits<double>::infinity());
-  if (is_constant_evaluated())
+  if (is_constant_evaluated(true))
     return !detail::isnan(value) && value < inf && value > -inf;
   return std::isfinite(value);
 }


### PR DESCRIPTION
Fix #3745

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
