### PR TITLE
implement year_month_day

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2088,17 +2088,17 @@ class year {
 
 class year_month_day {
  private:
-  year year_;
-  month month_;
-  day day_;
+  fmt::year year_;
+  fmt::month month_;
+  fmt::day day_;
 
  public:
   year_month_day() = default;
   constexpr year_month_day(const year& y, const month& m, const day& d) noexcept
       : year_(y), month_(m), day_(d) {}
-  constexpr year year() const noexcept { return year_; }
-  constexpr month month() const noexcept { return month_; }
-  constexpr day day() const noexcept { return day_; }
+  constexpr fmt::year year() const noexcept { return year_; }
+  constexpr fmt::month month() const noexcept { return month_; }
+  constexpr fmt::day day() const noexcept { return day_; }
 };
 #endif
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2105,19 +2105,20 @@ class year_month_day {
 template <typename Char>
 struct formatter<weekday, Char> : formatter<std::tm, Char> {
  private:
-  bool localized{false};
+  bool localized_{false};
   bool use_tm_formatter_{false};
 
  public:
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
-    auto begin = ctx.begin(), end = ctx.end();
-    if (begin != end && *begin == 'L') {
-      ++begin;
-      localized = true;
+    auto it = ctx.begin(), end = ctx.end();
+    if (it != end && *it == 'L') {
+      ++it;
+      localized_ = true;
     }
-    use_tm_formatter_ = !localized && (begin != nullptr);
-    return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : begin;
+    auto empty = (it == end || *it == '}');
+    use_tm_formatter_ = !empty && !localized_;
+    return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
   }
 
   template <typename FormatContext>
@@ -2127,7 +2128,7 @@ struct formatter<weekday, Char> : formatter<std::tm, Char> {
     if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(localized, ctx.locale());
+    detail::get_locale loc(localized_, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_weekday();
     return w.out();
@@ -2142,8 +2143,9 @@ struct formatter<day, Char> : formatter<std::tm, Char> {
  public:
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
-    use_tm_formatter_ = ctx.begin() != nullptr;
-    return formatter<std::tm, Char>::parse(ctx);
+    auto it = ctx.begin(), end = ctx.end();
+    use_tm_formatter_ = !(it == end || *it == '}');
+    return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
   }
 
   template <typename FormatContext>
@@ -2163,19 +2165,20 @@ struct formatter<day, Char> : formatter<std::tm, Char> {
 template <typename Char>
 struct formatter<month, Char> : formatter<std::tm, Char> {
  private:
-  bool localized{false};
+  bool localized_{false};
   bool use_tm_formatter_{false};
 
  public:
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
-    auto begin = ctx.begin(), end = ctx.end();
-    if (begin != end && *begin == 'L') {
-      ++begin;
-      localized = true;
+    auto it = ctx.begin(), end = ctx.end();
+    if (it != end && *it == 'L') {
+      ++it;
+      localized_ = true;
     }
-    use_tm_formatter_ = !localized && (begin != nullptr);
-    return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : begin;
+    auto empty = (it == end || *it == '}');
+    use_tm_formatter_ = !empty && !localized_;
+    return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
   }
 
   template <typename FormatContext>
@@ -2185,7 +2188,7 @@ struct formatter<month, Char> : formatter<std::tm, Char> {
     if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(localized, ctx.locale());
+    detail::get_locale loc(localized_, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_month();
     return w.out();
@@ -2200,8 +2203,9 @@ struct formatter<year, Char> : formatter<std::tm, Char> {
  public:
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
-    use_tm_formatter_ = ctx.begin() != nullptr;
-    return formatter<std::tm, Char>::parse(ctx);
+    auto it = ctx.begin(), end = ctx.end();
+    use_tm_formatter_ = !(it == end || *it == '}');
+    return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
   }
 
   template <typename FormatContext>
@@ -2226,8 +2230,9 @@ struct formatter<year_month_day, Char> : formatter<std::tm, Char> {
  public:
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
-    use_tm_formatter_ = ctx.begin() != nullptr;
-    return formatter<std::tm, Char>::parse(ctx);
+    auto it = ctx.begin(), end = ctx.end();
+    use_tm_formatter_ = !(it == end || *it == '}');
+    return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
   }
 
   template <typename FormatContext>

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2040,6 +2040,7 @@ using weekday = std::chrono::weekday;
 using day = std::chrono::day;
 using month = std::chrono::month;
 using year = std::chrono::year;
+using year_month_day = std::chrono::year_month_day;
 #else
 // A fallback version of weekday.
 class weekday {
@@ -2085,94 +2086,151 @@ class year {
   constexpr explicit operator int() const noexcept { return value_; }
 };
 
-class year_month_day {};
+class year_month_day {
+ private:
+  year year_;
+  month month_;
+  day day_;
+
+ public:
+  year_month_day() = default;
+  constexpr year_month_day(const year& y, const month& m, const day& d) noexcept
+      : year_(y), month_(m), day_(d) {}
+  constexpr year year() const noexcept { return year_; }
+  constexpr month month() const noexcept { return month_; }
+  constexpr day day() const noexcept { return day_; }
+};
 #endif
 
-// A rudimentary weekday formatter.
-template <typename Char> struct formatter<weekday, Char> {
+template <typename Char>
+struct formatter<weekday, Char> : formatter<std::tm, Char> {
  private:
-  bool localized = false;
+  bool use_tm_formatter_{false};
 
  public:
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
-    auto begin = ctx.begin(), end = ctx.end();
-    if (begin != end && *begin == 'L') {
-      ++begin;
-      localized = true;
-    }
-    return begin;
+    use_tm_formatter_ = ctx.begin() != nullptr;
+    return formatter<std::tm, Char>::parse(ctx);
   }
 
   template <typename FormatContext>
   auto format(weekday wd, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
     time.tm_wday = static_cast<int>(wd.c_encoding());
-    detail::get_locale loc(localized, ctx.locale());
+    if (use_tm_formatter_) {
+      return formatter<std::tm, Char>::format(time, ctx);
+    }
+    detail::get_locale loc(true, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_weekday();
     return w.out();
   }
 };
 
-template <typename Char> struct formatter<day, Char> {
+template <typename Char>
+struct formatter<day, Char> : formatter<std::tm, Char> {
+ private:
+  bool use_tm_formatter_{false};
+
+ public:
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
-    return ctx.begin();
+    use_tm_formatter_ = ctx.begin() != nullptr;
+    return formatter<std::tm, Char>::parse(ctx);
   }
 
   template <typename FormatContext>
   auto format(day d, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
     time.tm_mday = static_cast<int>(static_cast<unsigned>(d));
-    detail::get_locale loc(false, ctx.locale());
+    if (use_tm_formatter_) {
+      return formatter<std::tm, Char>::format(time, ctx);
+    }
+    detail::get_locale loc(true, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_day_of_month(detail::numeric_system::standard);
     return w.out();
   }
 };
 
-template <typename Char> struct formatter<month, Char> {
+template <typename Char>
+struct formatter<month, Char> : formatter<std::tm, Char> {
  private:
-  bool localized = false;
+  bool use_tm_formatter_{false};
 
  public:
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
-    auto begin = ctx.begin(), end = ctx.end();
-    if (begin != end && *begin == 'L') {
-      ++begin;
-      localized = true;
-    }
-    return begin;
+    use_tm_formatter_ = ctx.begin() != nullptr;
+    return formatter<std::tm, Char>::parse(ctx);
   }
 
   template <typename FormatContext>
   auto format(month m, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
-    // std::chrono::month has a range of 1-12, std::tm requires 0-11
     time.tm_mon = static_cast<int>(static_cast<unsigned>(m)) - 1;
-    detail::get_locale loc(localized, ctx.locale());
+    if (use_tm_formatter_) {
+      return formatter<std::tm, Char>::format(time, ctx);
+    }
+    detail::get_locale loc(true, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_month();
     return w.out();
   }
 };
 
-template <typename Char> struct formatter<year, Char> {
+template <typename Char>
+struct formatter<year, Char> : formatter<std::tm, Char> {
+ private:
+  bool use_tm_formatter_{false};
+
+ public:
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
-    return ctx.begin();
+    use_tm_formatter_ = ctx.begin() != nullptr;
+    return formatter<std::tm, Char>::parse(ctx);
   }
 
   template <typename FormatContext>
   auto format(year y, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
-    // std::tm::tm_year is years since 1900
     time.tm_year = static_cast<int>(y) - 1900;
+    if (use_tm_formatter_) {
+      return formatter<std::tm, Char>::format(time, ctx);
+    }
     detail::get_locale loc(true, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_year(detail::numeric_system::standard);
+    return w.out();
+  }
+};
+
+template <typename Char>
+struct formatter<year_month_day, Char> : formatter<std::tm, Char> {
+ private:
+  bool use_tm_formatter_{false};
+
+ public:
+  FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
+      -> decltype(ctx.begin()) {
+    use_tm_formatter_ = ctx.begin() != nullptr;
+    return formatter<std::tm, Char>::parse(ctx);
+  }
+
+  template <typename FormatContext>
+  auto format(year_month_day val, FormatContext& ctx) const
+      -> decltype(ctx.out()) {
+    auto time = std::tm();
+    time.tm_year = static_cast<int>(val.year()) - 1900;
+    time.tm_mon = static_cast<int>(static_cast<unsigned>(val.month())) - 1;
+    time.tm_mday = static_cast<int>(static_cast<unsigned>(val.day()));
+    if (use_tm_formatter_) {
+      return formatter<std::tm, Char>::format(time, ctx);
+    }
+    detail::get_locale loc(true, ctx.locale());
+    auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
+    w.on_iso_date();
     return w.out();
   }
 };

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2105,13 +2105,19 @@ class year_month_day {
 template <typename Char>
 struct formatter<weekday, Char> : formatter<std::tm, Char> {
  private:
+  bool localized{false};
   bool use_tm_formatter_{false};
 
  public:
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
-    use_tm_formatter_ = ctx.begin() != nullptr;
-    return formatter<std::tm, Char>::parse(ctx);
+    auto begin = ctx.begin(), end = ctx.end();
+    if (begin != end && *begin == 'L') {
+      ++begin;
+      localized = true;
+    }
+    use_tm_formatter_ = !localized && (begin != nullptr);
+    return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : begin;
   }
 
   template <typename FormatContext>
@@ -2121,7 +2127,7 @@ struct formatter<weekday, Char> : formatter<std::tm, Char> {
     if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(true, ctx.locale());
+    detail::get_locale loc(localized, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_weekday();
     return w.out();
@@ -2147,7 +2153,7 @@ struct formatter<day, Char> : formatter<std::tm, Char> {
     if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(true, ctx.locale());
+    detail::get_locale loc(false, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_day_of_month(detail::numeric_system::standard);
     return w.out();
@@ -2157,13 +2163,19 @@ struct formatter<day, Char> : formatter<std::tm, Char> {
 template <typename Char>
 struct formatter<month, Char> : formatter<std::tm, Char> {
  private:
+  bool localized{false};
   bool use_tm_formatter_{false};
 
  public:
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
-    use_tm_formatter_ = ctx.begin() != nullptr;
-    return formatter<std::tm, Char>::parse(ctx);
+    auto begin = ctx.begin(), end = ctx.end();
+    if (begin != end && *begin == 'L') {
+      ++begin;
+      localized = true;
+    }
+    use_tm_formatter_ = !localized && (begin != nullptr);
+    return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : begin;
   }
 
   template <typename FormatContext>
@@ -2173,7 +2185,7 @@ struct formatter<month, Char> : formatter<std::tm, Char> {
     if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(true, ctx.locale());
+    detail::get_locale loc(localized, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_month();
     return w.out();
@@ -2199,7 +2211,7 @@ struct formatter<year, Char> : formatter<std::tm, Char> {
     if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(true, ctx.locale());
+    detail::get_locale loc(false, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_year(detail::numeric_system::standard);
     return w.out();

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2114,10 +2114,10 @@ struct formatter<weekday, Char> : private formatter<std::tm, Char> {
     auto it = ctx.begin(), end = ctx.end();
     if (it != end && *it == 'L') {
       ++it;
-      localized_ = true;
+      use_tm_formatter_ = localized_ = true;
+      return it;
     }
-    auto empty = (it == end || *it == '}');
-    use_tm_formatter_ = !empty && !localized_;
+    use_tm_formatter_ = it != end && *it != '}';
     return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
   }
 
@@ -2144,7 +2144,7 @@ struct formatter<day, Char> : private formatter<std::tm, Char> {
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
     auto it = ctx.begin(), end = ctx.end();
-    use_tm_formatter_ = (it != end && *it != '}');
+    use_tm_formatter_ = it != end && *it != '}';
     return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
   }
 
@@ -2174,10 +2174,10 @@ struct formatter<month, Char> : private formatter<std::tm, Char> {
     auto it = ctx.begin(), end = ctx.end();
     if (it != end && *it == 'L') {
       ++it;
-      localized_ = true;
+      use_tm_formatter_ = localized_ = true;
+      return it;
     }
-    auto empty = (it == end || *it == '}');
-    use_tm_formatter_ = !empty && !localized_;
+    use_tm_formatter_ = it != end && *it != '}';
     return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
   }
 
@@ -2204,7 +2204,7 @@ struct formatter<year, Char> : private formatter<std::tm, Char> {
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
     auto it = ctx.begin(), end = ctx.end();
-    use_tm_formatter_ = (it != end && *it != '}');
+    use_tm_formatter_ = it != end && *it != '}';
     return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
   }
 
@@ -2231,7 +2231,7 @@ struct formatter<year_month_day, Char> : private formatter<std::tm, Char> {
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
     auto it = ctx.begin(), end = ctx.end();
-    use_tm_formatter_ = (it != end && *it != '}');
+    use_tm_formatter_ = it != end && *it != '}';
     return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
   }
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2042,9 +2042,8 @@ using month = std::chrono::month;
 using year = std::chrono::year;
 using year_month_day = std::chrono::year_month_day;
 #else
-class calendar_base {};
 // A fallback version of weekday.
-class weekday : calendar_base {
+class weekday {
  private:
   unsigned char value_;
 
@@ -2055,7 +2054,7 @@ class weekday : calendar_base {
   constexpr auto c_encoding() const noexcept -> unsigned { return value_; }
 };
 
-class day : calendar_base {
+class day {
  private:
   unsigned char value_;
 
@@ -2066,7 +2065,7 @@ class day : calendar_base {
   constexpr explicit operator unsigned() const noexcept { return value_; }
 };
 
-class month : calendar_base {
+class month {
  private:
   unsigned char value_;
 
@@ -2077,7 +2076,7 @@ class month : calendar_base {
   constexpr explicit operator unsigned() const noexcept { return value_; }
 };
 
-class year : calendar_base {
+class year {
  private:
   int value_;
 
@@ -2087,7 +2086,7 @@ class year : calendar_base {
   constexpr explicit operator int() const noexcept { return value_; }
 };
 
-class year_month_day : calendar_base {
+class year_month_day {
  private:
   fmt::year year_;
   fmt::month month_;
@@ -2095,8 +2094,7 @@ class year_month_day : calendar_base {
 
  public:
   year_month_day() = default;
-  constexpr year_month_day(const fmt::year& y, const fmt::month& m,
-                           const fmt::day& d) noexcept
+  constexpr year_month_day(const year& y, const month& m, const day& d) noexcept
       : year_(y), month_(m), day_(d) {}
   constexpr fmt::year year() const noexcept { return year_; }
   constexpr fmt::month month() const noexcept { return month_; }
@@ -2105,28 +2103,23 @@ class year_month_day : calendar_base {
 #endif
 
 template <typename Char>
-struct formatter<calendar_base, Char> : formatter<std::tm, Char> {
- protected:
-  bool localized_{false};
+struct formatter<weekday, Char> : formatter<std::tm, Char> {
+ private:
+  bool localized{false};
   bool use_tm_formatter_{false};
 
  public:
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
-    auto it = ctx.begin(), end = ctx.end();
-    if (it != end && *it == 'L') {
-      ++it;
-      localized_ = true;
+    auto begin = ctx.begin(), end = ctx.end();
+    if (begin != end && *begin == 'L') {
+      ++begin;
+      localized = true;
     }
-    auto empty = (it == end || *it == '}');
-    use_tm_formatter_ = !empty && !localized_;
-    return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
+    use_tm_formatter_ = !localized && (begin != nullptr);
+    return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : begin;
   }
-};
 
-template <typename Char>
-struct formatter<weekday, Char> : formatter<calendar_base, Char> {
- public:
   template <typename FormatContext>
   auto format(weekday wd, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
@@ -2134,7 +2127,7 @@ struct formatter<weekday, Char> : formatter<calendar_base, Char> {
     if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(localized_, ctx.locale());
+    detail::get_locale loc(localized, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_weekday();
     return w.out();
@@ -2142,8 +2135,17 @@ struct formatter<weekday, Char> : formatter<calendar_base, Char> {
 };
 
 template <typename Char>
-struct formatter<day, Char> : formatter<calendar_base, Char> {
+struct formatter<day, Char> : formatter<std::tm, Char> {
+ private:
+  bool use_tm_formatter_{false};
+
  public:
+  FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
+      -> decltype(ctx.begin()) {
+    use_tm_formatter_ = ctx.begin() != nullptr;
+    return formatter<std::tm, Char>::parse(ctx);
+  }
+
   template <typename FormatContext>
   auto format(day d, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
@@ -2151,7 +2153,7 @@ struct formatter<day, Char> : formatter<calendar_base, Char> {
     if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(localized_, ctx.locale());
+    detail::get_locale loc(false, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_day_of_month(detail::numeric_system::standard);
     return w.out();
@@ -2159,8 +2161,23 @@ struct formatter<day, Char> : formatter<calendar_base, Char> {
 };
 
 template <typename Char>
-struct formatter<month, Char> : formatter<calendar_base, Char> {
+struct formatter<month, Char> : formatter<std::tm, Char> {
+ private:
+  bool localized{false};
+  bool use_tm_formatter_{false};
+
  public:
+  FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
+      -> decltype(ctx.begin()) {
+    auto begin = ctx.begin(), end = ctx.end();
+    if (begin != end && *begin == 'L') {
+      ++begin;
+      localized = true;
+    }
+    use_tm_formatter_ = !localized && (begin != nullptr);
+    return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : begin;
+  }
+
   template <typename FormatContext>
   auto format(month m, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
@@ -2168,7 +2185,7 @@ struct formatter<month, Char> : formatter<calendar_base, Char> {
     if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(localized_, ctx.locale());
+    detail::get_locale loc(localized, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_month();
     return w.out();
@@ -2176,8 +2193,17 @@ struct formatter<month, Char> : formatter<calendar_base, Char> {
 };
 
 template <typename Char>
-struct formatter<year, Char> : formatter<calendar_base, Char> {
+struct formatter<year, Char> : formatter<std::tm, Char> {
+ private:
+  bool use_tm_formatter_{false};
+
  public:
+  FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
+      -> decltype(ctx.begin()) {
+    use_tm_formatter_ = ctx.begin() != nullptr;
+    return formatter<std::tm, Char>::parse(ctx);
+  }
+
   template <typename FormatContext>
   auto format(year y, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
@@ -2185,7 +2211,7 @@ struct formatter<year, Char> : formatter<calendar_base, Char> {
     if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(localized_, ctx.locale());
+    detail::get_locale loc(false, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_year(detail::numeric_system::standard);
     return w.out();
@@ -2193,8 +2219,17 @@ struct formatter<year, Char> : formatter<calendar_base, Char> {
 };
 
 template <typename Char>
-struct formatter<year_month_day, Char> : formatter<calendar_base, Char> {
+struct formatter<year_month_day, Char> : formatter<std::tm, Char> {
+ private:
+  bool use_tm_formatter_{false};
+
  public:
+  FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
+      -> decltype(ctx.begin()) {
+    use_tm_formatter_ = ctx.begin() != nullptr;
+    return formatter<std::tm, Char>::parse(ctx);
+  }
+
   template <typename FormatContext>
   auto format(year_month_day val, FormatContext& ctx) const
       -> decltype(ctx.out()) {
@@ -2205,7 +2240,7 @@ struct formatter<year_month_day, Char> : formatter<calendar_base, Char> {
     if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(localized_, ctx.locale());
+    detail::get_locale loc(true, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_iso_date();
     return w.out();

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2131,10 +2131,10 @@ struct formatter<weekday, Char> : formatter<calendar_base, Char> {
   auto format(weekday wd, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
     time.tm_wday = static_cast<int>(wd.c_encoding());
-    if (this->use_tm_formatter_) {
+    if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(this->localized_, ctx.locale());
+    detail::get_locale loc(localized_, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_weekday();
     return w.out();
@@ -2148,10 +2148,10 @@ struct formatter<day, Char> : formatter<calendar_base, Char> {
   auto format(day d, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
     time.tm_mday = static_cast<int>(static_cast<unsigned>(d));
-    if (this->use_tm_formatter_) {
+    if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(this->localized_, ctx.locale());
+    detail::get_locale loc(localized_, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_day_of_month(detail::numeric_system::standard);
     return w.out();
@@ -2165,10 +2165,10 @@ struct formatter<month, Char> : formatter<calendar_base, Char> {
   auto format(month m, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
     time.tm_mon = static_cast<int>(static_cast<unsigned>(m)) - 1;
-    if (this->use_tm_formatter_) {
+    if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(this->localized_, ctx.locale());
+    detail::get_locale loc(localized_, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_month();
     return w.out();
@@ -2182,10 +2182,10 @@ struct formatter<year, Char> : formatter<calendar_base, Char> {
   auto format(year y, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
     time.tm_year = static_cast<int>(y) - 1900;
-    if (this->use_tm_formatter_) {
+    if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(this->localized_, ctx.locale());
+    detail::get_locale loc(localized_, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_year(detail::numeric_system::standard);
     return w.out();
@@ -2202,10 +2202,10 @@ struct formatter<year_month_day, Char> : formatter<calendar_base, Char> {
     time.tm_year = static_cast<int>(val.year()) - 1900;
     time.tm_mon = static_cast<int>(static_cast<unsigned>(val.month())) - 1;
     time.tm_mday = static_cast<int>(static_cast<unsigned>(val.day()));
-    if (this->use_tm_formatter_) {
+    if (use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(this->localized_, ctx.locale());
+    detail::get_locale loc(localized_, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_iso_date();
     return w.out();

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2114,7 +2114,7 @@ struct formatter<weekday, Char> : private formatter<std::tm, Char> {
     auto it = ctx.begin(), end = ctx.end();
     if (it != end && *it == 'L') {
       ++it;
-      use_tm_formatter_ = localized_ = true;
+      localized_ = true;
       return it;
     }
     use_tm_formatter_ = it != end && *it != '}';
@@ -2174,7 +2174,7 @@ struct formatter<month, Char> : private formatter<std::tm, Char> {
     auto it = ctx.begin(), end = ctx.end();
     if (it != end && *it == 'L') {
       ++it;
-      use_tm_formatter_ = localized_ = true;
+      localized_ = true;
       return it;
     }
     use_tm_formatter_ = it != end && *it != '}';

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2103,7 +2103,7 @@ class year_month_day {
 #endif
 
 template <typename Char>
-struct formatter<weekday, Char> : formatter<std::tm, Char> {
+struct formatter<weekday, Char> : private formatter<std::tm, Char> {
  private:
   bool localized_{false};
   bool use_tm_formatter_{false};
@@ -2136,7 +2136,7 @@ struct formatter<weekday, Char> : formatter<std::tm, Char> {
 };
 
 template <typename Char>
-struct formatter<day, Char> : formatter<std::tm, Char> {
+struct formatter<day, Char> : private formatter<std::tm, Char> {
  private:
   bool use_tm_formatter_{false};
 
@@ -2144,7 +2144,7 @@ struct formatter<day, Char> : formatter<std::tm, Char> {
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
     auto it = ctx.begin(), end = ctx.end();
-    use_tm_formatter_ = !(it == end || *it == '}');
+    use_tm_formatter_ = (it != end && *it != '}');
     return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
   }
 
@@ -2163,7 +2163,7 @@ struct formatter<day, Char> : formatter<std::tm, Char> {
 };
 
 template <typename Char>
-struct formatter<month, Char> : formatter<std::tm, Char> {
+struct formatter<month, Char> : private formatter<std::tm, Char> {
  private:
   bool localized_{false};
   bool use_tm_formatter_{false};
@@ -2196,7 +2196,7 @@ struct formatter<month, Char> : formatter<std::tm, Char> {
 };
 
 template <typename Char>
-struct formatter<year, Char> : formatter<std::tm, Char> {
+struct formatter<year, Char> : private formatter<std::tm, Char> {
  private:
   bool use_tm_formatter_{false};
 
@@ -2204,7 +2204,7 @@ struct formatter<year, Char> : formatter<std::tm, Char> {
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
     auto it = ctx.begin(), end = ctx.end();
-    use_tm_formatter_ = !(it == end || *it == '}');
+    use_tm_formatter_ = (it != end && *it != '}');
     return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
   }
 
@@ -2223,7 +2223,7 @@ struct formatter<year, Char> : formatter<std::tm, Char> {
 };
 
 template <typename Char>
-struct formatter<year_month_day, Char> : formatter<std::tm, Char> {
+struct formatter<year_month_day, Char> : private formatter<std::tm, Char> {
  private:
   bool use_tm_formatter_{false};
 
@@ -2231,7 +2231,7 @@ struct formatter<year_month_day, Char> : formatter<std::tm, Char> {
   FMT_CONSTEXPR auto parse(basic_format_parse_context<Char>& ctx)
       -> decltype(ctx.begin()) {
     auto it = ctx.begin(), end = ctx.end();
-    use_tm_formatter_ = !(it == end || *it == '}');
+    use_tm_formatter_ = (it != end && *it != '}');
     return use_tm_formatter_ ? formatter<std::tm, Char>::parse(ctx) : it;
   }
 

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2131,10 +2131,10 @@ struct formatter<weekday, Char> : formatter<calendar_base, Char> {
   auto format(weekday wd, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
     time.tm_wday = static_cast<int>(wd.c_encoding());
-    if (use_tm_formatter_) {
+    if (this->use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(localized_, ctx.locale());
+    detail::get_locale loc(this->localized_, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_weekday();
     return w.out();
@@ -2148,10 +2148,10 @@ struct formatter<day, Char> : formatter<calendar_base, Char> {
   auto format(day d, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
     time.tm_mday = static_cast<int>(static_cast<unsigned>(d));
-    if (use_tm_formatter_) {
+    if (this->use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(localized_, ctx.locale());
+    detail::get_locale loc(this->localized_, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_day_of_month(detail::numeric_system::standard);
     return w.out();
@@ -2165,10 +2165,10 @@ struct formatter<month, Char> : formatter<calendar_base, Char> {
   auto format(month m, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
     time.tm_mon = static_cast<int>(static_cast<unsigned>(m)) - 1;
-    if (use_tm_formatter_) {
+    if (this->use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(localized_, ctx.locale());
+    detail::get_locale loc(this->localized_, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_abbr_month();
     return w.out();
@@ -2182,10 +2182,10 @@ struct formatter<year, Char> : formatter<calendar_base, Char> {
   auto format(year y, FormatContext& ctx) const -> decltype(ctx.out()) {
     auto time = std::tm();
     time.tm_year = static_cast<int>(y) - 1900;
-    if (use_tm_formatter_) {
+    if (this->use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(localized_, ctx.locale());
+    detail::get_locale loc(this->localized_, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_year(detail::numeric_system::standard);
     return w.out();
@@ -2202,10 +2202,10 @@ struct formatter<year_month_day, Char> : formatter<calendar_base, Char> {
     time.tm_year = static_cast<int>(val.year()) - 1900;
     time.tm_mon = static_cast<int>(static_cast<unsigned>(val.month())) - 1;
     time.tm_mday = static_cast<int>(static_cast<unsigned>(val.day()));
-    if (use_tm_formatter_) {
+    if (this->use_tm_formatter_) {
       return formatter<std::tm, Char>::format(time, ctx);
     }
-    detail::get_locale loc(localized_, ctx.locale());
+    detail::get_locale loc(this->localized_, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
     w.on_iso_date();
     return w.out();

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -1038,6 +1038,7 @@ TEST(chrono_test, year_month_day) {
   auto loc = get_locale("es_ES.UTF-8");
   std::locale::global(loc);
   if (loc != std::locale::classic()) {
+    EXPECT_EQ(fmt::format(loc, "{:L}", month), "ene.");
     EXPECT_EQ(fmt::format(loc, "{:%b}", month), "ene.");
   }
 }

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -749,17 +749,18 @@ TEST(chrono_test, unsigned_duration) {
 }
 
 TEST(chrono_test, weekday) {
-  std::locale::global(std::locale::classic());
+  auto loc = get_locale("es_ES.UTF-8");
+  std::locale::global(loc);
+
   auto sat = fmt::weekday(6);
 
   EXPECT_EQ(fmt::format("{}", sat), "Sat");
   EXPECT_EQ(fmt::format("{:%a}", sat), "Sat");
   EXPECT_EQ(fmt::format("{:%A}", sat), "Saturday");
 
-  auto loc = get_locale("es_ES.UTF-8");
-  std::locale::global(loc);
   if (loc != std::locale::classic()) {
     auto saturdays = std::vector<std::string>{"sáb", "sá."};
+    EXPECT_THAT(saturdays, Contains(fmt::format(loc, "{:L}", sat)));
     EXPECT_THAT(saturdays, Contains(fmt::format(loc, "{:%a}", sat)));
   }
 }
@@ -1012,8 +1013,6 @@ TEST(chrono_test, out_of_range) {
 }
 
 TEST(chrono_test, year_month_day) {
-  std::locale::global(std::locale::classic());
-
   auto year = fmt::year(2024);
   auto month = fmt::month(1);
   auto day = fmt::day(1);

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -1038,7 +1038,8 @@ TEST(chrono_test, year_month_day) {
   auto loc = get_locale("es_ES.UTF-8");
   std::locale::global(loc);
   if (loc != std::locale::classic()) {
-    EXPECT_EQ(fmt::format(loc, "{:L}", month), "ene.");
-    EXPECT_EQ(fmt::format(loc, "{:%b}", month), "ene.");
+    auto months = std::vector<std::string>{"ene.", "ene"};
+    EXPECT_THAT(months, Contains(fmt::format(loc, "{:L}", month)));
+    EXPECT_THAT(months, Contains(fmt::format(loc, "{:%b}", month)));
   }
 }

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -749,15 +749,14 @@ TEST(chrono_test, unsigned_duration) {
 }
 
 TEST(chrono_test, weekday) {
-  auto loc = get_locale("en_US.UTF-8");
-  std::locale::global(loc);
+  std::locale::global(std::locale::classic());
   auto sat = fmt::weekday(6);
 
   EXPECT_EQ(fmt::format("{}", sat), "Sat");
   EXPECT_EQ(fmt::format("{:%a}", sat), "Sat");
   EXPECT_EQ(fmt::format("{:%A}", sat), "Saturday");
 
-  loc = get_locale("es_ES.UTF-8");
+  auto loc = get_locale("es_ES.UTF-8");
   std::locale::global(loc);
   if (loc != std::locale::classic()) {
     auto saturdays = std::vector<std::string>{"sáb", "sá."};
@@ -1013,8 +1012,7 @@ TEST(chrono_test, out_of_range) {
 }
 
 TEST(chrono_test, year_month_day) {
-  auto loc = get_locale("en_US.UTF-8");
-  std::locale::global(loc);
+  std::locale::global(std::locale::classic());
 
   auto year = fmt::year(2024);
   auto month = fmt::month(1);
@@ -1038,7 +1036,7 @@ TEST(chrono_test, year_month_day) {
   EXPECT_EQ(fmt::format("{:%Y-%b-%d}", ymd), "2024-Jan-01");
   EXPECT_EQ(fmt::format("{:%Y-%B-%d}", ymd), "2024-January-01");
 
-  loc = get_locale("es_ES.UTF-8");
+  auto loc = get_locale("es_ES.UTF-8");
   std::locale::global(loc);
   if (loc != std::locale::classic()) {
     EXPECT_EQ(fmt::format(loc, "{:%b}", month), "ene.");

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -749,20 +749,19 @@ TEST(chrono_test, unsigned_duration) {
 }
 
 TEST(chrono_test, weekday) {
-  auto loc = get_locale("es_ES.UTF-8");
+  auto loc = get_locale("en_US.UTF-8");
   std::locale::global(loc);
   auto sat = fmt::weekday(6);
 
-  auto tm = std::tm();
-  tm.tm_wday = static_cast<int>(sat.c_encoding());
-
   EXPECT_EQ(fmt::format("{}", sat), "Sat");
-  EXPECT_EQ(fmt::format("{:%a}", tm), "Sat");
+  EXPECT_EQ(fmt::format("{:%a}", sat), "Sat");
+  EXPECT_EQ(fmt::format("{:%A}", sat), "Saturday");
 
+  loc = get_locale("es_ES.UTF-8");
+  std::locale::global(loc);
   if (loc != std::locale::classic()) {
     auto saturdays = std::vector<std::string>{"sáb", "sá."};
-    EXPECT_THAT(saturdays, Contains(fmt::format(loc, "{:L}", sat)));
-    EXPECT_THAT(saturdays, Contains(fmt::format(loc, "{:%a}", tm)));
+    EXPECT_THAT(saturdays, Contains(fmt::format(loc, "{:%a}", sat)));
   }
 }
 
@@ -1014,13 +1013,34 @@ TEST(chrono_test, out_of_range) {
 }
 
 TEST(chrono_test, year_month_day) {
-  auto loc = get_locale("es_ES.UTF-8");
-  std::locale::global(loc);  
+  auto loc = get_locale("en_US.UTF-8");
+  std::locale::global(loc);
+
   auto year = fmt::year(2024);
   auto month = fmt::month(1);
   auto day = fmt::day(1);
+  auto ymd = fmt::year_month_day(year, month, day);
 
   EXPECT_EQ(fmt::format("{}", year), "2024");
+  EXPECT_EQ(fmt::format("{:%Y}", year), "2024");
+  EXPECT_EQ(fmt::format("{:%y}", year), "24");
+
   EXPECT_EQ(fmt::format("{}", month), "Jan");
+  EXPECT_EQ(fmt::format("{:%m}", month), "01");
+  EXPECT_EQ(fmt::format("{:%b}", month), "Jan");
+  EXPECT_EQ(fmt::format("{:%B}", month), "January");
+
   EXPECT_EQ(fmt::format("{}", day), "01");
+  EXPECT_EQ(fmt::format("{:%d}", day), "01");
+
+  EXPECT_EQ(fmt::format("{}", ymd), "2024-01-01");
+  EXPECT_EQ(fmt::format("{:%Y-%m-%d}", ymd), "2024-01-01");
+  EXPECT_EQ(fmt::format("{:%Y-%b-%d}", ymd), "2024-Jan-01");
+  EXPECT_EQ(fmt::format("{:%Y-%B-%d}", ymd), "2024-January-01");
+
+  loc = get_locale("es_ES.UTF-8");
+  std::locale::global(loc);
+  if (loc != std::locale::classic()) {
+    EXPECT_EQ(fmt::format(loc, "{:%b}", month), "ene.");
+  }
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
also changed weekday, day, month, year's formatter to use formatter<std::tm, Char> so they all support the format strings

fixes #3772 