### PR TITLE
Include <filesystem> only if FMT_CPP_LIB_FILESYSTEM is set

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -27,9 +27,6 @@
 
 // Check FMT_CPLUSPLUS to suppress a bogus warning in MSVC.
 #  if FMT_CPLUSPLUS >= 201703L
-#    if FMT_HAS_INCLUDE(<filesystem>)
-#      include <filesystem>
-#    endif
 #    if FMT_HAS_INCLUDE(<variant>)
 #      include <variant>
 #    endif
@@ -79,6 +76,7 @@
 #endif
 
 #if FMT_CPP_LIB_FILESYSTEM
+#  include <filesystem>
 FMT_BEGIN_NAMESPACE
 
 namespace detail {


### PR DESCRIPTION
This change results out of necessity since the Nintendo Switch console SDK does not support `std::filesystem`. The SDK still provides the `<filesystem>` header, but with an `#error` directive, effectively breaking any build that includes `<filesystem>`

Because `<filesystem>` is present, `FMT_HAS_INCLUDE` is insufficient here. With this change and `FMT_CPP_LIB_FILESYSTEM` in place, one can define `FMT_CPP_LIB_FILESYSTEM=0` to work around this issue.

This assumes that `<filesystem>` can be included (without warnings) if `FMT_CPP_LIB_FILESYSTEM` is set. If this is not the case, fmt would be broken even before this change as `std::filesystem::path` is used without the accompanying header.

---

I've tested this locally using:
- MSVC Version 19.42.34435 (Win10)
- GCC 12.2.0 (WSL)
- Clang 15.0.6 (WSL)
- Clang Nintendo version 1.16.4 (Clang 16.0.6)