### PR TITLE
fix: Make basic_format_arg::visit() const

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1760,7 +1760,7 @@ template <typename Context> class basic_format_arg {
    * `vis(value)` will be called with the value of type `double`.
    */
   template <typename Visitor>
-  FMT_CONSTEXPR auto visit(Visitor&& vis) -> decltype(vis(0)) {
+  FMT_CONSTEXPR auto visit(Visitor&& vis) const -> decltype(vis(0)) {
     switch (type_) {
     case detail::type::none_type:
       break;


### PR DESCRIPTION
https://github.com/fmtlib/fmt/blob/24c1f886afc35278ba95556345adcb9804f4c4f1/include/fmt/base.h#L1812C1-L1816C2

`visit_format_arg` accepts a `const basic_format_arg &` and forwards to `basic_format_arg::visit()` which is not const.

```c++
template <typename Visitor, typename Context>
FMT_DEPRECATED FMT_CONSTEXPR auto visit_format_arg(
    Visitor&& vis, const basic_format_arg<Context>& arg) -> decltype(vis(0)) {
  return arg.visit(static_cast<Visitor&&>(vis));
}
```

Not sure if this is the correct fix, but causing issues in pre-11 formatters still using `visit_format_arg`.