### PR TITLE
Enable consteval in MSVC VS2019 version 16.10

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -224,8 +224,9 @@
         __apple_build_version__ >= 14000029L) &&                 \
        FMT_CPLUSPLUS >= 202002L) ||                              \
       (defined(__cpp_consteval) &&                               \
-       (!FMT_MSC_VERSION || _MSC_FULL_VER >= 193030704))
-// consteval is broken in MSVC before VS2022 and Apple clang before 14.
+       (!FMT_MSC_VERSION || FMT_MSC_VERSION >= 1929))
+// consteval is broken in MSVC before VS2019 version 16.10 and Apple clang
+// before 14.
 #    define FMT_CONSTEVAL consteval
 #    define FMT_HAS_CONSTEVAL
 #  else


### PR DESCRIPTION
``consteval`` have been implemented in MSVC since VS2019 16.10.