### PR TITLE
Suppress a bogus warning in MSVC

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -35,9 +35,11 @@
 #    if FMT_HAS_INCLUDE(<optional>)
 #      include <optional>
 #    endif
-#    if FMT_HAS_INCLUDE(<source_location>)
-#      include <source_location>
-#    endif
+#  endif
+// Use > instead of >= in the version check because <source_location> may be
+// available after C++17 but before C++20 is marked as implemented.
+#  if FMT_CPLUSPLUS > 201703L && FMT_HAS_INCLUDE(<source_location>)
+#    include <source_location>
 #  endif
 #  if FMT_CPLUSPLUS > 202002L && FMT_HAS_INCLUDE(<expected>)
 #    include <expected>

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -17,7 +17,7 @@
 #include <utility>
 #include <vector>
 
-#if FMT_HAS_INCLUDE(<ranges>)
+#if FMT_CPLUSPLUS > 201703L && FMT_HAS_INCLUDE(<ranges>)
 #  include <ranges>
 #endif
 


### PR DESCRIPTION
``<source_location>`` and ``<ranges>`` is C++20 heades (``FMT_CPLUSPLUS > 201703L``), not C++17 (``FMT_CPLUSPLUS >= 201703L``).


Warnings:

```
The contents of <ranges> are available only with C++20 or later.
The contents of <source_location> are available only with C++20 consteval support.
```
