### PR TITLE
Disable range formatter when user provides one

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -513,6 +513,7 @@ template <typename R, typename Char>
 struct formatter<
     R, Char,
     enable_if_t<conjunction<
+        bool_constant<!detail::has_format_as<R>{}>,
         bool_constant<range_format_kind<R, Char>::value !=
                           range_format::disabled &&
                       range_format_kind<R, Char>::value != range_format::map>


### PR DESCRIPTION
Disable formatting type as range if user provided format_as function exists, using that instead. Should fix issue raised in #3839 by @drouhard

Edit: ah, this will need a similar workaround to `detail::is_formattable_delayed` for old msvc versions, before it will pass all the CI tests