### PR TITLE
Add support formatting std::expected<void, E>

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2819,11 +2819,11 @@ template <typename Char, typename... T> class fstring {
 template <typename... T> using format_string = typename fstring<char, T...>::t;
 
 template <typename T, typename Char = char>
-using is_formattable = bool_constant<!std::is_base_of<
-    detail::unformattable,
-    detail::mapped_t<
-        conditional_t<std::is_same<T, void>::value, detail::unformattable, T>,
-        Char>>::value>;
+using is_formattable = bool_constant<
+    !std::is_base_of<detail::unformattable,
+                     detail::mapped_t<conditional_t<std::is_void<T>::value,
+                                                    detail::unformattable, T>,
+                                      Char>>::value>;
 
 #ifdef __cpp_concepts
 template <typename T, typename Char = char>

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -279,7 +279,8 @@ FMT_BEGIN_NAMESPACE
 FMT_EXPORT
 template <typename T, typename E, typename Char>
 struct formatter<std::expected<T, E>, Char,
-                 std::enable_if_t<is_formattable<T, Char>::value &&
+                 std::enable_if_t<(std::is_void<T>::value ||
+                                   is_formattable<T, Char>::value) &&
                                   is_formattable<E, Char>::value>> {
   FMT_CONSTEXPR auto parse(parse_context<Char>& ctx) -> const Char* {
     return ctx.begin();
@@ -292,7 +293,8 @@ struct formatter<std::expected<T, E>, Char,
 
     if (value.has_value()) {
       out = detail::write<Char>(out, "expected(");
-      out = detail::write_escaped_alternative<Char>(out, *value);
+      if constexpr (!std::is_void<T>::value)
+        out = detail::write_escaped_alternative<Char>(out, *value);
     } else {
       out = detail::write<Char>(out, "unexpected(");
       out = detail::write_escaped_alternative<Char>(out, value.error());

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -140,6 +140,7 @@ TEST(std_test, optional) {
 
 TEST(std_test, expected) {
 #ifdef __cpp_lib_expected
+  EXPECT_EQ(fmt::format("{}", std::expected<void, int>{}), "expected()");
   EXPECT_EQ(fmt::format("{}", std::expected<int, int>{1}), "expected(1)");
   EXPECT_EQ(fmt::format("{}", std::expected<int, int>{std::unexpected(1)}),
             "unexpected(1)");
@@ -163,6 +164,7 @@ TEST(std_test, expected) {
   EXPECT_FALSE(
       (fmt::is_formattable<std::expected<int, unformattable2>>::value));
   EXPECT_TRUE((fmt::is_formattable<std::expected<int, int>>::value));
+  EXPECT_TRUE((fmt::is_formattable<std::expected<void, int>>::value));
 #endif
 }
 


### PR DESCRIPTION
Fix for issue #4145.

Requires #4151. With #4151 we can remove temporary CI commit.