### PR TITLE
Fix broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Try {fmt} in [Compiler Explorer](https://godbolt.org/z/8Mx1EW73v).
 
 # Features
 
-- Simple [format API](https://fmt.dev/latest/api.html) with positional
+- Simple [format API](https://fmt.dev/latest/api/) with positional
   arguments for localization
 - Implementation of [C++20
   std::format](https://en.cppreference.com/w/cpp/utility/format) and
   [C++23 std::print](https://en.cppreference.com/w/cpp/io/print)
-- [Format string syntax](https://fmt.dev/latest/syntax.html) similar
+- [Format string syntax](https://fmt.dev/latest/syntax/) similar
   to Python\'s
   [format](https://docs.python.org/3/library/stdtypes.html#str.format)
 - Fast IEEE 754 floating-point formatter with correct rounding,
@@ -37,10 +37,10 @@ Try {fmt} in [Compiler Explorer](https://godbolt.org/z/8Mx1EW73v).
   [Dragonbox](https://github.com/jk-jeon/dragonbox) algorithm
 - Portable Unicode support
 - Safe [printf
-  implementation](https://fmt.dev/latest/api.html#printf-formatting)
+  implementation](https://fmt.dev/latest/api/#printf-formatting)
   including the POSIX extension for positional arguments
 - Extensibility: [support for user-defined
-  types](https://fmt.dev/latest/api.html#formatting-user-defined-types)
+  types](https://fmt.dev/latest/api/#formatting-user-defined-types)
 - High performance: faster than common standard library
   implementations of `(s)printf`, iostreams, `to_string` and
   `to_chars`, see [Speed tests](#speed-tests) and [Converting a
@@ -58,8 +58,8 @@ Try {fmt} in [Compiler Explorer](https://godbolt.org/z/8Mx1EW73v).
   buffer overflow errors
 - Ease of use: small self-contained code base, no external
   dependencies, permissive MIT
-  [license](https://github.com/fmtlib/fmt/blob/master/LICENSE.rst)
-- [Portability](https://fmt.dev/latest/index.html#portability) with
+  [license](https://github.com/fmtlib/fmt/blob/master/LICENSE)
+- [Portability](https://fmt.dev/latest/#portability) with
   consistent output across platforms and support for older compilers
 - Clean warning-free codebase even on high warning levels such as
   `-Wall -Wextra -pedantic`
@@ -243,7 +243,7 @@ header-only library so it doesn\'t provide any linkage options.
 ## Running the tests
 
 Please refer to [Building the
-library](https://fmt.dev/latest/usage.html#building-the-library) for
+library](https://fmt.dev/latest/get-started/#building-from-source) for
 instructions on how to build the library and run the unit tests.
 
 Benchmarks reside in a separate repository,
@@ -297,7 +297,7 @@ converts to `std::print`.)
   underwater vehicle
 - [Drake](https://drake.mit.edu/): a planning, control, and analysis
   toolbox for nonlinear dynamical systems (MIT)
-- [Envoy](https://lyft.github.io/envoy/): C++ L7 proxy and
+- [Envoy](https://github.com/envoyproxy/envoy): C++ L7 proxy and
   communication bus (Lyft)
 - [FiveM](https://fivem.net/): a modification framework for GTA V
 - [fmtlog](https://github.com/MengRao/fmtlog): a performant
@@ -456,7 +456,7 @@ second](http://www.zverovich.net/2020/06/13/fast-int-to-string-revisited.html).
 
 # Documentation License
 
-The [Format String Syntax](https://fmt.dev/latest/syntax.html) section
+The [Format String Syntax](https://fmt.dev/latest/syntax/) section
 in the documentation is based on the one from Python [string module
 documentation](https://docs.python.org/3/library/string.html#module-string).
 For this reason, the documentation is distributed under the Python


### PR DESCRIPTION
not sure it is needed to change https://fmt.dev/latest/ to https://fmt.dev/dev/，since https://fmt.dev/latest/ is still available