### PR TITLE
Fix: enable `FMT_NORETURN` without exception support too

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -175,8 +175,7 @@
 #endif
 
 // Disable [[noreturn]] on MSVC/NVCC because of bogus unreachable code warnings.
-#if FMT_HAS_CPP_ATTRIBUTE(noreturn) && FMT_EXCEPTIONS && !FMT_MSC_VERSION && \
-    !defined(__NVCC__)
+#if FMT_HAS_CPP_ATTRIBUTE(noreturn) && !FMT_MSC_VERSION && !defined(__NVCC__)
 #  define FMT_NORETURN [[noreturn]]
 #else
 #  define FMT_NORETURN
@@ -2754,7 +2753,9 @@ template <typename Char, typename... Args> class format_string_checker {
     return id >= 0 && id < num_args ? parse_funcs_[id](context_) : begin;
   }
 
-  FMT_CONSTEXPR void on_error(const char* message) { report_error(message); }
+  FMT_NORETURN FMT_CONSTEXPR void on_error(const char* message) {
+    report_error(message);
+  }
 };
 
 // A base class for compile-time strings.

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -4302,7 +4302,7 @@ void vformat_to(buffer<Char>& buf, basic_string_view<Char> fmt,
       return begin;
     }
 
-    void on_error(const char* message) { report_error(message); }
+    FMT_NORETURN void on_error(const char* message) { report_error(message); }
   };
   detail::parse_format_string<false>(fmt, format_handler(out, fmt, args, loc));
 }


### PR DESCRIPTION
When building `format.cc` as such with GCC 13.2.1:

    $ g++ -c format.cc -DFMT_EXCEPTIONS=0 -Wmissing-noreturn -Werror

I get:

    In file included from format.cc:8:
    fmt/format-inl.h: In function ‘void fmt::v10::detail::assert_fail(const char*, int, const char*)’:
    fmt/format-inl.h:30:15: error: function might be candidate for attribute ‘noreturn’ [-Werror=suggest-attribute=noreturn]
       30 | FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
          |               ^~~~~~~~~~~
    fmt/format-inl.h: In function ‘void fmt::v10::report_error(const char*)’:
    fmt/format-inl.h:129:15: error: function might be candidate for attribute ‘noreturn’ [-Werror=suggest-attribute=noreturn]
      129 | FMT_FUNC void report_error(const char* message) {
          |               ^~~~~~~~~~~~
    cc1plus: all warnings being treated as errors

Note that, with `FMT_EXCEPTIONS` defined to 0:

* `report_error(const char *)` uses `FMT_THROW()` which expands to calling `assert_fail()`.

* `assert_fail()` calls `std::terminate()` which has the `[[noreturn]]` attribute [since C++11](https://en.cppreference.com/w/cpp/error/terminate).

Therefore, with `FMT_EXCEPTIONS` defined to 0, both `assert_fail()` and `report_error()` need to have the `[[noreturn]]` attribute too (if available). In other words, `FMT_NORETURN` doesn't depend on `FMT_EXCEPTIONS`.

Also adding `FMT_NORETURN` to two `on_error()` functions which call `report_error(const char *)`.

Other `report_error()` overloads eventually return, therefore they don't need `FMT_NORETURN`.