### PR TITLE
Fix conversion warning in filesystem::path formatter

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -120,7 +120,7 @@ template <typename Char> struct formatter<std::filesystem::path, Char> {
   format_specs<Char> specs_;
   detail::arg_ref<Char> width_ref_;
   bool debug_ = false;
-  Char path_type_ = 0;
+  char path_type_ = 0;
 
  public:
   FMT_CONSTEXPR void set_debug_format(bool set = true) { debug_ = set; }
@@ -137,7 +137,7 @@ template <typename Char> struct formatter<std::filesystem::path, Char> {
       debug_ = true;
       ++it;
     }
-    if (it != end && (*it == 'g')) path_type_ = *it++;
+    if (it != end && (*it == 'g')) path_type_ = detail::to_ascii(*it++);
     return it;
   }
 

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -120,7 +120,7 @@ template <typename Char> struct formatter<std::filesystem::path, Char> {
   format_specs<Char> specs_;
   detail::arg_ref<Char> width_ref_;
   bool debug_ = false;
-  char path_type_ = 0;
+  Char path_type_ = 0;
 
  public:
   FMT_CONSTEXPR void set_debug_format(bool set = true) { debug_ = set; }


### PR DESCRIPTION
Use template character type to eliminate MSVC conversion warning when formatting a wide chararacter path:

fmt\std.h(140,49): warning C4244: '=': conversion from 'const Char' to 'char', possible loss of data

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
