### PR TITLE
Fix wchar_t to char conversion warnings

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2130,7 +2130,7 @@ auto write_int(OutputIt out, UInt value, unsigned prefix,
   case presentation_type::none:
   case presentation_type::dec: {
     num_digits = count_digits(value);
-    format_decimal<Char>(appender(buffer), value, num_digits);
+    format_decimal<char>(appender(buffer), value, num_digits);
     break;
   }
   case presentation_type::hex_lower:
@@ -2139,7 +2139,7 @@ auto write_int(OutputIt out, UInt value, unsigned prefix,
     if (specs.alt)
       prefix_append(prefix, unsigned(upper ? 'X' : 'x') << 8 | '0');
     num_digits = count_digits<4>(value);
-    format_uint<4, Char>(appender(buffer), value, num_digits, upper);
+    format_uint<4, char>(appender(buffer), value, num_digits, upper);
     break;
   }
   case presentation_type::bin_lower:
@@ -2148,7 +2148,7 @@ auto write_int(OutputIt out, UInt value, unsigned prefix,
     if (specs.alt)
       prefix_append(prefix, unsigned(upper ? 'B' : 'b') << 8 | '0');
     num_digits = count_digits<1>(value);
-    format_uint<1, Char>(appender(buffer), value, num_digits);
+    format_uint<1, char>(appender(buffer), value, num_digits);
     break;
   }
   case presentation_type::oct: {
@@ -2157,7 +2157,7 @@ auto write_int(OutputIt out, UInt value, unsigned prefix,
     // is not greater than the number of digits.
     if (specs.alt && specs.precision <= num_digits && value != 0)
       prefix_append(prefix, '0');
-    format_uint<3, Char>(appender(buffer), value, num_digits);
+    format_uint<3, char>(appender(buffer), value, num_digits);
     break;
   }
   case presentation_type::chr:


### PR DESCRIPTION
Warnings is introduced in PR #3750

Sample:

```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\include\xutility(135,50): warning C4244: 'initializing': conversion from 'const _Elem' to '_Ty', possible loss of data [D:\a\fmt\build\test\printf-test.vcxproj]
          with
          [
              _Elem=wchar_t
          ]
          and
          [
              _Ty=char
          ]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\include\xutility(134): message : see reference to function template instantiation '_Ty *std::construct_at<_Ty,const _Elem&,void>(_Ty *const ,const _Elem &) noexcept(<expr>)' being compiled [D:\a\fmt\build\test\printf-test.vcxproj]
          with
          [
              _Ty=char,
              _Elem=wchar_t
  enforce-checks-test.cc
          ]

```