### PR TITLE
Add .vs folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.xcodeproj
 *~
 .vscode/
+.vs/
 /CMakeScripts
 /Testing
 /_CPack_Packages


### PR DESCRIPTION
Opening the fmt folder as a CMake project with Visual Studio creates this directory. The contents can be ignored.

This is primarily a quality of life tweak for Visual Studio users.
