### PR TITLE
Export fmt::dynamic_format_arg_store

### DIFF
--- a/include/fmt/args.h
+++ b/include/fmt/args.h
@@ -71,7 +71,7 @@ class dynamic_arg_list {
  * It can be implicitly converted into `fmt::basic_format_args` for passing
  * into type-erased formatting functions such as `fmt::vformat`.
  */
-template <typename Context> class dynamic_format_arg_store {
+FMT_EXPORT template <typename Context> class dynamic_format_arg_store {
  private:
   using char_type = typename Context::char_type;
 


### PR DESCRIPTION
When consuming `fmt` as a C++20 module I could not access `fmt::dynamic_format_arg_store`.

I believe it should be exported and this PR fixes that!