### PR TITLE
Fix invalid fmt::formatter<>::format return type

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -140,7 +140,7 @@ without implementing them yourself. For example::
     // parse is inherited from formatter<string_view>.
 
     auto format(color c, format_context& ctx) const
-      -> format_parse_context::iterator;
+      -> format_context::iterator;
   };
 
   // color.cc:
@@ -148,7 +148,7 @@ without implementing them yourself. For example::
   #include <fmt/format.h>
 
   auto fmt::formatter<color>::format(color c, format_context& ctx) const
-      -> format_parse_context::iterator {
+      -> format_context::iterator {
     string_view name = "unknown";
     switch (c) {
     case color::red:   name = "red"; break;


### PR DESCRIPTION
Issue: #3894

Fix: https://godbolt.org/z/T5Kqc9n14