### PR TITLE
Address MSVC C4127 warning when formatting non unicode `tm`

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -364,7 +364,7 @@ void write_codecvt(codecvt_result<CodeUnit>& out, string_view in,
 template <typename OutputIt>
 auto write_encoded_tm_str(OutputIt out, string_view in, const std::locale& loc)
     -> OutputIt {
-  if (detail::use_utf8 && loc != get_classic_locale()) {
+  if (const_check(detail::use_utf8) && loc != get_classic_locale()) {
     // char16_t and char32_t codecvts are broken in MSVC (linkage errors) and
     // gcc-4.
 #if FMT_MSC_VERSION != 0 ||  \


### PR DESCRIPTION
Use `const_check` to silence visual studio's W4 level diagnostic regarding conditional expressions being constants, addresses https://github.com/fmtlib/fmt/issues/4294

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
