### PR TITLE
add disable_colors

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -187,6 +187,8 @@ enum class emphasis : uint8_t {
   strikethrough = 1 << 7,
 };
 
+FMT_INLINE bool disable_colors = false;
+
 // rgb is a struct for red, green and blue colors.
 // Using the name "rgb" makes some editors show the color in a tooltip.
 struct rgb {
@@ -487,7 +489,7 @@ inline void vprint(FILE* f, const text_style& ts, string_view fmt,
 template <typename... T>
 void print(FILE* f, const text_style& ts, format_string<T...> fmt,
            T&&... args) {
-  vprint(f, ts, fmt, fmt::make_format_args(args...));
+  vprint(f, disable_colors ? fmt::text_style() : ts, fmt, fmt::make_format_args(args...));
 }
 
 /**
@@ -503,7 +505,7 @@ void print(FILE* f, const text_style& ts, format_string<T...> fmt,
  */
 template <typename... T>
 void print(const text_style& ts, format_string<T...> fmt, T&&... args) {
-  return print(stdout, ts, fmt, std::forward<T>(args)...);
+  return print(stdout, disable_colors ? fmt::text_style() : ts, fmt, std::forward<T>(args)...);
 }
 
 inline auto vformat(const text_style& ts, string_view fmt, format_args args)
@@ -528,7 +530,7 @@ inline auto vformat(const text_style& ts, string_view fmt, format_args args)
 template <typename... T>
 inline auto format(const text_style& ts, format_string<T...> fmt, T&&... args)
     -> std::string {
-  return fmt::vformat(ts, fmt, fmt::make_format_args(args...));
+  return fmt::vformat(disable_colors ? fmt::text_style() : ts, fmt, fmt::make_format_args(args...));
 }
 
 /**

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -471,7 +471,7 @@ void vformat_to(
 inline void vprint(FILE* f, const text_style& ts, string_view fmt,
                    format_args args) {
   auto buf = memory_buffer();
-  detail::vformat_to(buf, ts, fmt, args);
+  detail::vformat_to(buf, disable_colors ? fmt::text_style() : ts, fmt, args);
   print(f, FMT_STRING("{}"), string_view(buf.begin(), buf.size()));
 }
 
@@ -489,7 +489,7 @@ inline void vprint(FILE* f, const text_style& ts, string_view fmt,
 template <typename... T>
 void print(FILE* f, const text_style& ts, format_string<T...> fmt,
            T&&... args) {
-  vprint(f, disable_colors ? fmt::text_style() : ts, fmt, fmt::make_format_args(args...));
+  vprint(f, ts, fmt, fmt::make_format_args(args...));
 }
 
 /**
@@ -505,13 +505,13 @@ void print(FILE* f, const text_style& ts, format_string<T...> fmt,
  */
 template <typename... T>
 void print(const text_style& ts, format_string<T...> fmt, T&&... args) {
-  return print(stdout, disable_colors ? fmt::text_style() : ts, fmt, std::forward<T>(args)...);
+  return print(stdout, ts, fmt, std::forward<T>(args)...);
 }
 
 inline auto vformat(const text_style& ts, string_view fmt, format_args args)
     -> std::string {
   auto buf = memory_buffer();
-  detail::vformat_to(buf, ts, fmt, args);
+  detail::vformat_to(buf, disable_colors ? fmt::text_style() : ts, fmt, args);
   return fmt::to_string(buf);
 }
 
@@ -530,7 +530,7 @@ inline auto vformat(const text_style& ts, string_view fmt, format_args args)
 template <typename... T>
 inline auto format(const text_style& ts, format_string<T...> fmt, T&&... args)
     -> std::string {
-  return fmt::vformat(disable_colors ? fmt::text_style() : ts, fmt, fmt::make_format_args(args...));
+  return fmt::vformat(ts, fmt, fmt::make_format_args(args...));
 }
 
 /**
@@ -541,7 +541,7 @@ template <typename OutputIt,
 auto vformat_to(OutputIt out, const text_style& ts, string_view fmt,
                 format_args args) -> OutputIt {
   auto&& buf = detail::get_buffer<char>(out);
-  detail::vformat_to(buf, ts, fmt, args);
+  detail::vformat_to(buf, disable_colors ? fmt::text_style() : ts, fmt, args);
   return detail::get_iterator(buf, out);
 }
 
@@ -561,7 +561,7 @@ template <typename OutputIt, typename... T,
           FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
 inline auto format_to(OutputIt out, const text_style& ts,
                       format_string<T...> fmt, T&&... args) -> OutputIt {
-  return vformat_to(out, ts, fmt, fmt::make_format_args(args...));
+  return vformat_to(out, disable_colors ? fmt::text_style() : ts, fmt, fmt::make_format_args(args...));
 }
 
 template <typename T, typename Char>

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -187,7 +187,7 @@ enum class emphasis : uint8_t {
   strikethrough = 1 << 7,
 };
 
-FMT_INLINE bool disable_colors = false;
+inline bool disable_colors;
 
 // rgb is a struct for red, green and blue colors.
 // Using the name "rgb" makes some editors show the color in a tooltip.

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -446,6 +446,10 @@ template <typename Char>
 void vformat_to(
     buffer<Char>& buf, const text_style& ts, basic_string_view<Char> format_str,
     basic_format_args<buffered_context<type_identity_t<Char>>> args) {
+  if (disable_colors) {
+    detail::vformat_to(buf, format_str, args, {});
+    return;
+  }
   bool has_style = false;
   if (ts.has_emphasis()) {
     has_style = true;
@@ -471,7 +475,7 @@ void vformat_to(
 inline void vprint(FILE* f, const text_style& ts, string_view fmt,
                    format_args args) {
   auto buf = memory_buffer();
-  detail::vformat_to(buf, disable_colors ? fmt::text_style() : ts, fmt, args);
+  detail::vformat_to(buf, ts, fmt, args);
   print(f, FMT_STRING("{}"), string_view(buf.begin(), buf.size()));
 }
 
@@ -511,7 +515,7 @@ void print(const text_style& ts, format_string<T...> fmt, T&&... args) {
 inline auto vformat(const text_style& ts, string_view fmt, format_args args)
     -> std::string {
   auto buf = memory_buffer();
-  detail::vformat_to(buf, disable_colors ? fmt::text_style() : ts, fmt, args);
+  detail::vformat_to(buf, ts, fmt, args);
   return fmt::to_string(buf);
 }
 
@@ -541,7 +545,7 @@ template <typename OutputIt,
 auto vformat_to(OutputIt out, const text_style& ts, string_view fmt,
                 format_args args) -> OutputIt {
   auto&& buf = detail::get_buffer<char>(out);
-  detail::vformat_to(buf, disable_colors ? fmt::text_style() : ts, fmt, args);
+  detail::vformat_to(buf, ts, fmt, args);
   return detail::get_iterator(buf, out);
 }
 
@@ -561,7 +565,7 @@ template <typename OutputIt, typename... T,
           FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
 inline auto format_to(OutputIt out, const text_style& ts,
                       format_string<T...> fmt, T&&... args) -> OutputIt {
-  return vformat_to(out, disable_colors ? fmt::text_style() : ts, fmt, fmt::make_format_args(args...));
+  return vformat_to(out, ts, fmt, fmt::make_format_args(args...));
 }
 
 template <typename T, typename Char>

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -187,7 +187,7 @@ enum class emphasis : uint8_t {
   strikethrough = 1 << 7,
 };
 
-inline bool disable_colors;
+inline bool disable_colors = false;
 
 // rgb is a struct for red, green and blue colors.
 // Using the name "rgb" makes some editors show the color in a tooltip.


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
disable_colors is just a normal bool which the dev or the user can decide in the program if disable the printing of colors or not.

an example:
```cpp
#include <fmt/color.h>

int main() {
  // prints "Hello" in red fg
  fmt::print(fg(fmt::terminal_color::red), "Hello\n");
  // let's disable all colors prints
  fmt::disable_colors = true;
  // prints "Hello" in blank color
  fmt::print(fg(fmt::terminal_color::red), "Hello\n");
}
```
this can be also useful in cases where the user has the enviroment variable `NO_COLOR` set (https://no-color.org).
another example:
```cpp
#include <fmt/color.h>

int main() {
    char *no_color = getenv("NO_COLOR");

    // prints "Hello" in red fg
    fmt::print(fg(fmt::terminal_color::red), "Hello\n");
    
    if (no_color != NULL && no_color[0] != '\0')
        fmt::disable_colors = true;

    // will prints "Hello" in blank color if we have $NO_COLOR set, else it will print it in red
    fmt::print(fg(fmt::terminal_color::red), "Hello\n");
}
```


Fixes #2137