### PR TITLE
Fix `isnan` so it doesn't cause FP errors

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2695,7 +2695,7 @@ FMT_CONSTEXPR20 auto write_float(OutputIt out, const DecimalFP& f,
 }
 
 template <typename T> constexpr auto isnan(T value) -> bool {
-  return !(value >= value);  // std::isnan doesn't support __float128.
+  return value != value;  // std::isnan doesn't support __float128.
 }
 
 template <typename T, typename Enable = void>


### PR DESCRIPTION
As described in #3948, the current internal implementation of `isnan` triggers a floating-point exception as a side effect, unlike `std::isnan`. This can cause issues for users attempting to find other causes of FP exceptions in their code.

Fix by changing `isnan` to use `value != value` as a test, which does not have side effects.

I also added a test to confirm that FP exceptions are not raised (as suggested by @vitaut). I've confirmed that it fails with the current implementation and passes with this one.

Fixes #3948.