### PR TITLE
Fix warning: identifier '_a' preceded by whitespace in a literal operator declaration is deprecated

### DIFF
--- a/include/fmt/xchar.h
+++ b/include/fmt/xchar.h
@@ -70,7 +70,7 @@ constexpr format_arg_store<wformat_context, T...> make_wformat_args(
 
 inline namespace literals {
 #if FMT_USE_USER_DEFINED_LITERALS && !FMT_USE_NONTYPE_TEMPLATE_ARGS
-constexpr detail::udl_arg<wchar_t> operator"" _a(const wchar_t* s, size_t) {
+constexpr detail::udl_arg<wchar_t> operator""_a(const wchar_t* s, size_t) {
   return {s};
 }
 #endif


### PR DESCRIPTION
Fix error (clang-17):
```
In file included from /home/runner/work/fmt/fmt/test/printf-test.cc:14:
/home/runner/work/fmt/fmt/include/fmt/xchar.h:73:47: error: identifier '_a' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
   73 | constexpr detail::udl_arg<wchar_t> operator"" _a(const wchar_t* s, size_t) {
      |                                    ~~~~~~~~~~~^~
      |                                    operator""_a
```