### PR TITLE
Enable inheriting from formatter<std::string_view>

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3978,9 +3978,15 @@ struct formatter<T, Char, enable_if_t<detail::has_format_as<T>::value>>
   }
 };
 
-#define FMT_FORMAT_AS(Type, Base) \
-  template <typename Char>        \
-  struct formatter<Type, Char> : formatter<Base, Char> {}
+#define FMT_FORMAT_AS(Type, Base)                                              \
+  template <typename Char>                                                     \
+  struct formatter<Type, Char> : formatter<Base, Char> {                       \
+    template <typename FormatContext>                                          \
+    auto format(Type value, FormatContext& ctx) const -> decltype(ctx.out()) { \
+      using base = formatter<Base, Char>;                                      \
+      return base::format(value, ctx);                                         \
+    }                                                                          \
+  }
 
 FMT_FORMAT_AS(signed char, int);
 FMT_FORMAT_AS(unsigned char, unsigned);

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1650,6 +1650,20 @@ TEST(format_test, format_explicitly_convertible_to_std_string_view) {
   EXPECT_EQ("'foo'",
             fmt::format("{}", explicitly_convertible_to_std_string_view()));
 }
+
+struct convertible_to_std_string_view {
+  operator std::string_view() const noexcept { return "Hi there"; }
+};
+FMT_BEGIN_NAMESPACE
+template <>
+class formatter<convertible_to_std_string_view>
+    : public formatter<std::string_view> {};
+FMT_END_NAMESPACE
+
+TEST(format_test, format_implicitly_convertible_and_inherits_string_view) {
+  static_assert(fmt::is_formattable<convertible_to_std_string_view>{}, "");
+  EXPECT_EQ("Hi there", fmt::format("{}", convertible_to_std_string_view{}));
+}
 #endif
 
 class Answer {};


### PR DESCRIPTION
Fixes #4036

This formatter specialization with `base::format` means a class implicitly convertible to `std::string_view` will now be converted by this format function before being passed to the `fmt::string_view` format function.
This wouldn't work previously as the compiler may only perform one implicit conversion, and we need 2 here (from our type, to `std::string_view`, to `fmt::string_view`).
