### PR TITLE
Fix conversion warning on chrono.h

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1281,7 +1281,7 @@ class tm_writer {
     std::time_t gt = std::mktime(&gtm);
     std::tm ltm = gmtime(gt);
     std::time_t lt = std::mktime(&ltm);
-    long offset = gt - lt;
+    long offset = static_cast<long>(gt - lt);
     write_utc_offset(offset, ns);
 #endif
   }

--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1244,7 +1244,7 @@ class tm_writer {
     write_year_extended(year, pad);
   }
 
-  void write_utc_offset(long offset, numeric_system ns) {
+  void write_utc_offset(long long offset, numeric_system ns) {
     if (offset < 0) {
       *out_++ = '-';
       offset = -offset;
@@ -1281,7 +1281,7 @@ class tm_writer {
     std::time_t gt = std::mktime(&gtm);
     std::tm ltm = gmtime(gt);
     std::time_t lt = std::mktime(&ltm);
-    long offset = static_cast<long>(gt - lt);
+    long long offset = gt - lt;
     write_utc_offset(offset, ns);
 #endif
   }


### PR DESCRIPTION
Casting from 'long long int' into 'long int' to remove the warning from -Wconversion as the method write_utc_offset accepts a long, and the offset should be in the range of a long variable.  

