### PR TITLE
Fix MSVC warning: "The contents of <bit> are available only with C++20 or later."

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -49,7 +49,8 @@
 
 #include "base.h"
 
-#if FMT_HAS_INCLUDE(<bit>)
+// Checking FMT_CPLUSPLUS for warning suppression in MSVC.
+#if FMT_HAS_INCLUDE(<bit>) && FMT_CPLUSPLUS >= 201703L
 #  include <bit>  // std::bit_cast
 #endif
 


### PR DESCRIPTION
Separate PR for MSVC warning.