### PR TITLE
Conform `std::iterator_traits<fmt::appender>` to [iterator.traits]/1

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2382,11 +2382,6 @@ template <typename T> class basic_appender {
   detail::buffer<T>* container;
 
  public:
-  using iterator_category = int;
-  using value_type = T;
-  using pointer = T*;
-  using reference = T&;
-  using difference_type = decltype(pointer() - pointer());
   using container_type = detail::buffer<T>;
 
   FMT_CONSTEXPR basic_appender(detail::buffer<T>& buf) : container(&buf) {}

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -727,7 +727,8 @@ class basic_specs {
   char fill_data_[max_fill_size] = {' '};
 
   FMT_CONSTEXPR void set_fill_size(size_t size) {
-    data_ = (data_ & ~fill_size_mask) | (size << fill_size_shift);
+    data_ &= ~fill_size_mask;
+    data_ |= static_cast<unsigned long>(size << fill_size_shift);
   }
 
  public:

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -727,8 +727,7 @@ class basic_specs {
   char fill_data_[max_fill_size] = {' '};
 
   FMT_CONSTEXPR void set_fill_size(size_t size) {
-    data_ &= ~fill_size_mask;
-    data_ |= static_cast<unsigned long>(size << fill_size_shift);
+    data_ = (data_ & ~fill_size_mask) | (size << fill_size_shift);
   }
 
  public:

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -122,7 +122,8 @@ namespace std {
 template <class T> struct iterator_traits<fmt::basic_appender<T>> {
   using iterator_category = output_iterator_tag;
   using value_type = T;
-  using difference_type = decltype(static_cast<int*>(nullptr) - static_cast<int*>(nullptr));
+  using difference_type =
+      decltype(static_cast<int*>(nullptr) - static_cast<int*>(nullptr));
   using pointer = void;
   using reference = void;
 };

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -122,7 +122,7 @@ namespace std {
 template <class T> struct iterator_traits<fmt::basic_appender<T>> {
   using iterator_category = output_iterator_tag;
   using value_type = T;
-  using difference_type = void;
+  using difference_type = decltype(static_cast<int*>(nullptr) - static_cast<int*>(nullptr));
   using pointer = void;
   using reference = void;
 };

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -119,11 +119,12 @@
 #endif
 
 namespace std {
-template <> struct iterator_traits<fmt::appender> {
+template <class T> struct iterator_traits<fmt::basic_appender<T>> {
   using iterator_category = output_iterator_tag;
-  using value_type = char;
-  using reference = char&;
-  using difference_type = fmt::appender::difference_type;
+  using value_type = T;
+  using difference_type = void;
+  using pointer = void;
+  using reference = void;
 };
 }  // namespace std
 


### PR DESCRIPTION
> In addition, the types
> ```c++
> iterator_traits<I>::pointer
> iterator_traits<I>::reference
> ```
> shall be defined as the iterator’s pointer and reference types; that is, for an iterator object `a` of class type, the same type as `decltype(a.operator->())` and `decltype(*a)`, respectively. The type `iterator_traits<I>::pointer` shall be void for an iterator of class type `I` that does not support `operator->`. Additionally, in the case of an output iterator, the types
> ```c++
> iterator_traits<I>::value_type
> iterator_traits<I>::difference_type
> iterator_traits<I>::reference
> ```
> may be defined as `void`.

Also removes the unnecessary member types from `basic_appender`.
