### PR TITLE
Fix broken CI for shared library on macos and linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,7 @@ jobs:
         cxx: [g++-4.9, g++-10, clang++-9]
         build_type: [Debug, Release]
         std: [11]
+        shared: [""]
         include:
           - cxx: g++-4.9
             install: sudo apt install g++-4.9
@@ -54,7 +55,11 @@ jobs:
             std: 20
             cxxflags: -stdlib=libc++
             install: sudo apt install libc++-11-dev libc++abi-11-dev
-          - shared: -DBUILD_SHARED_LIBS=ON
+          - cxx: g++-11
+            build_type: Release
+            std: 23
+            install: sudo apt install g++-11
+            shared: -DBUILD_SHARED_LIBS=ON
 
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,11 +12,15 @@ jobs:
         os: [macos-13, macos-14]
         build_type: [Debug, Release]
         std: [11, 17, 20]
+        shared: [""]
         exclude:
           - { os: macos-13, std: 11 }
           - { os: macos-13, std: 17 }
         include:
-          - shared: -DBUILD_SHARED_LIBS=ON
+          - os: macos-14
+            std: 23
+            build_type: Release
+            shared: -DBUILD_SHARED_LIBS=ON
 
     runs-on: '${{ matrix.os }}'
 


### PR DESCRIPTION
Bug is introduced in #2293 (shared library build not working in CI)

Additionally, a C++23 for shared libraries is added.

I think it would be better to fix #4150 before this and use gcc-14 instead of gcc-11 in this PR or make this change later.