### PR TITLE
Mark namespace scope constexpr variable 'buffer_size' inline.

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -383,7 +383,7 @@ class file_buffer final : public buffer<char> {
 
 }  // namespace detail
 
-constexpr auto buffer_size = detail::buffer_size();
+inline constexpr auto buffer_size = detail::buffer_size();
 
 /// A fast output stream for writing from a single thread. Writing from
 /// multiple threads without external synchronization may result in a data race.

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -383,7 +383,7 @@ class file_buffer final : public buffer<char> {
 
 }  // namespace detail
 
-inline constexpr auto buffer_size = detail::buffer_size();
+FMT_INLINE_VARIABLE constexpr auto buffer_size = detail::buffer_size();
 
 /// A fast output stream for writing from a single thread. Writing from
 /// multiple threads without external synchronization may result in a data race.


### PR DESCRIPTION
This tiny change works around possible clang bug which currently prevents compilation on clang with modules and `FMT_ATTACH_TO_GLOBAL_MODULE`. From my understanding, std library implementations changed such `constexpr` namespace scope variables to be `inline` after C++17, so I think this is perhaps a good change regardless of whether clang is wrong here or not (from my limited understanding, I think it protects against possible ODR violations and has no downside).

With both this and https://github.com/fmtlib/fmt/pull/4083, I can successfully build `fmt` with modules + `FMT_ATTACH_TO_GLOBAL_MODULE` on Windows+MSVC, Windows+Clang and Linux+Clang. 