### PR TITLE
Add 2 more constexprs to fix compile error

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -616,7 +616,8 @@ constexpr auto to_string_view(const Char* s) -> basic_string_view<Char> {
   return s;
 }
 template <typename T, FMT_ENABLE_IF(is_std_string_like<T>::value)>
-constexpr auto to_string_view(const T& s) -> basic_string_view<typename T::value_type> {
+constexpr auto to_string_view(const T& s)
+    -> basic_string_view<typename T::value_type> {
   return s;
 }
 template <typename Char>

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -612,11 +612,11 @@ namespace detail {
 // to it, deducing Char. Explicitly convertible types such as the ones returned
 // from FMT_STRING are intentionally excluded.
 template <typename Char, FMT_ENABLE_IF(is_char<Char>::value)>
-auto to_string_view(const Char* s) -> basic_string_view<Char> {
+constexpr auto to_string_view(const Char* s) -> basic_string_view<Char> {
   return s;
 }
 template <typename T, FMT_ENABLE_IF(is_std_string_like<T>::value)>
-auto to_string_view(const T& s) -> basic_string_view<typename T::value_type> {
+constexpr auto to_string_view(const T& s) -> basic_string_view<typename T::value_type> {
   return s;
 }
 template <typename Char>


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

Example code where this fails:

https://compiler-explorer.com/z/31d3bjxer

With my branch this code succeeds just fine (the compilation error is on purpose, this is `cat` implemented as a compile error:

https://compiler-explorer.com/z/EzEY6Tse9