### PR TITLE
minor binding issue #4088

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -649,7 +649,7 @@ FMT_CONSTEXPR inline auto get_units() -> const char* {
   if (std::is_same<Period, std::femto>::value) return "fs";
   if (std::is_same<Period, std::pico>::value) return "ps";
   if (std::is_same<Period, std::nano>::value) return "ns";
-  if (std::is_same<Period, std::micro>::value) return "µs";
+  if (std::is_same<Period, std::micro>::value) return "us";
   if (std::is_same<Period, std::milli>::value) return "ms";
   if (std::is_same<Period, std::centi>::value) return "cs";
   if (std::is_same<Period, std::deci>::value) return "ds";


### PR DESCRIPTION
compatibility issue:
    replaced "µ" with "u" cause terminals without UTF-8 encoding can't show "µ" properly.
