### PR TITLE
Specialize `formatter` for all `std::basic_string` types

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -4017,10 +4017,13 @@ FMT_FORMAT_AS(unsigned short, unsigned);
 FMT_FORMAT_AS(long, detail::long_type);
 FMT_FORMAT_AS(unsigned long, detail::ulong_type);
 FMT_FORMAT_AS(Char*, const Char*);
-FMT_FORMAT_AS(std::basic_string<Char>, basic_string_view<Char>);
 FMT_FORMAT_AS(std::nullptr_t, const void*);
 FMT_FORMAT_AS(detail::std_string_view<Char>, basic_string_view<Char>);
 FMT_FORMAT_AS(void*, const void*);
+
+template <typename Char, typename Traits, typename Allocator>
+class formatter<std::basic_string<Char, Traits, Allocator>, Char>
+    : public formatter<basic_string_view<Char>, Char> {};
 
 template <typename Char, size_t N>
 struct formatter<Char[N], Char> : formatter<basic_string_view<Char>, Char> {};

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -22,6 +22,7 @@
 #include <iterator>            // std::back_inserter
 #include <list>                // std::list
 #include <mutex>               // std::mutex
+#include <string>              // std::string
 #include <thread>              // std::thread
 #include <type_traits>         // std::is_default_constructible
 
@@ -2222,16 +2223,21 @@ template <typename Char, typename... T> void check_enabled_formatters() {
 }
 
 TEST(format_test, test_formatters_enabled) {
+  using custom_string =
+      std::basic_string<char, std::char_traits<char>, mock_allocator<char>>;
+  using custom_wstring = std::basic_string<wchar_t, std::char_traits<wchar_t>,
+                                           mock_allocator<wchar_t>>;
+
   check_enabled_formatters<char, bool, char, signed char, unsigned char, short,
                            unsigned short, int, unsigned, long, unsigned long,
                            long long, unsigned long long, float, double,
                            long double, void*, const void*, char*, const char*,
-                           std::string, std::nullptr_t>();
-  check_enabled_formatters<wchar_t, bool, wchar_t, signed char, unsigned char,
-                           short, unsigned short, int, unsigned, long,
-                           unsigned long, long long, unsigned long long, float,
-                           double, long double, void*, const void*, wchar_t*,
-                           const wchar_t*, std::wstring, std::nullptr_t>();
+                           std::string, custom_string, std::nullptr_t>();
+  check_enabled_formatters<
+      wchar_t, bool, wchar_t, signed char, unsigned char, short, unsigned short,
+      int, unsigned, long, unsigned long, long long, unsigned long long, float,
+      double, long double, void*, const void*, wchar_t*, const wchar_t*,
+      std::wstring, custom_wstring, std::nullptr_t>();
 }
 
 TEST(format_int_test, data) {

--- a/test/mock-allocator.h
+++ b/test/mock-allocator.h
@@ -20,6 +20,16 @@ template <typename T> class mock_allocator {
   using value_type = T;
   using size_type = size_t;
 
+  using pointer = T*;
+  using const_pointer = const T*;
+  using reference = T&;
+  using const_reference = const T&;
+  using difference_type = ptrdiff_t;
+
+  template <typename U> struct rebind {
+    using other = mock_allocator<U>;
+  };
+
   mock_allocator() {}
   mock_allocator(const mock_allocator&) {}
 


### PR DESCRIPTION
This fixes #3938 by adding a `formatter` partial specialization that covers all `std::basic_string` types, such as `std::pmr::string`.

Additionally, this adds the old-school allocator member types to `mock_allocator` in order to make GCC 4.8 happy. If GCC 4.8 support is removed in the future, these member types can be removed as they are the defaults of `allocator_traits`.
