### PR TITLE
Compilation Error with MSVC (14.43.34808) with -std:c++latest

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2323,7 +2323,7 @@ constexpr auto encode_types() -> unsigned long long {
 template <typename Context, typename... T, size_t NUM_ARGS = sizeof...(T)>
 constexpr auto make_descriptor() -> unsigned long long {
   return NUM_ARGS <= max_packed_args ? encode_types<Context, T...>()
-                                     : is_unpacked_bit | NUM_ARGS;
+                                     : static_cast<unsigned long long>(is_unpacked_bit) | NUM_ARGS;
 }
 
 template <typename Context, int NUM_ARGS>


### PR DESCRIPTION
Fixes the following error with MSVC
```
d:\vcpkg\installed\arm64-msvc-static-md\include\fmt\base.h(2302): error C2446: ':': no conversion from 'std::tuple<T1,T2>' to 'unsigned __int64'
        with
        [
            T1=fmt::v11::detail::<unnamed-enum-is_unpacked_bit>,
            T2=size_t
        ]
d:\vcpkg\installed\arm64-msvc-static-md\include\fmt\base.h(2302): note: the template instantiation context (the oldest one first) is
D:\optimlir\proto\CodeTemplates.h(103): note: see reference to function template instantiation 'std::string fmt::v11::format<fmt::v11::join_view<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>,std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>,char>>(fmt::v11::fstring<fmt::v11::join_view<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>,std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>,char>>,fmt::v11::join_view<std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>,std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<_Ty>>>,char> &&)' being compiled
        with
        [
            _Ty=std::string
        ]
```

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
