### PR TITLE
Implement 2 more overloads for println.

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -523,7 +523,7 @@ void println(FILE* f, const text_style& ts, format_string<T...> fmt,
   print(f, ts, fmt, std::forward<T>(args)...);
 
   // The newline you asked for..
-  print("\n");
+  print(f, text_style(), "\n");
 }
 
 /**
@@ -542,7 +542,7 @@ void println(const text_style& ts, format_string<T...> fmt, T&&... args) {
   print(stdout, ts, fmt, std::forward<T>(args)...);
 
   // The newline you asked for..
-  print("\n");
+  print(f, text_style(), "\n");
 }
 
 inline auto vformat(const text_style& ts, string_view fmt, format_args args)

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -506,6 +506,39 @@ void print(const text_style& ts, format_string<T...> fmt, T&&... args) {
   return print(stdout, ts, fmt, std::forward<T>(args)...);
 }
 
+/**
+  \rst
+  Formats a string and prints it to the specified file stream using ANSI
+  escape sequences to specify text formatting, with a newline at the end.
+
+  **Example**::
+
+    fmt::print(fmt::emphasis::bold | fg(fmt::color::red),
+               "Elapsed time: {0:.2f} seconds", 1.23);
+  \endrst
+ */
+template <typename... T>
+void println(FILE* f, const text_style& ts, format_string<T...> fmt,
+           T&&... args) {
+  return print(f, ts, fmt + "\n", std::forward<T>(args)...);
+}
+
+/**
+  \rst
+  Formats a string and prints it to stdout using ANSI escape sequences to
+  specify text formatting, with a newline at the end.
+
+  **Example**::
+
+    fmt::print(fmt::emphasis::bold | fg(fmt::color::red),
+               "Elapsed time: {0:.2f} seconds", 1.23);
+  \endrst
+ */
+template <typename... T>
+void println(const text_style& ts, format_string<T...> fmt, T&&... args) {
+  return print(stdout, ts, fmt + "\n", std::forward<T>(args)...);
+}
+
 inline auto vformat(const text_style& ts, string_view fmt, format_args args)
     -> std::string {
   auto buf = memory_buffer();

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -513,7 +513,7 @@ void print(const text_style& ts, format_string<T...> fmt, T&&... args) {
 
   **Example**::
 
-    fmt::print(fmt::emphasis::bold | fg(fmt::color::red),
+    fmt::println(fmt::emphasis::bold | fg(fmt::color::red),
                "Elapsed time: {0:.2f} seconds", 1.23);
   \endrst
  */
@@ -542,7 +542,7 @@ void println(const text_style& ts, format_string<T...> fmt, T&&... args) {
   print(stdout, ts, fmt, std::forward<T>(args)...);
 
   // The newline you asked for..
-  print(f, text_style(), "\n");
+  print(stdout, text_style(), "\n");
 }
 
 inline auto vformat(const text_style& ts, string_view fmt, format_args args)

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -520,7 +520,10 @@ void print(const text_style& ts, format_string<T...> fmt, T&&... args) {
 template <typename... T>
 void println(FILE* f, const text_style& ts, format_string<T...> fmt,
            T&&... args) {
-  return print(f, ts, fmt + "\n", std::forward<T>(args)...);
+  print(f, ts, fmt, std::forward<T>(args)...);
+
+  // The newline you asked for..
+  print("\n");
 }
 
 /**
@@ -536,7 +539,10 @@ void println(FILE* f, const text_style& ts, format_string<T...> fmt,
  */
 template <typename... T>
 void println(const text_style& ts, format_string<T...> fmt, T&&... args) {
-  return print(stdout, ts, fmt + "\n", std::forward<T>(args)...);
+  print(stdout, ts, fmt + "\n", std::forward<T>(args)...);
+
+  // The newline you asked for..
+  print("\n");
 }
 
 inline auto vformat(const text_style& ts, string_view fmt, format_args args)

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -539,7 +539,7 @@ void println(FILE* f, const text_style& ts, format_string<T...> fmt,
  */
 template <typename... T>
 void println(const text_style& ts, format_string<T...> fmt, T&&... args) {
-  print(stdout, ts, fmt + "\n", std::forward<T>(args)...);
+  print(stdout, ts, fmt, std::forward<T>(args)...);
 
   // The newline you asked for..
   print("\n");

--- a/include/fmt/xchar.h
+++ b/include/fmt/xchar.h
@@ -280,6 +280,15 @@ template <typename... T> void println(wformat_string<T...> fmt, T&&... args) {
   return print(L"{}\n", fmt::format(fmt, std::forward<T>(args)...));
 }
 
+template <typename... T>
+void println(const text_style &ts, wformat_string<T...> fmt, T&&... args) {
+  return print(ts, L"{}\n", fmt::format(fmt, std::forward<T>(args)...));
+}
+
+template <typename... T> void println(std::FILE* f, const text_style &ts, wformat_string<T...> fmt, T&&... args) {
+  return print(f, ts, L"{}\n", fmt::format(fmt, std::forward<T>(args)...));
+}
+
 inline auto vformat(const text_style& ts, wstring_view fmt, wformat_args args)
     -> std::wstring {
   auto buf = wmemory_buffer();

--- a/include/fmt/xchar.h
+++ b/include/fmt/xchar.h
@@ -280,15 +280,6 @@ template <typename... T> void println(wformat_string<T...> fmt, T&&... args) {
   return print(L"{}\n", fmt::format(fmt, std::forward<T>(args)...));
 }
 
-template <typename... T>
-void println(const text_style &ts, wformat_string<T...> fmt, T&&... args) {
-  return print(ts, L"{}\n", fmt::format(fmt, std::forward<T>(args)...));
-}
-
-template <typename... T> void println(std::FILE* f, const text_style &ts, wformat_string<T...> fmt, T&&... args) {
-  return print(f, ts, L"{}\n", fmt::format(fmt, std::forward<T>(args)...));
-}
-
 inline auto vformat(const text_style& ts, wstring_view fmt, wformat_args args)
     -> std::wstring {
   auto buf = wmemory_buffer();


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
Since println was first implemented, there were 2 overloads for print() that were not present in println, This PR implements it.
