### PR TITLE
Guard against usage of _isatty when header was not included

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -18,7 +18,7 @@
 #  include <locale>
 #endif
 
-#if defined(_WIN32) && !defined(FMT_WINDOWS_NO_WCHAR)
+#if defined(_WIN32) && !defined(FMT_USE_WRITE_CONSOLE)
 #  include <io.h>  // _isatty
 #endif
 
@@ -1639,7 +1639,7 @@ class file_print_buffer : public buffer<char> {
   }
 };
 
-#if !defined(_WIN32) || defined(FMT_WINDOWS_NO_WCHAR)
+#if !defined(_WIN32) || defined(FMT_USE_WRITE_CONSOLE)
 FMT_FUNC auto write_console(int, string_view) -> bool { return false; }
 #else
 using dword = conditional_t<sizeof(long) == 4, unsigned long, unsigned>;
@@ -1665,7 +1665,7 @@ FMT_FUNC void vprint_mojibake(std::FILE* f, string_view fmt, format_args args,
 #endif
 
 FMT_FUNC void print(std::FILE* f, string_view text) {
-#if defined(_WIN32) && !defined(FMT_WINDOWS_NO_WCHAR)
+#if defined(_WIN32) && !defined(FMT_USE_WRITE_CONSOLE)
   int fd = _fileno(f);
   if (_isatty(fd)) {
     std::fflush(f);

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1665,7 +1665,7 @@ FMT_FUNC void vprint_mojibake(std::FILE* f, string_view fmt, format_args args,
 #endif
 
 FMT_FUNC void print(std::FILE* f, string_view text) {
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(FMT_WINDOWS_NO_WCHAR)
   int fd = _fileno(f);
   if (_isatty(fd)) {
     std::fflush(f);

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -344,7 +344,7 @@ TEST(format_impl_test, write_dragon_even) {
   if (!FMT_MSC_VERSION) EXPECT_EQ(s, "33554450");
 }
 
-#if defined(_WIN32) && !defined(FMT_WINDOWS_NO_WCHAR)
+#if defined(_WIN32) && !defined(FMT_USE_WRITE_CONSOLE)
 #  include <windows.h>
 
 TEST(format_impl_test, write_console_signature) {


### PR DESCRIPTION
The recent addition of the `FMT_WINDOWS_NO_WCHAR` flag tried to enable builds for Windows platforms that are not `WINAPI_FAMILY_DESKTOP_APP` as per the WINAPI family.
The inclusion of `<io.h>` became conditional on `FMT_WINDOWS_NO_WCHAR`. The usage of `_isatty` from that header however was not guarded. This PR tries to fix this.

There are two followup points for discussion:
* The name of `FMT_WINDOWS_NO_WCHAR` is incredibly misleading since it has nothing to do with wchar support but with the availability of the console output function `WriteConsoleW` only on `WINAPI_FAMILY_DESKTOP_APP` platforms. Should that macro be renamed?
* The need for `FMT_WINDOWS_NO_WCHAR` could be auto-detected by querying the `WINAPI_FAMILY` macros provided by the Windows header. Should this be included in `format.h` with the other config detection?