### PR TITLE
C++23 compatibility: basic_string_view cannot be constructed from nullptr

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -487,6 +487,8 @@ template <typename Char> class basic_string_view {
   constexpr basic_string_view(const Char* s, size_t count) noexcept
       : data_(s), size_(count) {}
 
+  constexpr basic_string_view(std::nullptr_t) = delete;
+
   /**
     Constructs a string reference object from a C string.
    */


### PR DESCRIPTION
In C++23 `std::basic_string_view` cannot be constructed from `nullptr`, this PR adds the same functionality to `fmt::basic_string_view`.