### PR TITLE
Ignore some more files in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,12 +3,14 @@
 *.xcodeproj
 *~
 .vscode/
+.cache/
 .vs/
 /CMakeScripts
 /Testing
 /_CPack_Packages
 /install_manifest.txt
 CMakeCache.txt
+CMakeUserPresets.json
 CMakeFiles
 CPack*.cmake
 CTestTestfile.cmake


### PR DESCRIPTION
`.cache` is generated by the clangd language server, `CMakeUserPresets.json` are local presets that shouldn't be checked in.