### PR TITLE
Fix CodeQL alert

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1899,12 +1899,10 @@ template <typename Context> class basic_format_args {
       if (id < max_size()) arg = args_[id];
       return arg;
     }
-    if (id >= detail::max_packed_args) return arg;
+    if (static_cast<unsigned>(id) >= detail::max_packed_args) return arg;
     arg.type_ = type(id);
     if (arg.type_ == detail::type::none_type) return arg;
-    if (id >= 0) {
-      arg.value_ = values_[id];
-    }
+    arg.value_ = values_[id];
     return arg;
   }
 

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1902,7 +1902,9 @@ template <typename Context> class basic_format_args {
     if (id >= detail::max_packed_args) return arg;
     arg.type_ = type(id);
     if (arg.type_ == detail::type::none_type) return arg;
-    arg.value_ = values_[id];
+    if (id >= 0) {
+      arg.value_ = values_[id];
+    }
     return arg;
   }
 


### PR DESCRIPTION
CodeQL found an issue in base.h via static analysis where the lower bound  of the index id is not being checked before accessing array values_. 

microsoft/react-native-windows#12702
