### PR TITLE
Add FMT_FORCE_FALLBACK_FILE to force the use of fallback_file

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1600,6 +1600,7 @@ template <typename F> class fallback_file : public file_base<F> {
   }
 };
 
+#ifndef FMT_FORCE_FALLBACK_FILE
 template <typename F, FMT_ENABLE_IF(sizeof(F::_p) != 0)>
 auto get_file(F* f, int) -> apple_file<F> {
   return f;
@@ -1608,6 +1609,8 @@ template <typename F, FMT_ENABLE_IF(sizeof(F::_IO_read_ptr) != 0)>
 inline auto get_file(F* f, int) -> glibc_file<F> {
   return f;
 }
+#endif
+
 inline auto get_file(FILE* f, ...) -> fallback_file<FILE> { return f; }
 
 using file_ref = decltype(get_file(static_cast<FILE*>(nullptr), 0));

--- a/test/scan.h
+++ b/test/scan.h
@@ -153,6 +153,7 @@ class string_scan_buffer final : public scan_buffer {
 
 class file_scan_buffer final : public scan_buffer {
  private:
+  #ifndef FMT_FORCE_FALLBACK_FILE
   template <typename F, FMT_ENABLE_IF(sizeof(F::_IO_read_ptr) != 0)>
   static auto get_file(F* f, int) -> glibc_file<F> {
     return f;
@@ -161,6 +162,7 @@ class file_scan_buffer final : public scan_buffer {
   static auto get_file(F* f, int) -> apple_file<F> {
     return f;
   }
+  #endif 
   static auto get_file(FILE* f, ...) -> fallback_file<FILE> { return f; }
 
   decltype(get_file(static_cast<FILE*>(nullptr), 0)) file_;


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

Add a define to opt out of attempting to use the library/platform specific files, as mentioned in https://github.com/fmtlib/fmt/issues/3992

Specifically this helps work around an issue with apple_file is detected for use on some platforms (ie game consoles) but has buffered functionality that the platform may not support, which can cause crashes.