### PR TITLE
Fix compatibility with older versions of VS

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -63,13 +63,6 @@
 #else
 #  define FMT_LIBCPP_VERSION 0
 #endif
-#ifdef _MSVC_STL_UPDATE
-#  define FMT_MSVC_STL_UPDATE _MSVC_STL_UPDATE
-#elif defined(_MSC_VER) && _MSC_VER < 1912  // VS 15.5
-#  define FMT_MSVC_STL_UPDATE _MSVC_LANG
-#else
-#  define FMT_MSVC_STL_UPDATE 0
-#endif
 
 // Detect __has_*.
 #ifdef __has_feature

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -65,10 +65,10 @@
 #endif
 #ifdef _MSVC_STL_UPDATE
 #  define FMT_MSVC_STL_UPDATE _MSVC_STL_UPDATE
-#elif defined(_MSC_VER) && _MSC_VER < 1912 // VS 15.5
-#    define FMT_MSVC_STL_UPDATE _MSVC_LANG
+#elif defined(_MSC_VER) && _MSC_VER < 1912  // VS 15.5
+#  define FMT_MSVC_STL_UPDATE _MSVC_LANG
 #else
-#    define FMT_MSVC_STL_UPDATE 0
+#  define FMT_MSVC_STL_UPDATE 0
 #endif
 
 // Detect __has_*.

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -46,6 +46,11 @@
 #else
 #  define FMT_MSC_VERSION 0
 #endif
+#ifdef _MSVC_LANG
+#  define FMT_CPLUSPLUS _MSVC_LANG
+#else
+#  define FMT_CPLUSPLUS __cplusplus
+#endif
 
 // Detect standard library versions.
 #ifdef _GLIBCXX_RELEASE
@@ -58,11 +63,12 @@
 #else
 #  define FMT_LIBCPP_VERSION 0
 #endif
-
-#ifdef _MSVC_LANG
-#  define FMT_CPLUSPLUS _MSVC_LANG
+#ifdef _MSVC_STL_UPDATE
+#  define FMT_MSVC_STL_UPDATE _MSVC_STL_UPDATE
+#elif defined(_MSC_VER) && _MSC_VER < 1912 // VS 15.5
+#    define FMT_MSVC_STL_UPDATE _MSVC_LANG
 #else
-#  define FMT_CPLUSPLUS __cplusplus
+#    define FMT_MSVC_STL_UPDATE 0
 #endif
 
 // Detect __has_*.

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -46,11 +46,6 @@
 #else
 #  define FMT_MSC_VERSION 0
 #endif
-#ifdef _MSVC_LANG
-#  define FMT_CPLUSPLUS _MSVC_LANG
-#else
-#  define FMT_CPLUSPLUS __cplusplus
-#endif
 
 // Detect standard library versions.
 #ifdef _GLIBCXX_RELEASE
@@ -62,6 +57,12 @@
 #  define FMT_LIBCPP_VERSION _LIBCPP_VERSION
 #else
 #  define FMT_LIBCPP_VERSION 0
+#endif
+
+#ifdef _MSVC_LANG
+#  define FMT_CPLUSPLUS _MSVC_LANG
+#else
+#  define FMT_CPLUSPLUS __cplusplus
 #endif
 
 // Detect __has_*.

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -35,7 +35,7 @@ class file_access {
   friend auto get_file(BufType& obj) -> FILE* { return obj.*FileMemberPtr; }
 };
 
-#ifdef _MSVC_STL_UPDATE
+#if FMT_MSVC_STL_UPDATE
 template class file_access<file_access_tag, std::filebuf,
                            &std::filebuf::_Myfile>;
 auto get_file(std::filebuf&) -> FILE*;
@@ -109,7 +109,7 @@ inline void vprint(std::ostream& os, string_view fmt, format_args args) {
   auto buffer = memory_buffer();
   detail::vformat_to(buffer, fmt, args);
   FILE* f = nullptr;
-#if defined(_MSVC_STL_UPDATE) && FMT_USE_RTTI
+#if FMT_MSVC_STL_UPDATE && FMT_USE_RTTI
   if (auto* buf = dynamic_cast<std::filebuf*>(os.rdbuf()))
     f = detail::get_file(*buf);
 #elif defined(_WIN32) && defined(__GLIBCXX__) && FMT_USE_RTTI

--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -22,6 +22,14 @@
 
 #include "chrono.h"  // formatbuf
 
+#ifdef _MSVC_STL_UPDATE
+#  define FMT_MSVC_STL_UPDATE _MSVC_STL_UPDATE
+#elif defined(_MSC_VER) && _MSC_VER < 1912  // VS 15.5
+#  define FMT_MSVC_STL_UPDATE _MSVC_LANG
+#else
+#  define FMT_MSVC_STL_UPDATE 0
+#endif
+
 FMT_BEGIN_NAMESPACE
 namespace detail {
 


### PR DESCRIPTION
In the previous PR, I mentioned that there were no compatibility issues, but I was wrong. I confused the versions of VS and MSVC. _MSVC_STL_UPDATE appeared later than the VS version that fmt promised to support. This PR will fix this issue.