### PR TITLE
Remove some redundant `const`s and `inline`s

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -326,7 +326,7 @@ inline auto get_classic_locale() -> const std::locale& {
 }
 
 template <typename CodeUnit> struct codecvt_result {
-  static constexpr const size_t max_size = 32;
+  static constexpr size_t max_size = 32;
   CodeUnit buf[max_size];
   CodeUnit* end;
 };
@@ -652,7 +652,7 @@ inline void write_digit2_separated(char* buf, unsigned a, unsigned b,
   // Add ASCII '0' to each digit byte and insert separators.
   digits |= 0x3030003030003030 | (usep << 16) | (usep << 40);
 
-  constexpr const size_t len = 8;
+  constexpr size_t len = 8;
   if (const_check(is_big_endian())) {
     char tmp[len];
     std::memcpy(tmp, &digits, len);

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -275,7 +275,7 @@ template <> struct cache_accessor<float> {
   static auto get_cached_power(int k) noexcept -> uint64_t {
     FMT_ASSERT(k >= float_info<float>::min_k && k <= float_info<float>::max_k,
                "k is out of range");
-    static constexpr const uint64_t pow10_significands[] = {
+    static constexpr uint64_t pow10_significands[] = {
         0x81ceb32c4b43fcf5, 0xa2425ff75e14fc32, 0xcad2f7f5359a3b3f,
         0xfd87b5f28300ca0e, 0x9e74d1b791e07e49, 0xc612062576589ddb,
         0xf79687aed3eec552, 0x9abe14cd44753b53, 0xc16d9a0095928a28,
@@ -370,7 +370,7 @@ template <> struct cache_accessor<double> {
     FMT_ASSERT(k >= float_info<double>::min_k && k <= float_info<double>::max_k,
                "k is out of range");
 
-    static constexpr const uint128_fallback pow10_significands[] = {
+    static constexpr uint128_fallback pow10_significands[] = {
 #if FMT_USE_FULL_CACHE_DRAGONBOX
       {0xff77b1fcbebcdc4f, 0x25e8e89c13bb0f7b},
       {0x9faacf3df73609b1, 0x77b191618c54e9ad},
@@ -1037,7 +1037,7 @@ template <> struct cache_accessor<double> {
 #if FMT_USE_FULL_CACHE_DRAGONBOX
     return pow10_significands[k - float_info<double>::min_k];
 #else
-    static constexpr const uint64_t powers_of_5_64[] = {
+    static constexpr uint64_t powers_of_5_64[] = {
         0x0000000000000001, 0x0000000000000005, 0x0000000000000019,
         0x000000000000007d, 0x0000000000000271, 0x0000000000000c35,
         0x0000000000003d09, 0x000000000001312d, 0x000000000005f5e1,

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -555,10 +555,10 @@ FMT_CONSTEXPR FMT_NOINLINE auto copy_noinline(InputIt begin, InputIt end,
  */
 FMT_CONSTEXPR inline auto utf8_decode(const char* s, uint32_t* c, int* e)
     -> const char* {
-  constexpr const int masks[] = {0x00, 0x7f, 0x1f, 0x0f, 0x07};
-  constexpr const uint32_t mins[] = {4194304, 0, 128, 2048, 65536};
-  constexpr const int shiftc[] = {0, 18, 12, 6, 0};
-  constexpr const int shifte[] = {0, 6, 4, 2, 0};
+  constexpr int masks[] = {0x00, 0x7f, 0x1f, 0x0f, 0x07};
+  constexpr uint32_t mins[] = {4194304, 0, 128, 2048, 65536};
+  constexpr int shiftc[] = {0, 18, 12, 6, 0};
+  constexpr int shifte[] = {0, 6, 4, 2, 0};
 
   int len = "\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\0\0\0\0\0\0\0\0\2\2\2\2\3\3\4"
       [static_cast<unsigned char>(*s) >> 3];
@@ -1044,7 +1044,7 @@ inline auto do_count_digits(uint64_t n) -> int {
       10, 11, 11, 11, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 15, 15,
       15, 16, 16, 16, 16, 17, 17, 17, 18, 18, 18, 19, 19, 19, 19, 20};
   auto t = bsr2log10[FMT_BUILTIN_CLZLL(n | 1) ^ 63];
-  static constexpr const uint64_t zero_or_powers_of_10[] = {
+  static constexpr uint64_t zero_or_powers_of_10[] = {
       0, 0, FMT_POWERS_OF_10(1U), FMT_POWERS_OF_10(1000000000ULL),
       10000000000000000000ULL};
   return t - (n < zero_or_powers_of_10[t]);
@@ -1519,7 +1519,7 @@ template <typename F> struct basic_fp {
   F f;
   int e;
 
-  static constexpr const int num_significand_bits =
+  static constexpr int num_significand_bits =
       static_cast<int>(sizeof(F) * num_bits<unsigned char>());
 
   constexpr basic_fp() : f(0), e(0) {}
@@ -1964,8 +1964,7 @@ FMT_CONSTEXPR auto make_write_int_arg(T value, sign s)
     prefix = 0x01000000 | '-';
     abs_value = 0 - abs_value;
   } else {
-    constexpr const unsigned prefixes[4] = {0, 0, 0x1000000u | '+',
-                                            0x1000000u | ' '};
+    constexpr unsigned prefixes[4] = {0, 0, 0x1000000u | '+', 0x1000000u | ' '};
     prefix = prefixes[static_cast<int>(s)];
   }
   return {abs_value, prefix};

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -30,7 +30,7 @@ template <typename T> class is_map {
   template <typename> static void check(...);
 
  public:
-  static constexpr const bool value =
+  static constexpr bool value =
       !std::is_void<decltype(check<T>(nullptr))>::value;
 };
 
@@ -39,7 +39,7 @@ template <typename T> class is_set {
   template <typename> static void check(...);
 
  public:
-  static constexpr const bool value =
+  static constexpr bool value =
       !std::is_void<decltype(check<T>(nullptr))>::value && !is_map<T>::value;
 };
 
@@ -118,7 +118,7 @@ template <typename T> class is_tuple_like_ {
   template <typename> static void check(...);
 
  public:
-  static constexpr const bool value =
+  static constexpr bool value =
       !std::is_void<decltype(check<T>(nullptr))>::value;
 };
 
@@ -152,7 +152,7 @@ using tuple_index_sequence = make_index_sequence<std::tuple_size<T>::value>;
 template <typename T, typename C, bool = is_tuple_like_<T>::value>
 class is_tuple_formattable_ {
  public:
-  static constexpr const bool value = false;
+  static constexpr bool value = false;
 };
 template <typename T, typename C> class is_tuple_formattable_<T, C, true> {
   template <size_t... Is>
@@ -168,7 +168,7 @@ template <typename T, typename C> class is_tuple_formattable_<T, C, true> {
                                        C>::value)...>{}));
 
  public:
-  static constexpr const bool value =
+  static constexpr bool value =
       decltype(check(tuple_index_sequence<T>{}))::value;
 };
 
@@ -280,13 +280,12 @@ template <typename FormatContext> struct format_tuple_element {
 }  // namespace detail
 
 template <typename T> struct is_tuple_like {
-  static constexpr const bool value =
+  static constexpr bool value =
       detail::is_tuple_like_<T>::value && !detail::is_range_<T>::value;
 };
 
 template <typename T, typename C> struct is_tuple_formattable {
-  static constexpr const bool value =
-      detail::is_tuple_formattable_<T, C>::value;
+  static constexpr bool value = detail::is_tuple_formattable_<T, C>::value;
 };
 
 template <typename Tuple, typename Char>
@@ -342,7 +341,7 @@ struct formatter<Tuple, Char,
 };
 
 template <typename T, typename Char> struct is_range {
-  static constexpr const bool value =
+  static constexpr bool value =
       detail::is_range_<T>::value && !detail::has_to_string_view<T>::value;
 };
 
@@ -752,7 +751,7 @@ template <typename T> class is_container_adaptor_like {
   template <typename> static void check(...);
 
  public:
-  static constexpr const bool value =
+  static constexpr bool value =
       !std::is_void<decltype(check<T>(nullptr))>::value;
 };
 

--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -134,7 +134,7 @@ template <typename Variant, typename Char> class is_variant_formattable {
       check(std::index_sequence<Is...>);
 
  public:
-  static constexpr const bool value = decltype(check(
+  static constexpr bool value = decltype(check(
       std::make_index_sequence<std::variant_size<Variant>::value>()))::value;
 };
 
@@ -218,9 +218,9 @@ struct has_flip<T, void_t<decltype(std::declval<T>().flip())>>
     : std::true_type {};
 
 template <typename T> struct is_bit_reference_like {
-  static constexpr const bool value =
-      std::is_convertible<T, bool>::value &&
-      std::is_nothrow_assignable<T, bool>::value && has_flip<T>::value;
+  static constexpr bool value = std::is_convertible<T, bool>::value &&
+                                std::is_nothrow_assignable<T, bool>::value &&
+                                has_flip<T>::value;
 };
 
 // Workaround for libc++ incompatibility with C++ standard.
@@ -228,7 +228,7 @@ template <typename T> struct is_bit_reference_like {
 #ifdef _LIBCPP_VERSION
 template <typename C>
 struct is_bit_reference_like<std::__bit_const_reference<C>> {
-  static constexpr const bool value = true;
+  static constexpr bool value = true;
 };
 #endif
 
@@ -443,7 +443,7 @@ template <> struct formatter<std::source_location> {
 #if FMT_CPP_LIB_VARIANT
 
 template <typename T> struct is_variant_like {
-  static constexpr const bool value = detail::is_variant_like_<T>::value;
+  static constexpr bool value = detail::is_variant_like_<T>::value;
 };
 
 template <typename Char> struct formatter<std::monostate, Char> {

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1940,8 +1940,8 @@ TEST(format_test, unpacked_args) {
 
 constexpr char with_null[3] = {'{', '}', '\0'};
 constexpr char no_null[2] = {'{', '}'};
-static constexpr const char static_with_null[3] = {'{', '}', '\0'};
-static constexpr const char static_no_null[2] = {'{', '}'};
+static constexpr char static_with_null[3] = {'{', '}', '\0'};
+static constexpr char static_no_null[2] = {'{', '}'};
 
 TEST(format_test, compile_time_string) {
   EXPECT_EQ(fmt::format(FMT_STRING("foo")), "foo");


### PR DESCRIPTION
`constexpr` variables are implicitly `const`, and member functions defined within their class definition are implicitly `inline`.
