### PR TITLE
Fix formatting into std::ostreambuf_iterator using a compiled format

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1203,7 +1203,7 @@ FMT_CONSTEXPR FMT_INLINE auto format_decimal(Char* out, UInt value,
 }
 
 template <typename Char, typename UInt, typename OutputIt,
-          FMT_ENABLE_IF(is_back_insert_iterator<OutputIt>::value)>
+          FMT_ENABLE_IF(!std::is_pointer<remove_cvref_t<OutputIt>>::value)>
 FMT_CONSTEXPR auto format_decimal(OutputIt out, UInt value, int num_digits)
     -> OutputIt {
   if (auto ptr = to_pointer<Char>(out, to_unsigned(num_digits))) {

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -7,6 +7,8 @@
 
 #include "fmt/compile.h"
 
+#include <iterator>
+#include <list>
 #include <type_traits>
 #include <vector>
 
@@ -197,6 +199,21 @@ TEST(compile_test, format_to_n) {
   res = fmt::format_to_n(buffer, buffer_size, FMT_COMPILE("{:x}"), 42);
   *res.out = '\0';
   EXPECT_STREQ("2a", buffer);
+}
+
+TEST(compile_test, output_iterators) {
+  std::list<char> out;
+  fmt::format_to(std::back_inserter(out), FMT_COMPILE("{}"), 42);
+  EXPECT_EQ("42", std::string(out.begin(), out.end()));
+
+  std::stringstream s;
+  fmt::format_to(std::ostream_iterator<char>(s), FMT_COMPILE("{}"), 42);
+  EXPECT_EQ("42", s.str());
+
+  std::stringstream s2;
+  fmt::format_to(std::ostreambuf_iterator<char>(s2), FMT_COMPILE("{}.{:06d}"),
+                 42, 43);
+  EXPECT_EQ("42.000043", s2.str());
 }
 
 #  if FMT_USE_CONSTEVAL && (!FMT_MSC_VERSION || FMT_MSC_VERSION >= 1940)

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2102,6 +2102,10 @@ TEST(format_test, output_iterators) {
   std::stringstream s;
   fmt::format_to(std::ostream_iterator<char>(s), "{}", 42);
   EXPECT_EQ("42", s.str());
+
+  std::stringstream s2;
+  fmt::format_to(std::ostreambuf_iterator<char>(s2), "{}.{:06d}", 42, 43);
+  EXPECT_EQ("42.000043", s2.str());
 }
 
 TEST(format_test, fill_via_appender) {


### PR DESCRIPTION
We need tests for format and for compile time format because it's usage different code path.

Bug was introduced in commit: https://github.com/fmtlib/fmt/commit/f6b4a23b83b36946072398bd04b7c7810df2d213#diff-bdc6f79e8e9f5b4331d66fb785636a87d29f55cf729865e13925b4209424c878
