### PR TITLE
Fix error of unitialized variable FMT_HEADERS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,7 @@ function(add_headers VAR)
 endfunction()
 
 # Define the fmt library, its includes and the needed defines.
+set(FMT_HEADERS) # to fix warning of uninitialized
 add_headers(FMT_HEADERS args.h base.h chrono.h color.h compile.h core.h format.h
                         format-inl.h os.h ostream.h printf.h ranges.h std.h
                         xchar.h)


### PR DESCRIPTION
This happen when using e.g. pedantic mode in cmake-init.

> -- Build type: Coverage
> CMake Error (dev) at build/ci-coverage/_deps/fmt-src/CMakeLists.txt:290 (set):
>   uninitialized variable 'FMT_HEADERS'
> Call Stack (most recent call first):
>   build/ci-coverage/_deps/fmt-src/CMakeLists.txt:298 (add_headers)
> This error is for project developers. Use -Wno-error=dev to suppress it.