### PR TITLE
gcc: fix -Wnvro warning

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1718,8 +1718,9 @@ auto find_escape(const Char* begin, const Char* end)
 
 inline auto find_escape(const char* begin, const char* end)
     -> find_escape_result<char> {
-  if (const_check(!use_utf8)) return find_escape<char>(begin, end);
-  auto result = find_escape_result<char>{end, nullptr, 0};
+  auto result = find_escape<char>(begin, end);
+  if (const_check(!use_utf8)) return result;
+  result = find_escape_result<char>{end, nullptr, 0};
   for_each_codepoint(string_view(begin, to_unsigned(end - begin)),
                      [&](uint32_t cp, string_view sv) {
                        if (needs_escape(cp)) {


### PR DESCRIPTION
Allows the copiler to elide the copy.