### PR TITLE
avoid include locale inline if c++20 modules are enabled

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -22,7 +22,7 @@
 
 #include "format.h"
 
-#if FMT_USE_LOCALE
+#if FMT_USE_LOCALE && !defined(FMT_MODULE)
 #  include <locale>
 #endif
 


### PR DESCRIPTION
MSVC hints with:
```
fmt\include\fmt\format-inl.h(26): warning C5244: '#include <locale>' in the purview of module 'fmt' appears erroneous.  Consider moving that directive before the module declaration, or replace the textual inclusion with 'import <locale>;'.
```

Then fails the build with `type redefinition`.

See https://github.com/arBmind/fmtlib-module-experiment for a full example.