### PR TITLE
Use FMT_THROW in report_error

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -147,12 +147,7 @@ FMT_FUNC void report_error(const char* message) {
   volatile bool b = true;
   if (!b) return;
 #endif
-#if FMT_USE_EXCEPTIONS
-  throw format_error(message);
-#else
-  fputs(message, stderr);
-  abort();
-#endif
+  FMT_THROW(format_error(message));
 }
 
 template <typename Locale> typename Locale::id format_facet<Locale>::id;


### PR DESCRIPTION
With exceptions: No change (if FMT_THROW is not user provided)

Without exceptions: Now also states where it comes from (report_error) and uses fprintf instead of fputs.

My motivation is, now that I have my own fmt::assert_failed, also to get rid of fputs for my embedded build.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
