### PR TITLE
Allow format_to_n to be executed at compile time

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1835,7 +1835,7 @@ class fixed_buffer_traits {
 
  public:
   constexpr explicit fixed_buffer_traits(size_t limit) : limit_(limit) {}
-  FMT_CONSTEXPR20 ~fixed_buffer_traits(){};
+  FMT_CONSTEXPR20 ~fixed_buffer_traits() = default;
   constexpr auto count() const -> size_t { return count_; }
   FMT_CONSTEXPR auto limit(size_t size) -> size_t {
     size_t n = limit_ > count_ ? limit_ - count_ : 0;
@@ -1912,7 +1912,7 @@ class iterator_buffer<T*, T, fixed_buffer_traits> : public fixed_buffer_traits,
   FMT_CONSTEXPR explicit iterator_buffer(T* out, size_t n = buffer_size)
       : fixed_buffer_traits(n), buffer<T>(grow, out, 0, n), out_(out) {}
   FMT_CONSTEXPR iterator_buffer(iterator_buffer&& other) noexcept
-      : fixed_buffer_traits(other),
+      : fixed_buffer_traits(static_cast<iterator_buffer&&>(other)),
         buffer<T>(static_cast<iterator_buffer&&>(other)),
         out_(other.out_) {
     if (this->data() != out_) {

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1449,8 +1449,7 @@ FMT_FUNC auto vformat(string_view fmt, format_args args) -> std::string {
 
 namespace detail {
 
-FMT_FUNC void vformat_to(buffer<char>& buf, string_view fmt, format_args args,
-                         locale_ref loc) {
+FMT_CONSTEXPR FMT_FUNC void vformat_to(buffer<char>& buf, string_view fmt, format_args args, locale_ref loc) {
   auto out = appender(buf);
   if (fmt.size() == 2 && equal2(fmt.data(), "{}"))
     return args.get(0).visit(default_arg_formatter<char>{out});

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1449,7 +1449,8 @@ FMT_FUNC auto vformat(string_view fmt, format_args args) -> std::string {
 
 namespace detail {
 
-FMT_CONSTEXPR FMT_FUNC void vformat_to(buffer<char>& buf, string_view fmt, format_args args, locale_ref loc) {
+FMT_CONSTEXPR FMT_FUNC void vformat_to(buffer<char>& buf, string_view fmt,
+                                       format_args args, locale_ref loc) {
   auto out = appender(buf);
   if (fmt.size() == 2 && equal2(fmt.data(), "{}"))
     return args.get(0).visit(default_arg_formatter<char>{out});

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -475,3 +475,18 @@ TEST(format_impl_test, to_utf8) {
   EXPECT_EQ(s, u.str());
   EXPECT_EQ(s.size(), u.size());
 }
+
+#if FMT_USE_CONSTEVAL
+TEST(format_test, format_to_n_constexpr) {
+  // This test doesn't have to be extensive -
+  // it just checks format_to_n can be done in constexpr context
+  constexpr bool result  = []{
+    std::array buffer {'x', 'x', 'x', 'x'};
+    fmt::format_to_n(buffer.data(), buffer.size(), "{}", 42);
+    fmt::format_to_n(buffer.data() + 2, 1, "{}", 'F');
+    return buffer == std::array{ '4', '2', 'F', 'x'};
+  }();
+
+  ASSERT_TRUE(result);
+}
+#endif


### PR DESCRIPTION
Hello!
Currently `fmt::format_to_n` cannot be executed at compile time. I needed this functionality in one of my personal project and didn't see a reason why wouldn't it be possible so here is a PR for that.