### PR TITLE
Fix compilation for folly::StringPiece args (regression from v10)

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -544,7 +544,7 @@ template <typename Char> class basic_string_view {
   /// `std::basic_string_view` object.
   template <typename S,
             FMT_ENABLE_IF(detail::is_std_string_like<S>::value&& std::is_same<
-                          typename S::value_type, Char>::value)>
+                          remove_const_t<typename S::value_type>, Char>::value)>
   FMT_CONSTEXPR basic_string_view(const S& s) noexcept
       : data_(s.data()), size_(s.size()) {}
 
@@ -626,7 +626,7 @@ constexpr auto to_string_view(const Char* s) -> basic_string_view<Char> {
 }
 template <typename T, FMT_ENABLE_IF(is_std_string_like<T>::value)>
 constexpr auto to_string_view(const T& s)
-    -> basic_string_view<typename T::value_type> {
+    -> basic_string_view<remove_const_t<typename T::value_type>> {
   return s;
 }
 template <typename Char>
@@ -742,7 +742,7 @@ FMT_DEPRECATED FMT_NORETURN inline void throw_format_error(
 /// String's character (code unit) type.
 template <typename S,
           typename V = decltype(detail::to_string_view(std::declval<S>()))>
-using char_t = typename V::value_type;
+using char_t = remove_const_t<typename V::value_type>;
 
 /**
  * Parsing context consisting of a format string range being parsed and an

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2463,3 +2463,16 @@ FMT_END_NAMESPACE
 TEST(format_test, ustring) {
   EXPECT_EQ(fmt::format("{}", ustring()), "ustring");
 }
+
+struct string_piece {
+  using value_type = char const;
+
+  auto find_first_of(value_type, size_t) const -> size_t;
+
+  auto data() const -> const char* { return "string_piece"; }
+  auto size() const -> size_t { return 12; }
+};
+
+TEST(format_test, string_piece) {
+  EXPECT_EQ(fmt::format("{}", string_piece()), "string_piece");
+}


### PR DESCRIPTION
When building fbthrift on Fedora Rawhide (which bundles fmt v11), the following assertion fails:

```
/usr/include/fmt/base.h:1612:17: error: static assertion failed: Mixing character types is disallowed.
 1612 |   static_assert(formattable_char, "Mixing character types is disallowed.");
      |                 ^~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1612:17: note: 'formattable_char' evaluates to false
```

This happens as it's trying to format a `folly::StringPiece` argument:

```
/usr/include/fmt/base.h: In instantiation of 'constexpr fmt::v11::detail::value<Context> fmt::v11::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v11::context; T = folly::Range<const char*>; typename std::enable_if<PACKED, int>::type <anonymous> = 0]':
/usr/include/fmt/base.h:2003:74:   required from 'constexpr fmt::v11::detail::format_arg_store<Context, NUM_ARGS, 0, DESC> fmt::v11::make_format_args(T& ...) [with Context = context; T = {folly::Range<const char*>, folly::Range<const char*>}; long unsigned int NUM_ARGS = 2; long unsigned int NUM_NAMED_ARGS = 0; long long unsigned int DESC = 255; typename std::enable_if<(NUM_NAMED_ARGS == 0), int>::type <anonymous> = 0]'
 2003 |   return {{detail::make_arg<NUM_ARGS <= detail::max_packed_args, Context>(
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 2004 |       args)...}};
      |       ~~~~~
```

This is ultimately caused by `folly::Range<const char*>` defining `value_type` as `const char`, which does not compare equal to `char`.

This change is a potential fix that uses `remove_const_t` to remove the const-ness of `value_type` for string-like types.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
