### PR TITLE
Add std::complex formatter

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <bitset>
+#include <complex>
 #include <cstdlib>
 #include <exception>
 #include <memory>
@@ -584,6 +585,32 @@ struct formatter<std::atomic_flag, Char> : formatter<bool, Char> {
   }
 };
 #endif  // __cpp_lib_atomic_flag_test
+
+FMT_EXPORT
+template <typename F, typename Char>
+struct formatter<std::complex<F>, Char> : nested_formatter<F, Char> {
+ private:
+  // Functor because C++11 doesn't support generic lambdas.
+  struct writer {
+    const formatter<std::complex<F>, Char>* f;
+    const std::complex<F>& c;
+
+    template <typename OutputIt>
+    FMT_CONSTEXPR auto operator()(OutputIt out) -> OutputIt {
+      auto format =
+          detail::string_literal<Char, '(', '{', '}', ',', '{', '}', ')'>{};
+      return fmt::format_to(out, basic_string_view<Char>(format),
+                            f->nested(c.real()), f->nested(c.imag()));
+    }
+  };
+
+ public:
+  template <typename FormatContext>
+  auto format(const std::complex<F>& c, FormatContext& ctx) const
+      -> decltype(ctx.out()) {
+    return this->write_padded(ctx, writer{this, c});
+  }
+};
 
 FMT_END_NAMESPACE
 #endif  // FMT_STD_H_

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -111,19 +111,27 @@ TEST(std_test, optional) {
 TEST(std_test, expected) {
 #ifdef __cpp_lib_expected
   EXPECT_EQ(fmt::format("{}", std::expected<int, int>{1}), "expected(1)");
-  EXPECT_EQ(fmt::format("{}", std::expected<int, int>{std::unexpected(1)}), "unexpected(1)");
-  EXPECT_EQ(fmt::format("{}", std::expected<std::string, int>{"test"}), "expected(\"test\")");
-  EXPECT_EQ(fmt::format("{}", std::expected<int, std::string>{std::unexpected("test")}), "unexpected(\"test\")");
+  EXPECT_EQ(fmt::format("{}", std::expected<int, int>{std::unexpected(1)}),
+            "unexpected(1)");
+  EXPECT_EQ(fmt::format("{}", std::expected<std::string, int>{"test"}),
+            "expected(\"test\")");
+  EXPECT_EQ(fmt::format(
+                "{}", std::expected<int, std::string>{std::unexpected("test")}),
+            "unexpected(\"test\")");
   EXPECT_EQ(fmt::format("{}", std::expected<char, int>{'a'}), "expected('a')");
-  EXPECT_EQ(fmt::format("{}", std::expected<int, char>{std::unexpected('a')}), "unexpected('a')");
+  EXPECT_EQ(fmt::format("{}", std::expected<int, char>{std::unexpected('a')}),
+            "unexpected('a')");
 
   struct unformattable1 {};
   struct unformattable2 {};
   EXPECT_FALSE((fmt::is_formattable<unformattable1>::value));
   EXPECT_FALSE((fmt::is_formattable<unformattable2>::value));
-  EXPECT_FALSE((fmt::is_formattable<std::expected<unformattable1, unformattable2>>::value));
-  EXPECT_FALSE((fmt::is_formattable<std::expected<unformattable1, int>>::value));
-  EXPECT_FALSE((fmt::is_formattable<std::expected<int, unformattable2>>::value));
+  EXPECT_FALSE((fmt::is_formattable<
+                std::expected<unformattable1, unformattable2>>::value));
+  EXPECT_FALSE(
+      (fmt::is_formattable<std::expected<unformattable1, int>>::value));
+  EXPECT_FALSE(
+      (fmt::is_formattable<std::expected<int, unformattable2>>::value));
   EXPECT_TRUE((fmt::is_formattable<std::expected<int, int>>::value));
 #endif
 }

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -65,6 +65,12 @@ TEST(std_test, thread_id) {
   EXPECT_FALSE(fmt::format("{}", std::this_thread::get_id()).empty());
 }
 
+TEST(std_test, complex) {
+  EXPECT_EQ(fmt::format("{}", std::complex<double>(1, 2.2)), "(1,2.2)");
+  EXPECT_EQ(fmt::format("{:>20.2f}", std::complex<double>(1, 2.2)),
+            "         (1.00,2.20)");
+}
+
 #ifdef __cpp_lib_source_location
 TEST(std_test, source_location) {
   std::source_location loc = std::source_location::current();

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -562,49 +562,6 @@ TEST(locale_test, int_formatter) {
   EXPECT_EQ(fmt::to_string(buf), "12,345");
 }
 
-FMT_BEGIN_NAMESPACE
-template <class charT> struct formatter<std::complex<double>, charT> {
- private:
-  detail::dynamic_format_specs<char> specs_;
-
- public:
-  FMT_CONSTEXPR typename basic_format_parse_context<charT>::iterator parse(
-      basic_format_parse_context<charT>& ctx) {
-    auto end = parse_format_specs(ctx.begin(), ctx.end(), specs_, ctx,
-                                  detail::type::float_type);
-    detail::parse_float_type_spec(specs_);
-    return end;
-  }
-
-  template <class FormatContext>
-  typename FormatContext::iterator format(const std::complex<double>& c,
-                                          FormatContext& ctx) const {
-    auto specs = specs_;
-    detail::handle_dynamic_spec<detail::precision_checker>(
-        specs.precision, specs.precision_ref, ctx);
-    auto fspecs = std::string();
-    if (specs.precision > 0) fspecs = fmt::format(".{}", specs.precision);
-    if (specs.type == presentation_type::fixed) fspecs += 'f';
-    auto real = fmt::format(ctx.locale().template get<std::locale>(),
-                            fmt::runtime("{:" + fspecs + "}"), c.real());
-    auto imag = fmt::format(ctx.locale().template get<std::locale>(),
-                            fmt::runtime("{:" + fspecs + "}"), c.imag());
-    auto fill_align_width = std::string();
-    if (specs.width > 0) fill_align_width = fmt::format(">{}", specs.width);
-    return fmt::format_to(ctx.out(), runtime("{:" + fill_align_width + "}"),
-                          c.real() != 0 ? fmt::format("({}+{}i)", real, imag)
-                                        : fmt::format("{}i", imag));
-  }
-};
-FMT_END_NAMESPACE
-
-TEST(locale_test, complex) {
-  std::string s = fmt::format("{}", std::complex<double>(1, 2));
-  EXPECT_EQ(s, "(1+2i)");
-  EXPECT_EQ(fmt::format("{:.2f}", std::complex<double>(1, 2)), "(1.00+2.00i)");
-  EXPECT_EQ(fmt::format("{:8}", std::complex<double>(1, 2)), "  (1+2i)");
-}
-
 TEST(locale_test, chrono_weekday) {
   auto loc = get_locale("es_ES.UTF-8", "Spanish_Spain.1252");
   auto loc_old = std::locale::global(loc);
@@ -623,6 +580,13 @@ TEST(locale_test, chrono_weekday) {
 
 TEST(locale_test, sign) {
   EXPECT_EQ(fmt::format(std::locale(), L"{:L}", -50), L"-50");
+}
+
+TEST(std_test_xchar, complex) {
+  auto s = fmt::format(L"{}", std::complex<double>(1, 2));
+  EXPECT_EQ(s, L"(1,2)");
+  EXPECT_EQ(fmt::format(L"{:.2f}", std::complex<double>(1, 2)), L"(1.00,2.00)");
+  EXPECT_EQ(fmt::format(L"{:8}", std::complex<double>(1, 2)), L"(1,2)   ");
 }
 
 TEST(std_test_xchar, optional) {


### PR DESCRIPTION
Issue: #3886

Output format is compatible with ``operator<<(std::complex)`` https://en.cppreference.com/w/cpp/numeric/complex/operator_ltltgtgt