### PR TITLE
Silence unreachable code warnings in MSVC when FMT_USE_EXCEPTIONS are…

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -138,8 +138,12 @@ FMT_FUNC void report_error(const char* message) {
   // from MSVC.
   FMT_THROW(format_error(message));
 #else
-  fputs(message, stderr);
-  abort();
+  // Silence unreachable code warnings in MSVC.
+  volatile bool b = true;
+  if (b) {
+    fputs(message, stderr);
+    abort();
+  }
 #endif
 }
 


### PR DESCRIPTION

Removes warnings about unreachable code in VS 2022, 17.14.12 when exceptions are disabled. 

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
