### PR TITLE
Fix position location code - linking fmt occurs error suggesting  recompile with -fPIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ if (${CMAKE_VERSION} VERSION_LESS 3.12)
   cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
 endif ()
 
+set(CMAKE_POSITION_INDEPENDENT_CODE on)
 # Determine if fmt is built as a subproject (using add_subdirectory)
 # or if it is the master project.
 if (NOT DEFINED FMT_MASTER_PROJECT)


### PR DESCRIPTION
Linking with fmt could to get a error like
the following:
/usr/local/lib/libfmt.a(format.cc.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC

To fix it, CMAKE_POSITION_INDEPENDENT_CODE must be configured.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
