### PR TITLE
Update fmt/std.h section

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -520,16 +520,16 @@ Standard Library Types Formatting
 
 ``fmt/std.h`` provides formatters for:
 
-* `std::filesystem::path <https://en.cppreference.com/w/cpp/filesystem/path>`_
-* `std::thread::id <https://en.cppreference.com/w/cpp/thread/thread/id>`_
-* `std::monostate <https://en.cppreference.com/w/cpp/utility/variant/monostate>`_
-* `std::variant <https://en.cppreference.com/w/cpp/utility/variant/variant>`_
-* `std::optional <https://en.cppreference.com/w/cpp/utility/optional>`_
-* `std::source_location <https://en.cppreference.com/w/cpp/utility/source_location>`_
-* `std::bitset <https://en.cppreference.com/w/cpp/utility/bitset>`_
-* `std::error_code <https://en.cppreference.com/w/cpp/error/error_code>`_
 * `std::atomic <https://en.cppreference.com/w/cpp/atomic/atomic>`_
 * `std::atomic_flag <https://en.cppreference.com/w/cpp/atomic/atomic_flag>`_
+* `std::bitset <https://en.cppreference.com/w/cpp/utility/bitset>`_
+* `std::error_code <https://en.cppreference.com/w/cpp/error/error_code>`_
+* `std::filesystem::path <https://en.cppreference.com/w/cpp/filesystem/path>`_
+* `std::monostate <https://en.cppreference.com/w/cpp/utility/variant/monostate>`_
+* `std::optional <https://en.cppreference.com/w/cpp/utility/optional>`_
+* `std::source_location <https://en.cppreference.com/w/cpp/utility/source_location>`_
+* `std::thread::id <https://en.cppreference.com/w/cpp/thread/thread/id>`_
+* `std::variant <https://en.cppreference.com/w/cpp/utility/variant/variant>`_
 
 Formatting Variants
 -------------------

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -525,6 +525,11 @@ Standard Library Types Formatting
 * `std::monostate <https://en.cppreference.com/w/cpp/utility/variant/monostate>`_
 * `std::variant <https://en.cppreference.com/w/cpp/utility/variant/variant>`_
 * `std::optional <https://en.cppreference.com/w/cpp/utility/optional>`_
+* `std::source_location <https://en.cppreference.com/w/cpp/utility/source_location>`_
+* `std::bitset <https://en.cppreference.com/w/cpp/utility/bitset>`_
+* `std::error_code <https://en.cppreference.com/w/cpp/error/error_code>`_
+* `std::atomic <https://en.cppreference.com/w/cpp/atomic/atomic>`_
+* `std::atomic_flag <https://en.cppreference.com/w/cpp/atomic/atomic_flag>`_
 
 Formatting Variants
 -------------------


### PR DESCRIPTION
This is just trying to keep the `std.h` documentation up-to-date. I just opened https://github.com/tupaschoal/fmt/blob/7ba6420540383f378c48834beb46f9cec5504dd2/include/fmt/std.h and looked through all formatter specializations:

`std::bitset` https://github.com/tupaschoal/fmt/blob/master/include/fmt/std.h#L172
`std::source_location` https://github.com/tupaschoal/fmt/blob/master/include/fmt/std.h#L248
`std::error_code` https://github.com/tupaschoal/fmt/blob/master/include/fmt/std.h#L365
`std::atomic` https://github.com/tupaschoal/fmt/blob/master/include/fmt/std.h#L514
`std::atomic_flag` https://github.com/tupaschoal/fmt/blob/master/include/fmt/std.h#L527

PS: I added an optional commit to sort the section, because as it grows I think it gets easier to read