### PR TITLE
Fix buffer overflow if output iterator is std::back_insert_iterator and value is escaped (debug format)

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2388,9 +2388,12 @@ FMT_CONSTEXPR auto write(OutputIt out, basic_string_view<Char> s,
     size = code_point_index(s, to_unsigned(specs.precision));
   bool is_debug = specs.type == presentation_type::debug;
   size_t width = 0;
+
+  if (is_debug) size = write_escaped_string(counting_iterator{}, s).count();
+
   if (specs.width != 0) {
     if (is_debug)
-      width = write_escaped_string(counting_iterator{}, s).count();
+      width = size;
     else
       width = compute_width(basic_string_view<Char>(data, size));
   }

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -85,6 +85,16 @@ TEST(compile_test, format_default) {
 #  endif
 }
 
+TEST(compile_test, format_escape) {
+  EXPECT_EQ("\"string\"", fmt::format(FMT_COMPILE("{:?}"), "string"));
+  EXPECT_EQ("prefix \"string\"",
+            fmt::format(FMT_COMPILE("prefix {:?}"), "string"));
+  EXPECT_EQ("\"string\" suffix",
+            fmt::format(FMT_COMPILE("{:?} suffix"), "string"));
+  EXPECT_EQ("\"abc\"", fmt::format(FMT_COMPILE("{0:<5?}"), "abc"));
+  EXPECT_EQ("\"abc\"  ", fmt::format(FMT_COMPILE("{0:<7?}"), "abc"));
+}
+
 TEST(compile_test, format_wide_string) {
   EXPECT_EQ(L"42", fmt::format(FMT_COMPILE(L"{}"), 42));
 }
@@ -288,7 +298,7 @@ TEST(compile_test, compile_format_string_literal) {
 //  line 8635)
 #if (FMT_CPLUSPLUS >= 202002L ||                                \
      (FMT_CPLUSPLUS >= 201709L && FMT_GCC_VERSION >= 1002)) &&  \
-    ((!FMT_GLIBCXX_RELEASE || FMT_GLIBCXX_RELEASE >= 10) &&  \
+    ((!FMT_GLIBCXX_RELEASE || FMT_GLIBCXX_RELEASE >= 10) &&     \
      (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION >= 10000) && \
      (!FMT_MSC_VERSION ||                                       \
       (FMT_MSC_VERSION >= 1928 && FMT_MSC_VERSION < 1930))) &&  \


### PR DESCRIPTION
Issue: #3795

For ``std::back_insert_iterator`` output iterator ``reserve`` return raw pointer:

https://github.com/fmtlib/fmt/blob/58a6bd48a8dc7ea74bb9fd900c60fd333a85725f/include/fmt/format.h#L571-L582

If ``size`` is incorrect, ``write_padded`` may overflow this container:
https://github.com/fmtlib/fmt/blob/58a6bd48a8dc7ea74bb9fd900c60fd333a85725f/include/fmt/format.h#L1798-L1818

@vitaut