### PR TITLE
Make compatible with WASI

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -29,7 +29,8 @@
 #  if (FMT_HAS_INCLUDE(<fcntl.h>) || defined(__APPLE__) || \
        defined(__linux__)) &&                              \
       (!defined(WINAPI_FAMILY) ||                          \
-       (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP))
+       (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)) &&    \
+      !defined(__wasm__)
 #    include <fcntl.h>  // for O_RDONLY
 #    define FMT_USE_FCNTL 1
 #  else


### PR DESCRIPTION
WASI is a POSIX subset that doesn't have `dup`, `dup2`, or `pipe` system calls.

Fixes #4496.

It is not completely clear to me that this is the right fix, nor is it clear to me why fmt needs these syscalls in first place. But it seems to fix the build.