### PR TITLE
Fix dynamic named arg format spec handling

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1707,9 +1707,9 @@ class format_string_checker {
     context_.advance_to(begin);
     if (id >= 0 && id < NUM_ARGS) return parse_funcs_[id](context_);
 
-    // If id is out of range, it means we do not know the type and cannot parse the format at
-    // compile time. Instead, skip over content until we finish the format spec, accounting
-    // for any nested replacements.
+    // If id is out of range, it means we do not know the type and cannot parse
+    // the format at compile time. Instead, skip over content until we finish
+    // the format spec, accounting for any nested replacements.
     auto bracket_count = 0;
     while (begin != end && (bracket_count > 0 || *begin != '}')) {
       if (*begin == '{')

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1706,7 +1706,19 @@ class format_string_checker {
       -> const Char* {
     context_.advance_to(begin);
     if (id >= 0 && id < NUM_ARGS) return parse_funcs_[id](context_);
-    while (begin != end && *begin != '}') ++begin;
+
+    // If id is out of range, it means we do not know the type and cannot parse the format at
+    // compile time. Instead, skip over content until we finish the format spec, accounting
+    // for any nested replacements.
+    auto bracket_count = 0;
+    while (begin != end && (bracket_count > 0 || *begin != '}')) {
+      if (*begin == '{')
+        ++bracket_count;
+      else if (*begin == '}')
+        --bracket_count;
+
+      ++begin;
+    }
     return begin;
   }
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -582,6 +582,8 @@ TEST(format_test, named_arg) {
   EXPECT_EQ("1/a/A", fmt::format("{_1}/{a_}/{A_}", fmt::arg("a_", 'a'),
                                  fmt::arg("A_", "A"), fmt::arg("_1", 1)));
   EXPECT_EQ(fmt::format("{0:{width}}", -42, fmt::arg("width", 4)), " -42");
+  EXPECT_EQ(fmt::format("{value:{width}}", fmt::arg("value", -42),
+      fmt::arg("width", 4)), " -42");
   EXPECT_EQ("st",
             fmt::format("{0:.{precision}}", "str", fmt::arg("precision", 2)));
   EXPECT_EQ(fmt::format("{} {two}", 1, fmt::arg("two", 2)), "1 2");


### PR DESCRIPTION
When dealing with dynamic named format args, need to account for nested named args when skipping the content of the replacement.

Fixes #4360

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
