### PR TITLE
Support println for color formatting

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -3008,6 +3008,7 @@ FMT_NODISCARD FMT_INLINE auto formatted_size(format_string<T...> fmt,
 FMT_API void vprint(string_view fmt, format_args args);
 FMT_API void vprint(FILE* f, string_view fmt, format_args args);
 FMT_API void vprint_buffered(FILE* f, string_view fmt, format_args args);
+FMT_API void vprintln(string_view fmt, format_args args);
 FMT_API void vprintln(FILE* f, string_view fmt, format_args args);
 
 /**

--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -473,19 +473,52 @@ inline void vprint(FILE* f, const text_style& ts, string_view fmt,
   print(f, FMT_STRING("{}"), string_view(buf.begin(), buf.size()));
 }
 
+inline void vprintln(FILE* f, const text_style& ts, string_view fmt,
+                     format_args args) {
+  auto buf = memory_buffer();
+  detail::vformat_to(buf, ts, fmt, args);
+  buf.push_back('\n');
+  print(f, FMT_STRING("{}"), string_view(buf.begin(), buf.size()));
+}
+
+inline void vprint(const text_style& ts, string_view fmt, format_args args) {
+  vprint(stdout, ts, fmt, args);
+}
+
+inline void vprintln(const text_style& ts, string_view fmt, format_args args) {
+  vprintln(stdout, ts, fmt, args);
+}
+
 /**
  * Formats a string and prints it to the specified file stream using ANSI
  * escape sequences to specify text formatting.
  *
  * **Example**:
  *
- *     fmt::print(fmt::emphasis::bold | fg(fmt::color::red),
+ *     fmt::print(stderr,
+ *                fmt::emphasis::bold | fg(fmt::color::red),
  *                "Elapsed time: {0:.2f} seconds", 1.23);
  */
 template <typename... T>
 void print(FILE* f, const text_style& ts, format_string<T...> fmt,
            T&&... args) {
   vprint(f, ts, fmt, fmt::make_format_args(args...));
+}
+
+/**
+ * Formats a string and prints it to the specified file stream followed
+ * by a newline using ANSI escape sequences to specify text formatting.
+ *
+ * **Example**:
+ *
+ *     fmt::println(stderr,
+ *                  fmt::emphasis::bold | fg(fmt::color::red),
+ *                  "Elapsed time: {0:.2f} seconds", 1.23);
+ */
+template <typename... T>
+void println(FILE* f, const text_style& ts, format_string<T...> fmt,
+           T&&... args) {
+  vprintln(f, ts, fmt, fmt::make_format_args(args...));
 }
 
 /**
@@ -499,7 +532,21 @@ void print(FILE* f, const text_style& ts, format_string<T...> fmt,
  */
 template <typename... T>
 void print(const text_style& ts, format_string<T...> fmt, T&&... args) {
-  return print(stdout, ts, fmt, std::forward<T>(args)...);
+  print(stdout, ts, fmt, std::forward<T>(args)...);
+}
+
+/**
+ * Formats a string and prints it to stdout followed by a newline using
+ * ANSI escape sequences to specify text formatting.
+ *
+ * **Example**:
+ *
+ *     fmt::println(fmt::emphasis::bold | fg(fmt::color::red),
+ *                  "Elapsed time: {0:.2f} seconds", 1.23);
+ */
+template <typename... T>
+void println(const text_style& ts, format_string<T...> fmt, T&&... args) {
+  println(stdout, ts, fmt, std::forward<T>(args)...);
 }
 
 inline auto vformat(const text_style& ts, string_view fmt, format_args args)

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1732,6 +1732,10 @@ FMT_FUNC void vprint(string_view fmt, format_args args) {
   vprint(stdout, fmt, args);
 }
 
+FMT_FUNC void vprintln(string_view fmt, format_args args) {
+  vprintln(stdout, fmt, args);
+}
+
 namespace detail {
 
 struct singleton {

--- a/test/color-test.cc
+++ b/test/color-test.cc
@@ -67,6 +67,21 @@ TEST(color_test, format_to) {
 }
 
 TEST(color_test, print) {
-  EXPECT_WRITE(stdout, fmt::print(fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30)"),
-               "\x1b[38;2;255;020;030mrgb(255,20,30)\x1b[0m");
+  EXPECT_WRITE(stderr,
+               fmt::print(stderr, fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30) {:}", 123),
+               "\x1b[38;2;255;020;030mrgb(255,20,30) 123\x1b[0m");
+
+  EXPECT_WRITE(stdout,
+               fmt::print(fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30) {:}", 123),
+               "\x1b[38;2;255;020;030mrgb(255,20,30) 123\x1b[0m");
+}
+
+TEST(color_test, println) {
+  EXPECT_WRITE(stderr,
+               fmt::println(stderr, fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30) {:}", 123),
+               "\x1b[38;2;255;020;030mrgb(255,20,30) 123\x1b[0m\n");
+
+  EXPECT_WRITE(stdout,
+               fmt::println(fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30) {:}", 123),
+               "\x1b[38;2;255;020;030mrgb(255,20,30) 123\x1b[0m\n");
 }

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1801,6 +1801,17 @@ TEST(format_test, print) {
                "Don't panic!\n");
 }
 
+TEST(module_test, vprint) {
+  EXPECT_WRITE(stdout, fmt::vprint("Don't {}!", fmt::make_format_args("panic")),
+               "Don't panic!");
+  EXPECT_WRITE(stderr, fmt::vprint(stderr, "Don't {}!", fmt::make_format_args("panic")),
+               "Don't panic!");
+  EXPECT_WRITE(stdout, fmt::vprintln("Don't {}!", fmt::make_format_args("panic")),
+               "Don't panic!\n");
+  EXPECT_WRITE(stderr, fmt::vprintln(stderr, "Don't {}!", fmt::make_format_args("panic")),
+               "Don't panic!\n");
+}
+
 TEST(format_test, big_print) {
   enum { count = 5000 };
   auto big_print = []() {


### PR DESCRIPTION
This PR is to provide necessary APIs to implement `println` for color formatting. This was found while we are trying to use `println` (which is a very cool feature !) to print text with some colors or styles in our projects.
