### PR TITLE
Check range_begin is dereferenceable

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -68,7 +68,7 @@ template <typename T, typename Enable = void>
 struct has_member_fn_begin_end_t : std::false_type {};
 
 template <typename T>
-struct has_member_fn_begin_end_t<T, void_t<decltype(std::declval<T>().begin()),
+struct has_member_fn_begin_end_t<T, void_t<decltype(*std::declval<T>().begin()),
                                            decltype(std::declval<T>().end())>>
     : std::true_type {};
 
@@ -99,15 +99,15 @@ struct has_mutable_begin_end : std::false_type {};
 
 template <typename T>
 struct has_const_begin_end<
-    T,
-    void_t<
-        decltype(detail::range_begin(std::declval<const remove_cvref_t<T>&>())),
-        decltype(detail::range_end(std::declval<const remove_cvref_t<T>&>()))>>
+    T, void_t<decltype(*detail::range_begin(
+                  std::declval<const remove_cvref_t<T>&>())),
+              decltype(detail::range_end(
+                  std::declval<const remove_cvref_t<T>&>()))>>
     : std::true_type {};
 
 template <typename T>
 struct has_mutable_begin_end<
-    T, void_t<decltype(detail::range_begin(std::declval<T&>())),
+    T, void_t<decltype(*detail::range_begin(std::declval<T&>())),
               decltype(detail::range_end(std::declval<T&>())),
               // the extra int here is because older versions of MSVC don't
               // SFINAE properly unless there are distinct types

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -742,3 +742,9 @@ TEST(ranges_test, movable_only_istream_iter_join) {
   EXPECT_EQ("1, 2, 3, 4, 5",
             fmt::format("{}", fmt::join(std::move(first), last, ", ")));
 }
+
+struct not_range {
+  void begin() const {}
+  void end() const {}
+};
+static_assert(!fmt::is_formattable<not_range>{}, "");


### PR DESCRIPTION
Fixes issue #3839

An Eigen 3.4 2x2 matrix has a begin member function that returns void and a static_assert that evaluates to false (as you're not meant to call begin on a non-1d matrix). 
However this doesn't play nicely with the SFINAE checks at the moment in fmt as they simply perform a SFINAE check that the expression `T{}.begin()` is valid, which evaluating to `void` is (even though it's of course not a valid type for an iterator):

https://github.com/fmtlib/fmt/blob/75e892420ed84a058f0a494d693a6baf5212eac4/include/fmt/ranges.h#L100-L104


---

To model a range more strictly to eliminate this case:

If we look at the c++20 concept for a [range](https://en.cppreference.com/w/cpp/ranges/range), it requires `ranges::begin` on the type, and that requires the iterator type satisfy [input_or_output_iterator](https://en.cppreference.com/w/cpp/iterator/input_or_output_iterator), which specifically notes that `begin` returns: `The exposition-only concept /*can-reference*/ is satisfied if and only if the type is referenceable (in particular, not void).`

So just check we can deref the result of that type to fix this case, and not incorrectly identify a type with `void begin/end` functions as a range. Note we don't want to do this for the type returned by `end`, as (in c++ >= 20) it may be a different sentinel type that is not dereferenceable