### PR TITLE
Wrap private module fragment content within conditional extern "C++"

### DIFF
--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -127,9 +127,17 @@ extern "C++" {
 module :private;
 #endif
 
+#ifdef FMT_ATTACH_TO_GLOBAL_MODULE
+extern "C++" {
+#endif
+
 #if FMT_HAS_INCLUDE("format.cc")
 #  include "format.cc"
 #endif
 #if FMT_OS && FMT_HAS_INCLUDE("os.cc")
 #  include "os.cc"
+#endif
+
+#ifdef FMT_ATTACH_TO_GLOBAL_MODULE
+}
 #endif


### PR DESCRIPTION
This change fixes some errors generated by clang when building with modules, where it complained that with `FMT_ATTACH_TO_GLOBAL_MODULE` enabled the private module fragment definitions did not match their declarations.

MSVC did not reject the original code, however I've verified that MSVC is still happy after this change.