### PR TITLE
Fix format_to + FMT_STRING for wide character type

### DIFF
--- a/include/fmt/xchar.h
+++ b/include/fmt/xchar.h
@@ -127,6 +127,15 @@ auto join(const std::tuple<T...>& tuple, basic_string_view<wchar_t> sep)
   return {tuple, sep};
 }
 
+template <typename Char, FMT_ENABLE_IF(!std::is_same<Char, char>::value)>
+auto vformat(basic_string_view<Char> format_str,
+             typename detail::vformat_args<Char>::type args)
+    -> std::basic_string<Char> {
+  auto buf = basic_memory_buffer<Char>();
+  detail::vformat_to(buf, format_str, args);
+  return to_string(buf);
+}
+
 template <typename... T>
 auto format(wformat_string<T...> fmt, T&&... args) -> std::wstring {
   return vformat(fmt::wstring_view(fmt), fmt::make_wformat_args(args...));
@@ -137,15 +146,6 @@ auto format_to(OutputIt out, wformat_string<T...> fmt, T&&... args)
     -> OutputIt {
   return vformat_to(out, fmt::wstring_view(fmt),
                     fmt::make_wformat_args(args...));
-}
-
-template <typename Char, FMT_ENABLE_IF(!std::is_same<Char, char>::value)>
-auto vformat(basic_string_view<Char> format_str,
-             typename detail::vformat_args<Char>::type args)
-    -> std::basic_string<Char> {
-  auto buf = basic_memory_buffer<Char>();
-  detail::vformat_to(buf, format_str, args);
-  return to_string(buf);
 }
 
 // Pass char_t as a default template parameter instead of using

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -195,6 +195,12 @@ TEST(xchar_test, format_to) {
   EXPECT_STREQ(buf.data(), L"42");
 }
 
+TEST(xchar_test, compile_time_string_format_to) {
+  std::wstring ws;
+  fmt::format_to(std::back_inserter(ws), FMT_STRING(L"{}"), 42);
+  EXPECT_EQ(L"42", ws);
+}
+
 TEST(xchar_test, vformat_to) {
   int n = 42;
   auto args = fmt::make_wformat_args(n);


### PR DESCRIPTION
Fixes issue #3925

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
