### PR TITLE
Small fixes for some issues with modules builds

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2465,7 +2465,6 @@ inline void vprint_mojibake(FILE*, string_view, const format_args&, bool) {}
 }  // namespace detail
 
 // The main public API.
-FMT_BEGIN_EXPORT
 
 template <typename Char>
 FMT_CONSTEXPR void parse_context<Char>::do_check_arg_id(int arg_id) {
@@ -2483,6 +2482,8 @@ FMT_CONSTEXPR void parse_context<Char>::check_dynamic_spec(int arg_id) {
   if (detail::is_constant_evaluated() && use_constexpr_cast)
     static_cast<compile_parse_context<Char>*>(this)->check_dynamic_spec(arg_id);
 }
+
+FMT_BEGIN_EXPORT
 
 // An output iterator that appends to a buffer. It is used instead of
 // back_insert_iterator to reduce symbol sizes and avoid <iterator> dependency.

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -196,7 +196,7 @@ FMT_END_NAMESPACE
 #  endif
 #endif
 
-#if FMT_MSC_VERSION
+#if FMT_MSC_VERSION && !defined(FMT_MODULE)
 #  include <intrin.h>  // _BitScanReverse[64], _BitScanForward[64], _umul128
 #endif
 


### PR DESCRIPTION
1. I think some recent changes caused a regression by rearranging some code such that some out-of-line member function definitions ended up in the module export scope. The errors encountered (on Clang) were as follows:
```
In file included from C:\Coding\Build2\third-party-packaging\build2-packaging\fmt\fmt\fmt\src\fmt.cc:107:
In file included from C:\Coding\Build2\third-party-packaging\build2-packaging\fmt\fmt\fmt/include\fmt/args.h:17:
In file included from C:\Coding\Build2\third-party-packaging\build2-packaging\fmt\fmt\fmt/include\fmt\format.h:41:
C:\Coding\Build2\third-party-packaging\build2-packaging\fmt\fmt\fmt/include\fmt\base.h:2471:41: error: cannot export 'do_check_arg_id' as it is not at namespace scope
 2471 | FMT_CONSTEXPR void parse_context<Char>::do_check_arg_id(int arg_id) {
      |                    ~~~~~~~~~~~~~~~~~~~~~^
```
2. Unsure if this was a recent regression or not, but the MSVC-specific inclusion of `intrin.h` was being done within the module purview.