### PR TITLE
README.md: update to remove "not yet release" remarks on clang-tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,7 @@ or the bloat test:
 
 # Migrating code
 
-[clang-tidy](https://clang.llvm.org/extra/clang-tidy/) v17 (not yet
-released) provides the
+[clang-tidy](https://clang.llvm.org/extra/clang-tidy/) v18 provides the
 [modernize-use-std-print](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-std-print.html)
 check that is capable of converting occurrences of `printf` and
 `fprintf` to `fmt::print` if configured to do so. (By default it


### PR DESCRIPTION
clang v18 was released, see
https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.6 so let's drop the remarks of "not yet released", and encourage user to the latest stable release of clang-tidy.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
