### PR TITLE
Module linkage fixes for shared build

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1792,9 +1792,9 @@ template <typename T> class buffer {
 };
 
 struct buffer_traits {
-  FMT_CONSTEXPR explicit buffer_traits(size_t) {}
-  FMT_CONSTEXPR auto count() const -> size_t { return 0; }
-  FMT_CONSTEXPR auto limit(size_t size) -> size_t { return size; }
+  constexpr explicit buffer_traits(size_t) {}
+  constexpr auto count() const -> size_t { return 0; }
+  constexpr auto limit(size_t size) -> size_t { return size; }
 };
 
 class fixed_buffer_traits {
@@ -1803,9 +1803,9 @@ class fixed_buffer_traits {
   size_t limit_;
 
  public:
-  FMT_CONSTEXPR explicit fixed_buffer_traits(size_t limit) : limit_(limit) {}
-  FMT_CONSTEXPR auto count() const -> size_t { return count_; }
-  FMT_CONSTEXPR auto limit(size_t size) -> size_t {
+  constexpr explicit fixed_buffer_traits(size_t limit) : limit_(limit) {}
+  constexpr auto count() const -> size_t { return count_; }
+  constexpr auto limit(size_t size) -> size_t {
     size_t n = limit_ > count_ ? limit_ - count_ : 0;
     count_ += size;
     return size < n ? size : n;
@@ -2223,7 +2223,7 @@ struct locale_ref {
  public:
   constexpr locale_ref() : locale_(nullptr) {}
   template <typename Locale> explicit locale_ref(const Locale& loc);
-  FMT_INLINE explicit operator bool() const noexcept { return locale_ != nullptr; }
+  inline explicit operator bool() const noexcept { return locale_ != nullptr; }
 #endif
 
   template <typename Locale> auto get() const -> Locale;
@@ -2598,7 +2598,7 @@ class context : private detail::locale_ref {
   void operator=(const context&) = delete;
 
   FMT_CONSTEXPR auto arg(int id) const -> format_arg { return args_.get(id); }
-  FMT_INLINE auto arg(string_view name) -> format_arg { return args_.get(name); }
+  inline auto arg(string_view name) -> format_arg { return args_.get(name); }
   FMT_CONSTEXPR auto arg_id(string_view name) -> int {
     return args_.get_id(name);
   }

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1885,9 +1885,9 @@ template <typename T> class buffer {
 };
 
 struct buffer_traits {
-  explicit buffer_traits(size_t) {}
-  auto count() const -> size_t { return 0; }
-  auto limit(size_t size) -> size_t { return size; }
+  FMT_CONSTEXPR explicit buffer_traits(size_t) {}
+  FMT_CONSTEXPR auto count() const -> size_t { return 0; }
+  FMT_CONSTEXPR auto limit(size_t size) -> size_t { return size; }
 };
 
 class fixed_buffer_traits {
@@ -1896,9 +1896,9 @@ class fixed_buffer_traits {
   size_t limit_;
 
  public:
-  explicit fixed_buffer_traits(size_t limit) : limit_(limit) {}
-  auto count() const -> size_t { return count_; }
-  auto limit(size_t size) -> size_t {
+  FMT_CONSTEXPR explicit fixed_buffer_traits(size_t limit) : limit_(limit) {}
+  FMT_CONSTEXPR auto count() const -> size_t { return count_; }
+  FMT_CONSTEXPR auto limit(size_t size) -> size_t {
     size_t n = limit_ > count_ ? limit_ - count_ : 0;
     count_ += size;
     return size < n ? size : n;
@@ -2297,7 +2297,7 @@ struct locale_ref {
  public:
   constexpr locale_ref() : locale_(nullptr) {}
   template <typename Locale> explicit locale_ref(const Locale& loc);
-  explicit operator bool() const noexcept { return locale_ != nullptr; }
+  FMT_INLINE explicit operator bool() const noexcept { return locale_ != nullptr; }
 #endif
 
   template <typename Locale> auto get() const -> Locale;
@@ -2673,7 +2673,7 @@ class context : private detail::locale_ref {
   void operator=(const context&) = delete;
 
   FMT_CONSTEXPR auto arg(int id) const -> format_arg { return args_.get(id); }
-  auto arg(string_view name) -> format_arg { return args_.get(name); }
+  FMT_CONSTEXPR auto arg(string_view name) -> format_arg { return args_.get(name); }
   FMT_CONSTEXPR auto arg_id(string_view name) -> int {
     return args_.get_id(name);
   }
@@ -2682,7 +2682,7 @@ class context : private detail::locale_ref {
   FMT_CONSTEXPR auto out() -> iterator { return out_; }
 
   // Advances the begin iterator to `it`.
-  void advance_to(iterator) {}
+  FMT_CONSTEXPR void advance_to(iterator) {}
 
   FMT_CONSTEXPR auto locale() -> detail::locale_ref { return *this; }
 };

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1790,7 +1790,7 @@ template <typename T> class buffer {
 struct buffer_traits {
   constexpr explicit buffer_traits(size_t) {}
   constexpr auto count() const -> size_t { return 0; }
-  FMT_CONSTEXPR auto limit(size_t size) -> size_t { return size; }
+  constexpr auto limit(size_t size) const -> size_t { return size; }
 };
 
 class fixed_buffer_traits {

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2598,7 +2598,7 @@ class context : private detail::locale_ref {
   void operator=(const context&) = delete;
 
   FMT_CONSTEXPR auto arg(int id) const -> format_arg { return args_.get(id); }
-  FMT_CONSTEXPR auto arg(string_view name) -> format_arg { return args_.get(name); }
+  FMT_INLINE auto arg(string_view name) -> format_arg { return args_.get(name); }
   FMT_CONSTEXPR auto arg_id(string_view name) -> int {
     return args_.get_id(name);
   }

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1790,7 +1790,7 @@ template <typename T> class buffer {
 struct buffer_traits {
   constexpr explicit buffer_traits(size_t) {}
   constexpr auto count() const -> size_t { return 0; }
-  constexpr auto limit(size_t size) -> size_t { return size; }
+  FMT_CONSTEXPR auto limit(size_t size) -> size_t { return size; }
 };
 
 class fixed_buffer_traits {
@@ -1801,7 +1801,7 @@ class fixed_buffer_traits {
  public:
   constexpr explicit fixed_buffer_traits(size_t limit) : limit_(limit) {}
   constexpr auto count() const -> size_t { return count_; }
-  constexpr auto limit(size_t size) -> size_t {
+  FMT_CONSTEXPR auto limit(size_t size) -> size_t {
     size_t n = limit_ > count_ ? limit_ - count_ : 0;
     count_ += size;
     return size < n ? size : n;

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -912,7 +912,9 @@ template <typename Derived> struct null_chrono_spec_handler {
 };
 
 struct tm_format_checker : null_chrono_spec_handler<tm_format_checker> {
-  FMT_NORETURN inline void unsupported() { FMT_THROW(format_error("no format")); }
+  FMT_NORETURN inline void unsupported() {
+    FMT_THROW(format_error("no format"));
+  }
 
   template <typename Char>
   FMT_CONSTEXPR void on_text(const Char*, const Char*) {}

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -521,24 +521,24 @@ inline auto localtime(std::time_t time) -> std::tm {
     std::time_t time_;
     std::tm tm_;
 
-    dispatcher(std::time_t t) : time_(t) {}
+    FMT_INLINE dispatcher(std::time_t t) : time_(t) {}
 
-    auto run() -> bool {
+    FMT_INLINE auto run() -> bool {
       using namespace fmt::detail;
       return handle(localtime_r(&time_, &tm_));
     }
 
-    auto handle(std::tm* tm) -> bool { return tm != nullptr; }
+    FMT_INLINE auto handle(std::tm* tm) -> bool { return tm != nullptr; }
 
-    auto handle(detail::null<>) -> bool {
+    FMT_INLINE auto handle(detail::null<>) -> bool {
       using namespace fmt::detail;
       return fallback(localtime_s(&tm_, &time_));
     }
 
-    auto fallback(int res) -> bool { return res == 0; }
+    FMT_INLINE auto fallback(int res) -> bool { return res == 0; }
 
 #if !FMT_MSC_VERSION
-    auto fallback(detail::null<>) -> bool {
+    FMT_INLINE auto fallback(detail::null<>) -> bool {
       using namespace fmt::detail;
       std::tm* tm = std::localtime(&time_);
       if (tm) tm_ = *tm;
@@ -570,24 +570,24 @@ inline auto gmtime(std::time_t time) -> std::tm {
     std::time_t time_;
     std::tm tm_;
 
-    dispatcher(std::time_t t) : time_(t) {}
+    FMT_INLINE dispatcher(std::time_t t) : time_(t) {}
 
-    auto run() -> bool {
+    FMT_INLINE auto run() -> bool {
       using namespace fmt::detail;
       return handle(gmtime_r(&time_, &tm_));
     }
 
-    auto handle(std::tm* tm) -> bool { return tm != nullptr; }
+    FMT_INLINE auto handle(std::tm* tm) -> bool { return tm != nullptr; }
 
-    auto handle(detail::null<>) -> bool {
+    FMT_INLINE auto handle(detail::null<>) -> bool {
       using namespace fmt::detail;
       return fallback(gmtime_s(&tm_, &time_));
     }
 
-    auto fallback(int res) -> bool { return res == 0; }
+    FMT_INLINE auto fallback(int res) -> bool { return res == 0; }
 
 #if !FMT_MSC_VERSION
-    auto fallback(detail::null<>) -> bool {
+    FMT_INLINE auto fallback(detail::null<>) -> bool {
       std::tm* tm = std::gmtime(&time_);
       if (tm) tm_ = *tm;
       return tm != nullptr;
@@ -891,7 +891,7 @@ template <typename Derived> struct null_chrono_spec_handler {
 };
 
 struct tm_format_checker : null_chrono_spec_handler<tm_format_checker> {
-  FMT_NORETURN void unsupported() { FMT_THROW(format_error("no format")); }
+  FMT_NORETURN FMT_INLINE void unsupported() { FMT_THROW(format_error("no format")); }
 
   template <typename Char>
   FMT_CONSTEXPR void on_text(const Char*, const Char*) {}
@@ -1545,7 +1545,7 @@ class tm_writer {
 struct chrono_format_checker : null_chrono_spec_handler<chrono_format_checker> {
   bool has_precision_integral = false;
 
-  FMT_NORETURN void unsupported() { FMT_THROW(format_error("no date")); }
+  FMT_NORETURN FMT_INLINE void unsupported() { FMT_THROW(format_error("no date")); }
 
   template <typename Char>
   FMT_CONSTEXPR void on_text(const Char*, const Char*) {}
@@ -1667,14 +1667,14 @@ class get_locale {
   bool has_locale_ = false;
 
  public:
-  get_locale(bool localized, locale_ref loc) : has_locale_(localized) {
+  FMT_INLINE get_locale(bool localized, locale_ref loc) : has_locale_(localized) {
     if (localized)
       ::new (&locale_) std::locale(loc.template get<std::locale>());
   }
-  ~get_locale() {
+  FMT_INLINE ~get_locale() {
     if (has_locale_) locale_.~locale();
   }
-  operator const std::locale&() const {
+  FMT_INLINE operator const std::locale&() const {
     return has_locale_ ? locale_ : get_classic_locale();
   }
 };

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -540,24 +540,24 @@ inline auto localtime(std::time_t time) -> std::tm {
     std::time_t time_;
     std::tm tm_;
 
-    FMT_INLINE dispatcher(std::time_t t) : time_(t) {}
+    inline dispatcher(std::time_t t) : time_(t) {}
 
-    FMT_INLINE auto run() -> bool {
+    inline auto run() -> bool {
       using namespace fmt::detail;
       return handle(localtime_r(&time_, &tm_));
     }
 
-    FMT_INLINE auto handle(std::tm* tm) -> bool { return tm != nullptr; }
+    inline auto handle(std::tm* tm) -> bool { return tm != nullptr; }
 
-    FMT_INLINE auto handle(detail::null<>) -> bool {
+    inline auto handle(detail::null<>) -> bool {
       using namespace fmt::detail;
       return fallback(localtime_s(&tm_, &time_));
     }
 
-    FMT_INLINE auto fallback(int res) -> bool { return res == 0; }
+    inline auto fallback(int res) -> bool { return res == 0; }
 
 #if !FMT_MSC_VERSION
-    FMT_INLINE auto fallback(detail::null<>) -> bool {
+    inline auto fallback(detail::null<>) -> bool {
       using namespace fmt::detail;
       std::tm* tm = std::localtime(&time_);
       if (tm) tm_ = *tm;
@@ -591,24 +591,24 @@ inline auto gmtime(std::time_t time) -> std::tm {
     std::time_t time_;
     std::tm tm_;
 
-    FMT_INLINE dispatcher(std::time_t t) : time_(t) {}
+    inline dispatcher(std::time_t t) : time_(t) {}
 
-    FMT_INLINE auto run() -> bool {
+    inline auto run() -> bool {
       using namespace fmt::detail;
       return handle(gmtime_r(&time_, &tm_));
     }
 
-    FMT_INLINE auto handle(std::tm* tm) -> bool { return tm != nullptr; }
+    inline auto handle(std::tm* tm) -> bool { return tm != nullptr; }
 
-    FMT_INLINE auto handle(detail::null<>) -> bool {
+    inline auto handle(detail::null<>) -> bool {
       using namespace fmt::detail;
       return fallback(gmtime_s(&tm_, &time_));
     }
 
-    FMT_INLINE auto fallback(int res) -> bool { return res == 0; }
+    inline auto fallback(int res) -> bool { return res == 0; }
 
 #if !FMT_MSC_VERSION
-    FMT_INLINE auto fallback(detail::null<>) -> bool {
+    inline auto fallback(detail::null<>) -> bool {
       std::tm* tm = std::gmtime(&time_);
       if (tm) tm_ = *tm;
       return tm != nullptr;
@@ -912,7 +912,7 @@ template <typename Derived> struct null_chrono_spec_handler {
 };
 
 struct tm_format_checker : null_chrono_spec_handler<tm_format_checker> {
-  FMT_NORETURN FMT_INLINE void unsupported() { FMT_THROW(format_error("no format")); }
+  FMT_NORETURN inline void unsupported() { FMT_THROW(format_error("no format")); }
 
   template <typename Char>
   FMT_CONSTEXPR void on_text(const Char*, const Char*) {}
@@ -1572,7 +1572,7 @@ class tm_writer {
 struct chrono_format_checker : null_chrono_spec_handler<chrono_format_checker> {
   bool has_precision_integral = false;
 
-  FMT_NORETURN FMT_INLINE void unsupported() { FMT_THROW(format_error("no date")); }
+  FMT_NORETURN inline void unsupported() { FMT_THROW(format_error("no date")); }
 
   template <typename Char>
   FMT_CONSTEXPR void on_text(const Char*, const Char*) {}
@@ -1693,14 +1693,14 @@ class get_locale {
   bool has_locale_ = false;
 
  public:
-  FMT_INLINE get_locale(bool localized, locale_ref loc) : has_locale_(localized) {
+  inline get_locale(bool localized, locale_ref loc) : has_locale_(localized) {
     if (localized)
       ::new (&locale_) std::locale(loc.template get<std::locale>());
   }
-  FMT_INLINE ~get_locale() {
+  inline ~get_locale() {
     if (has_locale_) locale_.~locale();
   }
-  FMT_INLINE operator const std::locale&() const {
+  inline operator const std::locale&() const {
     return has_locale_ ? locale_ : get_classic_locale();
   }
 };

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -372,14 +372,14 @@ class uint128_fallback {
       -> uint128_fallback {
     return {~n.hi_, ~n.lo_};
   }
-  friend constexpr auto operator+(const uint128_fallback& lhs,
-                                  const uint128_fallback& rhs)
+  friend FMT_CONSTEXPR auto operator+(const uint128_fallback& lhs,
+                                      const uint128_fallback& rhs)
       -> uint128_fallback {
     auto result = uint128_fallback(lhs);
     result += rhs;
     return result;
   }
-  friend constexpr auto operator*(const uint128_fallback& lhs, uint32_t rhs)
+  friend FMT_CONSTEXPR auto operator*(const uint128_fallback& lhs, uint32_t rhs)
       -> uint128_fallback {
     FMT_ASSERT(lhs.hi_ == 0, "");
     uint64_t hi = (lhs.lo_ >> 32) * rhs;

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1419,7 +1419,9 @@ class utf8_to_utf16 {
 
  public:
   FMT_API explicit utf8_to_utf16(string_view s);
-  inline operator basic_string_view<wchar_t>() const { return {&buffer_[0], size()}; }
+  inline operator basic_string_view<wchar_t>() const {
+    return {&buffer_[0], size()};
+  }
   inline auto size() const -> size_t { return buffer_.size() - 1; }
   inline auto c_str() const -> const wchar_t* { return &buffer_[0]; }
   inline auto str() const -> std::wstring { return {&buffer_[0], size()}; }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -4134,7 +4134,7 @@ class format_int {
   }
 
   /// Returns the content of the output buffer as an `std::string`.
-  FMT_CONSTEXPR20 auto str() const -> std::string { return {str_, size()}; }
+  FMT_INLINE auto str() const -> std::string { return {str_, size()}; }
 };
 
 #define FMT_STRING_IMPL(s, base)                                           \

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -376,13 +376,14 @@ class uint128_fallback {
       -> uint128_fallback {
     return {~n.hi_, ~n.lo_};
   }
-  FMT_CONSTEXPR friend auto operator+(const uint128_fallback& lhs,
-                                      const uint128_fallback& rhs) -> uint128_fallback {
+  friend constexpr auto operator+(const uint128_fallback& lhs,
+                                  const uint128_fallback& rhs)
+      -> uint128_fallback {
     auto result = uint128_fallback(lhs);
     result += rhs;
     return result;
   }
-  FMT_CONSTEXPR friend auto operator*(const uint128_fallback& lhs, uint32_t rhs)
+  friend constexpr auto operator*(const uint128_fallback& lhs, uint32_t rhs)
       -> uint128_fallback {
     FMT_ASSERT(lhs.hi_ == 0, "");
     uint64_t hi = (lhs.lo_ >> 32) * rhs;
@@ -390,7 +391,7 @@ class uint128_fallback {
     uint64_t new_lo = (hi << 32) + lo;
     return {(hi >> 32) + (new_lo < lo ? 1 : 0), new_lo};
   }
-  FMT_CONSTEXPR friend auto operator-(const uint128_fallback& lhs, uint64_t rhs)
+  friend constexpr auto operator-(const uint128_fallback& lhs, uint64_t rhs)
       -> uint128_fallback {
     return {lhs.hi_ - (lhs.lo_ < rhs ? 1 : 0), lhs.lo_ - rhs};
   }
@@ -964,8 +965,8 @@ class writer {
   FILE* file_;
 
  public:
-  FMT_INLINE writer(FILE* f) : buf_(nullptr), file_(f) {}
-  FMT_INLINE writer(detail::buffer<char>& buf) : buf_(&buf) {}
+  inline writer(FILE* f) : buf_(nullptr), file_(f) {}
+  inline writer(detail::buffer<char>& buf) : buf_(&buf) {}
 
   /// Formats `args` according to specifications in `fmt` and writes the
   /// output to the file.
@@ -983,10 +984,10 @@ class string_buffer {
   detail::container_buffer<std::string> buf_;
 
  public:
-  FMT_INLINE string_buffer() : buf_(str_) {}
+  inline string_buffer() : buf_(str_) {}
 
-  FMT_INLINE operator writer() { return buf_; }
-  FMT_INLINE std::string& str() { return str_; }
+  inline operator writer() { return buf_; }
+  inline std::string& str() { return str_; }
 };
 
 template <typename T, size_t SIZE, typename Allocator>
@@ -1416,10 +1417,10 @@ class utf8_to_utf16 {
 
  public:
   FMT_API explicit utf8_to_utf16(string_view s);
-  FMT_INLINE operator basic_string_view<wchar_t>() const { return {&buffer_[0], size()}; }
-  FMT_INLINE auto size() const -> size_t { return buffer_.size() - 1; }
-  FMT_INLINE auto c_str() const -> const wchar_t* { return &buffer_[0]; }
-  FMT_INLINE auto str() const -> std::wstring { return {&buffer_[0], size()}; }
+  inline operator basic_string_view<wchar_t>() const { return {&buffer_[0], size()}; }
+  inline auto size() const -> size_t { return buffer_.size() - 1; }
+  inline auto c_str() const -> const wchar_t* { return &buffer_[0]; }
+  inline auto str() const -> std::wstring { return {&buffer_[0], size()}; }
 };
 
 enum class to_utf8_error_policy { abort, replace };
@@ -3925,7 +3926,7 @@ class bytes {
   friend struct formatter<bytes>;
 
  public:
-  FMT_INLINE explicit bytes(string_view data) : data_(data) {}
+  inline explicit bytes(string_view data) : data_(data) {}
 };
 
 template <> struct formatter<bytes> {
@@ -4134,7 +4135,7 @@ class format_int {
   }
 
   /// Returns the content of the output buffer as an `std::string`.
-  FMT_INLINE auto str() const -> std::string { return {str_, size()}; }
+  inline auto str() const -> std::string { return {str_, size()}; }
 };
 
 #define FMT_STRING_IMPL(s, base)                                           \

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -375,13 +375,13 @@ class uint128_fallback {
       -> uint128_fallback {
     return {~n.hi_, ~n.lo_};
   }
-  friend auto operator+(const uint128_fallback& lhs,
-                        const uint128_fallback& rhs) -> uint128_fallback {
+  FMT_CONSTEXPR friend auto operator+(const uint128_fallback& lhs,
+                                      const uint128_fallback& rhs) -> uint128_fallback {
     auto result = uint128_fallback(lhs);
     result += rhs;
     return result;
   }
-  friend auto operator*(const uint128_fallback& lhs, uint32_t rhs)
+  FMT_CONSTEXPR friend auto operator*(const uint128_fallback& lhs, uint32_t rhs)
       -> uint128_fallback {
     FMT_ASSERT(lhs.hi_ == 0, "");
     uint64_t hi = (lhs.lo_ >> 32) * rhs;
@@ -389,7 +389,7 @@ class uint128_fallback {
     uint64_t new_lo = (hi << 32) + lo;
     return {(hi >> 32) + (new_lo < lo ? 1 : 0), new_lo};
   }
-  friend auto operator-(const uint128_fallback& lhs, uint64_t rhs)
+  FMT_CONSTEXPR friend auto operator-(const uint128_fallback& lhs, uint64_t rhs)
       -> uint128_fallback {
     return {lhs.hi_ - (lhs.lo_ < rhs ? 1 : 0), lhs.lo_ - rhs};
   }
@@ -963,8 +963,8 @@ class writer {
   FILE* file_;
 
  public:
-  writer(FILE* f) : buf_(nullptr), file_(f) {}
-  writer(detail::buffer<char>& buf) : buf_(&buf) {}
+  FMT_INLINE writer(FILE* f) : buf_(nullptr), file_(f) {}
+  FMT_INLINE writer(detail::buffer<char>& buf) : buf_(&buf) {}
 
   /// Formats `args` according to specifications in `fmt` and writes the
   /// output to the file.
@@ -982,10 +982,10 @@ class string_buffer {
   detail::container_buffer<std::string> buf_;
 
  public:
-  string_buffer() : buf_(str_) {}
+  FMT_INLINE string_buffer() : buf_(str_) {}
 
-  operator writer() { return buf_; }
-  std::string& str() { return str_; }
+  FMT_INLINE operator writer() { return buf_; }
+  FMT_INLINE std::string& str() { return str_; }
 };
 
 template <typename T, size_t SIZE, typename Allocator>
@@ -1421,10 +1421,10 @@ class utf8_to_utf16 {
 
  public:
   FMT_API explicit utf8_to_utf16(string_view s);
-  operator basic_string_view<wchar_t>() const { return {&buffer_[0], size()}; }
-  auto size() const -> size_t { return buffer_.size() - 1; }
-  auto c_str() const -> const wchar_t* { return &buffer_[0]; }
-  auto str() const -> std::wstring { return {&buffer_[0], size()}; }
+  FMT_INLINE operator basic_string_view<wchar_t>() const { return {&buffer_[0], size()}; }
+  FMT_INLINE auto size() const -> size_t { return buffer_.size() - 1; }
+  FMT_INLINE auto c_str() const -> const wchar_t* { return &buffer_[0]; }
+  FMT_INLINE auto str() const -> std::wstring { return {&buffer_[0], size()}; }
 };
 
 enum class to_utf8_error_policy { abort, replace };
@@ -3946,7 +3946,7 @@ class bytes {
   friend struct formatter<bytes>;
 
  public:
-  explicit bytes(string_view data) : data_(data) {}
+  FMT_INLINE explicit bytes(string_view data) : data_(data) {}
 };
 
 template <> struct formatter<bytes> {
@@ -4155,7 +4155,7 @@ class format_int {
   }
 
   /// Returns the content of the output buffer as an `std::string`.
-  auto str() const -> std::string { return {str_, size()}; }
+  FMT_CONSTEXPR20 auto str() const -> std::string { return {str_, size()}; }
 };
 
 #define FMT_STRING_IMPL(s, base)                                           \

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -176,24 +176,24 @@ class buffered_file {
 
   friend class file;
 
-  explicit buffered_file(FILE* f) : file_(f) {}
+  FMT_INLINE explicit buffered_file(FILE* f) : file_(f) {}
 
  public:
   buffered_file(const buffered_file&) = delete;
   void operator=(const buffered_file&) = delete;
 
   // Constructs a buffered_file object which doesn't represent any file.
-  buffered_file() noexcept : file_(nullptr) {}
+  FMT_INLINE buffered_file() noexcept : file_(nullptr) {}
 
   // Destroys the object closing the file it represents if any.
   FMT_API ~buffered_file() noexcept;
 
  public:
-  buffered_file(buffered_file&& other) noexcept : file_(other.file_) {
+  FMT_INLINE buffered_file(buffered_file&& other) noexcept : file_(other.file_) {
     other.file_ = nullptr;
   }
 
-  auto operator=(buffered_file&& other) -> buffered_file& {
+  FMT_INLINE auto operator=(buffered_file&& other) -> buffered_file& {
     close();
     file_ = other.file_;
     other.file_ = nullptr;
@@ -207,7 +207,7 @@ class buffered_file {
   FMT_API void close();
 
   // Returns the pointer to a FILE object representing this file.
-  auto get() const noexcept -> FILE* { return file_; }
+  FMT_INLINE auto get() const noexcept -> FILE* { return file_; }
 
   FMT_API auto descriptor() const -> int;
 
@@ -248,7 +248,7 @@ class FMT_API file {
   };
 
   // Constructs a file object which doesn't represent any file.
-  file() noexcept : fd_(-1) {}
+  FMT_INLINE file() noexcept : fd_(-1) {}
 
   // Opens a file and constructs a file object representing this file.
   file(cstring_view path, int oflag);
@@ -257,10 +257,10 @@ class FMT_API file {
   file(const file&) = delete;
   void operator=(const file&) = delete;
 
-  file(file&& other) noexcept : fd_(other.fd_) { other.fd_ = -1; }
+  FMT_INLINE file(file&& other) noexcept : fd_(other.fd_) { other.fd_ = -1; }
 
   // Move assignment is not noexcept because close may throw.
-  auto operator=(file&& other) -> file& {
+  FMT_INLINE auto operator=(file&& other) -> file& {
     close();
     fd_ = other.fd_;
     other.fd_ = -1;
@@ -271,7 +271,7 @@ class FMT_API file {
   ~file() noexcept;
 
   // Returns the file descriptor.
-  auto descriptor() const noexcept -> int { return fd_; }
+  FMT_INLINE auto descriptor() const noexcept -> int { return fd_; }
 
   // Closes the file.
   void close();
@@ -326,7 +326,7 @@ namespace detail {
 struct buffer_size {
   buffer_size() = default;
   size_t value = 0;
-  auto operator=(size_t val) const -> buffer_size {
+  FMT_CONSTEXPR auto operator=(size_t val) const -> buffer_size {
     auto bs = buffer_size();
     bs.value = val;
     return bs;
@@ -337,7 +337,7 @@ struct ostream_params {
   int oflag = file::WRONLY | file::CREATE | file::TRUNC;
   size_t buffer_size = BUFSIZ > 32768 ? BUFSIZ : 32768;
 
-  ostream_params() {}
+  FMT_CONSTEXPR ostream_params() {}
 
   template <typename... T>
   ostream_params(T... params, int new_oflag) : ostream_params(params...) {
@@ -381,7 +381,7 @@ class FMT_API ostream : private detail::buffer<char> {
     return buf;
   }
 
-  void flush() {
+  FMT_INLINE void flush() {
     if (size() == 0) return;
     file_.write(data(), size() * sizeof(data()[0]));
     clear();
@@ -390,7 +390,7 @@ class FMT_API ostream : private detail::buffer<char> {
   template <typename... T>
   friend auto output_file(cstring_view path, T... params) -> ostream;
 
-  void close() {
+  FMT_INLINE void close() {
     flush();
     file_.close();
   }

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -324,7 +324,7 @@ auto getpagesize() -> long;
 namespace detail {
 
 struct buffer_size {
-  buffer_size() = default;
+  FMT_CONSTEXPR buffer_size() = default;
   size_t value = 0;
   FMT_CONSTEXPR auto operator=(size_t val) const -> buffer_size {
     auto bs = buffer_size();

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -326,7 +326,7 @@ namespace detail {
 struct buffer_size {
   constexpr buffer_size() = default;
   size_t value = 0;
-  constexpr auto operator=(size_t val) const -> buffer_size {
+  FMT_CONSTEXPR auto operator=(size_t val) const -> buffer_size {
     auto bs = buffer_size();
     bs.value = val;
     return bs;

--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -176,24 +176,24 @@ class buffered_file {
 
   friend class file;
 
-  FMT_INLINE explicit buffered_file(FILE* f) : file_(f) {}
+  inline explicit buffered_file(FILE* f) : file_(f) {}
 
  public:
   buffered_file(const buffered_file&) = delete;
   void operator=(const buffered_file&) = delete;
 
   // Constructs a buffered_file object which doesn't represent any file.
-  FMT_INLINE buffered_file() noexcept : file_(nullptr) {}
+  inline buffered_file() noexcept : file_(nullptr) {}
 
   // Destroys the object closing the file it represents if any.
   FMT_API ~buffered_file() noexcept;
 
  public:
-  FMT_INLINE buffered_file(buffered_file&& other) noexcept : file_(other.file_) {
+  inline buffered_file(buffered_file&& other) noexcept : file_(other.file_) {
     other.file_ = nullptr;
   }
 
-  FMT_INLINE auto operator=(buffered_file&& other) -> buffered_file& {
+  inline auto operator=(buffered_file&& other) -> buffered_file& {
     close();
     file_ = other.file_;
     other.file_ = nullptr;
@@ -207,7 +207,7 @@ class buffered_file {
   FMT_API void close();
 
   // Returns the pointer to a FILE object representing this file.
-  FMT_INLINE auto get() const noexcept -> FILE* { return file_; }
+  inline auto get() const noexcept -> FILE* { return file_; }
 
   FMT_API auto descriptor() const -> int;
 
@@ -248,7 +248,7 @@ class FMT_API file {
   };
 
   // Constructs a file object which doesn't represent any file.
-  FMT_INLINE file() noexcept : fd_(-1) {}
+  inline file() noexcept : fd_(-1) {}
 
   // Opens a file and constructs a file object representing this file.
   file(cstring_view path, int oflag);
@@ -257,10 +257,10 @@ class FMT_API file {
   file(const file&) = delete;
   void operator=(const file&) = delete;
 
-  FMT_INLINE file(file&& other) noexcept : fd_(other.fd_) { other.fd_ = -1; }
+  inline file(file&& other) noexcept : fd_(other.fd_) { other.fd_ = -1; }
 
   // Move assignment is not noexcept because close may throw.
-  FMT_INLINE auto operator=(file&& other) -> file& {
+  inline auto operator=(file&& other) -> file& {
     close();
     fd_ = other.fd_;
     other.fd_ = -1;
@@ -271,7 +271,7 @@ class FMT_API file {
   ~file() noexcept;
 
   // Returns the file descriptor.
-  FMT_INLINE auto descriptor() const noexcept -> int { return fd_; }
+  inline auto descriptor() const noexcept -> int { return fd_; }
 
   // Closes the file.
   void close();
@@ -324,9 +324,9 @@ auto getpagesize() -> long;
 namespace detail {
 
 struct buffer_size {
-  FMT_CONSTEXPR buffer_size() = default;
+  constexpr buffer_size() = default;
   size_t value = 0;
-  FMT_CONSTEXPR auto operator=(size_t val) const -> buffer_size {
+  constexpr auto operator=(size_t val) const -> buffer_size {
     auto bs = buffer_size();
     bs.value = val;
     return bs;
@@ -337,7 +337,7 @@ struct ostream_params {
   int oflag = file::WRONLY | file::CREATE | file::TRUNC;
   size_t buffer_size = BUFSIZ > 32768 ? BUFSIZ : 32768;
 
-  FMT_CONSTEXPR ostream_params() {}
+  constexpr ostream_params() {}
 
   template <typename... T>
   ostream_params(T... params, int new_oflag) : ostream_params(params...) {
@@ -381,7 +381,7 @@ class FMT_API ostream : private detail::buffer<char> {
     return buf;
   }
 
-  FMT_INLINE void flush() {
+  inline void flush() {
     if (size() == 0) return;
     file_.write(data(), size() * sizeof(data()[0]));
     clear();
@@ -390,7 +390,7 @@ class FMT_API ostream : private detail::buffer<char> {
   template <typename... T>
   friend auto output_file(cstring_view path, T... params) -> ostream;
 
-  FMT_INLINE void close() {
+  inline void close() {
     flush();
     file_.close();
   }

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -79,7 +79,7 @@ template <bool IsSigned> struct int_checker {
     unsigned max = to_unsigned(max_value<int>());
     return value <= max;
   }
-  FMT_INLINE static auto fits_in_int(bool) -> bool { return true; }
+  inline static auto fits_in_int(bool) -> bool { return true; }
 };
 
 template <> struct int_checker<true> {
@@ -87,7 +87,7 @@ template <> struct int_checker<true> {
     return value >= (std::numeric_limits<int>::min)() &&
            value <= max_value<int>();
   }
-  FMT_INLINE static auto fits_in_int(int) -> bool { return true; }
+  inline static auto fits_in_int(int) -> bool { return true; }
 };
 
 struct printf_precision_handler {
@@ -205,7 +205,7 @@ class printf_width_handler {
   format_specs& specs_;
 
  public:
-  FMT_INLINE explicit printf_width_handler(format_specs& specs) : specs_(specs) {}
+  inline explicit printf_width_handler(format_specs& specs) : specs_(specs) {}
 
   template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
   auto operator()(T value) -> unsigned {

--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -79,7 +79,7 @@ template <bool IsSigned> struct int_checker {
     unsigned max = to_unsigned(max_value<int>());
     return value <= max;
   }
-  static auto fits_in_int(bool) -> bool { return true; }
+  FMT_INLINE static auto fits_in_int(bool) -> bool { return true; }
 };
 
 template <> struct int_checker<true> {
@@ -87,7 +87,7 @@ template <> struct int_checker<true> {
     return value >= (std::numeric_limits<int>::min)() &&
            value <= max_value<int>();
   }
-  static auto fits_in_int(int) -> bool { return true; }
+  FMT_INLINE static auto fits_in_int(int) -> bool { return true; }
 };
 
 struct printf_precision_handler {
@@ -212,7 +212,7 @@ class printf_width_handler {
   format_specs& specs_;
 
  public:
-  explicit printf_width_handler(format_specs& specs) : specs_(specs) {}
+  FMT_INLINE explicit printf_width_handler(format_specs& specs) : specs_(specs) {}
 
   template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
   auto operator()(T value) -> unsigned {


### PR DESCRIPTION
Following on from #4153:

- In regards to `constexpr`, this was indeed a Clang bug, and anything already marked `constexpr` should be a non-issue; the problem has been fixed on Clang trunk with potential for it to be backported to the 19.x release.
- A number of other linker errors specific to mixing `#include` with `import` were also being caused by a related Clang bug, also now fixed on trunk.
- Despite this, a bunch of linker errors still remained when trying to consume the `fmt` module via a shared library build, due to the last bullet point in the linked issue.

This PR addresses those remaining issues by adding `FMT_INLINE`/`FMT_CONSTEXPR` to some member functions defined within the class definition. However, due to the nature of linker issues, problematic cases are only being picked up where a symbol is actually being used from an external dll/exe. Currently, the coverage for that is limited - `fmt`'s own CI is not yet running modules builds I think (or anyway not with `FMT_SHARED`); the `build2` `fmt` package CI also cannot stress test this as the very latest Clang is not available. Furthermore, I've so far only enabled a subset of the tests in the `build2` package.

Fundamentally, I think this addition of `inline` or `constexpr` is essentially needed on every single in-class defined member function which is intended for public use (or alternatively `FMT_API` on the member/class), which is probably a lot more than what I've addressed in these commits and would be quite intrusive. So of course feel free to merge if you like, but it's possible some more thought is warranted in regards to
- is every public member function in the headers actually intended to be usable directly by clients (this question of course also relates to what should be `export`ed from the module, but for `export`, doing things in bulk is possible and less intrusive in terms of code changes)
- is there a preference for exposing those that should be exposed as `inline` vs `FMT_API`