### PR TITLE
Allow getting size of dynamic format arg store

### DIFF
--- a/include/fmt/args.h
+++ b/include/fmt/args.h
@@ -210,6 +210,9 @@ template <typename Context> class dynamic_format_arg_store {
     data_.reserve(new_cap);
     named_info_.reserve(new_cap_named);
   }
+
+  /// Returns the number of elements in the store.
+  size_t size() const noexcept { return data_.size(); }
 };
 
 FMT_END_NAMESPACE

--- a/test/args-test.cc
+++ b/test/args-test.cc
@@ -186,3 +186,17 @@ TEST(args_test, move_constructor) {
   store.reset();
   EXPECT_EQ(fmt::vformat("{} {} {a1}", moved_store), "42 foo foo");
 }
+
+TEST(args_test, size) {
+  fmt::dynamic_format_arg_store<fmt::format_context> store;
+  EXPECT_EQ(store.size(), 0);
+
+  store.push_back(42);
+  EXPECT_EQ(store.size(), 1);
+
+  store.push_back("Molybdenum");
+  EXPECT_EQ(store.size(), 2);
+
+  store.clear();
+  EXPECT_EQ(store.size(), 0);
+}


### PR DESCRIPTION
Getting the size of the dynamic format arg store is useful if you use that class to dynamically pass around sets of format arguments and want to perform additional verification.

In my case, I am using it to check whether a message, that I'm applying the format args to, has the correct amount of placeholders and currently I have to track the arg count separately, even though that information is already present in the `fmt::dynamic_format_arg_store`.