### PR TITLE
Replace forward slashes by backslashes in BMI path for MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,13 @@ endfunction()
 # DEPRECATED! Should be merged into add_module_library.
 function(enable_module target)
   if (MSVC)
-    file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/${target}.ifc" BMI)
+    if(CMAKE_GENERATOR STREQUAL "Ninja")
+      # Ninja dyndep expects the .ifc output to be located in a specific relative path
+      file(RELATIVE_PATH BMI_DIR "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${target}.dir")
+    else()
+      set(BMI_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+    endif()
+    file(TO_NATIVE_PATH "${BMI_DIR}/${target}.ifc" BMI)
     target_compile_options(${target}
       PRIVATE /interface /ifcOutput ${BMI}
       INTERFACE /reference fmt=${BMI})


### PR DESCRIPTION
Using backslashes in the `BMI` variable in CMake leads to a build error:

```
D:\dev\sandbox\fmt_test\main.cpp(1,1): error C7684: module name 'fmt' has an ambiguous resolution to IFC [D:\dev\sandbo
x\fmt_test\build\main.vcxproj]
      D:\dev\sandbox\fmt_test\main.cpp(1,1):
      could be 'D:/dev/sandbox/fmt_test/build/fmt/fmt.ifc'
      D:\dev\sandbox\fmt_test\main.cpp(1,1):
      or       'D:\dev\sandbox\fmt_test\build\fmt\fmt.ifc'
```

This PR corrects that.

Note that this is doesn't fix Ninja builds which still lead to the result below, but I'm not entirely sure how they could be fixed:

```
c1xx: error C3472: new output file name fmt\CMakeFiles\fmt.dir\fmt.ifc (set on command line) conflicts with previous file name D:\dev\sandbox\fmt_test\build\fmt\fmt.ifc
ninja: build stopped: subcommand failed.
```
