### PR TITLE
Fix typo in gmock-gtest-all.cc

### DIFF
--- a/test/gtest/gmock-gtest-all.cc
+++ b/test/gtest/gmock-gtest-all.cc
@@ -1912,7 +1912,7 @@ void AssertHelper::operator=(const Message& message) const {
 namespace {
 
 // When TEST_P is found without a matching INSTANTIATE_TEST_SUITE_P
-// to creates test cases for it, a syntetic test case is
+// to creates test cases for it, a synthetic test case is
 // inserted to report ether an error or a log message.
 //
 // This configuration bit will likely be removed at some point.


### PR DESCRIPTION
syntetic -> synthetic

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
