### PR TITLE
Module purview can only contain direct preprocessor code

### DIFF
--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -41,8 +41,6 @@ module;
 #  include <stdint.h>
 #  include <stdio.h>
 #  include <time.h>
-
-import std;
 #endif
 #include <cerrno>
 #include <climits>
@@ -82,6 +80,10 @@ import std;
 #endif
 
 export module fmt;
+
+#ifdef FMT_IMPORT_STD
+import std;
+#endif
 
 #define FMT_EXPORT export
 #define FMT_BEGIN_EXPORT export {


### PR DESCRIPTION
Resolved MSVC Warning C5202: a global module fragment can only contain preprocessor directives

_P.S.: I deleted the prior branch too soon on my side, which irreversibly closed https://github.com/fmtlib/fmt/pull/4025._
