### PR TITLE
Don't always enable typeid usage under MSVC

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -54,8 +54,8 @@
 
 // Check if typeid is available.
 #ifndef FMT_USE_TYPEID
-// __RTTI is for EDG compilers. In MSVC typeid is available without RTTI.
-#  if defined(__GXX_RTTI) || FMT_HAS_FEATURE(cxx_rtti) || FMT_MSC_VERSION || \
+// __RTTI is for EDG compilers. _CPPRTTI is for MSVC.
+#  if defined(__GXX_RTTI) || FMT_HAS_FEATURE(cxx_rtti) || defined(_CPPRTTI) || \
       defined(__INTEL_RTTI__) || defined(__RTTI)
 #    define FMT_USE_TYPEID 1
 #  else


### PR DESCRIPTION
``FMT_USE_TYPEID`` is always being enabled currently when building with MSVC, even if the comment says that typeid is always available with MSVC, it is not exactly correct. In fact, building the first example from [here](https://learn.microsoft.com/en-us/cpp/cpp/typeid-operator?view=msvc-170)
```cpp
#include <iostream>
#include <typeinfo>

class Base {
public:
   virtual void vvfunc() {}
};

class Derived : public Base {};

using namespace std;
int main() {
   Derived* pd = new Derived;
   Base* pb = pd;
   cout << typeid( pb ).name() << endl;   //prints "class Base *"
   cout << typeid( *pb ).name() << endl;   //prints "class Derived"
   cout << typeid( pd ).name() << endl;   //prints "class Derived *"
   cout << typeid( *pd ).name() << endl;   //prints "class Derived"
   delete pd;
}
```

with exeptions disabled, will fail with the c++ exeption ``Access violation - no RTTI data!`` when calling `typeid` on the first dereferenced pointer. Even if this is not an issue with the current only place where it is used in fmt (haven't actually tested it), it's better to just disable it and not risk an exception being thrown when formatting an exception (would be pretty ironic tho).