### PR TITLE
Require clang >=15 for _BitInt support

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -394,7 +394,7 @@ inline auto map(uint128_opt) -> monostate { return {}; }
 #endif
 
 #ifndef FMT_USE_BITINT
-#  define FMT_USE_BITINT (FMT_CLANG_VERSION >= 1400)
+#  define FMT_USE_BITINT (FMT_CLANG_VERSION >= 1500)
 #endif
 
 #if FMT_USE_BITINT


### PR DESCRIPTION
For appleclang, fixes issue #4173

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
