### PR TITLE
Update checks for dynamic_cast usage when compiled with no rtti

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -279,6 +279,17 @@ import std;
 #  define FMT_UNICODE 1
 #endif
 
+// Check if rtti is available.
+#ifndef FMT_HAS_RTTI
+// __RTTI is for EDG compilers. _CPPRTTI is for MSVC.
+#  if defined(__GXX_RTTI) || FMT_HAS_FEATURE(cxx_rtti) || defined(_CPPRTTI) || \
+      defined(__INTEL_RTTI__) || defined(__RTTI)
+#    define FMT_HAS_RTTI 1
+#  else
+#    define FMT_HAS_RTTI 0
+#  endif
+#endif
+
 #define FMT_FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
 
 // Enable minimal optimizations for more compact code in debug mode.

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -280,13 +280,13 @@ import std;
 #endif
 
 // Check if rtti is available.
-#ifndef FMT_HAS_RTTI
+#ifndef FMT_USE_RTTI
 // __RTTI is for EDG compilers. _CPPRTTI is for MSVC.
 #  if defined(__GXX_RTTI) || FMT_HAS_FEATURE(cxx_rtti) || defined(_CPPRTTI) || \
       defined(__INTEL_RTTI__) || defined(__RTTI)
-#    define FMT_HAS_RTTI 1
+#    define FMT_USE_RTTI 1
 #  else
-#    define FMT_HAS_RTTI 0
+#    define FMT_USE_RTTI 0
 #  endif
 #endif
 

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -44,12 +44,12 @@ auto get_file(std::filebuf&) -> FILE*;
 inline auto write_ostream_unicode(std::ostream& os, fmt::string_view data)
     -> bool {
   FILE* f = nullptr;
-#if FMT_MSC_VERSION && FMT_HAS_RTTI
+#if FMT_MSC_VERSION && FMT_USE_RTTI
   if (auto* buf = dynamic_cast<std::filebuf*>(os.rdbuf()))
     f = get_file(*buf);
   else
     return false;
-#elif defined(_WIN32) && defined(__GLIBCXX__) && FMT_HAS_RTTI
+#elif defined(_WIN32) && defined(__GLIBCXX__) && FMT_USE_RTTI
   auto* rdbuf = os.rdbuf();
   if (auto* sfbuf = dynamic_cast<__gnu_cxx::stdio_sync_filebuf<char>*>(rdbuf))
     f = sfbuf->file();

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -44,12 +44,12 @@ auto get_file(std::filebuf&) -> FILE*;
 inline auto write_ostream_unicode(std::ostream& os, fmt::string_view data)
     -> bool {
   FILE* f = nullptr;
-#if FMT_MSC_VERSION
+#if FMT_MSC_VERSION && FMT_HAS_RTTI
   if (auto* buf = dynamic_cast<std::filebuf*>(os.rdbuf()))
     f = get_file(*buf);
   else
     return false;
-#elif defined(_WIN32) && defined(__GLIBCXX__)
+#elif defined(_WIN32) && defined(__GLIBCXX__) && FMT_HAS_RTTI
   auto* rdbuf = os.rdbuf();
   if (auto* sfbuf = dynamic_cast<__gnu_cxx::stdio_sync_filebuf<char>*>(rdbuf))
     f = sfbuf->file();

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -62,17 +62,6 @@
 #  endif
 #endif
 
-// Check if typeid is available.
-#ifndef FMT_USE_TYPEID
-// __RTTI is for EDG compilers. _CPPRTTI is for MSVC.
-#  if defined(__GXX_RTTI) || FMT_HAS_FEATURE(cxx_rtti) || defined(_CPPRTTI) || \
-      defined(__INTEL_RTTI__) || defined(__RTTI)
-#    define FMT_USE_TYPEID 1
-#  else
-#    define FMT_USE_TYPEID 0
-#  endif
-#endif
-
 // For older Xcode versions, __cpp_lib_xxx flags are inaccurately defined.
 #ifndef FMT_CPP_LIB_FILESYSTEM
 #  ifdef __cpp_lib_filesystem
@@ -443,7 +432,7 @@ struct formatter<
     if (it == end || *it == '}') return it;
     if (*it == 't') {
       ++it;
-      with_typename_ = FMT_USE_TYPEID != 0;
+      with_typename_ = FMT_HAS_RTTI != 0;
     }
     return it;
   }
@@ -455,7 +444,7 @@ struct formatter<
     if (!with_typename_)
       return detail::write_bytes<Char>(out, string_view(ex.what()));
 
-#if FMT_USE_TYPEID
+#if FMT_HAS_RTTI
     const std::type_info& ti = typeid(ex);
 #  ifdef FMT_HAS_ABI_CXA_DEMANGLE
     int status = 0;

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -432,7 +432,7 @@ struct formatter<
     if (it == end || *it == '}') return it;
     if (*it == 't') {
       ++it;
-      with_typename_ = FMT_HAS_RTTI != 0;
+      with_typename_ = FMT_USE_RTTI != 0;
     }
     return it;
   }
@@ -444,7 +444,7 @@ struct formatter<
     if (!with_typename_)
       return detail::write_bytes<Char>(out, string_view(ex.what()));
 
-#if FMT_HAS_RTTI
+#if FMT_USE_RTTI
     const std::type_info& ti = typeid(ex);
 #  ifdef FMT_HAS_ABI_CXA_DEMANGLE
     int status = 0;


### PR DESCRIPTION
The `FMT_USE_TYPEID` macro was renamed to `FMT_HAS_RTTI` and moved to `fmt/base.h` so that it can be used in other parts of the library.
That is now used to check wheter or not dynamic_cast should be used in the codebase, currently the only instances were in `write_ostream_unicode`.
This allows the library to be compiled properly with rtti disabled.