### PR TITLE
Implement fmt::year_month_day

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2088,17 +2088,17 @@ class year {
 
 class year_month_day {
  private:
-  year year_;
-  month month_;
-  day day_;
+  fmt::year year_;
+  fmt::month month_;
+  fmt::day day_;
 
  public:
   year_month_day() = default;
   constexpr year_month_day(const year& y, const month& m, const day& d) noexcept
       : year_(y), month_(m), day_(d) {}
-  constexpr year year() const noexcept { return year_; }
-  constexpr month month() const noexcept { return month_; }
-  constexpr day day() const noexcept { return day_; }
+  constexpr fmt::year year() const noexcept { return year_; }
+  constexpr fmt::month month() const noexcept { return month_; }
+  constexpr fmt::day day() const noexcept { return day_; }
 };
 #endif
 

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -749,15 +749,14 @@ TEST(chrono_test, unsigned_duration) {
 }
 
 TEST(chrono_test, weekday) {
-  auto loc = get_locale("en_US.UTF-8");
-  std::locale::global(loc);
+  std::locale::global(std::locale::classic());
   auto sat = fmt::weekday(6);
 
   EXPECT_EQ(fmt::format("{}", sat), "Sat");
   EXPECT_EQ(fmt::format("{:%a}", sat), "Sat");
   EXPECT_EQ(fmt::format("{:%A}", sat), "Saturday");
 
-  loc = get_locale("es_ES.UTF-8");
+  auto loc = get_locale("es_ES.UTF-8");
   std::locale::global(loc);
   if (loc != std::locale::classic()) {
     auto saturdays = std::vector<std::string>{"sáb", "sá."};
@@ -1013,8 +1012,7 @@ TEST(chrono_test, out_of_range) {
 }
 
 TEST(chrono_test, year_month_day) {
-  auto loc = get_locale("en_US.UTF-8");
-  std::locale::global(loc);
+  std::locale::global(std::locale::classic());
 
   auto year = fmt::year(2024);
   auto month = fmt::month(1);
@@ -1038,7 +1036,7 @@ TEST(chrono_test, year_month_day) {
   EXPECT_EQ(fmt::format("{:%Y-%b-%d}", ymd), "2024-Jan-01");
   EXPECT_EQ(fmt::format("{:%Y-%B-%d}", ymd), "2024-January-01");
 
-  loc = get_locale("es_ES.UTF-8");
+  auto loc = get_locale("es_ES.UTF-8");
   std::locale::global(loc);
   if (loc != std::locale::classic()) {
     EXPECT_EQ(fmt::format(loc, "{:%b}", month), "ene.");


### PR DESCRIPTION
Also changed weekday, day, month, year's formatter to use formatter<std::tm, Char> so they all support the format strings.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

fixes #3772 
