### PR TITLE
Change component prefix for NSIS compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,7 +431,7 @@ if (FMT_INSTALL)
 
   # Install the library and headers.
   install(TARGETS ${INSTALL_TARGETS}
-          COMPONENT fmt-core
+          COMPONENT fmt_core
           EXPORT ${targets_export_name}
           LIBRARY DESTINATION ${FMT_LIB_DIR}
           ARCHIVE DESTINATION ${FMT_LIB_DIR}
@@ -447,13 +447,13 @@ if (FMT_INSTALL)
   # Install version, config and target files.
   install(FILES ${project_config} ${version_config}
           DESTINATION ${FMT_CMAKE_DIR}
-          COMPONENT fmt-core)
+          COMPONENT fmt_core)
   install(EXPORT ${targets_export_name} DESTINATION ${FMT_CMAKE_DIR}
           NAMESPACE fmt::
-          COMPONENT fmt-core)
+          COMPONENT fmt_core)
 
   install(FILES "${pkgconfig}" DESTINATION "${FMT_PKGCONFIG_DIR}"
-          COMPONENT fmt-core)
+          COMPONENT fmt_core)
 endif ()
 
 function(add_doc_target)
@@ -490,7 +490,7 @@ function(add_doc_target)
   include(GNUInstallDirs)
   install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc-html/
           DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/fmt
-          COMPONENT fmt-doc OPTIONAL)
+          COMPONENT fmt_doc OPTIONAL)
 endfunction()
 
 if (FMT_DOC)


### PR DESCRIPTION
Fixes #4441.

NSIS does not accept the `-` character in variable names, so CPack on Windows fails with the current component names `fmt-core` and `fmt-doc`.

Switching to `fmt_core` and `fmt_doc` resolves the issue.