### PR TITLE
Improve std::complex formatter to be compatible with P2197R0

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -595,10 +595,15 @@ struct formatter<std::complex<F>, Char> : nested_formatter<F, Char> {
 
     template <typename OutputIt>
     FMT_CONSTEXPR auto operator()(OutputIt out) -> OutputIt {
-      auto format = detail::string_literal<Char, '(', '{', '}', '+', '{', '}',
-                                           'i', ')'>{};
-      return fmt::format_to(out, basic_string_view<Char>(format),
-                            f->nested(c.real()), f->nested(c.imag()));
+      if (c.real() != 0) {
+        auto format_full = detail::string_literal<Char, '(', '{', '}', '+', '{',
+                                                  '}', 'i', ')'>{};
+        return fmt::format_to(out, basic_string_view<Char>(format_full),
+                              f->nested(c.real()), f->nested(c.imag()));
+      }
+      auto format_imag = detail::string_literal<Char, '{', '}', 'i'>{};
+      return fmt::format_to(out, basic_string_view<Char>(format_imag),
+                            f->nested(c.imag()));
     }
   };
 

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -67,6 +67,7 @@ TEST(std_test, thread_id) {
 
 TEST(std_test, complex) {
   EXPECT_EQ(fmt::format("{}", std::complex<double>(1, 2.2)), "(1+2.2i)");
+  EXPECT_EQ(fmt::format("{}", std::complex<double>(0, 2.2)), "2.2i");
   EXPECT_EQ(fmt::format("{:>20.2f}", std::complex<double>(1, 2.2)),
             "        (1.00+2.20i)");
 }


### PR DESCRIPTION
P2197R0: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2197r0.html

```
Effects: Equivalent to:

 format_to(ctx.out(), "{:<fill-align-width>}",
           format(c.real() != 0 ? "({0}+{1}i)" : "{1}i", real, imag))
```
