### PR TITLE
Fix %S formatting for chrono durations with leading zeroes 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ set_verbose(FMT_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE STRING
             "Installation directory for include files, a relative path that "
             "will be joined with ${CMAKE_INSTALL_PREFIX} or an absolute path.")
 
-option(FMT_PEDANTIC "Enable extra warnings and expensive tests." OFF)
+option(FMT_PEDANTIC "Enable extra warnings and expensive tests." ON)
 option(FMT_WERROR "Halt the compilation with an error on compiler warnings."
        OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ set_verbose(FMT_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE STRING
             "Installation directory for include files, a relative path that "
             "will be joined with ${CMAKE_INSTALL_PREFIX} or an absolute path.")
 
-option(FMT_PEDANTIC "Enable extra warnings and expensive tests." ON)
+option(FMT_PEDANTIC "Enable extra warnings and expensive tests." OFF)
 option(FMT_WERROR "Halt the compilation with an error on compiler warnings."
        OFF)
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1155,41 +1155,37 @@ void write_fractional_seconds(OutputIt& out, Duration d, int precision = -1) {
     *out++ = '.';
     leading_zeroes = (std::min)(leading_zeroes, precision);
     int remaining = precision - leading_zeroes;
-    if (remaining < num_digits) { 
+    if (remaining < num_digits) {
       int num_truncated_digits = num_digits - remaining;
-      n /= to_unsigned(detail::pow10(to_unsigned(num_truncated_digits)-1));
+      n /= to_unsigned(detail::pow10(to_unsigned(num_truncated_digits) - 1));
       const int old_num_digits = detail::count_digits(n);
       auto roundingDigit = n % 10;
       n /= 10;
       if (n) {
         if (roundingDigit > 5 || (roundingDigit == 5 && n % 10 % 2 != 0)) {
           n += 1;
-        } 
+        }
         if (old_num_digits == detail::count_digits(n)) {
           if (leading_zeroes) {
-            out = std::fill_n(out, leading_zeroes-1, '0');
+            out = std::fill_n(out, leading_zeroes - 1, '0');
             *out++ = '1';
             out = std::fill_n(out, remaining, '0');
-          }
-          else {
+          } else {
             n -= 1;
             out = format_decimal<Char>(out, n, remaining).end;
           }
-        }
-        else {
+        } else {
           out = std::fill_n(out, leading_zeroes, '0');
           out = format_decimal<Char>(out, n, remaining).end;
         }
-      }
-      else { 
-        if (roundingDigit >= 5) { 
+      } else {
+        if (roundingDigit >= 5) {
           if (leading_zeroes) {
-            out = std::fill_n(out, leading_zeroes-1, '0');
+            out = std::fill_n(out, leading_zeroes - 1, '0');
             *out++ = '1';
             out = std::fill_n(out, remaining, '0');
           }
-        }
-        else {
+        } else {
           out = std::fill_n(out, leading_zeroes, '0');
         }
       }

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1151,47 +1151,19 @@ void write_fractional_seconds(OutputIt& out, Duration d, int precision = -1) {
       out = std::fill_n(out, leading_zeroes, '0');
       out = format_decimal<Char>(out, n, num_digits).end;
     }
-  } else {
+  } else if (precision > 0) {
     *out++ = '.';
     leading_zeroes = (std::min)(leading_zeroes, precision);
     int remaining = precision - leading_zeroes;
+    out = std::fill_n(out, leading_zeroes, '0');
     if (remaining < num_digits) {
       int num_truncated_digits = num_digits - remaining;
-      n /= to_unsigned(detail::pow10(to_unsigned(num_truncated_digits) - 1));
-      const int old_num_digits = detail::count_digits(n);
-      auto roundingDigit = n % 10;
-      n /= 10;
+      n /= to_unsigned(detail::pow10(to_unsigned(num_truncated_digits)));
       if (n) {
-        if (roundingDigit > 5 || (roundingDigit == 5 && n % 10 % 2 != 0)) {
-          n += 1;
-        }
-        if (old_num_digits == detail::count_digits(n)) {
-          if (leading_zeroes) {
-            out = std::fill_n(out, leading_zeroes - 1, '0');
-            *out++ = '1';
-            out = std::fill_n(out, remaining, '0');
-          } else {
-            n -= 1;
-            out = format_decimal<Char>(out, n, remaining).end;
-          }
-        } else {
-          out = std::fill_n(out, leading_zeroes, '0');
-          out = format_decimal<Char>(out, n, remaining).end;
-        }
-      } else {
-        if (roundingDigit >= 5) {
-          if (leading_zeroes) {
-            out = std::fill_n(out, leading_zeroes - 1, '0');
-            *out++ = '1';
-            out = std::fill_n(out, remaining, '0');
-          }
-        } else {
-          out = std::fill_n(out, leading_zeroes, '0');
-        }
+        out = format_decimal<Char>(out, n, remaining).end;
       }
       return;
     }
-    out = std::fill_n(out, leading_zeroes, '0');
     if (n) {
       out = format_decimal<Char>(out, n, num_digits).end;
       remaining -= num_digits;

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1161,23 +1161,37 @@ void write_fractional_seconds(OutputIt& out, Duration d, int precision = -1) {
       const int old_num_digits = detail::count_digits(n);
       auto roundingDigit = n % 10;
       n /= 10;
-      if (roundingDigit > 5 || (roundingDigit == 5 && n % 10 % 2 != 0)) {
-        n += 1;
-      } 
-      if (old_num_digits == detail::count_digits(n)) {
-        if (leading_zeroes) {
-          out = std::fill_n(out, leading_zeroes-1, '0');
-          *out++ = '1';
-          out = std::fill_n(out, remaining, '0');
+      if (n) {
+        if (roundingDigit > 5 || (roundingDigit == 5 && n % 10 % 2 != 0)) {
+          n += 1;
+        } 
+        if (old_num_digits == detail::count_digits(n)) {
+          if (leading_zeroes) {
+            out = std::fill_n(out, leading_zeroes-1, '0');
+            *out++ = '1';
+            out = std::fill_n(out, remaining, '0');
+          }
+          else {
+            n -= 1;
+            out = format_decimal<Char>(out, n, remaining).end;
+          }
         }
         else {
-          n -= 1;
+          out = std::fill_n(out, leading_zeroes, '0');
           out = format_decimal<Char>(out, n, remaining).end;
         }
       }
-      else {
-        out = std::fill_n(out, leading_zeroes, '0');
-        out = format_decimal<Char>(out, n, remaining).end;
+      else { 
+        if (roundingDigit >= 5) { 
+          if (leading_zeroes) {
+            out = std::fill_n(out, leading_zeroes-1, '0');
+            *out++ = '1';
+            out = std::fill_n(out, remaining, '0');
+          }
+        }
+        else {
+          out = std::fill_n(out, leading_zeroes, '0');
+        }
       }
       return;
     }

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1157,7 +1157,7 @@ void write_fractional_seconds(OutputIt& out, Duration d, int precision = -1) {
     int remaining = precision - leading_zeroes;
     if (remaining < num_digits) { 
       int num_truncated_digits = num_digits - remaining;
-      n /= to_unsigned(detail::pow10(to_unsigned(num_truncated_digits)-1)); //002999
+      n /= to_unsigned(detail::pow10(to_unsigned(num_truncated_digits)-1));
       const int old_num_digits = detail::count_digits(n);
       auto roundingDigit = n % 10;
       n /= 10;

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1159,7 +1159,7 @@ void write_fractional_seconds(OutputIt& out, Duration d, int precision = -1) {
       int num_truncated_digits = num_digits - remaining;
       n /= to_unsigned(detail::pow10(to_unsigned(num_truncated_digits)-1)); //002999
       const int old_num_digits = detail::count_digits(n);
-      int roundingDigit = n % 10;
+      auto roundingDigit = n % 10;
       n /= 10;
       if (roundingDigit > 5 || (roundingDigit == 5 && n % 10 % 2 != 0)) {
         n += 1;

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -803,6 +803,10 @@ TEST(chrono_test, cpp20_duration_subsecond_support) {
             "12.1");
   EXPECT_EQ(fmt::format("{:.2%S}", std::chrono::milliseconds{99999}),
             "39.99");
+  EXPECT_EQ(fmt::format("{:.2%S}", std::chrono::milliseconds{1000}),
+            "01.00");
+  EXPECT_EQ(fmt::format("{:.3%S}", std::chrono::milliseconds{1}),
+            "00.001");
   EXPECT_EQ(fmt::format("{:.3%S}", std::chrono::seconds{1234}), "34.000");
   EXPECT_EQ(fmt::format("{:.3%S}", std::chrono::hours{1234}), "00.000");
   EXPECT_EQ(fmt::format("{:.5%S}", dms(1.234)), "00.00123");

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -794,13 +794,11 @@ TEST(chrono_test, cpp20_duration_subsecond_support) {
   EXPECT_EQ(fmt::format("{:.2%S}", std::chrono::milliseconds{12345}),
             "12.34");
   EXPECT_EQ(fmt::format("{:.2%S}", std::chrono::milliseconds{12375}),
-            "12.38");
+            "12.37");
   EXPECT_EQ(fmt::format("{:.2%S}", std::chrono::milliseconds{-12375}),
-            "-12.38");
-  EXPECT_EQ(fmt::format("{:.2%S}", std::chrono::milliseconds{12054}),
-            "12.05");
-  EXPECT_EQ(fmt::format("{:.1%S}", std::chrono::milliseconds{12054}),
-            "12.1");
+            "-12.37");
+  EXPECT_EQ(fmt::format("{:.0%S}", std::chrono::milliseconds{12054}),
+            "12");
   EXPECT_EQ(fmt::format("{:.2%S}", std::chrono::milliseconds{99999}),
             "39.99");
   EXPECT_EQ(fmt::format("{:.2%S}", std::chrono::milliseconds{1000}),

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -791,6 +791,18 @@ TEST(chrono_test, cpp20_duration_subsecond_support) {
             "01.234000");
   EXPECT_EQ(fmt::format("{:.6%S}", std::chrono::milliseconds{-1234}),
             "-01.234000");
+  EXPECT_EQ(fmt::format("{:.2%S}", std::chrono::milliseconds{12345}),
+            "12.34");
+  EXPECT_EQ(fmt::format("{:.2%S}", std::chrono::milliseconds{12375}),
+            "12.38");
+  EXPECT_EQ(fmt::format("{:.2%S}", std::chrono::milliseconds{-12375}),
+            "-12.38");
+  EXPECT_EQ(fmt::format("{:.2%S}", std::chrono::milliseconds{12054}),
+            "12.05");
+  EXPECT_EQ(fmt::format("{:.1%S}", std::chrono::milliseconds{12054}),
+            "12.1");
+  EXPECT_EQ(fmt::format("{:.2%S}", std::chrono::milliseconds{99999}),
+            "39.99");
   EXPECT_EQ(fmt::format("{:.3%S}", std::chrono::seconds{1234}), "34.000");
   EXPECT_EQ(fmt::format("{:.3%S}", std::chrono::hours{1234}), "00.000");
   EXPECT_EQ(fmt::format("{:.5%S}", dms(1.234)), "00.00123");


### PR DESCRIPTION
My attempt to fix #3794. I implemented the rounding as round half to even and fixed the case where an extraneous 0 is added when the decimal part is 0.  Added tests as well.

I do have one question: what would be the desired behavior in the case where rounding up the subseconds/decimal part would eventually carry over to the integer part (the seconds) (for example: `01.99` rounded to precision .1)? As of right now, all numbers with `.9...` will not carry over regardless, so from the previous example, `01.99 -> 01.99`.  