### PR TITLE
msvc + ninja + modules: Fix build when consuming fmtlib while using a Ninja generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,18 +27,15 @@ endfunction()
 # DEPRECATED! Should be merged into add_module_library.
 function(enable_module target)
   if (MSVC)
-    if(CMAKE_GENERATOR STREQUAL "Ninja")
-      # Ninja dyndep expects the .ifc output to be located in a specific relative path
-      file(RELATIVE_PATH BMI_DIR "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${target}.dir")
-    else()
+    if(NOT CMAKE_GENERATOR STREQUAL "Ninja")
       set(BMI_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+      file(TO_NATIVE_PATH "${BMI_DIR}/${target}.ifc" BMI)
+      target_compile_options(${target}
+        PRIVATE /interface /ifcOutput ${BMI}
+        INTERFACE /reference fmt=${BMI})
+      set_target_properties(${target} PROPERTIES ADDITIONAL_CLEAN_FILES ${BMI})
+      set_source_files_properties(${BMI} PROPERTIES GENERATED ON)
     endif()
-    file(TO_NATIVE_PATH "${BMI_DIR}/${target}.ifc" BMI)
-    target_compile_options(${target}
-      PRIVATE /interface /ifcOutput ${BMI}
-      INTERFACE /reference fmt=${BMI})
-    set_target_properties(${target} PROPERTIES ADDITIONAL_CLEAN_FILES ${BMI})
-    set_source_files_properties(${BMI} PROPERTIES GENERATED ON)
   endif ()
 endfunction()
 


### PR DESCRIPTION
Fixes https://github.com/fmtlib/fmt/issues/4491. 

| Generator fmtlib -> consumer| Type| Old | New |
|--------|--------|--------|--------|
| VS -> VS | *| Works| Works |
| VS -> Ninja| find_package | Works | Works |
| VS -> Ninja| add_submodule| Broken | Works |
| Ninja -> VS | find_package | Broken | Broken |
| Ninja -> VS | add_submodule| Works| Works  |
| Ninja -> Ninja | find_package | Broken | Works |
| Ninja -> Ninja | add_submodule| Broken | Works |