### PR TITLE
Use the _MSVC_STL_UPDATE macro to detect STL

### DIFF
--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -35,7 +35,7 @@ class file_access {
   friend auto get_file(BufType& obj) -> FILE* { return obj.*FileMemberPtr; }
 };
 
-#if FMT_MSC_VERSION
+#if _MSVC_STL_UPDATE
 template class file_access<file_access_tag, std::filebuf,
                            &std::filebuf::_Myfile>;
 auto get_file(std::filebuf&) -> FILE*;
@@ -109,7 +109,7 @@ inline void vprint(std::ostream& os, string_view fmt, format_args args) {
   auto buffer = memory_buffer();
   detail::vformat_to(buffer, fmt, args);
   FILE* f = nullptr;
-#if FMT_MSC_VERSION && FMT_USE_RTTI
+#if _MSVC_STL_UPDATE && FMT_USE_RTTI
   if (auto* buf = dynamic_cast<std::filebuf*>(os.rdbuf()))
     f = detail::get_file(*buf);
 #elif defined(_WIN32) && defined(__GLIBCXX__) && FMT_USE_RTTI

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -35,7 +35,7 @@ class file_access {
   friend auto get_file(BufType& obj) -> FILE* { return obj.*FileMemberPtr; }
 };
 
-#if _MSVC_STL_UPDATE
+#ifdef _MSVC_STL_UPDATE
 template class file_access<file_access_tag, std::filebuf,
                            &std::filebuf::_Myfile>;
 auto get_file(std::filebuf&) -> FILE*;
@@ -109,7 +109,7 @@ inline void vprint(std::ostream& os, string_view fmt, format_args args) {
   auto buffer = memory_buffer();
   detail::vformat_to(buffer, fmt, args);
   FILE* f = nullptr;
-#if _MSVC_STL_UPDATE && FMT_USE_RTTI
+#if defined(_MSVC_STL_UPDATE) && FMT_USE_RTTI
   if (auto* buf = dynamic_cast<std::filebuf*>(os.rdbuf()))
     f = detail::get_file(*buf);
 #elif defined(_WIN32) && defined(__GLIBCXX__) && FMT_USE_RTTI


### PR DESCRIPTION
The current code's method of detecting the C++ standard library as STL is inaccurate, which will reject libc++ on Windows. The [_MSVC_STL_UPDATE](https://github.com/microsoft/STL/wiki/Macro-_MSVC_STL_UPDATE) macro is the documented way. fmt currently [requires Visual Studio 19.0](https://fmt.dev/11.0/), and this macro has existed [since Visual Studio 15.5](https://github.com/microsoft/STL/wiki/Macro-_MSVC_STL_UPDATE), so there are no compatibility issues.