### PR TITLE
Fix GCC 15 build errors with FMT_MODULE=ON

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -212,7 +212,7 @@ inline auto floor_log10_pow2_minus_log10_4_over_3(int e) noexcept -> int {
   return (e * 631305 - 261663) >> 21;
 }
 
-FMT_INLINE_VARIABLE constexpr struct {
+FMT_INLINE_VARIABLE constexpr struct div_small_pow10_infos_struct {
   uint32_t divisor;
   int shift_amount;
 } div_small_pow10_infos[] = {{10, 16}, {100, 16}};

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -113,7 +113,6 @@ void write_escaped_path(basic_memory_buffer<Char>& quoted,
 
 }  // namespace detail
 
-FMT_EXPORT
 template <typename Char> struct formatter<std::filesystem::path, Char> {
  private:
   format_specs specs_;
@@ -182,7 +181,6 @@ FMT_END_NAMESPACE
 #endif  // FMT_CPP_LIB_FILESYSTEM
 
 FMT_BEGIN_NAMESPACE
-FMT_EXPORT
 template <std::size_t N, typename Char>
 struct formatter<std::bitset<N>, Char>
     : nested_formatter<basic_string_view<Char>, Char> {
@@ -209,14 +207,12 @@ struct formatter<std::bitset<N>, Char>
   }
 };
 
-FMT_EXPORT
 template <typename Char>
 struct formatter<std::thread::id, Char> : basic_ostream_formatter<Char> {};
 FMT_END_NAMESPACE
 
 #ifdef __cpp_lib_optional
 FMT_BEGIN_NAMESPACE
-FMT_EXPORT
 template <typename T, typename Char>
 struct formatter<std::optional<T>, Char,
                  std::enable_if_t<is_formattable<T, Char>::value>> {
@@ -279,7 +275,6 @@ FMT_END_NAMESPACE
 #ifdef __cpp_lib_expected
 FMT_BEGIN_NAMESPACE
 
-FMT_EXPORT
 template <typename T, typename E, typename Char>
 struct formatter<std::expected<T, E>, Char,
                  std::enable_if_t<(std::is_void<T>::value ||
@@ -311,7 +306,6 @@ FMT_END_NAMESPACE
 
 #ifdef __cpp_lib_source_location
 FMT_BEGIN_NAMESPACE
-FMT_EXPORT
 template <> struct formatter<std::source_location> {
   FMT_CONSTEXPR auto parse(parse_context<>& ctx) { return ctx.begin(); }
 
@@ -367,7 +361,6 @@ template <typename T, typename C> struct is_variant_formattable {
       detail::is_variant_formattable_<T, C>::value;
 };
 
-FMT_EXPORT
 template <typename Char> struct formatter<std::monostate, Char> {
   FMT_CONSTEXPR auto parse(parse_context<Char>& ctx) -> const Char* {
     return ctx.begin();
@@ -380,7 +373,6 @@ template <typename Char> struct formatter<std::monostate, Char> {
   }
 };
 
-FMT_EXPORT
 template <typename Variant, typename Char>
 struct formatter<
     Variant, Char,
@@ -414,7 +406,6 @@ FMT_END_NAMESPACE
 #endif  // FMT_CPP_LIB_VARIANT
 
 FMT_BEGIN_NAMESPACE
-FMT_EXPORT
 template <> struct formatter<std::error_code> {
  private:
   format_specs specs_;
@@ -520,7 +511,6 @@ auto write_demangled_name(OutputIt out, const std::type_info& ti) -> OutputIt {
 
 }  // namespace detail
 
-FMT_EXPORT
 template <typename Char>
 struct formatter<std::type_info, Char  // DEPRECATED! Mixing code unit types.
                  > {
@@ -537,7 +527,6 @@ struct formatter<std::type_info, Char  // DEPRECATED! Mixing code unit types.
 };
 #endif
 
-FMT_EXPORT
 template <typename T, typename Char>
 struct formatter<
     T, Char,  // DEPRECATED! Mixing code unit types.
@@ -603,7 +592,6 @@ struct is_bit_reference_like<std::__bit_const_reference<C>> {
 // We can't use std::vector<bool, Allocator>::reference and
 // std::bitset<N>::reference because the compiler can't deduce Allocator and N
 // in partial specialization.
-FMT_EXPORT
 template <typename BitRef, typename Char>
 struct formatter<BitRef, Char,
                  enable_if_t<detail::is_bit_reference_like<BitRef>::value>>
@@ -623,7 +611,6 @@ template <typename T> auto ptr(const std::shared_ptr<T>& p) -> const void* {
   return p.get();
 }
 
-FMT_EXPORT
 template <typename T, typename Char>
 struct formatter<std::atomic<T>, Char,
                  enable_if_t<is_formattable<T, Char>::value>>
@@ -636,7 +623,6 @@ struct formatter<std::atomic<T>, Char,
 };
 
 #ifdef __cpp_lib_atomic_flag_test
-FMT_EXPORT
 template <typename Char>
 struct formatter<std::atomic_flag, Char> : formatter<bool, Char> {
   template <typename FormatContext>
@@ -647,7 +633,6 @@ struct formatter<std::atomic_flag, Char> : formatter<bool, Char> {
 };
 #endif  // __cpp_lib_atomic_flag_test
 
-FMT_EXPORT
 template <typename T, typename Char> struct formatter<std::complex<T>, Char> {
  private:
   detail::dynamic_format_specs<Char> specs_;
@@ -710,7 +695,6 @@ template <typename T, typename Char> struct formatter<std::complex<T>, Char> {
   }
 };
 
-FMT_EXPORT
 template <typename T, typename Char>
 struct formatter<std::reference_wrapper<T>, Char,
                  enable_if_t<is_formattable<remove_cvref_t<T>, Char>::value>>


### PR DESCRIPTION
Hi again,

I'm not sure how far you want to support GCC 15 before it's released, but here are a few fixes in case `fmt` needs to be built as a module with it. I doesn't look like merging the changes now would have any adverse effect.

Here are the steps to reproduce, with cmake 3.31.5 and GCC 15.0.1 20250205 (I couldn't build today's master for some reason) installed in /opt/gcc-dev:

```bash
mkdir build-gcc-15 && cd build-gcc-15
export CC=/opt/gcc-dev/bin/gcc
export CXX=/opt/gcc-dev/bin/g++
cmake .. -DFMT_MODULE=ON
cmake --build --target fmt
```

<details>
<summary>before 'Fix partial specialization in unbraced export-declaration':</summary>

```
In file included from /mnt/d/dev/libs/tools/fmt/src/fmt.cc:128:
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:117:33: error: declaration of partial specialization in unbraced export-declaration
  117 | template <typename Char> struct formatter<std::filesystem::path, Char> {
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:117:33: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:187:8: error: declaration of partial specialization in unbraced export-declaration
  187 | struct formatter<std::bitset<N>, Char>
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:187:8: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:214:8: error: declaration of partial specialization in unbraced export-declaration
  214 | struct formatter<std::thread::id, Char> : basic_ostream_formatter<Char> {};
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:214:8: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:221:8: error: declaration of partial specialization in unbraced export-declaration
  221 | struct formatter<std::optional<T>, Char,
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  222 |                  std::enable_if_t<is_formattable<T, Char>::value>> {
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:221:8: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:315:1: error: explicit specializations are not permitted here
  315 | template <> struct formatter<std::source_location> {
      | ^~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:315:1: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:371:33: error: declaration of partial specialization in unbraced export-declaration
  371 | template <typename Char> struct formatter<std::monostate, Char> {
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:371:33: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:385:8: error: declaration of partial specialization in unbraced export-declaration
  385 | struct formatter<
      |        ^~~~~~~~~~
  386 |     Variant, Char,
      |     ~~~~~~~~~~~~~~
  387 |     std::enable_if_t<std::conjunction_v<
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  388 |         is_variant_like<Variant>, is_variant_formattable<Variant, Char>>>> {
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:385:8: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:418:1: error: explicit specializations are not permitted here
  418 | template <> struct formatter<std::error_code> {
      | ^~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:418:1: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:525:8: error: declaration of partial specialization in unbraced export-declaration
  525 | struct formatter<std::type_info, Char  // DEPRECATED! Mixing code unit types.
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  526 |                  > {
      |                  ~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:525:8: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:542:8: error: declaration of partial specialization in unbraced export-declaration
  542 | struct formatter<
      |        ^~~~~~~~~~
  543 |     T, Char,  // DEPRECATED! Mixing code unit types.
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  544 |     typename std::enable_if<std::is_base_of<std::exception, T>::value>::type> {
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:542:8: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:608:8: error: declaration of partial specialization in unbraced export-declaration
  608 | struct formatter<BitRef, Char,
      |        ^~~~~~~~~~~~~~~~~~~~~~~
  609 |                  enable_if_t<detail::is_bit_reference_like<BitRef>::value>>
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:608:8: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:628:8: error: declaration of partial specialization in unbraced export-declaration
  628 | struct formatter<std::atomic<T>, Char,
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  629 |                  enable_if_t<is_formattable<T, Char>::value>>
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:628:8: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:641:8: error: declaration of partial specialization in unbraced export-declaration
  641 | struct formatter<std::atomic_flag, Char> : formatter<bool, Char> {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:641:8: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:651:45: error: declaration of partial specialization in unbraced export-declaration
  651 | template <typename T, typename Char> struct formatter<std::complex<T>, Char> {
      |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:651:45: note: a specialization is always exported alongside its primary template
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:715:8: error: declaration of partial specialization in unbraced export-declaration
  715 | struct formatter<std::reference_wrapper<T>, Char,
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  716 |                  enable_if_t<is_formattable<remove_cvref_t<T>, Char>::value>>
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/std.h:715:8: note: a specialization is always exported alongside its primary template
```
</details>

I couldn't find details or a reference in the C++ standard to fully understand the whys but my understanding is you can't directly `export` a partial template specialization. I think I got all the export blocks right but it would definitely warrant another check


<details>
<summary>before 'Fix TU-local entity exposition errors':</summary>

```
In file included from /mnt/d/dev/libs/tools/fmt/src/fmt.cc:148:
/mnt/d/dev/libs/tools/fmt/src/os.cc:74:7: error: ‘using {anonymous}::rwresult = ssize_t’ exposes TU-local entity ‘{anonymous}’
   74 | using rwresult = ssize_t;
      |       ^~~~~~~~
/mnt/d/dev/libs/tools/fmt/src/os.cc:62:1: note: ‘{anonymous}’ declared with internal linkage
   62 | namespace {
      | ^~~~~~~~~
In file included from /mnt/d/dev/libs/tools/fmt/src/format.cc:8,
                 from /mnt/d/dev/libs/tools/fmt/src/fmt.cc:145:
/mnt/d/dev/libs/tools/fmt/include/fmt/format-inl.h:218:3: error: ‘fmt::v11::detail::dragonbox::div_small_pow10_infos’ exposes TU-local entity ‘struct fmt::v11::detail::dragonbox::<unnamed>’
  218 | } div_small_pow10_infos[] = {{10, 16}, {100, 16}};
      |   ^~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/libs/tools/fmt/include/fmt/format-inl.h:215:38: note: ‘fmt::v11::detail::dragonbox::<unnamed struct>’ has no name and is not defined within a class, function, or initializer
  215 | FMT_INLINE_VARIABLE constexpr struct {
      |                                      ^
```

</details>

These 2 errors are related to the implementation of [P1815](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1815r2), which aims at "forbidding exposure of internal-linkage constructs to other translation units" and may make its way [into Clang](https://github.com/llvm/llvm-project/issues/54048) at some stage.

Better suggestions welcome for the name of the previously unnamed struct instantiated in `div_small_pow10_infos`  in `format-inl.h`. As it's already in `details::dragonbox` its actual name doesn't matter much.

I have checked it didn't break GCC 14, Clang 21 nor MSVC builds, whether `FMT_MODULE` is on or not.
