### PR TITLE
github: update lint.yml to post details on formatting issue

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   format_code:
@@ -21,6 +22,34 @@ jobs:
         clangformat: 17.0.5
 
     - name: Run clang-format
+      id: clang_format
       run: |
         find include src -name '*.h' -o -name '*.cc' |  xargs clang-format -i -style=file -fallback-style=none
-        git diff --exit-code
+        git diff | tee fmt.patch
+        if [ -s fmt.patch ]; then
+          exit 1
+        fi
+    - uses: actions/github-script@v7
+      if: failure() && steps.clang_format.outcome == 'failure'
+      with:
+        script: |
+          const fs = require('fs');
+          const patch = fs.readFileSync('fmt.patch', { encoding: 'utf8' });
+          const comment = `clang-format 17.0.5 found issues in the formatting in your code:
+          <details>
+          <summary>
+          View the diff from clang-format:
+          </summary>
+
+          \`\`\`diff
+          ${patch}
+          \`\`\`
+
+          </details>
+          `;
+          await github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: comment
+          });


### PR DESCRIPTION
before this change, contributers need to click into the "details" link for more details on the formatting issue identified by the lint workflow.

after this change, the workflow pastes the details with a comment, to provide more specific details on the formatting issue if any.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
