### PR TITLE
Add args() accessor back to fmt::format_context

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2656,6 +2656,7 @@ class context {
   FMT_CONSTEXPR auto arg_id(string_view name) const -> int {
     return args_.get_id(name);
   }
+  auto args() const -> const format_args& { return args_; }
 
   // Returns an iterator to the beginning of the output range.
   FMT_CONSTEXPR auto out() const -> iterator { return out_; }

--- a/test/base-test.cc
+++ b/test/base-test.cc
@@ -875,3 +875,12 @@ TEST(base_test, no_repeated_format_string_conversions) {
   fmt::format_to(buf, nondeterministic_format_string());
 #endif
 }
+
+TEST(base_test, format_context_accessors) {
+  class copier {
+    static fmt::format_context copy(fmt::appender app,
+                                    const fmt::format_context& ctx) {
+      return fmt::format_context(std::move(app), ctx.args(), ctx.locale());
+    }
+  };
+}

--- a/test/compile-error-test/CMakeLists.txt
+++ b/test/compile-error-test/CMakeLists.txt
@@ -211,5 +211,12 @@ if (CMAKE_CXX_STANDARD GREATER_EQUAL 20)
   " ERROR)
 endif ()
 
+# Copying a format_context
+expect_compile(format-context-accessors "
+  auto copy_context = [](fmt::appender app, const fmt::format_context& ctx)
+    -> fmt::format_context
+  { return fmt::format_context(std::move(app), ctx.args(), ctx.locale()); };
+")
+
 # Run all tests
 run_tests()

--- a/test/compile-error-test/CMakeLists.txt
+++ b/test/compile-error-test/CMakeLists.txt
@@ -211,12 +211,5 @@ if (CMAKE_CXX_STANDARD GREATER_EQUAL 20)
   " ERROR)
 endif ()
 
-# Copying a format_context
-expect_compile(format-context-accessors "
-  auto copy_context = [](fmt::appender app, const fmt::format_context& ctx)
-    -> fmt::format_context
-  { return fmt::format_context(std::move(app), ctx.args(), ctx.locale()); };
-")
-
 # Run all tests
 run_tests()


### PR DESCRIPTION
Fix #4307 

- Add `args() const` accessor back to `fmt::format_context`
- Add test that would fail to compile if you can't create a `fmt::format_context` from another `fmt::format_context` using `args() const` and `locale() const`
