### PR TITLE
Add support for println with compiled format string.

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -545,6 +545,21 @@ void print(const S& fmt, T&&... args) {
   print(stdout, fmt, std::forward<T>(args)...);
 }
 
+template <typename S, typename... T,
+          FMT_ENABLE_IF(is_compiled_string<S>::value)>
+void println(std::FILE* f, const S& fmt, T&&... args) {
+  auto buf = memory_buffer();
+  fmt::format_to(appender(buf), fmt, std::forward<T>(args)...);
+  buf.push_back('\n');
+  detail::print(f, {buf.data(), buf.size()});
+}
+
+template <typename S, typename... T,
+          FMT_ENABLE_IF(is_compiled_string<S>::value)>
+void println(const S& fmt, T&&... args) {
+  println(stdout, fmt, std::forward<T>(args)...);
+}
+
 template <size_t N> class static_format_result {
  private:
   char data[N];

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -312,7 +312,7 @@ TEST(compile_test, print) {
   fmt::print(FMT_COMPILE("{}"), std_context_test());
 }
 
-TEST(compile_test_bla, println) {
+TEST(compile_test, println) {
   EXPECT_WRITE(stdout, fmt::println(FMT_COMPILE("Thanks for all the {}!"), "fish"),
                "Thanks for all the fish!\n");
   EXPECT_WRITE(stderr, fmt::println(stderr, FMT_COMPILE("Thanks for all the {}!"), "panic"),

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -311,6 +311,14 @@ TEST(compile_test, print) {
                "Don't panic!");
   fmt::print(FMT_COMPILE("{}"), std_context_test());
 }
+
+TEST(compile_test_bla, println) {
+  EXPECT_WRITE(stdout, fmt::println(FMT_COMPILE("Thanks for all the {}!"), "fish"),
+               "Thanks for all the fish!\n");
+  EXPECT_WRITE(stderr, fmt::println(stderr, FMT_COMPILE("Thanks for all the {}!"), "panic"),
+               "Thanks for all the panic!\n");
+  fmt::println(FMT_COMPILE("{}"), std_context_test());
+}
 #endif
 
 #if FMT_USE_NONTYPE_TEMPLATE_ARGS


### PR DESCRIPTION
Using compiled format strings with `println` doesn't work because the corresponding overloads aren't defined. E.g., the following won't compile
```
#include <fmt/compile.h>
#include <fmt/base.h>
int main() { 
    fmt::println(FMT_COMPILE("{}"), "doesn't work");
}
```
The same works with `print`, see e.g. https://godbolt.org/z/8oMj6ofE3

This adds the missing overloads together with tests.