### PR TITLE
Fix warnings from MSVC

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -219,12 +219,12 @@ auto safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from,
   if (ec) return {};
   // multiply with Factor::num without overflow or underflow
   if (detail::const_check(Factor::num != 1)) {
-    const auto max1 = detail::max_value<IntermediateRep>() / Factor::num;
+    constexpr auto max1 = detail::max_value<IntermediateRep>() / Factor::num;
     if (count > max1) {
       ec = 1;
       return {};
     }
-    const auto min1 =
+    constexpr auto min1 =
         (std::numeric_limits<IntermediateRep>::min)() / Factor::num;
     if (detail::const_check(!std::is_unsigned<IntermediateRep>::value) &&
         count < min1) {

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -527,7 +527,7 @@ inline auto localtime(std::time_t time) -> std::tm {
     std::time_t time_;
     std::tm tm_;
 
-    dispatcher(std::time_t t) : time_(t) {}
+    dispatcher(std::time_t t) : time_(t), tm_() {}
 
     auto run() -> bool {
       using namespace fmt::detail;
@@ -576,7 +576,7 @@ inline auto gmtime(std::time_t time) -> std::tm {
     std::time_t time_;
     std::tm tm_;
 
-    dispatcher(std::time_t t) : time_(t) {}
+    dispatcher(std::time_t t) : time_(t), tm_() {}
 
     auto run() -> bool {
       using namespace fmt::detail;
@@ -1785,7 +1785,8 @@ class get_locale {
   bool has_locale_ = false;
 
  public:
-  get_locale(bool localized, locale_ref loc) : has_locale_(localized) {
+  get_locale(bool localized, locale_ref loc)
+      : locale_(), has_locale_(localized) {
     if (localized)
       ::new (&locale_) std::locale(loc.template get<std::locale>());
   }

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1253,7 +1253,7 @@ template <typename T> auto to_decimal(T x) noexcept -> decimal_fp<T> {
   auto br = bit_cast<carrier_uint>(x);
 
   // Extract significand bits and exponent bits.
-  const carrier_uint significand_mask =
+  constexpr carrier_uint significand_mask =
       (static_cast<carrier_uint>(1) << num_significand_bits<T>()) - 1;
   carrier_uint significand = (br & significand_mask);
   int exponent =

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1633,10 +1633,10 @@ template <typename F> struct basic_fp {
     static_assert(std::numeric_limits<Float>::digits <= 113, "unsupported FP");
     // Assume Float is in the format [sign][exponent][significand].
     using carrier_uint = typename dragonbox::float_info<Float>::carrier_uint;
-    const auto num_float_significand_bits =
+    constexpr auto num_float_significand_bits =
         detail::num_significand_bits<Float>();
-    const auto implicit_bit = carrier_uint(1) << num_float_significand_bits;
-    const auto significand_mask = implicit_bit - 1;
+    constexpr auto implicit_bit = carrier_uint(1) << num_float_significand_bits;
+    constexpr auto significand_mask = implicit_bit - 1;
     auto u = bit_cast<carrier_uint>(n);
     f = static_cast<F>(u & significand_mask);
     auto biased_e = static_cast<int>((u & exponent_mask<Float>()) >>
@@ -2802,7 +2802,7 @@ class bigint {
   FMT_CONSTEXPR20 void multiply(UInt value) {
     using half_uint =
         conditional_t<std::is_same<UInt, uint128_t>::value, uint64_t, uint32_t>;
-    const int shift = num_bits<half_uint>() - bigit_bits;
+    constexpr int shift = num_bits<half_uint>() - bigit_bits;
     const UInt lower = static_cast<half_uint>(value);
     const UInt upper = value >> num_bits<half_uint>();
     UInt carry = 0;
@@ -3289,7 +3289,7 @@ FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs,
     using info = dragonbox::float_info<double>;
     auto br = bit_cast<uint64_t>(static_cast<double>(value));
 
-    const uint64_t significand_mask =
+    constexpr uint64_t significand_mask =
         (static_cast<uint64_t>(1) << num_significand_bits<double>()) - 1;
     uint64_t significand = (br & significand_mask);
     int exponent = static_cast<int>((br & exponent_mask<double>()) >>
@@ -3625,7 +3625,7 @@ FMT_CONSTEXPR20 auto write(OutputIt out, T value) -> OutputIt {
   constexpr auto specs = format_specs();
   using floaty = conditional_t<std::is_same<T, long double>::value, double, T>;
   using floaty_uint = typename dragonbox::float_info<floaty>::carrier_uint;
-  floaty_uint mask = exponent_mask<floaty>();
+  constexpr floaty_uint mask = exponent_mask<floaty>();
   if ((bit_cast<floaty_uint>(value) & mask) == mask)
     return write_nonfinite<Char>(out, std::isnan(value), specs, sign);
 

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -390,7 +390,7 @@ class file_buffer final : public buffer<char> {
 
  public:
   FMT_API file_buffer(cstring_view path, const ostream_params& params);
-  FMT_API file_buffer(file_buffer&& other);
+  FMT_API file_buffer(file_buffer&& other) noexcept;
   FMT_API ~file_buffer();
 
   void flush() {

--- a/src/os.cc
+++ b/src/os.cc
@@ -381,7 +381,7 @@ file_buffer::file_buffer(cstring_view path, const ostream_params& params)
   set(new char[params.buffer_size], params.buffer_size);
 }
 
-file_buffer::file_buffer(file_buffer&& other)
+file_buffer::file_buffer(file_buffer&& other) noexcept
     : buffer<char>(grow, other.data(), other.size(), other.capacity()),
       file_(std::move(other.file_)) {
   other.clear();


### PR DESCRIPTION
Following warnings are detected by MSVC Code Analysis.

- [C26439](https://learn.microsoft.com/en-us/cpp/code-quality/c26439?view=msvc-170&f1url=%3FappId%3DDev17IDEF1%26l%3DEN-US%26k%3Dk(C26439)%26rd%3Dtrue) : This kind of function may not throw. Declare it `noexcept`.
- [C26495](https://learn.microsoft.com/en-us/cpp/code-quality/c26495?view=msvc-170&f1url=%3FappId%3DDev17IDEF1%26l%3DEN-US%26k%3Dk(C26495)%26rd%3Dtrue) : Variable is uninitialized. Always initialize a member variable (type.6).
- [C26498](https://learn.microsoft.com/en-us/cpp/code-quality/c26498?view=msvc-170&f1url=%3FappId%3DDev17IDEF1%26l%3DEN-US%26k%3Dk(C26498)%26rd%3Dtrue) : The function is `constexpr`, mark variable `constexpr` if compile-time evaluation is desired (con.5).