### PR TITLE
Fix reference_wrapper ambiguity with format_as

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -713,6 +713,7 @@ template <typename T, typename Char> struct formatter<std::complex<T>, Char> {
   }
 };
 
+namespace detail {
 template <typename T, typename Enable = void>
 struct has_format_as : std::false_type {};
 template <typename T>
@@ -725,15 +726,15 @@ template <typename T>
 struct has_format_as_member<
     T, void_t<decltype(formatter<T>::format_as(std::declval<const T&>()))>>
     : std::true_type {};
+}  // namespace detail
 
 // Guard against format_as because reference_wrappers are implicitly convertible
 // to T&
-
 template <typename T, typename Char>
-struct formatter<
-    std::reference_wrapper<T>, Char,
-    enable_if_t<is_formattable<remove_cvref_t<T>, Char>::value &&
-                !has_format_as<T>::value && !has_format_as_member<T>::value>>
+struct formatter<std::reference_wrapper<T>, Char,
+                 enable_if_t<is_formattable<remove_cvref_t<T>, Char>::value &&
+                             !detail::has_format_as<T>::value &&
+                             !detail::has_format_as_member<T>::value>>
     : formatter<remove_cvref_t<T>, Char> {
   template <typename FormatContext>
   auto format(std::reference_wrapper<T> ref, FormatContext& ctx) const

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -713,9 +713,27 @@ template <typename T, typename Char> struct formatter<std::complex<T>, Char> {
   }
 };
 
+template <typename T, typename Enable = void>
+struct has_format_as : std::false_type {};
+template <typename T>
+struct has_format_as<T, void_t<decltype(format_as(std::declval<const T&>()))>>
+    : std::true_type {};
+
+template <typename T, typename Enable = void>
+struct has_format_as_member : std::false_type {};
+template <typename T>
+struct has_format_as_member<
+    T, void_t<decltype(formatter<T>::format_as(std::declval<const T&>()))>>
+    : std::true_type {};
+
+// Guard against format_as because reference_wrappers are implicitly convertible
+// to T&
+
 template <typename T, typename Char>
-struct formatter<std::reference_wrapper<T>, Char,
-                 enable_if_t<is_formattable<remove_cvref_t<T>, Char>::value>>
+struct formatter<
+    std::reference_wrapper<T>, Char,
+    enable_if_t<is_formattable<remove_cvref_t<T>, Char>::value &&
+                !has_format_as<T>::value && !has_format_as_member<T>::value>>
     : formatter<remove_cvref_t<T>, Char> {
   template <typename FormatContext>
   auto format(std::reference_wrapper<T> ref, FormatContext& ctx) const

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -414,4 +414,22 @@ TEST(std_test, format_shared_ptr) {
 TEST(std_test, format_reference_wrapper) {
   int num = 35;
   EXPECT_EQ("35", fmt::to_string(std::cref(num)));
+  EXPECT_EQ("35", fmt::to_string(std::ref(num)));
+  EXPECT_EQ("35", fmt::format("{}", std::cref(num)));
+  EXPECT_EQ("35", fmt::format("{}", std::ref(num)));
+}
+
+// Regression test for https://github.com/fmtlib/fmt/issues/4424
+struct type_with_format_as {
+  int x;
+};
+
+int format_as(const type_with_format_as& t) { return t.x; }
+
+TEST(std_test, format_reference_wrapper_with_format_as) {
+  type_with_format_as t{20};
+  EXPECT_EQ("20", fmt::to_string(std::cref(t)));
+  EXPECT_EQ("20", fmt::to_string(std::ref(t)));
+  EXPECT_EQ("20", fmt::format("{}", std::cref(t)));
+  EXPECT_EQ("20", fmt::format("{}", std::ref(t)));
 }

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -433,3 +433,17 @@ TEST(std_test, format_reference_wrapper_with_format_as) {
   EXPECT_EQ("20", fmt::format("{}", std::cref(t)));
   EXPECT_EQ("20", fmt::format("{}", std::ref(t)));
 }
+
+struct type_with_format_as_string {
+    std::string str;
+};
+
+std::string format_as(const type_with_format_as_string& t) { return t.str; }
+
+TEST(std_test, format_reference_wrapper_with_format_as_string) {
+  type_with_format_as_string t{"foo"};
+  EXPECT_EQ("foo", fmt::to_string(std::cref(t)));
+  EXPECT_EQ("foo", fmt::to_string(std::ref(t)));
+  EXPECT_EQ("foo", fmt::format("{}", std::cref(t)));
+  EXPECT_EQ("foo", fmt::format("{}", std::ref(t)));
+}

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -435,7 +435,7 @@ TEST(std_test, format_reference_wrapper_with_format_as) {
 }
 
 struct type_with_format_as_string {
-    std::string str;
+  std::string str;
 };
 
 std::string format_as(const type_with_format_as_string& t) { return t.str; }


### PR DESCRIPTION
This PR fixes #4424. It was unfortunately not possible to just implement this with `template <typename T> T& format_as(std::reference_wrapper<T>);` in the general case so I've just guarded the formatter specialization for format_as.

Happy to adjust the changes here if needed!