### PR TITLE
ci: Remove macos-11 runners, add macos-14

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,11 +9,10 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-11, macos-13]
+        os: [macos-13, macos-14]
         build_type: [Debug, Release]
         std: [11, 17, 20]
         exclude:
-          - { os: macos-11, std: 20 }
           - { os: macos-13, std: 11 }
           - { os: macos-13, std: 17 }
         include:


### PR DESCRIPTION
On June 28, 2024, macos-11 runners will be removed.
