### PR TITLE
Range formatting documentation 

### DIFF
--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -491,9 +491,9 @@ Range Format Specifications
 Format specifications for range types have the following syntax:
 
 .. productionlist:: sf
-   range_format_spec: [":" [`n`][`range_type`][`range_underlying_spec`]]
+   range_format_spec: [":" ["n"][`range_type`][`range_underlying_spec`]]
 
-The `n` option formats the range without the opening and closing brackets. 
+The ``'n'`` option formats the range without the opening and closing brackets. 
 
 The available presentation types for `range_type` are:
 
@@ -505,18 +505,18 @@ The available presentation types for `range_type` are:
 | ``'?s'``| Debug format. The range is formatted as an escaped       |        
 |         | string.                                                  |
 +---------+----------------------------------------------------------+
-| none    | Default format. The range is formatted with a separator  |
+| none    | Default format. The range is formatted with a separator. |
 |         |                                                          |
 +---------+----------------------------------------------------------+
 
-If `range_type` is `s` or `?s`, the underlying type of the range must be a character type. The 
-`n` option and `range_underlying_spec` are mutually exclusive with `s` and `?s`. 
+If `range_type` is ``'s'`` or ``'?s'``, the underlying type of the range must be a character type. The 
+``'n'`` option and `range_underlying_spec` are mutually exclusive with ``'s'`` and ``'?s'``. 
 
-The `underlying_spec` is parsed based on the formatter of the range's
+The `range_underlying_spec` is parsed based on the formatter of the range's
 reference type.
 
 By default, a range of characters or strings is printed escaped and quoted. But
-if any `underlying_spec` is provided (even if it is empty), then the characters
+if any `range_underlying_spec` is provided (even if it is empty), then the characters
 or strings are printed according to the provided specification.
 
 Examples::

--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -506,10 +506,9 @@ The available presentation types for `range_type` are:
 |         | string.                                                  |
 +---------+----------------------------------------------------------+
 | none    | Default format. The range is formatted with a separator. |
-|         |                                                          |
 +---------+----------------------------------------------------------+
 
-If `range_type` is ``'s'`` or ``'?s'``, the underlying type of the range must be a character type. The 
+If `range_type` is ``'s'`` or ``'?s'``, the range element type must be a character type. The 
 ``'n'`` option and `range_underlying_spec` are mutually exclusive with ``'s'`` and ``'?s'``. 
 
 The `range_underlying_spec` is parsed based on the formatter of the range's

--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -493,7 +493,7 @@ Format specifications for range types have the following syntax:
 .. productionlist:: sf
    range_format_spec: [":" [`n`][`range_type`][`range_underlying_spec`]]
 
-The `n` option causes the range to be formatted without the opening and closing brackets. 
+The `n` option formats the range without the opening and closing brackets. 
 
 The available presentation types for `range_type` are:
 
@@ -509,7 +509,8 @@ The available presentation types for `range_type` are:
 |         |                                                          |
 +---------+----------------------------------------------------------+
 
-If `range_type` is `s` or `?s`, the underlying type of the range must be a char type.
+If `range_type` is `s` or `?s`, the underlying type of the range must be a character type. The 
+`n` option and `range_underlying_spec` are mutually exclusive with `s` and `?s`. 
 
 The `underlying_spec` is parsed based on the formatter of the range's
 reference type.
@@ -526,6 +527,12 @@ Examples::
   // Result: [0xa, 0x14, 0x1e]
   fmt::format("{}", vector{'h', 'e', 'l', 'l', 'o'});
   // Result: ['h', 'e', 'l', 'l', 'o']
+  fmt::format("{:n}", vector{'h', 'e', 'l', 'l', 'o'});
+  // Result: 'h', 'e', 'l', 'l', 'o'
+  fmt::format("{:s}", vector{'h', 'e', 'l', 'l', 'o'});
+  // Result: "hello"
+  fmt::format("{:?s}", vector{'h', 'e', 'l', 'l', 'o', '\n'});
+  // Result: "hello\n"
   fmt::format("{::}", vector{'h', 'e', 'l', 'l', 'o'});
   // Result: [h, e, l, l, o]
   fmt::format("{::d}", vector{'h', 'e', 'l', 'l', 'o'});

--- a/doc/syntax.rst
+++ b/doc/syntax.rst
@@ -491,7 +491,25 @@ Range Format Specifications
 Format specifications for range types have the following syntax:
 
 .. productionlist:: sf
-   range_format_spec: [":" [`underlying_spec`]]
+   range_format_spec: [":" [`n`][`range_type`][`range_underlying_spec`]]
+
+The `n` option causes the range to be formatted without the opening and closing brackets. 
+
+The available presentation types for `range_type` are:
+
++---------+----------------------------------------------------------+
+| Type    | Meaning                                                  |
++=========+==========================================================+
+| ``'s'`` | String format. The range is formatted as a string.       |                                                     
++---------+----------------------------------------------------------+
+| ``'?s'``| Debug format. The range is formatted as an escaped       |        
+|         | string.                                                  |
++---------+----------------------------------------------------------+
+| none    | Default format. The range is formatted with a separator  |
+|         |                                                          |
++---------+----------------------------------------------------------+
+
+If `range_type` is `s` or `?s`, the underlying type of the range must be a char type.
 
 The `underlying_spec` is parsed based on the formatter of the range's
 reference type.


### PR DESCRIPTION
A follow-up to #3863, this adds documentation and examples for `n` and `range_type` options in the range format specification. 