### PR TITLE
Fix custom formatter example

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -139,14 +139,16 @@ without implementing them yourself. For example::
   template <> struct fmt::formatter<color>: formatter<string_view> {
     // parse is inherited from formatter<string_view>.
 
-    auto format(color c, format_context& ctx) const;
+    auto format(color c, format_context& ctx) const
+      -> format_parse_context::iterator;
   };
 
   // color.cc:
   #include "color.h"
   #include <fmt/format.h>
 
-  auto fmt::formatter<color>::format(color c, format_context& ctx) const {
+  auto fmt::formatter<color>::format(color c, format_context& ctx) const
+      -> format_parse_context::iterator {
     string_view name = "unknown";
     switch (c) {
     case color::red:   name = "red"; break;


### PR DESCRIPTION
Add a return type declaration so the example builds when the formatter is used in a different compilation unit than it's implemented.

closes #3818 
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
