### PR TITLE
Add parameter to the fallback to_sys function

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -261,7 +261,8 @@ namespace detail {
 using utc_clock = std::chrono::utc_clock;
 #else
 struct utc_clock {
-  void to_sys();
+  template <typename T>
+  void to_sys(T);
 };
 #endif
 


### PR DESCRIPTION
Add parameter to the fallback to_sys function. Fixes issue #4297.