### PR TITLE
Fix warning C4702 emitted from format.h (MSVC)

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2218,7 +2218,6 @@ FMT_CONSTEXPR FMT_INLINE auto write_int(OutputIt out, write_int_arg<T> arg,
   case presentation_type::chr:
     return write_char<Char>(out, static_cast<Char>(abs_value), specs);
   }
-  return out;
 }
 template <typename Char, typename OutputIt, typename T>
 FMT_CONSTEXPR FMT_NOINLINE auto write_int_noinline(OutputIt out,


### PR DESCRIPTION
Compiler: MSVC, Windows x64, Visual Studio 17.9.1
C++ standard: Any (recreatable with anything from c++14 to c++latest)
Fmtlib version: Master branch
Warning level: /W4 or higher

Hi. This is a new warning, not emitted when using the 10.2.1-release, but recreatable from the master branch.

It can easily be recreated by the following lines of code:

```cpp
#define FMT_HEADER_ONLY
#include <fmt/format.h>

void test
{
   fmt::println("test");
}
```
![bilde](https://github.com/fmtlib/fmt/assets/19634818/6f1a15be-27d6-4b0a-a3b9-945f60200f6d)

It seems that the default-label in the switch-case prevents execution from reaching the bottom of the function. MSVC therefore emits a warning. I haven't tested this on other platforms