### PR TITLE
Update documentation

### DIFF
--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -153,7 +153,8 @@ Preceding the *width* field by a zero (``'0'``) character enables sign-aware
 zero-padding for numeric types. It forces the padding to be placed after the
 sign or base (if any) but before the digits. This is used for printing fields in
 the form '+000000120'. This option is only valid for numeric types and it has no
-effect on formatting of infinity and NaN.
+effect on formatting of infinity and NaN. This option is ignored when any
+alignment specifier is present.
 
 The *precision* is a decimal number indicating how many digits should be
 displayed after the decimal point for a floating-point value formatted with


### PR DESCRIPTION
Add a note about the numerical zero being ignored when an alignment flag is present in the format specifier.

This change was introduced in a585571e90e7f5645bcf6548cef42078db940f49 to be compatible with std::format, but misses documentation.

Closes #3788 