### PR TITLE
Show more details on "argument not found" error

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -4272,7 +4272,14 @@ void vformat_to(buffer<Char>& buf, basic_string_view<Char> fmt,
     FMT_CONSTEXPR auto on_arg_id(basic_string_view<Char> id) -> int {
       parse_context.check_arg_id(id);
       int arg_id = context.arg_id(id);
-      if (arg_id < 0) report_error("argument not found");
+      if (arg_id < 0) {
+          if constexpr (std::is_same_v<Char, char>) {
+            std::string errmsg = "argument not found: " + std::string(id.data(), id.size());
+            report_error(errmsg.c_str());
+          } else {
+            report_error("argument not found");
+          }
+      }
       return arg_id;
     }
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

This is quite an "example only" patch which is used for RFC.

## Purpose
- Show more detail error messages on format error

## Problem
While using `fmt::vformat(..)` -like interfaces, if the format argument is not found in parameters, only an ambiguous "argument not found" exception is thrown. Here is an example:

```
#include <iostream>
#include "fmt/format.h"
#include "fmt/core.h"
#include "fmt/args.h"

int main() {
    fmt::dynamic_format_arg_store<fmt::format_context> store;
    store.push_back(fmt::arg("FOO", "foo"));
    // Someone forget to add the "BAR" -> "bar" mapping

    std::string s = fmt::vformat("FOO: {FOO}, BAR: {BAR}", store);

    std::cout << s << std::endl;
}
```

Running the program above results in error
```
terminate called after throwing an instance of 'fmt::v10::format_error'
  what():  argument not found
Aborted (core dumped)
```

By using the patch in the PR, a clear error message show up so that developer could know that it is the problem of the "BAR" key, so they can fix the problem quickly:
```
terminate called after throwing an instance of 'fmt::v10::format_error'
  what():  argument not found: BAR
Aborted (core dumped)
```

By the way, in Python, things are similar. Code like

```
print("FOOL is {FOOL}, BAR is {BAR}".format(FOOL="fool"))
```
results in
```
KeyError: 'BAR'
```

Any comments? Should I fix other places?
