### PR TITLE
Replace memset with constexpr fill_n in bigint::align and fix memset count to account for sizeof T

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -553,7 +553,7 @@ FMT_CONSTEXPR auto fill_n(OutputIt out, Size count, const T& value)
 template <typename T, typename Size>
 FMT_CONSTEXPR20 auto fill_n(T* out, Size count, char value) -> T* {
   if (is_constant_evaluated()) return fill_n<T*, Size, T>(out, count, value);
-  std::memset(out, value, to_unsigned(count));
+  std::memset(out, value, to_unsigned(count) * sizeof(T));
   return out + count;
 }
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2799,7 +2799,7 @@ class bigint {
     bigits_.resize(to_unsigned(num_bigits + exp_difference));
     for (int i = num_bigits - 1, j = i + exp_difference; i >= 0; --i, --j)
       bigits_[j] = bigits_[i];
-    memset(bigits_.data(), 0, to_unsigned(exp_difference) * sizeof(bigit));
+    fill_n(bigits_.data(), to_unsigned(exp_difference), 0);
     exp_ -= exp_difference;
   }
 


### PR DESCRIPTION
Had an issue with a particularly pedantic compiler that flagged the use of memset (a non-constexpr labeled function) in the use of bigint::align when it's marked FMT_CONSTEXPR=constexpr.
Using the internal fill_n allows the function to stay constexpr and use memset when it isn't.

Also noticed that when memset is used in fill_n, it doesn't account for sizeof(T) so when using fill_n to clear a large buffer, memset will leave a portion of the buffer unmodified.