### PR TITLE
Support to disable formatters for std::optional and std::expected

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -77,6 +77,22 @@
 #  endif
 #endif
 
+#ifndef FMT_CPP_LIB_OPTIONAL
+#  ifdef __cpp_lib_optional
+#    define FMT_CPP_LIB_OPTIONAL __cpp_lib_optional
+#  else
+#    define FMT_CPP_LIB_OPTIONAL 0
+#  endif
+#endif
+
+#ifndef FMT_CPP_LIB_EXPECTED
+#  ifdef __cpp_lib_expected
+#    define FMT_CPP_LIB_EXPECTED __cpp_lib_expected
+#  else
+#    define FMT_CPP_LIB_EXPECTED 0
+#  endif
+#endif
+
 FMT_BEGIN_NAMESPACE
 namespace detail {
 
@@ -111,7 +127,7 @@ void write_escaped_path(basic_memory_buffer<Char>& quoted,
 
 #endif  // FMT_CPP_LIB_FILESYSTEM
 
-#if defined(__cpp_lib_expected) || FMT_CPP_LIB_VARIANT
+#if FMT_CPP_LIB_EXPECTED || FMT_CPP_LIB_VARIANT
 template <typename Char, typename OutputIt, typename T>
 auto write_escaped_alternative(OutputIt out, const T& v) -> OutputIt {
   if constexpr (has_to_string_view<T>::value)
@@ -350,7 +366,7 @@ struct formatter<std::bitset<N>, Char>
 template <typename Char>
 struct formatter<std::thread::id, Char> : basic_ostream_formatter<Char> {};
 
-#ifdef __cpp_lib_optional
+#if FMT_CPP_LIB_OPTIONAL
 template <typename T, typename Char>
 struct formatter<std::optional<T>, Char,
                  std::enable_if_t<is_formattable<T, Char>::value>> {
@@ -389,9 +405,9 @@ struct formatter<std::optional<T>, Char,
     return detail::write(out, ')');
   }
 };
-#endif  // __cpp_lib_optional
+#endif  // FMT_CPP_LIB_OPTIONAL
 
-#ifdef __cpp_lib_expected
+#if FMT_CPP_LIB_EXPECTED
 template <typename T, typename E, typename Char>
 struct formatter<std::expected<T, E>, Char,
                  std::enable_if_t<(std::is_void<T>::value ||
@@ -418,7 +434,7 @@ struct formatter<std::expected<T, E>, Char,
     return out;
   }
 };
-#endif  // __cpp_lib_expected
+#endif  // FMT_CPP_LIB_EXPECTED
 
 #ifdef __cpp_lib_source_location
 template <> struct formatter<std::source_location> {

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -65,7 +65,7 @@ TEST(ranges_std_test, format_quote_path) {
       std::vector<std::filesystem::path>{"path1/file1.txt", "path2/file2.txt"};
   EXPECT_EQ(fmt::format("{}", vec),
             "[\"path1/file1.txt\", \"path2/file2.txt\"]");
-#  ifdef __cpp_lib_optional
+#  if FMT_CPP_LIB_OPTIONAL
   auto o = std::optional<std::filesystem::path>("path/file.txt");
   EXPECT_EQ(fmt::format("{}", o), "optional(\"path/file.txt\")");
   EXPECT_EQ(fmt::format("{:?}", o), "optional(\"path/file.txt\")");
@@ -121,7 +121,7 @@ TEST(std_test, source_location) {
 #endif
 
 TEST(std_test, optional) {
-#ifdef __cpp_lib_optional
+#if FMT_CPP_LIB_OPTIONAL
   EXPECT_EQ(fmt::format("{}", std::optional<int>{}), "none");
   EXPECT_EQ(fmt::format("{}", std::pair{1, "second"}), "(1, \"second\")");
   EXPECT_EQ(fmt::format("{}", std::vector{std::optional{1}, std::optional{2},
@@ -149,7 +149,7 @@ TEST(std_test, optional) {
 }
 
 TEST(std_test, expected) {
-#ifdef __cpp_lib_expected
+#if FMT_CPP_LIB_EXPECTED
   EXPECT_EQ(fmt::format("{}", std::expected<void, int>{}), "expected()");
   EXPECT_EQ(fmt::format("{}", std::expected<int, int>{1}), "expected(1)");
   EXPECT_EQ(fmt::format("{}", std::expected<int, int>{std::unexpected(1)}),
@@ -198,7 +198,7 @@ class my_class {
 };
 }  // namespace my_nso
 TEST(std_test, optional_format_as) {
-#ifdef __cpp_lib_optional
+#if FMT_CPP_LIB_OPTIONAL
   EXPECT_EQ(fmt::format("{}", std::optional<my_nso::my_number>{}), "none");
   EXPECT_EQ(fmt::format("{}", std::optional{my_nso::my_number::one}),
             "optional(\"first\")");

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -411,7 +411,7 @@ TEST(std_test_xchar, complex) {
 }
 
 TEST(std_test_xchar, optional) {
-#  ifdef __cpp_lib_optional
+#  if FMT_CPP_LIB_OPTIONAL
   EXPECT_EQ(fmt::format(L"{}", std::optional{L'C'}), L"optional(\'C\')");
   EXPECT_EQ(fmt::format(L"{}", std::optional{std::wstring{L"wide string"}}),
             L"optional(\"wide string\")");


### PR DESCRIPTION
This MR adds support to disable formatters for `std::optional` and `std::expected`, for example, if a custom standard definition is preferred.

The MR follows the same approach as for `std::variant` in https://github.com/fmtlib/fmt/pull/3716.

To disable these formatters, define the respective macros

```c++
#define FMT_CPP_LIB_OPTIONAL 0
#define FMT_CPP_LIB_EXPECTED 0
```
before loading the fmt library (or via command line to the compiler).