### PR TITLE
Improve compile-time formatting

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -467,6 +467,8 @@ FMT_INLINE std::basic_string<typename S::char_type> format(const S&,
 template <typename OutputIt, typename S, typename... Args,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
 FMT_CONSTEXPR OutputIt format_to(OutputIt out, const S&, Args&&... args) {
+  // Check that all types are formattable.
+  [[maybe_unused]] auto formattable_check = fmt::make_format_args(args...);
   constexpr auto compiled = detail::compile<Args...>(S());
   if constexpr (std::is_same<remove_cvref_t<decltype(compiled)>,
                              detail::unknown_format>()) {

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -964,6 +964,7 @@ class FMT_SO_VISIBILITY("default") format_error : public std::runtime_error {
 namespace detail_exported {
 #if FMT_USE_NONTYPE_TEMPLATE_ARGS
 template <typename Char, size_t N> struct fixed_string {
+  constexpr fixed_string() = default;
   constexpr fixed_string(const Char (&str)[N]) {
     detail::copy<Char, const Char*, Char*>(static_cast<const Char*>(str),
                                            str + N, data);

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -288,9 +288,9 @@ TEST(compile_test, compile_format_string_literal) {
 //  (compiler file
 //  'D:\a\_work\1\s\src\vctools\Compiler\CxxFE\sl\p1\c\constexpr\constexpr.cpp',
 //  line 8635)
-#if FMT_USE_CONSTEVAL &&                                     \
-    (!FMT_MSC_VERSION ||                                     \
-     (FMT_MSC_VERSION >= 1928 && FMT_MSC_VERSION < 1930)) && \
+// Can't support MSVC 19.28 & 19.29, because C++20 constexpr is required for
+// fmt::v11::detail::buffer<T>::append.
+#if FMT_USE_CONSTEVAL && (!FMT_MSC_VERSION || (FMT_MSC_VERSION >= 1939)) && \
     defined(__cpp_lib_is_constant_evaluated)
 template <size_t max_string_length, typename Char = char> struct test_string {
   template <typename T> constexpr bool operator==(const T& rhs) const noexcept {
@@ -302,6 +302,7 @@ template <size_t max_string_length, typename Char = char> struct test_string {
 template <size_t max_string_length, typename Char = char, typename... Args>
 consteval auto test_format(auto format, const Args&... args) {
   test_string<max_string_length, Char> string{};
+  fmt::detail::ignore_unused(fmt::formatted_size(format, args...));
   fmt::format_to(string.buffer, format, args...);
   return string;
 }
@@ -334,6 +335,7 @@ TEST(compile_time_formatting_test, integer) {
   EXPECT_EQ("0X4A", test_format<5>(FMT_COMPILE("{:#X}"), 0x4a));
 
   EXPECT_EQ("   42", test_format<6>(FMT_COMPILE("{:5}"), 42));
+  EXPECT_EQ("   42", test_format<6>(FMT_COMPILE("{:5}"), 42l));
   EXPECT_EQ("   42", test_format<6>(FMT_COMPILE("{:5}"), 42ll));
   EXPECT_EQ("   42", test_format<6>(FMT_COMPILE("{:5}"), 42ull));
 


### PR DESCRIPTION
This PR improves compile-time formatting. More specifically:

- A few `FMT_CONSTEXPR(20)` specifiers were added.
- `detail_exported::fixed_string` type is now formattable and has a UDL operator.
- The compile-time `fmt::format` functions now generate the same error as the runtime ones when a type is not formattable.
- An extra check was added to one of the `write()` overload's `enable_if`s to avoid ambiguity when a type is unformattable during compile-time formatting.
- The compile-time formatting tests are now generated as type-parametrized tests, for both formatting to a fixed length buffer, as well as to an `std::string_view`. This requires some rather ugly macros, but they allow avoiding duplicating all those tests.
