### PR TITLE
Fix error: cannot use 'try' with exceptions disabled in Win LLVM Clang

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -146,6 +146,8 @@
 // Use the provided definition.
 #elif defined(__GNUC__) && !defined(__EXCEPTIONS)
 #  define FMT_USE_EXCEPTIONS 0
+#elif defined(__clang__) && !defined(__cpp_exceptions)
+#  define FMT_USE_EXCEPTIONS 0
 #elif FMT_MSC_VERSION && !_HAS_EXCEPTIONS
 #  define FMT_USE_EXCEPTIONS 0
 #else


### PR DESCRIPTION
Fixes #4207.

LLVM Clang on Windows does not define `__GNUC__`. The preprocessor falls to `#elif FMT_MSC_VERSION && !_HAS_EXCEPTIONS` with `_HAS_EXCEPTIONS 1` defined in vcruntime.h:104.
