### PR TITLE
Really fix MSVC warning about <bit> only being available in C++20.

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -54,7 +54,7 @@
 #include "base.h"
 
 // Checking FMT_CPLUSPLUS for warning suppression in MSVC.
-#if FMT_HAS_INCLUDE(<bit>) && FMT_CPLUSPLUS >= 202002L
+#if FMT_HAS_INCLUDE(<bit>) && FMT_CPLUSPLUS > 201703L
 #  include <bit>  // std::bit_cast
 #endif
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -54,7 +54,7 @@
 #include "base.h"
 
 // Checking FMT_CPLUSPLUS for warning suppression in MSVC.
-#if FMT_HAS_INCLUDE(<bit>) && FMT_CPLUSPLUS >= 201703L
+#if FMT_HAS_INCLUDE(<bit>) && FMT_CPLUSPLUS >= 202002L
 #  include <bit>  // std::bit_cast
 #endif
 


### PR DESCRIPTION
The warning states "The contents of <bit> are available only with C++20 or later.", but the check was for C++17 and later.

Follow-up to #3807.
