### PR TITLE
Add IWYU pragma for provider header

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -38,7 +38,7 @@
 #  define FMT_REMOVE_TRANSITIVE_INCLUDES
 #endif
 
-#include "base.h"
+#include "base.h"  // IWYU pragma: export
 
 #ifndef FMT_MODULE
 #  include <cmath>    // std::signbit


### PR DESCRIPTION
This PR suggests adding an [IWYU pragma](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-begin_exportsend_exports) to the provider header `fmt/format.h`. This allows the header to be used as intended without warnings in projects with strict [clangd include diagnostics configuration](https://clangd.llvm.org/guides/include-cleaner).