### PR TITLE
Unreachable code & constexpr constructor bigint()

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -468,10 +468,19 @@ constexpr FMT_ALWAYS_INLINE const char* narrow(const char* s) { return s; }
 template <typename Char>
 FMT_CONSTEXPR auto compare(const Char* s1, const Char* s2, std::size_t n)
     -> int {
-  if (!is_constant_evaluated() && sizeof(Char) == 1) return memcmp(s1, s2, n);
+  if (!is_constant_evaluated() && sizeof(Char) == 1) 
+  {
+    return memcmp(s1, s2, n);
+  }
   for (; n != 0; ++s1, ++s2, --n) {
-    if (*s1 < *s2) return -1;
-    if (*s1 > *s2) return 1;
+    if (*s1 < *s2) 
+    {
+      return -1;
+    }
+    if (*s1 > *s2) 
+    {
+      return 1;
+    }
   }
   return 0;
 }
@@ -542,10 +551,11 @@ template <typename Char> class basic_string_view {
       size_ = __builtin_strlen(detail::narrow(s));
       return;
     }
-#endif
+#else
     size_t len = 0;
     while (*s++) ++len;
     size_ = len;
+#endif
   }
 
   /// Constructs a string reference from a `std::basic_string` or a

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2516,7 +2516,7 @@ class bigint {
   enum { bigit_bits = num_bits<bigit>() };
   enum { bigits_capacity = 32 };
   basic_memory_buffer<bigit, bigits_capacity> bigits_;
-  int exp_;
+  int exp_ = 0;
 
   friend struct formatter<bigint>;
 
@@ -2594,7 +2594,7 @@ class bigint {
   }
 
  public:
-  FMT_CONSTEXPR bigint() : exp_(0) {}
+  FMT_CONSTEXPR bigint() = default;
   explicit bigint(uint64_t n) { assign(n); }
 
   bigint(const bigint&) = delete;


### PR DESCRIPTION
Proprietary, strict compiler complains about the following:

Unreachable code: certain branches in `fmt/base.h` are unreachable.
Fix: Add branches

Constexpr constructor constructing non-constexpr member: 
Fix: make constexpr constructor default. 
