### PR TITLE
Report error on duplicate named arg names

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1060,20 +1060,18 @@ template <typename... Args> constexpr auto count_static_named_args() -> int {
 }
 
 template <typename Char> struct named_arg_info {
-  FMT_CONSTEXPR named_arg_info() : name(nullptr), id(0) {}
-  FMT_CONSTEXPR named_arg_info(const Char* a_name, const int an_id)
-      : name(a_name), id(an_id) {}
   const Char* name;
   int id;
 };
 
 template <typename Char>
 FMT_CONSTEXPR void check_for_duplicate(
-    const named_arg_info<Char>* const named_args, const int named_arg_index,
-    const Char* const arg_name) {
-  const basic_string_view<Char> arg_name_view(arg_name);
+    named_arg_info<Char>* named_args, int named_arg_index,
+    basic_string_view<Char> arg_name) {
+  if (named_arg_index <= 0) return;
+
   for (auto i = 0; i < named_arg_index; ++i) {
-    if (basic_string_view<Char>(named_args[i].name) == arg_name_view) {
+    if (basic_string_view<Char>(named_args[i].name) == arg_name) {
       report_error("duplicate named args found");
     }
   }
@@ -1087,7 +1085,7 @@ void init_named_arg(named_arg_info<Char>*, int& arg_index, int&, const T&) {
 template <typename Char, typename T, FMT_ENABLE_IF(is_named_arg<T>::value)>
 void init_named_arg(named_arg_info<Char>* named_args, int& arg_index,
                     int& named_arg_index, const T& arg) {
-  check_for_duplicate(named_args, named_arg_index, arg.name);
+  check_for_duplicate<Char>(named_args, named_arg_index, arg.name);
   named_args[named_arg_index++] = {arg.name, arg_index++};
 }
 
@@ -1101,7 +1099,7 @@ template <typename T, typename Char,
           FMT_ENABLE_IF(is_static_named_arg<T>::value)>
 FMT_CONSTEXPR void init_static_named_arg(named_arg_info<Char>* named_args,
                                          int& arg_index, int& named_arg_index) {
-  check_for_duplicate(named_args, named_arg_index, T::name);
+  check_for_duplicate<Char>(named_args, named_arg_index, T::name);
   named_args[named_arg_index++] = {T::name, arg_index++};
 }
 

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1072,7 +1072,8 @@ template <typename Char, typename T, FMT_ENABLE_IF(is_named_arg<T>::value)>
 void init_named_arg(named_arg_info<Char>* named_args, int& arg_index,
                     int& named_arg_index, const T& arg) {
   for (auto i = 0; i < named_arg_index; ++i) {
-    if (basic_string_view<Char>(named_args[i].name) == basic_string_view<Char>(arg.name)) {
+    if (basic_string_view<Char>(named_args[i].name) ==
+        basic_string_view<Char>(arg.name)) {
       report_error("duplicate named args found");
     }
   }
@@ -1090,7 +1091,8 @@ template <typename T, typename Char,
 FMT_CONSTEXPR void init_static_named_arg(named_arg_info<Char>* named_args,
                                          int& arg_index, int& named_arg_index) {
   for (auto i = 0; i < named_arg_index; ++i) {
-    if (basic_string_view<Char>(named_args[i].name) == basic_string_view<Char>(T::name)) {
+    if (basic_string_view<Char>(named_args[i].name) ==
+        basic_string_view<Char>(T::name)) {
       report_error("duplicate named args found");
     }
   }

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1062,7 +1062,7 @@ template <typename... Args> constexpr auto count_static_named_args() -> int {
 template <typename Char> struct named_arg_info {
   FMT_CONSTEXPR named_arg_info() : name(nullptr), id(0) {}
   FMT_CONSTEXPR named_arg_info(const Char* a_name, const int an_id)
-    : name(a_name), id(an_id) {}
+      : name(a_name), id(an_id) {}
   const Char* name;
   int id;
 };

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1064,19 +1064,27 @@ template <typename Char> struct named_arg_info {
   int id;
 };
 
+template <typename Char>
+FMT_CONSTEXPR void check_for_duplicate(
+    const named_arg_info<Char>* const named_args, const int named_arg_index,
+    const Char* const arg_name) {
+  const basic_string_view arg_name_view(arg_name);
+  for (auto i = 0; i < named_arg_index; ++i) {
+    if (basic_string_view<Char>(named_args[i].name) == arg_name_view) {
+      report_error("duplicate named args found");
+    }
+  }
+}
+
 template <typename Char, typename T, FMT_ENABLE_IF(!is_named_arg<T>::value)>
 void init_named_arg(named_arg_info<Char>*, int& arg_index, int&, const T&) {
   ++arg_index;
 }
+
 template <typename Char, typename T, FMT_ENABLE_IF(is_named_arg<T>::value)>
 void init_named_arg(named_arg_info<Char>* named_args, int& arg_index,
                     int& named_arg_index, const T& arg) {
-  for (auto i = 0; i < named_arg_index; ++i) {
-    if (basic_string_view<Char>(named_args[i].name) ==
-        basic_string_view<Char>(arg.name)) {
-      report_error("duplicate named args found");
-    }
-  }
+  check_for_duplicate(named_args, named_arg_index, arg.name);
   named_args[named_arg_index++] = {arg.name, arg_index++};
 }
 
@@ -1090,12 +1098,7 @@ template <typename T, typename Char,
           FMT_ENABLE_IF(is_static_named_arg<T>::value)>
 FMT_CONSTEXPR void init_static_named_arg(named_arg_info<Char>* named_args,
                                          int& arg_index, int& named_arg_index) {
-  for (auto i = 0; i < named_arg_index; ++i) {
-    if (basic_string_view<Char>(named_args[i].name) ==
-        basic_string_view<Char>(T::name)) {
-      report_error("duplicate named args found");
-    }
-  }
+  check_for_duplicate(named_args, named_arg_index, T::name);
   named_args[named_arg_index++] = {T::name, arg_index++};
 }
 

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1071,6 +1071,11 @@ void init_named_arg(named_arg_info<Char>*, int& arg_index, int&, const T&) {
 template <typename Char, typename T, FMT_ENABLE_IF(is_named_arg<T>::value)>
 void init_named_arg(named_arg_info<Char>* named_args, int& arg_index,
                     int& named_arg_index, const T& arg) {
+  for (auto i = 0; i < named_arg_index; ++i) {
+    if (basic_string_view<Char>(named_args[i].name) == basic_string_view<Char>(arg.name)) {
+      report_error("duplicate named args found");
+    }
+  }
   named_args[named_arg_index++] = {arg.name, arg_index++};
 }
 
@@ -1084,6 +1089,11 @@ template <typename T, typename Char,
           FMT_ENABLE_IF(is_static_named_arg<T>::value)>
 FMT_CONSTEXPR void init_static_named_arg(named_arg_info<Char>* named_args,
                                          int& arg_index, int& named_arg_index) {
+  for (auto i = 0; i < named_arg_index; ++i) {
+    if (basic_string_view<Char>(named_args[i].name) == basic_string_view<Char>(T::name)) {
+      report_error("duplicate named args found");
+    }
+  }
   named_args[named_arg_index++] = {T::name, arg_index++};
 }
 

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1065,9 +1065,9 @@ template <typename Char> struct named_arg_info {
 };
 
 template <typename Char>
-FMT_CONSTEXPR void check_for_duplicate(
-    named_arg_info<Char>* named_args, int named_arg_index,
-    basic_string_view<Char> arg_name) {
+FMT_CONSTEXPR void check_for_duplicate(named_arg_info<Char>* named_args,
+                                       int named_arg_index,
+                                       basic_string_view<Char> arg_name) {
   if (named_arg_index <= 0) return;
 
   for (auto i = 0; i < named_arg_index; ++i) {

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1060,6 +1060,11 @@ template <typename... Args> constexpr auto count_static_named_args() -> int {
 }
 
 template <typename Char> struct named_arg_info {
+  FMT_CONSTEXPR named_arg_info() : name(nullptr), id(0) {}
+  FMT_CONSTEXPR named_arg_info(const Char* a_name, const int an_id)
+    : name(a_name),
+      id(an_id) {
+  }
   const Char* name;
   int id;
 };

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1062,9 +1062,7 @@ template <typename... Args> constexpr auto count_static_named_args() -> int {
 template <typename Char> struct named_arg_info {
   FMT_CONSTEXPR named_arg_info() : name(nullptr), id(0) {}
   FMT_CONSTEXPR named_arg_info(const Char* a_name, const int an_id)
-    : name(a_name),
-      id(an_id) {
-  }
+    : name(a_name), id(an_id) {}
   const Char* name;
   int id;
 };

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1068,7 +1068,7 @@ template <typename Char>
 FMT_CONSTEXPR void check_for_duplicate(
     const named_arg_info<Char>* const named_args, const int named_arg_index,
     const Char* const arg_name) {
-  const basic_string_view arg_name_view(arg_name);
+  const basic_string_view<Char> arg_name_view(arg_name);
   for (auto i = 0; i < named_arg_index; ++i) {
     if (basic_string_view<Char>(named_args[i].name) == arg_name_view) {
       report_error("duplicate named args found");

--- a/test/compile-error-test/CMakeLists.txt
+++ b/test/compile-error-test/CMakeLists.txt
@@ -209,14 +209,6 @@ if (CMAKE_CXX_STANDARD GREATER_EQUAL 20)
       #error
     #endif
   " ERROR)
-  expect_compile(format-string-duplicate-name-error "
-    #if defined(FMT_HAS_CONSTEVAL) && FMT_USE_NONTYPE_TEMPLATE_ARGS
-      using namespace fmt::literals;
-      fmt::print(\"{bar}\", \"bar\"_a=42, \"bar\"_a=43);
-    #else
-      #error
-    #endif
-  " ERROR)
 endif ()
 
 # Run all tests

--- a/test/compile-error-test/CMakeLists.txt
+++ b/test/compile-error-test/CMakeLists.txt
@@ -209,6 +209,14 @@ if (CMAKE_CXX_STANDARD GREATER_EQUAL 20)
       #error
     #endif
   " ERROR)
+  expect_compile(format-string-duplicate-name-error "
+    #if defined(FMT_HAS_CONSTEVAL) && FMT_USE_NONTYPE_TEMPLATE_ARGS
+      using namespace fmt::literals;
+      fmt::print(\"{bar}\", \"bar\"_a=42, \"bar\"_a=43);
+    #else
+      #error
+    #endif
+  " ERROR)
 endif ()
 
 # Run all tests

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -582,8 +582,6 @@ TEST(format_test, named_arg) {
   EXPECT_EQ("1/a/A", fmt::format("{_1}/{a_}/{A_}", fmt::arg("a_", 'a'),
                                  fmt::arg("A_", "A"), fmt::arg("_1", 1)));
   EXPECT_EQ(fmt::format("{0:{width}}", -42, fmt::arg("width", 4)), " -42");
-  EXPECT_THROW_MSG(fmt::format("{enum}", fmt::arg("enum", 1), fmt::arg("enum", 10)),
-      format_error, "duplicate named args found");
   EXPECT_EQ("st",
             fmt::format("{0:.{precision}}", "str", fmt::arg("precision", 2)));
   EXPECT_EQ(fmt::format("{} {two}", 1, fmt::arg("two", 2)), "1 2");
@@ -601,6 +599,8 @@ TEST(format_test, named_arg) {
   EXPECT_THROW_MSG((void)fmt::format(runtime("{a} {}"), fmt::arg("a", 2), 42),
                    format_error,
                    "cannot switch from manual to automatic argument indexing");
+  EXPECT_THROW_MSG((void)fmt::format("{enum}", fmt::arg("enum", 1),
+      fmt::arg("enum", 10)), format_error, "duplicate named args found");
 }
 
 TEST(format_test, auto_arg_index) {

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -582,6 +582,8 @@ TEST(format_test, named_arg) {
   EXPECT_EQ("1/a/A", fmt::format("{_1}/{a_}/{A_}", fmt::arg("a_", 'a'),
                                  fmt::arg("A_", "A"), fmt::arg("_1", 1)));
   EXPECT_EQ(fmt::format("{0:{width}}", -42, fmt::arg("width", 4)), " -42");
+  EXPECT_THROW_MSG(fmt::format("{enum}", fmt::arg("enum", 1), fmt::arg("enum", 10)),
+      format_error, "duplicate named args found");
   EXPECT_EQ("st",
             fmt::format("{0:.{precision}}", "str", fmt::arg("precision", 2)));
   EXPECT_EQ(fmt::format("{} {two}", 1, fmt::arg("two", 2)), "1 2");

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -599,8 +599,8 @@ TEST(format_test, named_arg) {
   EXPECT_THROW_MSG((void)fmt::format(runtime("{a} {}"), fmt::arg("a", 2), 42),
                    format_error,
                    "cannot switch from manual to automatic argument indexing");
-  EXPECT_THROW_MSG((void)fmt::format("{enum}", fmt::arg("enum", 1),
-      fmt::arg("enum", 10)), format_error, "duplicate named args found");
+  EXPECT_THROW_MSG((void)fmt::format("{a}", fmt::arg("a", 1),
+      fmt::arg("a", 10)), format_error, "duplicate named args found");
 }
 
 TEST(format_test, auto_arg_index) {


### PR DESCRIPTION
Compile error will happen if static named args are used and enabled. Runtime exception will be thrown in other cases.
#4282

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
