### PR TITLE
is_convertible_v -> is_convertible::value

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -148,7 +148,7 @@ template <typename Char, typename T, int N> struct field {
   template <typename OutputIt, typename... Args>
   constexpr OutputIt format(OutputIt out, const Args&... args) const {
     const T& arg = get_arg_checked<T, N>(args...);
-    if constexpr (std::is_convertible_v<T, basic_string_view<Char>>) {
+    if constexpr (std::is_convertible<T, basic_string_view<Char>>::value) {
       auto s = basic_string_view<Char>(arg);
       return copy<Char>(s.begin(), s.end(), out);
     }


### PR DESCRIPTION
This allows compilation using older toolchains.
For example, I'm using clang++ 9.0.1 on a couple machines with header files from GCC 5 & 4.8.2, which don't define `is_convertible_v`.