### PR TITLE
Fix missing includes in fmt.cc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ function(add_module_library name)
     target_compile_options(${name} PUBLIC -fmodules-ts)
   endif ()
 
+  target_compile_definitions(${name} PRIVATE FMT_MODULE)
+
   if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.28 AND CMAKE_GENERATOR STREQUAL "Ninja")
     target_sources(${name} PUBLIC FILE_SET fmt TYPE CXX_MODULES FILES ${sources})
   else()

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -8,9 +8,12 @@
 #ifndef FMT_BASE_H_
 #define FMT_BASE_H_
 
-#include <limits.h>  // CHAR_BIT
-#include <stdio.h>   // FILE
-#include <string.h>  // strlen
+// c headers are preferable for performance reasons
+#ifndef FMT_MODULE
+#  include <limits.h>  // CHAR_BIT
+#  include <stdio.h>   // FILE
+#  include <string.h>  // strlen
+#endif
 
 #ifndef FMT_IMPORT_STD
 // <cstddef> is also included transitively from <type_traits>.

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -2144,8 +2144,7 @@ struct formatter<day, Char> : private formatter<std::tm, Char> {
     if (use_tm_formatter_) return formatter<std::tm, Char>::format(time, ctx);
     detail::get_locale loc(false, ctx.locale());
     auto w = detail::tm_writer<decltype(ctx.out()), Char>(loc, ctx.out(), time);
-    w.on_day_of_month(detail::numeric_system::standard,
-                      detail::pad_type::zero);
+    w.on_day_of_month(detail::numeric_system::standard, detail::pad_type::zero);
     return w.out();
   }
 };

--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -6,6 +6,7 @@ module;
 #  include <algorithm>
 #  include <chrono>
 #  include <cmath>
+#  include <complex>
 #  include <cstddef>
 #  include <cstdint>
 #  include <cstdio>
@@ -13,6 +14,7 @@ module;
 #  include <cstring>
 #  include <ctime>
 #  include <exception>
+#  include <expected>
 #  include <filesystem>
 #  include <fstream>
 #  include <functional>
@@ -22,6 +24,7 @@ module;
 #  include <memory>
 #  include <optional>
 #  include <ostream>
+#  include <source_location>
 #  include <stdexcept>
 #  include <string>
 #  include <string_view>
@@ -104,7 +107,9 @@ extern "C++" {
 #if FMT_OS
 #  include "fmt/os.h"
 #endif
+#include "fmt/ostream.h"
 #include "fmt/printf.h"
+#include "fmt/ranges.h"
 #include "fmt/std.h"
 #include "fmt/xchar.h"
 


### PR DESCRIPTION
This causes duplicated std definitions in the fmt module, e.g.,

```console
ld.lld: error: undefined symbol: std::_LIBCPP_ABI_NAMESPACE::source_location@fmt::file_name[abi:v170000]() const
```
