### PR TITLE
Give useful error when misusing fmt::ptr.

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3824,7 +3824,7 @@ struct formatter<T, Char, void_t<detail::format_as_result<T>>>
  *     auto s = fmt::format("{}", fmt::ptr(p));
  */
 template <typename T> auto ptr(T p) -> const void* {
-  static_assert(std::is_pointer<T>::value, "");
+  static_assert(std::is_pointer<T>::value, "fmt::ptr used with non-pointer");
   return detail::bit_cast<const void*>(p);
 }
 


### PR DESCRIPTION
static_assert(bla, "") prints an empty message but not the condition with  MSVC. Add an informative message.

E.g.
`int i; fmt::print("{}", fmt::ptr(i))`
will print the empty message from the static_assert and the code location, but not the static_assert's condition. This patch makes it print a useful message.

I audited all static_asserts, and this appears to be the only user-facing static_assert that didn't contain a message.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
