### PR TITLE
Add support for _BitInt on clang

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3950,6 +3950,11 @@ class formatter<std::basic_string<Char, Traits, Allocator>, Char>
 template <typename Char, size_t N>
 struct formatter<Char[N], Char> : formatter<basic_string_view<Char>, Char> {};
 
+template <typename T, typename Char>
+struct formatter<T, Char,
+                 enable_if_t<(detail::bitint_traits<T>::is_formattable)>>
+    : formatter<typename detail::bitint_traits<T>::formatter_type, Char> {};
+
 /**
  * Converts `p` to `const void*` for pointer formatting.
  *

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -30,10 +30,13 @@
 #  include <version>
 #endif
 
+#include <limits.h>
+
+#include <limits>
+
 #include "gtest-extra.h"
 #include "mock-allocator.h"
 #include "util.h"
-
 using fmt::basic_memory_buffer;
 using fmt::format_error;
 using fmt::memory_buffer;
@@ -931,8 +934,7 @@ TEST(format_test, runtime_width) {
 }
 
 TEST(format_test, exponent_range) {
-  for (int e = -1074; e <= 1023; ++e)
-    (void)fmt::format("{}", std::ldexp(1, e));
+  for (int e = -1074; e <= 1023; ++e) (void)fmt::format("{}", std::ldexp(1, e));
 }
 
 TEST(format_test, precision) {
@@ -2507,3 +2509,62 @@ TEST(format_test, writer) {
   fmt::writer(s).print("foo");
   EXPECT_EQ(s.str(), "foo");
 }
+
+#if FMT_USE_BITINT
+#  pragma clang diagnostic ignored "-Wbit-int-extension"
+
+template <size_t N, bool is_signed>
+using bitint_helper =
+    fmt::conditional_t<is_signed, _BitInt(N), unsigned _BitInt(N)>;
+template <size_t N> using signed_bitint = bitint_helper<N, true>;
+template <size_t N> using unsigned_bitint = bitint_helper<N, false>;
+
+TEST(format_test, bitint) {
+  EXPECT_EQ(fmt::format("{}", unsigned_bitint<3>(7)), "7");
+  EXPECT_EQ(fmt::format("{}", signed_bitint<7>()), "0");
+
+  EXPECT_EQ(fmt::format("{}", unsigned_bitint<15>(31000)), "31000");
+  EXPECT_EQ(fmt::format("{}", signed_bitint<16>(INT16_MIN)), "-32768");
+  EXPECT_EQ(fmt::format("{}", signed_bitint<16>(INT16_MAX)), "32767");
+
+  EXPECT_EQ(fmt::format("{}", unsigned_bitint<32>(4294967295)), "4294967295");
+
+  EXPECT_EQ(fmt::format("{}", unsigned_bitint<47>(140737488355327ULL)),
+            "140737488355327");
+  EXPECT_EQ(fmt::format("{}", signed_bitint<47>(-40737488355327LL)),
+            "-40737488355327");
+
+  // Check lvalues and const
+  auto a = signed_bitint<8>(0);
+  auto b = unsigned_bitint<32>(4294967295);
+  const auto c = signed_bitint<7>(0);
+  const auto d = unsigned_bitint<32>(4294967295);
+  EXPECT_EQ(fmt::format("{}", a), "0");
+  EXPECT_EQ(fmt::format("{}", b), "4294967295");
+  EXPECT_EQ(fmt::format("{}", c), "0");
+  EXPECT_EQ(fmt::format("{}", d), "4294967295");
+
+  static_assert(fmt::is_formattable<signed_bitint<64>, char>{}, "");
+  static_assert(fmt::is_formattable<unsigned_bitint<64>, char>{}, "");
+
+#  if FMT_USE_INT128
+  static_assert(fmt::is_formattable<signed_bitint<128>, char>{}, "");
+  static_assert(fmt::is_formattable<unsigned_bitint<128>, char>{}, "");
+
+  EXPECT_EQ(fmt::format("{}", signed_bitint<128>(0)), "0");
+  EXPECT_EQ(fmt::format("{}", unsigned_bitint<128>(0)), "0");
+  EXPECT_EQ("9223372036854775808",
+            fmt::format("{}", signed_bitint<65>(INT64_MAX) + 1));
+  EXPECT_EQ("-9223372036854775809",
+            fmt::format("{}", signed_bitint<65>(INT64_MIN) - 1));
+  EXPECT_EQ("18446744073709551616",
+            fmt::format("{}", unsigned_bitint<66>(UINT64_MAX) + 1));
+  EXPECT_EQ("170141183460469231731687303715884105727",
+            fmt::format("{}", signed_bitint<128>(int128_max)));
+  EXPECT_EQ("-170141183460469231731687303715884105728",
+            fmt::format("{}", signed_bitint<128>(int128_min)));
+  EXPECT_EQ("340282366920938463463374607431768211455",
+            fmt::format("{}", unsigned_bitint<128>(uint128_max)));
+#  endif
+}
+#endif


### PR DESCRIPTION
Issue #4007

Only enabled for clang >= 14 as that's all that supports `_BitInt` at the moment

We need a forwarding reference for `map` to be a "more specialized" match; `const T&`, `T` etc. are ambiguous.

I'm not too familiar, would there be a better way to do this by adding an entry into `enum class type` for `_BitInt`s? Or this is fine?

---

Fyi this worked in version 9 because of this catch-all overload:

https://github.com/fmtlib/fmt/blob/a33701196adfad74917046096bf5a2aa0ab0bb50/include/fmt/core.h#L1506-L1516

Which was then subsequently narrowed down to extended FP types (which "broke" the accidental support for this):

https://github.com/fmtlib/fmt/blob/6a192f8d34cbca3bf6a06575d8f159043d8c7f79/include/fmt/base.h#L1527-L1537

