### PR TITLE
Use `void(*)(void*)` instead of `decltype(&std::free)` to satisfy clang in CUDA mode

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -415,7 +415,7 @@ struct formatter<
 #  ifdef FMT_HAS_ABI_CXA_DEMANGLE
     int status = 0;
     std::size_t size = 0;
-    std::unique_ptr<char, decltype(&std::free)> demangled_name_ptr(
+    std::unique_ptr<char, void(*)(void*)> demangled_name_ptr(
         abi::__cxa_demangle(ti.name(), nullptr, &size, &status), &std::free);
 
     string_view demangled_name_view;


### PR DESCRIPTION
Fixes #3740. It seems like clang is ok with `&std::free` passed as an argument to the `unique_ptr` constructor (I think it's able to pick host/device overloads based on the function where it's used, but not inside `decltype`), so that is intentionally left unchanged.