### PR TITLE
Add missing include for crtdbg.h

### DIFF
--- a/test/gtest-extra.h
+++ b/test/gtest-extra.h
@@ -15,6 +15,10 @@
 #include "fmt/os.h"
 #include "gmock/gmock.h"
 
+#ifdef _MSC_VER
+#  include <crtdbg.h>
+#endif
+
 #define FMT_TEST_THROW_(statement, expected_exception, expected_message, fail) \
   GTEST_AMBIGUOUS_ELSE_BLOCKER_                                                \
   if (::testing::AssertionResult gtest_ar = ::testing::AssertionSuccess()) {   \


### PR DESCRIPTION
This header uses _CRT_ASSERT, which is defined in crtdbg.h but does not include it, causing a build error in format-test.cc

Fixes the issue by including the header

Fixes https://github.com/fmtlib/fmt/issues/4533 