### PR TITLE
Add FMT_USER_PROVIDED_ASSERT_FAIL

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -33,12 +33,14 @@
 FMT_BEGIN_NAMESPACE
 namespace detail {
 
+#ifndef FMT_USER_PROVIDED_ASSERT_FAIL
 FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
   // Use unchecked std::fprintf to avoid triggering another assertion when
   // writing to stderr fails.
   fprintf(stderr, "%s:%d: assertion failed: %s", file, line, message);
   abort();
 }
+#endif
 
 FMT_FUNC void format_error_code(detail::buffer<char>& out, int error_code,
                                 string_view message) noexcept {


### PR DESCRIPTION
That way one can provide ones own implementation for details::assert_fail.
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
