### PR TITLE
test: Add null-check for safe_fopen to prevent potential null dereference

### DIFF
--- a/test/os-test.cc
+++ b/test/os-test.cc
@@ -317,6 +317,7 @@ TEST(file_test, default_ctor) {
 TEST(file_test, open_buffered_file_in_ctor) {
   auto test_file = uniq_file_name(__LINE__);
   FILE* fp = safe_fopen(test_file.c_str(), "w");
+  ASSERT_NE(fp, nullptr) << "safe_fopen failed to open " << test_file;
   std::fputs(file_content, fp);
   std::fclose(fp);
   file f(test_file.c_str(), file::RDONLY);


### PR DESCRIPTION

Bug Description
In test/os-test.cc, the following code creates and writes to a file using safe_fopen():

FILE* fp = safe_fopen(test_file.c_str(), "w");
std::fputs(file_content, fp);
std::fclose(fp);

If safe_fopen() fails to open the file (due to permissions, disk issues, etc.), it returns a null pointer. This leads to std::fputs() and std::fclose() dereferencing a potentially null pointer, causing undefined behavior or a crash.

Root Cause
The safe_fopen() function is defined in include/fmt/util.h:

inline auto safe_fopen(const char* filename, const char* mode) -> FILE* {
#if defined(_WIN32) && !defined(__MINGW32__)
  FILE* f = nullptr;
  errno = fopen_s(&f, filename, mode);
  return f;
#else
  return std::fopen(filename, mode);
#endif
}

On failure, both fopen() and fopen_s() return nullptr, but the calling test code does not check for this possibility.

Patch
We add an assertion to ensure the file pointer is not null before proceeding:

 TEST(file_test, open_buffered_file_in_ctor) {
   auto test_file = uniq_file_name(__LINE__);
   FILE* fp = safe_fopen(test_file.c_str(), "w");
+  ASSERT_NE(fp, nullptr) << "safe_fopen failed to open file: " << test_file;
   std::fputs(file_content, fp);
   std::fclose(fp);
   file f(test_file.c_str(), file::RDONLY);

This ensures the test fails gracefully if file opening fails, and avoids undefined behavior from null dereferencing.

Impact

Increases robustness and correctness of unit tests.

Prevents undefined behavior during test execution.

Ensures test reliability across environments with different file system constraints.

Commit Message

test: Add null-check for safe_fopen in file_test.open_buffered_file_in_ctor

Ensure safe_fopen() does not return nullptr before use to avoid null pointer dereference.

Let me know if you’d like to add a regression test or error handling logic beyond test assertions.

