### PR TITLE
add extern template/explicit instantiations for wchar_t.

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -4224,6 +4224,9 @@ FMT_BEGIN_EXPORT
 extern template FMT_API void vformat_to(buffer<char>&, string_view,
                                         typename vformat_args<>::type,
                                         locale_ref);
+extern template FMT_API void vformat_to(buffer<wchar_t>&, basic_string_view<wchar_t>,
+                                        typename vformat_args<wchar_t>::type,
+                                        locale_ref);
 extern template FMT_API auto thousands_sep_impl<char>(locale_ref)
     -> thousands_sep_result<char>;
 extern template FMT_API auto thousands_sep_impl<wchar_t>(locale_ref)

--- a/src/format.cc
+++ b/src/format.cc
@@ -40,5 +40,9 @@ template FMT_API auto decimal_point_impl(locale_ref) -> wchar_t;
 
 template FMT_API void buffer<wchar_t>::append(const wchar_t*, const wchar_t*);
 
+template FMT_API void vformat_to(buffer<wchar_t>&, basic_string_view<wchar_t>,
+                                 typename vformat_args<wchar_t>::type,
+                                 locale_ref);
+
 }  // namespace detail
 FMT_END_NAMESPACE


### PR DESCRIPTION
it supposed to save some build time when not header-only version of the library is used.
in our project we've noticed that significant amount of time is spent by compiler instantiating this:
```
223332 ms: fmt::detail::vformat_to<wchar_t> (3305 times, avg 67 ms)
```
This commit fixes the issue.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
