### PR TITLE
CI: add lint github workflow for running clang-format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: lint
+
+on:
+  pull_request:
+    paths:
+      - '**.h'
+      - '**.cc'
+
+permissions:
+  contents: read
+
+jobs:
+  format_code:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install clang-format
+      uses: aminya/setup-cpp@v1
+      with:
+        clangformat: 17.0.5
+
+    - name: Run clang-format
+      run: |
+        find include src -name '*.h' -o -name '*.cc' |  xargs clang-format -i -style=file -fallback-style=none
+        git diff --exit-code


### PR DESCRIPTION
so that we can identify changes which do not confirm to the clang-format rules.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
