### PR TITLE
Fix scope for glibc ext for sec, min, and hour

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -708,8 +708,8 @@ FMT_CONSTEXPR auto parse_chrono_format(const Char* begin, const Char* end,
   if (begin == end || *begin == '}') return begin;
   if (*begin != '%') FMT_THROW(format_error("invalid format"));
   auto ptr = begin;
-  pad_type pad = pad_type::unspecified;
   while (ptr != end) {
+    pad_type pad = pad_type::unspecified;
     auto c = *ptr;
     if (c == '}') break;
     if (c != '%') {

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -956,6 +956,7 @@ TEST(chrono_test, glibc_extensions) {
     EXPECT_EQ(fmt::format("{:%0I,%0H,%0M,%0S}", d), "01,01,02,03");
     EXPECT_EQ(fmt::format("{:%_I,%_H,%_M,%_S}", d), " 1, 1, 2, 3");
     EXPECT_EQ(fmt::format("{:%-I,%-H,%-M,%-S}", d), "1,1,2,3");
+    EXPECT_EQ(fmt::format("{:%-I,%H,%M,%S}", d), "1,01,02,03");
 
     EXPECT_EQ(fmt::format("{:%OI,%OH,%OM,%OS}", d), "01,01,02,03");
     EXPECT_EQ(fmt::format("{:%0OI,%0OH,%0OM,%0OS}", d), "01,01,02,03");


### PR DESCRIPTION
Issue: #3811