### PR TITLE
Fix unwanted char promotion in decimal writer with wchar_t

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3429,7 +3429,7 @@ FMT_CONSTEXPR20 auto write(OutputIt out, T value) -> OutputIt {
   if (s != sign::none) *it++ = Char('-');
   // Insert a decimal point after the first digit and add an exponent.
   it = write_significand(it, dec.significand, significand_size, 1,
-                         has_decimal_point ? '.' : Char());
+                         has_decimal_point ? Char('.') : Char());
   *it++ = Char('e');
   it = write_exponent<Char>(exp, it);
   return base_iterator(out, it);


### PR DESCRIPTION
In
```cpp
  it = write_significand(it, dec.significand, significand_size, 1,
                         has_decimal_point ? '.' : Char());
```

`'.'` being a prvalue of type `char`, `Char` being `wchar_t`, the result of the ternary is `int`, leading to `write_significand` taking on `Char=int`, leading to a conversion warning down the line with strict warning settings (i.e. /W4 on MSVC).

[MSVC warning (relevant line is 67)](https://pastebin.com/Akvaf60t)