### PR TITLE
Fix `import std` in clang++, and add options for `import std.compat`

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -225,7 +225,7 @@ template <typename T> struct is_bit_reference_like {
 
 // Workaround for libc++ incompatibility with C++ standard.
 // According to the Standard, `bitset::operator[] const` returns bool.
-#ifdef _LIBCPP_VERSION
+#if defined(_LIBCPP_VERSION) && !defined(FMT_IMPORT_STD)
 template <typename C>
 struct is_bit_reference_like<std::__bit_const_reference<C>> {
   static constexpr bool value = true;

--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -51,6 +51,8 @@ module;
 #  include <stdint.h>
 #  include <stdio.h>
 #  include <time.h>
+#  include <string.h>
+#  include <stdlib.h>
 #endif
 #include <cerrno>
 #include <climits>

--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -50,9 +50,9 @@ module;
 #  include <limits.h>
 #  include <stdint.h>
 #  include <stdio.h>
-#  include <time.h>
-#  include <string.h>
 #  include <stdlib.h>
+#  include <string.h>
+#  include <time.h>
 #endif
 #include <cerrno>
 #include <climits>

--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -46,7 +46,7 @@ module;
 #  include <utility>
 #  include <variant>
 #  include <vector>
-#elifndef FMT_IMPORT_STD_COMPAT
+#else
 #  include <limits.h>
 #  include <stdint.h>
 #  include <stdio.h>
@@ -95,8 +95,6 @@ export module fmt;
 
 #ifdef FMT_IMPORT_STD
 import std;
-#elifdef FMT_IMPORT_STD_COMPAT
-import std.compat;
 #endif
 
 #define FMT_EXPORT export

--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -46,7 +46,7 @@ module;
 #  include <utility>
 #  include <variant>
 #  include <vector>
-#else
+#elifndef FMT_IMPORT_STD_COMPAT
 #  include <limits.h>
 #  include <stdint.h>
 #  include <stdio.h>
@@ -95,6 +95,8 @@ export module fmt;
 
 #ifdef FMT_IMPORT_STD
 import std;
+#elifdef FMT_IMPORT_STD_COMPAT
+import std.compat;
 #endif
 
 #define FMT_EXPORT export


### PR DESCRIPTION
When `#define FMT_IMPORT_STD`, `{fmt}` will do `import std` instead of `#include <std...>`. However this is currently broken on clang++. This PR fixes:
1. clang++ cannot find `memcpy`, `memcmp`, `abort` when importing std. Fix it by adding `#include <string.h>` and `#include <stdlib.h>` in global module.
2. `include/fmt/std.h` uses `std::__bit_const_reference` which is not exported by libc++ and cannot be found. Guard it by macros.

BTW, we can import C std symbols by `import std.compat`, and in this case we do not need the `<limits.h>`, `<stdint.h>`... as well. So that I add an optional  `FMT_IMPORT_STD_COMPAT` macro to tell `{fmt}` whether `import std.compat`.

**Thank you!**