### PR TITLE
Added generator expression to /utf-8 compile option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,8 +347,8 @@ add_library(fmt::fmt-header-only ALIAS fmt-header-only)
 
 if (MSVC)
   # Unicode support requires compiling with /utf-8.
-  target_compile_options(fmt PUBLIC /utf-8)
-  target_compile_options(fmt-header-only INTERFACE /utf-8)
+  target_compile_options(fmt PUBLIC $<$<COMPILE_LANGUAGE:CXX>:/utf-8>)
+  target_compile_options(fmt-header-only INTERFACE $<$<COMPILE_LANGUAGE:CXX>:/utf-8>)
 endif ()
 
 target_compile_definitions(fmt-header-only INTERFACE FMT_HEADER_ONLY=1)


### PR DESCRIPTION
Do not pass the compile options in the project to other compilers such as nvcc

When using the library within a project with multiple compilers, the compiler option should only be passed to the msvc compiler.