### PR TITLE
Combined emphases into a single escape sequence

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -409,13 +409,16 @@ template <typename Char> struct ansi_color_escape {
     if (has_emphasis(em, emphasis::conceal)) em_codes[6] = 8;
     if (has_emphasis(em, emphasis::strikethrough)) em_codes[7] = 9;
 
+    buffer[size++] = static_cast<Char>('\x1b');
+    buffer[size++] = static_cast<Char>('[');
+
     for (size_t i = 0; i < num_emphases; ++i) {
       if (!em_codes[i]) continue;
-      buffer[size++] = static_cast<Char>('\x1b');
-      buffer[size++] = static_cast<Char>('[');
       buffer[size++] = static_cast<Char>('0' + em_codes[i]);
-      buffer[size++] = static_cast<Char>('m');
+      buffer[size++] = static_cast<Char>(';');
     }
+
+    buffer[size - 1] = static_cast<Char>('m');
   }
   FMT_CONSTEXPR operator const Char*() const noexcept { return buffer; }
 

--- a/test/color-test.cc
+++ b/test/color-test.cc
@@ -121,7 +121,7 @@ TEST(color_test, format) {
                                fmt::emphasis::underline | fmt::emphasis::blink |
                                fmt::emphasis::reverse | fmt::emphasis::conceal |
                                fmt::emphasis::strikethrough)),
-      "\x1b[1m\x1b[2m\x1b[3m\x1b[4m\x1b[5m\x1b[7m\x1b[8m\x1b[9mall\x1b[0m");
+      "\x1b[1;2;3;4;5;7;8;9mall\x1b[0m");
 }
 
 TEST(color_test, format_to) {


### PR DESCRIPTION
Instead of generating separate escape sequences for each emphasis (e.g. `\x1b[1m\x1b[3m` for bold and italic), combine them into a single escape sequence by separating the codes with semicolons (e.g. `\x1b[1;3m`).