### PR TITLE
Added FMT_IMPORT_STD feature macro

### DIFF
--- a/include/fmt/args.h
+++ b/include/fmt/args.h
@@ -8,9 +8,11 @@
 #ifndef FMT_ARGS_H_
 #define FMT_ARGS_H_
 
-#include <functional>  // std::reference_wrapper
-#include <memory>      // std::unique_ptr
-#include <vector>
+#ifndef FMT_IMPORT_STD
+#  include <functional>  // std::reference_wrapper
+#  include <memory>      // std::unique_ptr
+#  include <vector>
+#endif
 
 #include "format.h"  // std_string_view
 

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -12,9 +12,13 @@
 #include <stdio.h>   // FILE
 #include <string.h>  // strlen
 
+#ifndef FMT_IMPORT_STD
 // <cstddef> is also included transitively from <type_traits>.
-#include <cstddef>      // std::byte
-#include <type_traits>  // std::enable_if
+#  include <cstddef>      // std::byte
+#  include <type_traits>  // std::enable_if
+#else
+import std;
+#endif
 
 // The fmt library version in the form major * 10000 + minor * 100 + patch.
 #define FMT_VERSION 100202

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -8,15 +8,17 @@
 #ifndef FMT_CHRONO_H_
 #define FMT_CHRONO_H_
 
-#include <algorithm>
-#include <chrono>
-#include <cmath>    // std::isfinite
-#include <cstring>  // std::memcpy
-#include <ctime>
-#include <iterator>
-#include <locale>
-#include <ostream>
-#include <type_traits>
+#ifndef FMT_IMPORT_STD
+#  include <algorithm>
+#  include <chrono>
+#  include <cmath>    // std::isfinite
+#  include <cstring>  // std::memcpy
+#  include <ctime>
+#  include <iterator>
+#  include <locale>
+#  include <ostream>
+#  include <type_traits>
+#endif
 
 #include "format.h"
 

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -8,7 +8,9 @@
 #ifndef FMT_COMPILE_H_
 #define FMT_COMPILE_H_
 
-#include <iterator>  // std::back_inserter
+#ifndef FMT_IMPORT_STD
+#  include <iterator>  // std::back_inserter
+#endif
 
 #include "format.h"
 

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -8,13 +8,15 @@
 #ifndef FMT_FORMAT_INL_H_
 #define FMT_FORMAT_INL_H_
 
-#include <algorithm>
+#ifndef FMT_IMPORT_STD
+#  include <algorithm>
+#  include <cmath>
+#  include <exception>
+#endif
 #include <cerrno>  // errno
 #include <climits>
-#include <cmath>
-#include <exception>
 
-#ifndef FMT_STATIC_THOUSANDS_SEPARATOR
+#if !defined(FMT_STATIC_THOUSANDS_SEPARATOR) && !defined(FMT_IMPORT_STD)
 #  include <locale>
 #endif
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -38,30 +38,35 @@
 #  define FMT_REMOVE_TRANSITIVE_INCLUDES
 #endif
 
-#include <cmath>             // std::signbit
-#include <cstdint>           // uint32_t
-#include <cstring>           // std::memcpy
-#include <initializer_list>  // std::initializer_list
-#include <limits>            // std::numeric_limits
-#if defined(__GLIBCXX__) && !defined(_GLIBCXX_USE_DUAL_ABI)
+#ifndef FMT_IMPORT_STD
+#  include <cmath>             // std::signbit
+#  include <cstdint>           // uint32_t
+#  include <cstring>           // std::memcpy
+#  include <initializer_list>  // std::initializer_list
+#  include <limits>            // std::numeric_limits
+#  if defined(__GLIBCXX__) && !defined(_GLIBCXX_USE_DUAL_ABI)
 // Workaround for pre gcc 5 libstdc++.
-#  include <memory>  // std::allocator_traits
+#    include <memory>  // std::allocator_traits
+#  endif
+#  include <stdexcept>     // std::runtime_error
+#  include <string>        // std::string
+#  include <system_error>  // std::system_error
 #endif
-#include <stdexcept>     // std::runtime_error
-#include <string>        // std::string
-#include <system_error>  // std::system_error
 
 #include "base.h"
 
 // Checking FMT_CPLUSPLUS for warning suppression in MSVC.
-#if FMT_HAS_INCLUDE(<bit>) && FMT_CPLUSPLUS > 201703L
+#if FMT_HAS_INCLUDE(<bit>) && FMT_CPLUSPLUS > 201703L && \
+    !defined(FMT_IMPORT_STD)
 #  include <bit>  // std::bit_cast
 #endif
 
 // libc++ supports string_view in pre-c++17.
 #if FMT_HAS_INCLUDE(<string_view>) && \
     (FMT_CPLUSPLUS >= 201703L || defined(_LIBCPP_VERSION))
-#  include <string_view>
+#  ifndef FMT_IMPORT_STD
+#    include <string_view>
+#  endif
 #  define FMT_USE_STRING_VIEW
 #endif
 

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -9,9 +9,11 @@
 #define FMT_OS_H_
 
 #include <cerrno>
-#include <cstddef>
-#include <cstdio>
-#include <system_error>  // std::system_error
+#ifndef FMT_IMPORT_STD
+#  include <cstddef>
+#  include <cstdio>
+#  include <system_error>  // std::system_error
+#endif
 
 #include "format.h"
 

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -8,7 +8,9 @@
 #ifndef FMT_OSTREAM_H_
 #define FMT_OSTREAM_H_
 
-#include <fstream>  // std::filebuf
+#ifndef FMT_IMPORT_STD
+#  include <fstream>  // std::filebuf
+#endif
 
 #ifdef _WIN32
 #  ifdef __GLIBCXX__

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -8,8 +8,10 @@
 #ifndef FMT_PRINTF_H_
 #define FMT_PRINTF_H_
 
-#include <algorithm>  // std::max
-#include <limits>     // std::numeric_limits
+#ifndef FMT_IMPORT_STD
+#  include <algorithm>  // std::max
+#  include <limits>     // std::numeric_limits
+#endif
 
 #include "format.h"
 

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -8,10 +8,12 @@
 #ifndef FMT_RANGES_H_
 #define FMT_RANGES_H_
 
-#include <initializer_list>
-#include <iterator>
-#include <tuple>
-#include <type_traits>
+#ifndef FMT_IMPORT_STD
+#  include <initializer_list>
+#  include <iterator>
+#  include <tuple>
+#  include <type_traits>
+#endif
 
 #include "format.h"
 

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -8,17 +8,19 @@
 #ifndef FMT_STD_H_
 #define FMT_STD_H_
 
-#include <atomic>
-#include <bitset>
-#include <complex>
-#include <cstdlib>
-#include <exception>
-#include <memory>
-#include <thread>
-#include <type_traits>
-#include <typeinfo>
-#include <utility>
-#include <vector>
+#ifndef FMT_IMPORT_STD
+#  include <atomic>
+#  include <bitset>
+#  include <complex>
+#  include <cstdlib>
+#  include <exception>
+#  include <memory>
+#  include <thread>
+#  include <type_traits>
+#  include <typeinfo>
+#  include <utility>
+#  include <vector>
+#endif
 
 #include "format.h"
 #include "ostream.h"
@@ -26,25 +28,28 @@
 #if FMT_HAS_INCLUDE(<version>)
 #  include <version>
 #endif
+
+#ifndef FMT_IMPORT_STD
 // Checking FMT_CPLUSPLUS for warning suppression in MSVC.
-#if FMT_CPLUSPLUS >= 201703L
-#  if FMT_HAS_INCLUDE(<filesystem>)
-#    include <filesystem>
+#  if FMT_CPLUSPLUS >= 201703L
+#    if FMT_HAS_INCLUDE(<filesystem>)
+#      include <filesystem>
+#    endif
+#    if FMT_HAS_INCLUDE(<variant>)
+#      include <variant>
+#    endif
+#    if FMT_HAS_INCLUDE(<optional>)
+#      include <optional>
+#    endif
 #  endif
-#  if FMT_HAS_INCLUDE(<variant>)
-#    include <variant>
-#  endif
-#  if FMT_HAS_INCLUDE(<optional>)
-#    include <optional>
-#  endif
-#endif
 
-#if FMT_HAS_INCLUDE(<expected>) && FMT_CPLUSPLUS > 202002L
-#  include <expected>
-#endif
+#  if FMT_HAS_INCLUDE(<expected>) && FMT_CPLUSPLUS > 202002L
+#    include <expected>
+#  endif
 
-#if FMT_CPLUSPLUS > 201703L && FMT_HAS_INCLUDE(<source_location>)
-#  include <source_location>
+#  if FMT_CPLUSPLUS > 201703L && FMT_HAS_INCLUDE(<source_location>)
+#    include <source_location>
+#  endif
 #endif
 
 // GCC 4 does not support FMT_HAS_INCLUDE.

--- a/include/fmt/xchar.h
+++ b/include/fmt/xchar.h
@@ -8,13 +8,15 @@
 #ifndef FMT_XCHAR_H_
 #define FMT_XCHAR_H_
 
-#include <cwchar>
+#ifndef FMT_IMPORT_STD
+#  include <cwchar>
+#endif
 
 #include "color.h"
 #include "format.h"
 #include "ranges.h"
 
-#ifndef FMT_STATIC_THOUSANDS_SEPARATOR
+#if !defined(FMT_STATIC_THOUSANDS_SEPARATOR) && !defined(FMT_IMPORT_STD)
 #  include <locale>
 #endif
 

--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -2,37 +2,44 @@ module;
 
 // Put all implementation-provided headers into the global module fragment
 // to prevent attachment to this module.
-#include <algorithm>
+#ifndef FMT_IMPORT_STD
+#  include <algorithm>
+#  include <chrono>
+#  include <cmath>
+#  include <cstddef>
+#  include <cstdint>
+#  include <cstdio>
+#  include <cstdlib>
+#  include <cstring>
+#  include <ctime>
+#  include <exception>
+#  include <filesystem>
+#  include <fstream>
+#  include <functional>
+#  include <iterator>
+#  include <limits>
+#  include <locale>
+#  include <memory>
+#  include <optional>
+#  include <ostream>
+#  include <stdexcept>
+#  include <string>
+#  include <string_view>
+#  include <system_error>
+#  include <thread>
+#  include <type_traits>
+#  include <typeinfo>
+#  include <utility>
+#  include <variant>
+#  include <vector>
+#else
+#  include <limits.h>
+#  include <stdint.h>
+#  include <stdio.h>
+#  include <time.h>
+#endif
 #include <cerrno>
-#include <chrono>
 #include <climits>
-#include <cmath>
-#include <cstddef>
-#include <cstdint>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
-#include <exception>
-#include <filesystem>
-#include <fstream>
-#include <functional>
-#include <iterator>
-#include <limits>
-#include <locale>
-#include <memory>
-#include <optional>
-#include <ostream>
-#include <stdexcept>
-#include <string>
-#include <string_view>
-#include <system_error>
-#include <thread>
-#include <type_traits>
-#include <typeinfo>
-#include <utility>
-#include <variant>
-#include <vector>
 #include <version>
 
 #if __has_include(<cxxabi.h>)


### PR DESCRIPTION
How to use? Add `#define FMT_IMPORT_STD` underneath `module;` in fmt.cc.
