### PR TITLE
Revert cmake_minimum_required to 3.26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8...3.28)
+cmake_minimum_required(VERSION 3.8...3.26)
 
 # Fallback for using newer policies on CMake <3.12.
 if (${CMAKE_VERSION} VERSION_LESS 3.12)


### PR DESCRIPTION
Fix #3993

Looks like cmake 3.28 will automatically add `set(CMAKE_CXX_SCAN_FOR_MODULES ON)` and cause build failed.