### PR TITLE
std.h c++23 build fix

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -269,9 +269,9 @@ FMT_BEGIN_NAMESPACE
 
 FMT_EXPORT
 template <typename T, typename E, typename Char>
-struct formatter<
-    std::expected<T, E>, Char,
-    std::enable_if_t<is_formattable<T, Char> && is_formattable<E, Char>>> {
+struct formatter<std::expected<T, E>, Char,
+                 std::enable_if_t<is_formattable<T, Char>::value &&
+                                  is_formattable<E, Char>::value>> {
   template <typename ParseContext>
   FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
     return ctx.begin();


### PR DESCRIPTION
Add ::value to is_formattable<...> as per suggestion by @vitaut in https://github.com/fmtlib/fmt/issues/3854

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
