### PR TITLE
Fix format_as for non-const begin/end views

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -4000,7 +4000,9 @@ struct formatter<T, Char, enable_if_t<detail::has_format_as<T>::value>>
   template <typename FormatContext>
   auto format(const T& value, FormatContext& ctx) const -> decltype(ctx.out()) {
     using base = formatter<detail::format_as_t<T>, Char>;
-    return base::format(format_as(value), ctx);
+    // format functions expect lvalue refs, not rvalues
+    auto&& val = format_as(value);
+    return base::format(val, ctx);
   }
 };
 


### PR DESCRIPTION
Fixes issue #3752

`base::format` does not accept rvalues, using the result of `format_as` directly means it is passed one. Doesn't matter for ranges with a const begin and end, but since `std::ranges::filter_view` caches the next value to return, it only has a [mutable begin/end iterator](https://en.cppreference.com/w/cpp/ranges/filter_view#begin).

If we just store the result of `format_as` in a temporary variable, we can pass it as an lvalue.

Since we use it in
https://github.com/fmtlib/fmt/blob/1dc71f21eadac50c85b5c840ca7db2bf7a507b15/include/fmt/ranges.h#L485-L490
And we don't call `std::forward` anyway, I don't think we're performing any pessimisation by making this change

---

Another way to fix this is by providing a `&&` overload of
https://github.com/fmtlib/fmt/blob/1dc71f21eadac50c85b5c840ca7db2bf7a507b15/include/fmt/ranges.h#L541-L545
However other control paths (that pass lvalues) then flow through this, which doesn't seem right, so didn't opt for that method