### PR TITLE
Include <algorithm> for std::copy

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -8,6 +8,7 @@
 #ifndef FMT_COLOR_H_
 #define FMT_COLOR_H_
 
+#include <algorithm>                   // std::copy
 #include "format.h"
 
 FMT_BEGIN_NAMESPACE


### PR DESCRIPTION
Some headers like color.h are using std::copy API
from C++ std library, but missing to include the
right header [1]

[1] https://en.cppreference.com/w/cpp/algorithm/copy

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
