### PR TITLE
Fix warning C4365 emitted from printf.h

### DIFF
--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -60,7 +60,7 @@ namespace detail {
 // signed and unsigned integers.
 template <bool IsSigned> struct int_checker {
   template <typename T> static auto fits_in_int(T value) -> bool {
-    unsigned max = max_value<int>();
+    unsigned max = to_unsigned(max_value<int>());
     return value <= max;
   }
   static auto fits_in_int(bool) -> bool { return true; }
@@ -205,7 +205,7 @@ class printf_width_handler {
       specs_.align = align::left;
       width = 0 - width;
     }
-    unsigned int_max = max_value<int>();
+    unsigned int_max = to_unsigned(max_value<int>());
     if (width > int_max) report_error("number is too big");
     return static_cast<unsigned>(width);
   }


### PR DESCRIPTION
Compiler: MSVC, Windows x64, Visual Studio 17.9.1
C++ standard: /std::c++latest
Fmtlib version: 10.2.1

Hi. Thanks for a fantastic library.

While we've generally gotten a few warnings from fmtlib during the last few years, they have decreased over time. On the 10.2.1 release, with our current setup, we only got a single one, a C4365. There might be others, that aren't caught by us, since we disable a few warnings. Our warning level is /W4.

![Skjermbilde 2024-02-23 234117](https://github.com/fmtlib/fmt/assets/19634818/ee3fdf6d-aa1d-42d0-a943-88d64e19f02d)

I have not yet been able to create a minimal reproduction case. The following code will compile in a freshly created Visual Studio project, but not in ours:

```cpp
#define FMT_HEADER_ONLY
#include "fmt/printf.h"

void test
{
   fmt::printf("%s", "test");
}
```

But the fix for this [issue](https://github.com/fmtlib/fmt/issues/2233), worked for us. If required I can work more on finding a minimal reproduction case.
