### PR TITLE
Fix -Wmissing-noreturn warning

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -444,7 +444,7 @@ struct is_same_arithmetic_type
                                          std::is_floating_point<Rep2>::value)> {
 };
 
-inline void throw_duration_error() {
+FMT_NORETURN inline void throw_duration_error() {
   FMT_THROW(format_error("cannot format duration"));
 }
 


### PR DESCRIPTION
Fixes warning reported by top of trunk Clang:

```
include/fmt/chrono.h:447:36: error: function 'throw_duration_error' could be declared with attribute 'noreturn' [-Werror,-Wmissing-noreturn]
```

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
