### PR TITLE
Fixed MSVC C2661: no overloaded function takes 2 arguments

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -147,12 +147,6 @@ FMT_API FMT_FUNC auto format_facet<std::locale>::do_put(
 }
 #endif
 
-FMT_FUNC auto vsystem_error(int error_code, string_view fmt, format_args args)
-    -> std::system_error {
-  auto ec = std::error_code(error_code, std::generic_category());
-  return std::system_error(ec, vformat(fmt, args));
-}
-
 namespace detail {
 
 template <typename F>
@@ -1432,6 +1426,12 @@ FMT_FUNC auto vformat(string_view fmt, format_args args) -> std::string {
   auto buffer = memory_buffer();
   detail::vformat_to(buffer, fmt, args);
   return to_string(buffer);
+}
+
+FMT_FUNC auto vsystem_error(int error_code, string_view fmt, format_args args)
+    -> std::system_error {
+  auto ec = std::error_code(error_code, std::generic_category());
+  return std::system_error(ec, vformat(fmt, args));
 }
 
 namespace detail {


### PR DESCRIPTION
Fixed Error C2661 'fmt::v10::vformat': no overloaded function takes 2 arguments for MSVC v17.9.5 (fmt module).
