### PR TITLE
🛠 Add basic array safety functions and backwards-compatible result type

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2876,7 +2876,7 @@ FMT_INLINE auto format_to_n(OutputIt out, size_t n, format_string<T...> fmt,
 
 template <typename OutputIt, typename OutputSen = OutputIt>
 struct format_to_result {
-  /** Iterator past the end of the last write. */
+  /** Iterator pointing to just after the last succesful write in the range. */
   OutputIt out;
   /** Sentinel indicating the end of the output range. */
   OutputSen out_last;

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2811,8 +2811,6 @@ using format_string = basic_format_string<char, type_identity_t<Args>...>;
 inline auto runtime(string_view s) -> runtime_format_string<> { return {{s}}; }
 #endif
 
-template <typename... Args>
-using format_string = basic_format_string<char, type_identity_t<Args>...>;
 /** Formats a string and writes the output to ``out``. */
 template <typename OutputIt,
           FMT_ENABLE_IF(detail::is_output_iterator<remove_cvref_t<OutputIt>,

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -259,6 +259,8 @@
 #  define FMT_UNICODE !FMT_MSC_VERSION
 #endif
 
+#define FMT_FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
+
 // Enable minimal optimizations for more compact code in debug mode.
 FMT_GCC_PRAGMA("GCC push_options")
 #if !defined(__OPTIMIZE__) && !defined(__CUDACC__)
@@ -2809,13 +2811,41 @@ using format_string = basic_format_string<char, type_identity_t<Args>...>;
 inline auto runtime(string_view s) -> runtime_format_string<> { return {{s}}; }
 #endif
 
+template <typename... Args>
+using format_string = basic_format_string<char, type_identity_t<Args>...>;
 /** Formats a string and writes the output to ``out``. */
 template <typename OutputIt,
-          FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
-auto vformat_to(OutputIt out, string_view fmt, format_args args) -> OutputIt {
+          FMT_ENABLE_IF(detail::is_output_iterator<remove_cvref_t<OutputIt>,
+                                                   char>::value)>
+auto vformat_to(OutputIt&& out, string_view fmt, format_args args)
+    -> remove_cvref_t<OutputIt> {
   auto&& buf = detail::get_buffer<char>(out);
   detail::vformat_to(buf, fmt, args, {});
   return detail::get_iterator(buf, out);
+}
+
+template <typename OutputIt, typename OutputSen = OutputIt>
+struct format_to_result {
+  /** Iterator past the end of the last write. */
+  OutputIt out;
+  /** Iterator to the end of the output range. */
+  OutputSen out_last;
+
+  FMT_CONSTEXPR operator OutputIt&() & noexcept { return out; }
+  FMT_CONSTEXPR operator const OutputIt&() const& noexcept { return out; }
+  FMT_CONSTEXPR operator OutputIt&&() && noexcept {
+    return static_cast<OutputIt&&>(out);
+  }
+};
+
+/** Formats a string and writes the output to ``out``. */
+template <size_t Size>
+auto vformat_to(char (&out)[Size], string_view fmt, format_args args)
+    -> format_to_result<char*> {
+  using traits = detail::fixed_buffer_traits;
+  auto buf = detail::iterator_buffer<char*, char, traits>(out, Size);
+  detail::vformat_to(buf, fmt, args, {});
+  return {out + buf.count(), out + Size};
 }
 
 /**
@@ -2831,9 +2861,28 @@ auto vformat_to(OutputIt out, string_view fmt, format_args args) -> OutputIt {
  \endrst
  */
 template <typename OutputIt, typename... T,
-          FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
-FMT_INLINE auto format_to(OutputIt out, format_string<T...> fmt, T&&... args)
-    -> OutputIt {
+          FMT_ENABLE_IF(detail::is_output_iterator<remove_cvref_t<OutputIt>,
+                                                   char>::value)>
+FMT_INLINE auto format_to(OutputIt&& out, format_string<T...> fmt, T&&... args)
+    -> remove_cvref_t<OutputIt> {
+  return vformat_to(FMT_FWD(out), fmt, fmt::make_format_args(args...));
+}
+
+/**
+ \rst
+ Formats ``args`` according to specifications in ``fmt``, writes the result to
+ the output iterator ``out`` and returns the iterator past the end of the output
+ range. `format_to` does not append a terminating null character.
+
+ **Example**::
+
+   auto out = std::vector<char>();
+   fmt::format_to(std::back_inserter(out), "{}", 42);
+ \endrst
+ */
+template <size_t Size, typename... T>
+FMT_INLINE auto format_to(char (&out)[Size], format_string<T...> fmt,
+                          T&&... args) -> format_to_result<char*> {
   return vformat_to(out, fmt, fmt::make_format_args(args...));
 }
 

--- a/test/base-test.cc
+++ b/test/base-test.cc
@@ -12,7 +12,7 @@
 #include <climits>      // INT_MAX
 #include <cstring>      // std::strlen
 #include <functional>   // std::equal_to
-#include <iterator>     // std::back_insert_iterator
+#include <iterator>     // std::back_insert_iterator, std::distance
 #include <limits>       // std::numeric_limits
 #include <string>       // std::string
 #include <type_traits>  // std::is_same
@@ -690,6 +690,47 @@ TEST(core_test, format_to) {
   auto s = std::string();
   fmt::format_to(std::back_inserter(s), "{}", 42);
   EXPECT_EQ(s, "42");
+}
+
+TEST(core_test, format_to_c_array) {
+  char buffer[4];
+  auto result = fmt::format_to(buffer, "{}", 12345);
+  EXPECT_EQ(4, std::distance(&buffer[0], result.out));
+  EXPECT_EQ(0, std::distance(result.out, result.out_last));
+  EXPECT_EQ(buffer + 4, result.out);
+  EXPECT_EQ("1234", fmt::string_view(buffer, 4));
+
+  result = fmt::format_to(buffer, "{:s}", "foobar");
+  EXPECT_EQ(4, std::distance(&buffer[0], result.out));
+  EXPECT_EQ(0, std::distance(result.out, result.out_last));
+  EXPECT_EQ(buffer + 4, result.out);
+  EXPECT_EQ("foob", fmt::string_view(buffer, 4));
+
+  buffer[0] = 'x';
+  buffer[1] = 'x';
+  buffer[2] = 'x';
+  buffer[3] = 'x';
+  result = fmt::format_to(buffer, "{}", 'A');
+  EXPECT_EQ(1, std::distance(&buffer[0], result.out));
+  EXPECT_EQ(3, std::distance(result.out, result.out_last));
+  EXPECT_EQ(buffer + 1, result.out);
+  EXPECT_EQ("Axxx", fmt::string_view(buffer, 4));
+
+  result = fmt::format_to(buffer, "{}{} ", 'B', 'C');
+  EXPECT_EQ(3, std::distance(&buffer[0], result.out));
+  EXPECT_EQ(1, std::distance(result.out, result.out_last));
+  EXPECT_EQ(buffer + 3, result.out);
+  EXPECT_EQ("BC x", fmt::string_view(buffer, 4));
+
+  result = fmt::format_to(buffer, "{}", "ABCDE");
+  EXPECT_EQ(4, std::distance(&buffer[0], result.out));
+  EXPECT_EQ(0, std::distance(result.out, result.out_last));
+  EXPECT_EQ("ABCD", fmt::string_view(buffer, 4));
+
+  result = fmt::format_to(buffer, "{}", std::string(1000, '*'));
+  EXPECT_EQ(4, std::distance(&buffer[0], result.out));
+  EXPECT_EQ(0, std::distance(result.out, result.out_last));
+  EXPECT_EQ("****", fmt::string_view(buffer, 4));
 }
 
 #ifdef __cpp_lib_byte

--- a/test/base-test.cc
+++ b/test/base-test.cc
@@ -9,6 +9,8 @@
 #include "test-assert.h"
 // clang-format on
 
+#include "fmt/base.h"
+
 #include <climits>      // INT_MAX
 #include <cstring>      // std::strlen
 #include <functional>   // std::equal_to
@@ -17,7 +19,6 @@
 #include <string>       // std::string
 #include <type_traits>  // std::is_same
 
-#include "fmt/base.h"
 #include "gmock/gmock.h"
 
 using fmt::string_view;


### PR DESCRIPTION
This pull request follows-up on #3756 by doing one part of what was asked; just array overloads to cover that case. A separate PR will handle the enhanced functionality for range-based calls to `format_to` (and a potentially new API call) in `fmt/range.h` (and not in core).

Unlike the general-purpose sketch in #3756, this one is meant to be merged.