### PR TITLE
Fix regression in #3710

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -495,7 +495,8 @@ struct range_formatter<
     for (; it != end; ++it) {
       if (i > 0) out = detail::copy<Char>(separator_, out);
       ctx.advance_to(out);
-      out = underlying_.format(mapper.map(*it), ctx);
+      auto&& item = *it;  // Need an lvalue
+      out = underlying_.format(mapper.map(item), ctx);
       ++i;
     }
     out = detail::copy<Char>(closing_bracket_, out);

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -506,7 +506,7 @@ TEST(ranges_test, format_join_adl_begin_end) {
 
 #endif  // FMT_RANGES_TEST_ENABLE_JOIN
 
-#if defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 202302L
+#if defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 202207L
 TEST(ranges_test, nested_ranges) {
   auto l = std::list{1, 2, 3};
   auto r = std::views::iota(0, 3) | std::views::transform([&l](auto i) {


### PR DESCRIPTION
Fix regression in #3710 
Regression introduced in 11f2f30
Already have a test for this, but needed to make `__cpp_lib_ranges` check smaller to enable it