### PR TITLE
Move `is_compiled_string` to public API

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -19,10 +19,10 @@ FMT_BEGIN_NAMESPACE
 // A compile-time string which is compiled into fast formatting code.
 FMT_EXPORT class compiled_string {};
 
-namespace detail {
-
 template <typename S>
 struct is_compiled_string : std::is_base_of<compiled_string, S> {};
+
+namespace detail {
 
 /**
  * Converts a string literal `s` into a format string that will be parsed at
@@ -425,7 +425,7 @@ constexpr auto compile_format_string(S fmt) {
 }
 
 template <typename... Args, typename S,
-          FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
+          FMT_ENABLE_IF(is_compiled_string<S>::value)>
 constexpr auto compile(S fmt) {
   constexpr auto str = basic_string_view<typename S::char_type>(fmt);
   if constexpr (str.size() == 0) {
@@ -461,7 +461,7 @@ constexpr FMT_INLINE OutputIt format_to(OutputIt out, const CompiledFormat& cf,
 }
 
 template <typename S, typename... Args,
-          FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
+          FMT_ENABLE_IF(is_compiled_string<S>::value)>
 FMT_INLINE std::basic_string<typename S::char_type> format(const S&,
                                                            Args&&... args) {
   if constexpr (std::is_same<typename S::char_type, char>::value) {
@@ -488,7 +488,7 @@ FMT_INLINE std::basic_string<typename S::char_type> format(const S&,
 }
 
 template <typename OutputIt, typename S, typename... Args,
-          FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
+          FMT_ENABLE_IF(is_compiled_string<S>::value)>
 FMT_CONSTEXPR OutputIt format_to(OutputIt out, const S&, Args&&... args) {
   constexpr auto compiled = detail::compile<Args...>(S());
   if constexpr (std::is_same<remove_cvref_t<decltype(compiled)>,
@@ -503,7 +503,7 @@ FMT_CONSTEXPR OutputIt format_to(OutputIt out, const S&, Args&&... args) {
 #endif
 
 template <typename OutputIt, typename S, typename... Args,
-          FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
+          FMT_ENABLE_IF(is_compiled_string<S>::value)>
 auto format_to_n(OutputIt out, size_t n, const S& fmt, Args&&... args)
     -> format_to_n_result<OutputIt> {
   using traits = detail::fixed_buffer_traits;
@@ -513,7 +513,7 @@ auto format_to_n(OutputIt out, size_t n, const S& fmt, Args&&... args)
 }
 
 template <typename S, typename... Args,
-          FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
+          FMT_ENABLE_IF(is_compiled_string<S>::value)>
 FMT_CONSTEXPR20 auto formatted_size(const S& fmt, const Args&... args)
     -> size_t {
   auto buf = detail::counting_buffer<>();
@@ -522,7 +522,7 @@ FMT_CONSTEXPR20 auto formatted_size(const S& fmt, const Args&... args)
 }
 
 template <typename S, typename... Args,
-          FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
+          FMT_ENABLE_IF(is_compiled_string<S>::value)>
 void print(std::FILE* f, const S& fmt, const Args&... args) {
   auto buf = memory_buffer();
   fmt::format_to(appender(buf), fmt, args...);
@@ -530,7 +530,7 @@ void print(std::FILE* f, const S& fmt, const Args&... args) {
 }
 
 template <typename S, typename... Args,
-          FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
+          FMT_ENABLE_IF(is_compiled_string<S>::value)>
 void print(const S& fmt, const Args&... args) {
   print(stdout, fmt, args...);
 }

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -316,6 +316,18 @@ TEST(compile_test, compile_format_string_literal) {
 }
 #endif
 
+#if defined(__cpp_if_constexpr) && defined(__cpp_return_type_deduction)
+template <typename S>
+bool check_is_compiled_string(const S&) {
+  return fmt::is_compiled_string<S>::value;
+}
+
+TEST(compile_test, is_compiled_string) {
+  EXPECT_TRUE(check_is_compiled_string(FMT_COMPILE("asdf")));
+  EXPECT_TRUE(check_is_compiled_string(FMT_COMPILE("{}")));
+}
+#endif
+
 // MSVS 2019 19.29.30145.0 - OK
 // MSVS 2022 19.32.31332.0, 19.37.32826.1 - compile-test.cc(362,3): fatal error
 // C1001: Internal compiler error.


### PR DESCRIPTION
Fixes #4335

Moves `is_compiled_string` to public API and adds a test for it.