### PR TITLE
Avoiding __builtin_strlen

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -539,7 +539,7 @@ template <typename Char> class basic_string_view {
 #endif
   FMT_CONSTEXPR20 basic_string_view(const Char* s) : data_(s) {
 #if FMT_HAS_BUILTIN(__builtin_strlen) || FMT_GCC_VERSION || FMT_CLANG_VERSION
-    if (std::is_same<Char, char>::value) {
+    if (std::is_same<Char, char>::value && !detail::is_constant_evaluated()) {
       size_ = __builtin_strlen(detail::narrow(s));
       return;
     }

--- a/test/base-test.cc
+++ b/test/base-test.cc
@@ -92,6 +92,29 @@ TEST(string_view_test, compare) {
   check_op<std::greater_equal>();
 }
 
+#if FMT_USE_CONSTEVAL
+namespace {
+
+template <size_t N>
+struct fixed_string {
+    char data[N] = {};
+
+    constexpr fixed_string(char const (&m)[N]) {
+        for (size_t i = 0; i != N; ++i) {
+            data[i] = m[i];
+        }
+    }
+};
+
+}
+
+TEST(string_view_test, from_constexpr_fixed_string) {
+  static constexpr auto fs = fixed_string<5>("x={}");
+  static constexpr auto fmt = fmt::string_view(fs.data);
+  EXPECT_EQ(fmt, "x={}");
+}
+#endif
+
 TEST(base_test, is_locking) {
   EXPECT_FALSE(fmt::detail::is_locking<const char(&)[3]>());
 }

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2564,6 +2564,7 @@ auto fmt::formatter<incomplete_type>::format(const incomplete_type&,
   return formatter<int>::format(42, ctx);
 }
 
+#if FMT_CPLUSPLUS >= 201703L
 namespace {
 
 template <size_t N>
@@ -2583,3 +2584,4 @@ TEST(format_test, fixed_string_constant) {
   static constexpr auto f = fixed_string<5>("x={}");
   EXPECT_EQ(fmt::format(f.data, 42), "x=42");
 }
+#endif

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2580,8 +2580,9 @@ struct fixed_string {
 
 }
 
-TEST(format_test, fixed_string_constant) {
-  static constexpr auto f = fixed_string<5>("x={}");
-  EXPECT_EQ(fmt::format(f.data, 42), "x=42");
+TEST(base_test, from_constexpr_fixed_string) {
+  static constexpr auto fs = fixed_string<5>("x={}");
+  static constexpr auto fmt = fmt::string_view(fs.data);
+  EXPECT_EQ(fmt, "x={}");
 }
 #endif

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2564,7 +2564,7 @@ auto fmt::formatter<incomplete_type>::format(const incomplete_type&,
   return formatter<int>::format(42, ctx);
 }
 
-#if FMT_CPLUSPLUS >= 201703L
+#if FMT_USE_CONSTEVAL
 namespace {
 
 template <size_t N>

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2563,26 +2563,3 @@ auto fmt::formatter<incomplete_type>::format(const incomplete_type&,
     -> fmt::appender {
   return formatter<int>::format(42, ctx);
 }
-
-#if FMT_USE_CONSTEVAL
-namespace {
-
-template <size_t N>
-struct fixed_string {
-    char data[N] = {};
-
-    constexpr fixed_string(char const (&m)[N]) {
-        for (size_t i = 0; i != N; ++i) {
-            data[i] = m[i];
-        }
-    }
-};
-
-}
-
-TEST(base_test, from_constexpr_fixed_string) {
-  static constexpr auto fs = fixed_string<5>("x={}");
-  static constexpr auto fmt = fmt::string_view(fs.data);
-  EXPECT_EQ(fmt, "x={}");
-}
-#endif

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2563,3 +2563,23 @@ auto fmt::formatter<incomplete_type>::format(const incomplete_type&,
     -> fmt::appender {
   return formatter<int>::format(42, ctx);
 }
+
+namespace {
+
+template <size_t N>
+struct fixed_string {
+    char data[N] = {};
+
+    constexpr fixed_string(char const (&m)[N]) {
+        for (size_t i = 0; i != N; ++i) {
+            data[i] = m[i];
+        }
+    }
+};
+
+}
+
+TEST(format_test, fixed_string_constant) {
+  static constexpr auto f = fixed_string<5>("x={}");
+  EXPECT_EQ(fmt::format(f.data, 42), "x=42");
+}


### PR DESCRIPTION
The added test fails on gcc 14 because of the call to `__builtin_strlen`, so just avoiding it during constant evaluation. Fixed #4423. 