### PR TITLE
Suppress a "loop not reachable" warning in nvcc

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -465,6 +465,9 @@ static_assert(!FMT_UNICODE || use_utf8,
 template <typename T> constexpr const char* narrow(const T*) { return nullptr; }
 constexpr FMT_ALWAYS_INLINE const char* narrow(const char* s) { return s; }
 
+#if defined(__NVCC__)
+#  pragma nv_diag_suppress 128
+#endif
 template <typename Char>
 FMT_CONSTEXPR auto compare(const Char* s1, const Char* s2, std::size_t n)
     -> int {
@@ -475,6 +478,9 @@ FMT_CONSTEXPR auto compare(const Char* s1, const Char* s2, std::size_t n)
   }
   return 0;
 }
+#if defined(__NVCC__)
+#  pragma nv_diag_default 128
+#endif
 
 namespace adl {
 using namespace std;


### PR DESCRIPTION
This compile-time optimization causes nvcc to throw a "loop not reachable" warning. Suppress it.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
