### PR TITLE
Support character range formatting 

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -426,9 +426,12 @@ struct range_formatter<
       is_debug = true;
       set_brackets({}, {});
       ++it;
+      if (it == end || *it != 's') {
+        report_error("invalid format specifier");
+      }
       FMT_FALLTHROUGH;
     case 's':
-      if (it == end || *it != 's' || !std::is_same<T, Char>::value) {
+      if (!std::is_same<T, Char>::value) {
         report_error("invalid format specifier");
       }
       if (!is_debug) {

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -456,7 +456,7 @@ struct range_formatter<
 
   template <typename Output, typename Iter, typename IterEnd, typename U = T,
             enable_if_t<std::is_same<U, Char>::value, bool> = true>
-  auto write_debug_string(Output& out, Iter& it, IterEnd& end) const {
+  auto write_debug_string(Output& out, Iter& it, IterEnd& end) const -> Output {
     auto buf = basic_memory_buffer<Char>();
     for (; it != end; ++it) {
       auto&& item = *it;
@@ -464,15 +464,15 @@ struct range_formatter<
     }
     format_specs spec_str{};
     spec_str.type = presentation_type::debug;
-    detail::write<Char>(out, basic_string_view<Char>(buf.data(), buf.size()),
+    return detail::write<Char>(out, basic_string_view<Char>(buf.data(), buf.size()),
                         spec_str);
   }
   template <typename Output, typename Iter, typename IterEnd, typename U = T,
             enable_if_t<!(std::is_same<U, Char>::value), bool> = true>
-  auto write_debug_string(Output& out, Iter& it, IterEnd& end) const {
-    detail::ignore_unused(out);
+  auto write_debug_string(Output& out, Iter& it, IterEnd& end) const -> Output {
     detail::ignore_unused(it);
     detail::ignore_unused(end);
+    return out;
   }
 
   template <typename R, typename FormatContext>
@@ -482,8 +482,7 @@ struct range_formatter<
     auto it = detail::range_begin(range);
     auto end = detail::range_end(range);
     if (is_string_format && is_debug) {
-      write_debug_string(out, it, end);
-      return out;
+      return write_debug_string(out, it, end);
     }
 
     out = detail::copy<Char>(opening_bracket_, out);

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -473,8 +473,8 @@ struct range_formatter<
         }
         format_specs spec_str{};
         spec_str.type = presentation_type::debug;
-        detail::write<Char>(out, basic_string_view<Char>(buf.data(), buf.size()),
-                            spec_str);
+        detail::write<Char>(
+            out, basic_string_view<Char>(buf.data(), buf.size()), spec_str);
       } else {
         for (; it != end; ++it) {
           ctx.advance_to(out);

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -391,6 +391,7 @@ struct range_formatter<
       detail::string_literal<Char, ']'>{};
   bool is_string_format = false;
   bool is_debug = false;
+
  public:
   FMT_CONSTEXPR range_formatter() {}
 
@@ -416,8 +417,7 @@ struct range_formatter<
     if (it != end && *it == 'n') {
       set_brackets({}, {});
       ++it;
-    }
-    else {
+    } else {
       bool check_for_s = false;
       if (it != end && *it == '?') {
         ++it;
@@ -427,35 +427,36 @@ struct range_formatter<
         is_debug = true;
       }
       if (it != end && *it == 's') {
-        if (!std::is_same<T,Char>::value) {
+        if (!std::is_same<T, Char>::value) {
           report_error("invalid format specifier");
         }
         if (!is_debug) {
-          set_brackets(detail::string_literal<Char, '"'>{}, detail::string_literal<Char, '"'>{});
+          set_brackets(detail::string_literal<Char, '"'>{},
+                       detail::string_literal<Char, '"'>{});
         }
         check_for_s = false;
         is_string_format = true;
-        ++it;  
-        
+        ++it;
       }
-      if (check_for_s) { 
+      if (check_for_s) {
         report_error("invalid format specifier");
-      } 
+      }
     }
 
-    if (it != end && *it != '}') { 
-      if (is_string_format || *it != ':') report_error("invalid format specifier");
+    if (it != end && *it != '}') {
+      if (is_string_format || *it != ':')
+        report_error("invalid format specifier");
       ++it;
     } else {
-      if (!is_string_format)
-        detail::maybe_set_debug_format(underlying_, true);
+      if (!is_string_format) detail::maybe_set_debug_format(underlying_, true);
     }
 
     ctx.advance_to(it);
     return underlying_.parse(ctx);
   }
 
-  template <typename R, typename FormatContext, typename U = T, enable_if_t<std::is_same<U,Char>::value, bool> = true>
+  template <typename R, typename FormatContext, typename U = T,
+            enable_if_t<std::is_same<U, Char>::value, bool> = true>
   auto format(R&& range, FormatContext& ctx) const -> decltype(ctx.out()) {
     detail::range_mapper<buffered_context<Char>> mapper;
     auto out = ctx.out();
@@ -472,22 +473,21 @@ struct range_formatter<
         }
         format_specs spec_str{};
         spec_str.type = presentation_type::debug;
-        detail::write<Char>(out, basic_string_view(buf.data(),buf.size()), spec_str);
-      }
-      else {
+        detail::write<Char>(out, basic_string_view<Char>(buf.data(), buf.size()),
+                            spec_str);
+      } else {
         for (; it != end; ++it) {
           ctx.advance_to(out);
           auto&& item = *it;
-          out = underlying_.format(mapper.map(item), ctx); 
+          out = underlying_.format(mapper.map(item), ctx);
         }
       }
-    }
-    else {
+    } else {
       for (; it != end; ++it) {
         if (i > 0) out = detail::copy<Char>(separator_, out);
         ctx.advance_to(out);
         auto&& item = *it;
-        out = underlying_.format(mapper.map(item), ctx); 
+        out = underlying_.format(mapper.map(item), ctx);
         ++i;
       }
     }
@@ -495,7 +495,8 @@ struct range_formatter<
     return out;
   }
 
-  template <typename R, typename FormatContext, typename U = T, enable_if_t<!(std::is_same<U,Char>::value), bool> = true>
+  template <typename R, typename FormatContext, typename U = T,
+            enable_if_t<!(std::is_same<U, Char>::value), bool> = true>
   auto format(R&& range, FormatContext& ctx) const -> decltype(ctx.out()) {
     detail::range_mapper<buffered_context<Char>> mapper;
     auto out = ctx.out();
@@ -507,7 +508,7 @@ struct range_formatter<
       if (i > 0) out = detail::copy<Char>(separator_, out);
       ctx.advance_to(out);
       auto&& item = *it;
-      out = underlying_.format(mapper.map(item), ctx); 
+      out = underlying_.format(mapper.map(item), ctx);
       ++i;
     }
     out = detail::copy<Char>(closing_bracket_, out);

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -464,8 +464,8 @@ struct range_formatter<
     }
     format_specs spec_str{};
     spec_str.type = presentation_type::debug;
-    return detail::write<Char>(out, basic_string_view<Char>(buf.data(), buf.size()),
-                        spec_str);
+    return detail::write<Char>(
+        out, basic_string_view<Char>(buf.data(), buf.size()), spec_str);
   }
   template <typename Output, typename Iter, typename IterEnd, typename U = T,
             enable_if_t<!(std::is_same<U, Char>::value), bool> = true>

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -58,8 +58,13 @@ TEST(ranges_test, format_vector) {
   EXPECT_EQ(fmt::format("{:n:#x}", v), "0x1, 0x2, 0x3, 0x5, 0x7, 0xb");
 
   auto vc = std::vector<char>{'a', 'b', 'c'};
+  auto vec = std::vector<char>{'a', '\n', '\t'};
   auto vvc = std::vector<std::vector<char>>{vc, vc};
   EXPECT_EQ(fmt::format("{}", vc), "['a', 'b', 'c']");
+  EXPECT_EQ(fmt::format("{:s}", vc), "\"abc\"");
+  EXPECT_EQ(fmt::format("{:?s}", vec), "\"a\\n\\t\"");
+  EXPECT_EQ(fmt::format("{:s}", vec), "\"a\n\t\"");
+  EXPECT_EQ(fmt::format("{::s}", vvc), "[\"abc\", \"abc\"]");
   EXPECT_EQ(fmt::format("{}", vvc), "[['a', 'b', 'c'], ['a', 'b', 'c']]");
   EXPECT_EQ(fmt::format("{:n}", vvc), "['a', 'b', 'c'], ['a', 'b', 'c']");
   EXPECT_EQ(fmt::format("{:n:n}", vvc), "'a', 'b', 'c', 'a', 'b', 'c'");


### PR DESCRIPTION
My attempt to fix #3857. Implemented the `:s` and `:?s` specifier for ranges of characters. Specifically for the debug case (`:?s`), the underlying writer for escaped chars included single quotes in the output, so I converted the range into a string first. Added tests as well. 