### PR TITLE
Draft: Add support for specifying the separator for range types

### DIFF
--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -89,6 +89,13 @@ TEST(ranges_test, format_map) {
   auto m = std::map<std::string, int>{{"one", 1}, {"two", 2}};
   EXPECT_EQ(fmt::format("{}", m), "{\"one\": 1, \"two\": 2}");
   EXPECT_EQ(fmt::format("{:n}", m), "\"one\": 1, \"two\": 2");
+  EXPECT_EQ(fmt::format("{:n:}", m), "\"one\": 1, \"two\": 2");
+  EXPECT_EQ(fmt::format("{:n:m}", m), "\"one\": 1, \"two\": 2");
+  EXPECT_EQ(fmt::format("{:n:n}", m), "\"one\"1, \"two\"2");
+  EXPECT_EQ(fmt::format("{::n}", m), "{\"one\"1, \"two\"2}");
+  EXPECT_EQ(fmt::format("{:n:m}", m), "\"one\": 1, \"two\": 2");
+  EXPECT_EQ(fmt::format("{:n:n,;}", m), "\"one\";1, \"two\";2");
+  EXPECT_EQ(fmt::format("{:n:,;}", m), "(\"one\";1), (\"two\";2)");
 }
 
 struct test_map_value {};
@@ -100,18 +107,6 @@ template <> struct formatter<test_map_value> : formatter<string_view> {
     return formatter<string_view>::format("foo", ctx);
   }
 };
-
-template <typename K>
-struct formatter<std::pair<K, test_map_value>> : formatter<string_view> {
-  auto format(std::pair<K, test_map_value>, format_context& ctx) const
-      -> format_context::iterator {
-    return ctx.out();
-  }
-};
-
-template <typename K>
-struct is_tuple_formattable<std::pair<K, test_map_value>, char>
-    : std::false_type {};
 
 FMT_END_NAMESPACE
 

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -23,6 +23,7 @@
 
 #include "fmt/format.h"
 #include "gtest/gtest.h"
+#include "gtest-extra.h"
 
 #if !FMT_GCC_VERSION || FMT_GCC_VERSION >= 601
 #  define FMT_RANGES_TEST_ENABLE_C_STYLE_ARRAY
@@ -170,6 +171,14 @@ TEST(ranges_test, format_adl_begin_end) {
 TEST(ranges_test, format_pair) {
   auto p = std::pair<int, float>(42, 1.5f);
   EXPECT_EQ(fmt::format("{}", p), "(42, 1.5)");
+  EXPECT_EQ(fmt::format("{:}", p), "(42, 1.5)");
+  EXPECT_EQ(fmt::format("{:m}", p), "42: 1.5");
+  EXPECT_EQ(fmt::format("{:n}", p), "421.5");
+  EXPECT_EQ(fmt::format("{:, }", p), "(42 1.5)");
+  EXPECT_EQ(fmt::format("{:,}", p), "(421.5)");
+  EXPECT_EQ(fmt::format("{:,; }", p), "(42; 1.5)");
+  EXPECT_EQ(fmt::format("{:n,; }", p), "42; 1.5");
+  EXPECT_EQ(fmt::format("{:n,=}", p), "42=1.5");
 }
 
 struct unformattable {};
@@ -178,6 +187,8 @@ TEST(ranges_test, format_tuple) {
   auto t =
       std::tuple<int, float, std::string, char>(42, 1.5f, "this is tuple", 'i');
   EXPECT_EQ(fmt::format("{}", t), "(42, 1.5, \"this is tuple\", 'i')");
+  EXPECT_EQ(fmt::format("{:n}", t), "421.5\"this is tuple\"'i'");
+  EXPECT_THROW_MSG((void)fmt::format(fmt::runtime("{:m}"), t), fmt::format_error, "'m' format specifier can only be used for tuples with 2 elements");
 
   EXPECT_EQ(fmt::format("{}", std::tuple<>()), "()");
 


### PR DESCRIPTION
This is a draft because I want to get some early feedback on whether this is something we want, and if I'm going about it the right way.

This adds support for the `m` and `n` specifiers for ranges and tuples, as described in [the cppreference page for `std::formatter<pair-or-tuple>`](https://en.cppreference.com/w/cpp/utility/format/tuple_formatter#Format_specification:~:text=certain%20argument%20types.-,The%20available%20tuple%20presentation%20types%20are%3A,.,-Member%20objects) and a new `,` specifier (feedback on the character to use is welcome), such that the separator for elements becomes the string after the specifier.

This partly reverts 16cec4f5913ef4c5c734290cd0d1eda39cf36bd0, but I may be missing the point of that commit, as all tests pass before that commit, including the test introduced in that commit, if the `struct formatter<std::pair<K, test_map_value>>` specialization is removed. I do not understand the point of that part of the test, as the test doesn't use that `formatter`. @vitaut Could you explain that?

