### PR TITLE
Silence a constexpr warning when compiling with MSVC and /W4

### DIFF
--- a/include/fmt/ostream.h
+++ b/include/fmt/ostream.h
@@ -150,7 +150,7 @@ inline void vprint(std::ostream& os, string_view fmt, format_args args) {
 FMT_EXPORT template <typename... T>
 void print(std::ostream& os, format_string<T...> fmt, T&&... args) {
   fmt::vargs<T...> vargs = {{args...}};
-  if (detail::use_utf8) return vprint(os, fmt.str, vargs);
+  if (detail::const_check(detail::use_utf8)) return vprint(os, fmt.str, vargs);
   auto buffer = memory_buffer();
   detail::vformat_to(buffer, fmt.str, vargs);
   detail::write_buffer(os, buffer);


### PR DESCRIPTION
Fixes #4314