### PR TITLE
Bazel support: Add missing platform dependency

### DIFF
--- a/support/bazel/MODULE.bazel
+++ b/support/bazel/MODULE.bazel
@@ -2,3 +2,5 @@ module(
    name = "fmt",
    compatibility_level = 10,
 )
+
+bazel_dep(name = "platforms", version = "0.0.10")


### PR DESCRIPTION
This PR only affect the Bazel build support. In detail: This PR adds the missing platform dependency.  `"@platforms//os:windows"` is referenced in the BUILD file, therefore this dependency is required.