### PR TITLE
update docs for meson

### DIFF
--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -202,7 +202,7 @@ For a static build, use the following subproject definition:
 
 For the header-only version, use:
 
-    fmt = subproject('fmt', default_options: ['-Dheader-only=true'])
+    fmt = subproject('fmt', default_options: ['header-only=true'])
     fmt_dep = fmt.get_variable('fmt_header_only_dep')
 
 ### Android NDK

--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -202,7 +202,7 @@ For a static build, use the following subproject definition:
 
 For the header-only version, use:
 
-    fmt = subproject('fmt')
+    fmt = subproject('fmt', default_options: ['-Dheader-only=true'])
     fmt_dep = fmt.get_variable('fmt_header_only_dep')
 
 ### Android NDK


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

current wrap for meson is not truly header only, a new option is added to disable building of libfmt when it's expected to be header-only.

https://github.com/mesonbuild/wrapdb/pull/1811

（and I find it's actually more easy to just use submodules instead of meson wrap for header only fmy...)