### PR TITLE
Default zoned time conversions to use earliest time

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -585,11 +585,13 @@ inline auto localtime(std::chrono::local_time<Duration> time) -> std::tm {
   using namespace std::chrono;
   using namespace fmt_detail;
 
-#if FMT_USE_EARLIEST_TIME
-  return localtime(detail::to_time_t(current_zone()->to_sys<Duration>(time, std::chrono::choose::earliest)));
-#else
-  return localtime(detail::to_time_t(current_zone()->to_sys<Duration>(time, std::chrono::choose::latest)));
-#endif
+#  if FMT_USE_EARLIEST_TIME
+  return localtime(detail::to_time_t(
+      current_zone()->to_sys<Duration>(time, std::chrono::choose::earliest)));
+#  else
+  return localtime(detail::to_time_t(
+      current_zone()->to_sys<Duration>(time, std::chrono::choose::latest)));
+#  endif
 }
 #endif
 


### PR DESCRIPTION
FMT_USE_EARLIEST_TIME is used to control if earliest or latest time is preferred. Tests are a bit tricky to write due to the system time zone being used by CI tools not necessarily having a DST time

Fixes #4350
