### PR TITLE
Suppress `formattable hides the global definition` warning 

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1662,10 +1662,10 @@ template <typename T, typename Char>
 FMT_VISIBILITY("hidden")  // Suppress an ld warning on macOS (#3769).
 FMT_CONSTEXPR auto invoke_parse(parse_context<Char>& ctx) -> const Char* {
   using mapped_type = remove_cvref_t<mapped_t<T, Char>>;
-  constexpr bool formattable =
+  constexpr bool is_formattable =
       std::is_constructible<formatter<mapped_type, Char>>::value;
-  if (!formattable) return ctx.begin();  // Error is reported in the value ctor.
-  using formatted_type = conditional_t<formattable, mapped_type, int>;
+  if (!is_formattable) return ctx.begin();  // Error is reported in the value ctor.
+  using formatted_type = conditional_t<is_formattable, mapped_type, int>;
   return formatter<formatted_type, Char>().parse(ctx);
 }
 

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -1658,16 +1658,23 @@ FMT_CONSTEXPR inline auto check_char_specs(const format_specs& specs) -> bool {
 // A base class for compile-time strings.
 struct compile_string {};
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4459)  // declaration hides global declaration
+#endif
 template <typename T, typename Char>
 FMT_VISIBILITY("hidden")  // Suppress an ld warning on macOS (#3769).
 FMT_CONSTEXPR auto invoke_parse(parse_context<Char>& ctx) -> const Char* {
   using mapped_type = remove_cvref_t<mapped_t<T, Char>>;
-  constexpr bool is_formattable =
+  constexpr bool formattable =
       std::is_constructible<formatter<mapped_type, Char>>::value;
-  if (!is_formattable) return ctx.begin();  // Error is reported in the value ctor.
-  using formatted_type = conditional_t<is_formattable, mapped_type, int>;
+  if (!formattable) return ctx.begin();  // Error is reported in the value ctor.
+  using formatted_type = conditional_t<formattable, mapped_type, int>;
   return formatter<formatted_type, Char>().parse(ctx);
 }
+#ifdef _MSC_VER
+#pragma warning(pop)  // Restore 4459
+#endif
 
 template <typename... T> struct arg_pack {};
 


### PR DESCRIPTION
This fixes the warning that is received on MSVC v17.3.6 with the compiler flag `/W4`. The warning is as follows: `declaration of 'formattable' hides global declaration`. It appears on every file where `fmt/core.h` is included.

~~I renamed it to `is_formattable` but this can be changed since it seems like `is_formattable` is used in other places as well.~~

EDIT: After looking through other PRs, namely #4377, I thought it may be preferred (and less breaking) to suppress the warnings via macros rather than change existing code. 