### PR TITLE
Handle allocator propagation in basic_memory_buffer::move, Fix #4487

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -851,7 +851,7 @@ class basic_memory_buffer : public detail::buffer<T> {
   allocator_move_impl(basic_memory_buffer& other) {
     T* data = other.data();
     if (alloc_ != other.alloc_ && data != other.store_) {
-      size_t size = other.size(), capacity = other.capacity();
+      size_t size = other.size();
       // Perform copy operation, allocators are different
       this->resize(size);
       detail::copy<T>(data, data + size, this->data());
@@ -862,7 +862,6 @@ class basic_memory_buffer : public detail::buffer<T> {
 
   // Move data from other to this buffer.
   FMT_CONSTEXPR20 void move(basic_memory_buffer& other) {
-    using alloc_traits = std::allocator_traits<Allocator>;
     T* data = other.data();
     size_t size = other.size(), capacity = other.capacity();
     // Replicate the behaviour of std library containers

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -752,11 +752,11 @@ template <typename T> struct allocator : private std::decay<void> {
 
   void deallocate(T* p, size_t) { std::free(p); }
 
-  friend bool operator==(allocator, allocator) noexcept {
+  FMT_CONSTEXPR20 friend bool operator==(allocator, allocator) noexcept {
     return true;  // All instances of this allocator are equivalent.
   }
 
-  friend bool operator!=(allocator a, allocator b) noexcept {
+  FMT_CONSTEXPR20 friend bool operator!=(allocator a, allocator b) noexcept {
     return !(a == b);
   }
 };
@@ -835,20 +835,22 @@ class basic_memory_buffer : public detail::buffer<T> {
 
  private:
   template <typename Alloc = Allocator>
-  typename std::enable_if<std::allocator_traits<Alloc>::
-                              propagate_on_container_move_assignment::value,
-                          bool>::type
-  allocator_move_impl(basic_memory_buffer& other) {
+  FMT_CONSTEXPR20
+      typename std::enable_if<std::allocator_traits<Alloc>::
+                                  propagate_on_container_move_assignment::value,
+                              bool>::type
+      allocator_move_impl(basic_memory_buffer& other) {
     alloc_ = std::move(other.alloc_);
     return true;
   }
   // If the allocator does not propagate,
   // then copy the content from source buffer.
   template <typename Alloc = Allocator>
-  typename std::enable_if<!std::allocator_traits<Alloc>::
-                              propagate_on_container_move_assignment::value,
-                          bool>::type
-  allocator_move_impl(basic_memory_buffer& other) {
+  FMT_CONSTEXPR20
+      typename std::enable_if<!std::allocator_traits<Alloc>::
+                                  propagate_on_container_move_assignment::value,
+                              bool>::type
+      allocator_move_impl(basic_memory_buffer& other) {
     T* data = other.data();
     if (alloc_ != other.alloc_ && data != other.store_) {
       size_t size = other.size();

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -853,10 +853,8 @@ class basic_memory_buffer : public detail::buffer<T> {
     if (alloc_ != other.alloc_ && data != other.store_) {
       size_t size = other.size(), capacity = other.capacity();
       // Perform copy operation, allocators are different
-      this->reserve(size);
-      detail::copy<T>(data, data + size, this->data());
       this->resize(size);
-      other.clear();
+      detail::copy<T>(data, data + size, this->data());
       return false;
     }
     return true;

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -307,7 +307,7 @@ TEST(memory_buffer_test, ctor) {
   EXPECT_EQ(123u, buffer.capacity());
 }
 
-using std_allocator = allocator_ref<std::allocator<char>>;
+using std_allocator = allocator_ref<std::allocator<char>, true>;
 
 TEST(memory_buffer_test, move_ctor_inline_buffer) {
   auto check_move_buffer =
@@ -349,6 +349,53 @@ TEST(memory_buffer_test, move_ctor_dynamic_buffer) {
   EXPECT_EQ(buffer.size(), 0);
   EXPECT_EQ(std::string(&buffer2[0], buffer2.size()), "testa");
   EXPECT_GT(buffer2.capacity(), 4u);
+}
+
+using std_allocator_n = allocator_ref<std::allocator<char>, false>;
+
+TEST(memory_buffer_test, move_ctor_inline_buffer_non_propagating) {
+  auto check_move_buffer =
+      [](const char* str,
+         basic_memory_buffer<char, 5, std_allocator_n>& buffer) {
+        std::allocator<char>* original_alloc_ptr = buffer.get_allocator().get();
+        basic_memory_buffer<char, 5, std_allocator_n> buffer2(
+            std::move(buffer));
+        EXPECT_EQ(str, std::string(&buffer[0], buffer.size()));
+        EXPECT_EQ(str, std::string(&buffer2[0], buffer2.size()));
+        EXPECT_EQ(5u, buffer2.capacity());
+        // Allocators should NOT be transferred; they remain distinct instances.
+        // The original buffer's allocator pointer should still be valid (not
+        // nullptr).
+        EXPECT_EQ(original_alloc_ptr, buffer.get_allocator().get());
+        EXPECT_NE(original_alloc_ptr, buffer2.get_allocator().get());
+      };
+  auto alloc = std::allocator<char>();
+  basic_memory_buffer<char, 5, std_allocator_n> buffer(
+      (std_allocator_n(&alloc)));
+  const char test[] = "test";
+  buffer.append(string_view(test, 4));
+  check_move_buffer("test", buffer);
+  buffer.push_back('a');
+  check_move_buffer("testa", buffer);
+}
+
+TEST(memory_buffer_test, move_ctor_dynamic_buffer_non_propagating) {
+  auto alloc = std::allocator<char>();
+  basic_memory_buffer<char, 4, std_allocator_n> buffer(
+      (std_allocator_n(&alloc)));
+  const char test[] = "test";
+  buffer.append(test, test + 4);
+  const char* inline_buffer_ptr = &buffer[0];
+  buffer.push_back('a');
+  EXPECT_NE(&buffer[0], inline_buffer_ptr);
+  std::allocator<char>* original_alloc_ptr = buffer.get_allocator().get();
+  basic_memory_buffer<char, 4, std_allocator_n> buffer2(std::move(buffer));
+  EXPECT_EQ(buffer.size(), 0);
+  EXPECT_EQ(std::string(&buffer2[0], buffer2.size()), "testa");
+  EXPECT_GT(buffer2.capacity(), 4u);
+  EXPECT_NE(&buffer2[0], inline_buffer_ptr);
+  EXPECT_EQ(original_alloc_ptr, buffer.get_allocator().get());
+  EXPECT_NE(original_alloc_ptr, buffer2.get_allocator().get());
 }
 
 void check_move_assign_buffer(const char* str,

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -394,7 +394,6 @@ TEST(memory_buffer_test, move_ctor_dynamic_buffer_non_propagating) {
   std::allocator<char>* original_alloc_ptr = buffer.get_allocator().get();
   basic_memory_buffer<char, 4, std_allocator_n> buffer2;
   buffer2 = std::move(buffer);
-  EXPECT_EQ(buffer.size(), 0);
   EXPECT_EQ(std::string(&buffer2[0], buffer2.size()), "testa");
   EXPECT_GT(buffer2.capacity(), 4u);
   EXPECT_NE(&buffer2[0], inline_buffer_ptr);

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -358,8 +358,11 @@ TEST(memory_buffer_test, move_ctor_inline_buffer_non_propagating) {
       [](const char* str,
          basic_memory_buffer<char, 5, std_allocator_n>& buffer) {
         std::allocator<char>* original_alloc_ptr = buffer.get_allocator().get();
+        const char* original_data_ptr = &buffer[0];
         basic_memory_buffer<char, 5, std_allocator_n> buffer2(
             std::move(buffer));
+        const char* new_data_ptr = &buffer2[0];
+        EXPECT_NE(original_data_ptr, new_data_ptr);
         EXPECT_EQ(str, std::string(&buffer[0], buffer.size()));
         EXPECT_EQ(str, std::string(&buffer2[0], buffer2.size()));
         EXPECT_EQ(5u, buffer2.capacity());
@@ -389,7 +392,8 @@ TEST(memory_buffer_test, move_ctor_dynamic_buffer_non_propagating) {
   buffer.push_back('a');
   EXPECT_NE(&buffer[0], inline_buffer_ptr);
   std::allocator<char>* original_alloc_ptr = buffer.get_allocator().get();
-  basic_memory_buffer<char, 4, std_allocator_n> buffer2(std::move(buffer));
+  basic_memory_buffer<char, 4, std_allocator_n> buffer2;
+  buffer2 = std::move(buffer);
   EXPECT_EQ(buffer.size(), 0);
   EXPECT_EQ(std::string(&buffer2[0], buffer2.size()), "testa");
   EXPECT_GT(buffer2.capacity(), 4u);

--- a/test/mock-allocator.h
+++ b/test/mock-allocator.h
@@ -37,7 +37,8 @@ template <typename T> class mock_allocator {
   MOCK_METHOD(void, deallocate, (T*, size_t));
 };
 
-template <typename Allocator> class allocator_ref {
+template <typename Allocator, bool PropagateOnMove = false>
+class allocator_ref {
  private:
   Allocator* alloc_;
 
@@ -48,6 +49,9 @@ template <typename Allocator> class allocator_ref {
 
  public:
   using value_type = typename Allocator::value_type;
+  using propagate_on_container_move_assignment =
+      typename std::conditional<PropagateOnMove, std::true_type,
+                                std::false_type>::type;
 
   explicit allocator_ref(Allocator* alloc = nullptr) : alloc_(alloc) {}
 
@@ -73,14 +77,16 @@ template <typename Allocator> class allocator_ref {
   }
   void deallocate(value_type* p, size_t n) { alloc_->deallocate(p, n); }
 
-  friend bool operator==(const allocator_ref& a, const allocator_ref& b) noexcept {
+  friend bool operator==(const allocator_ref& a,
+                         const allocator_ref& b) noexcept {
     if (a.alloc_ == b.alloc_) return true;
     if (a.alloc_ == nullptr || b.alloc_ == nullptr) return false;
 
-    return *a.alloc_ == *b.alloc_; 
+    return *a.alloc_ == *b.alloc_;
   }
 
-  friend bool operator!=(const allocator_ref& a, const allocator_ref& b) noexcept {
+  friend bool operator!=(const allocator_ref& a,
+                         const allocator_ref& b) noexcept {
     return !(a == b);
   }
 };

--- a/test/mock-allocator.h
+++ b/test/mock-allocator.h
@@ -72,6 +72,17 @@ template <typename Allocator> class allocator_ref {
     return std::allocator_traits<Allocator>::allocate(*alloc_, n);
   }
   void deallocate(value_type* p, size_t n) { alloc_->deallocate(p, n); }
+
+  friend bool operator==(const allocator_ref& a, const allocator_ref& b) noexcept {
+    if (a.alloc_ == b.alloc_) return true;
+    if (a.alloc_ == nullptr || b.alloc_ == nullptr) return false;
+
+    return *a.alloc_ == *b.alloc_; 
+  }
+
+  friend bool operator!=(const allocator_ref& a, const allocator_ref& b) noexcept {
+    return !(a == b);
+  }
 };
 
 #endif  // FMT_MOCK_ALLOCATOR_H_

--- a/test/mock-allocator.h
+++ b/test/mock-allocator.h
@@ -77,16 +77,16 @@ class allocator_ref {
   }
   void deallocate(value_type* p, size_t n) { alloc_->deallocate(p, n); }
 
-  friend bool operator==(const allocator_ref& a,
-                         const allocator_ref& b) noexcept {
+  FMT_CONSTEXPR20 friend bool operator==(const allocator_ref& a,
+                                         const allocator_ref& b) noexcept {
     if (a.alloc_ == b.alloc_) return true;
     if (a.alloc_ == nullptr || b.alloc_ == nullptr) return false;
 
     return *a.alloc_ == *b.alloc_;
   }
 
-  friend bool operator!=(const allocator_ref& a,
-                         const allocator_ref& b) noexcept {
+  FMT_CONSTEXPR20 friend bool operator!=(const allocator_ref& a,
+                                         const allocator_ref& b) noexcept {
     return !(a == b);
   }
 };


### PR DESCRIPTION
Fixes #4487.

This PR implements allocator-aware move behavior in `basic_memory_buffer`, following the suggestion by @dlex in the linked issue.

To enable allocator comparison (`alloc_ == other.alloc_`), I added `operator==` and `operator!=` to the following classes:

- [`allocator_ref`](https://github.com/fmtlib/fmt/blob/master/test/mock-allocator.h#L40)  
- [`allocator`](https://github.com/fmtlib/fmt/blob/master/include/fmt/format.h#L738)

### Summary of Changes

- Move logic now respects `std::allocator_traits<>::propagate_on_container_move_assignment`.
- If allocator propagation is disabled and the allocators differ, the buffer content is copied instead of moved.

### Test Failures

There are currently two failing tests (Test 7/21) that may need to be updated to match the new move semantics:

1. [`move_ctor_inline_buffer`](https://github.com/fmtlib/fmt/blob/master/test/format-test.cc#L322-L323)

```cpp
// Move should transfer allocator.
EXPECT_EQ(nullptr, buffer.get_allocator().get());
EXPECT_EQ(alloc, buffer2.get_allocator().get());
```

2. [`move_ctor_dynamic_buffer`](https://github.com/fmtlib/fmt/blob/master/test/format-test.cc#L348-L349)

```cpp
// Move should rip the guts of the first buffer.
EXPECT_EQ(&buffer[0], inline_buffer_ptr);
EXPECT_EQ(buffer.size(), 0);
```

I propose updating the above tests to align with the allocator propagation semantics. However, before proceeding, I’d like to get feedback from maintainers and reviewers. @vitaut 

Do these changes and the proposed test adjustments align with the intended design of `basic_memory_buffer`?
