### PR TITLE
Fix conversion a surrogate pair

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1418,10 +1418,12 @@ template <typename WChar, typename Buffer = memory_buffer> class to_utf8 {
           if (policy == to_utf8_error_policy::abort) return false;
           buf.append(string_view("\xEF\xBF\xBD"));
           --p;
+          continue;
         } else {
           c = (c << 10) + static_cast<uint32_t>(*p) - 0x35fdc00;
         }
-      } else if (c < 0x80) {
+      }
+      if (c < 0x80) {
         buf.push_back(static_cast<char>(c));
       } else if (c < 0x800) {
         buf.push_back(static_cast<char>(0xc0 | (c >> 6)));

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -35,6 +35,9 @@ TEST(std_test, path) {
                                    L"\x0447\x044B\x043D\x0430")),
             "Шчучыншчына");
   EXPECT_EQ(fmt::format("{}", path(L"\xd800")), "�");
+  EXPECT_EQ(fmt::format("{}", path(L"HEAD \xd800 TAIL")), "HEAD � TAIL");
+  EXPECT_EQ(fmt::format("{}", path(L"HEAD \xD83D\xDE00 TAIL")), "HEAD \xF0\x9F\x98\x80 TAIL");
+  EXPECT_EQ(fmt::format("{}", path(L"HEAD \xD83D\xD83D\xDE00 TAIL")), "HEAD �\xF0\x9F\x98\x80 TAIL");
   EXPECT_EQ(fmt::format("{:?}", path(L"\xd800")), "\"\\ud800\"");
 #  endif
 }


### PR DESCRIPTION
Fix for issue: #4094


Errors without fix:
https://github.com/phprus/fmt/actions/runs/10160437906/job/28096817999


```
14/19 Test #14: std-test .........................***Failed    0.02 sec
[==========] Running 18 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 16 tests from std_test
[ RUN      ] std_test.path
D:\a\fmt\fmt\test\std-test.cc(39): error: Expected equality of these values:
  fmt::format("{}", path(L"HEAD \xD83D\xDE00 TAIL"))
    Which is: "HEAD  TAIL"
  "HEAD \xF0\x9F\x98\x80 TAIL"
    Which is: "HEAD \xF0\x9F\x98\x80 TAIL"
    As Text: "HEAD 😀 TAIL"
D:\a\fmt\fmt\test\std-test.cc(40): error: Expected equality of these values:
  fmt::format("{}", path(L"HEAD \xD83D\xD83D\xDE00 TAIL"))
    Which is: "HEAD \xEF\xBF\xBD TAIL"
    As Text: "HEAD � TAIL"
  "HEAD �\xF0\x9F\x98\x80 TAIL"
    Which is: "HEAD \xEF\xBF\xBD\xF0\x9F\x98\x80 TAIL"
    As Text: "HEAD �😀 TAIL"
[  FAILED  ] std_test.path (1 ms)
```