### PR TITLE
Update msys2/setup-msys2 to v2.23.0

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Set timezone
       run: tzutil /s "Ekaterinburg Standard Time"
       shell: cmd
-    - uses: msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff # v2
+    - uses: msys2/setup-msys2@d0e80f58dffbc64f6a3a1f43527d469b4fc7b6c8 # v2.23.0
       with:
         release: false
         msystem: ${{matrix.sys}}


### PR DESCRIPTION
Fix warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

https://github.com/fmtlib/fmt/actions/runs/9487050692