### PR TITLE
[docs] Add Conan instructions in the getting-started page

### DIFF
--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -78,6 +78,17 @@ community contributors. If the version is out of date, please [create an
 issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg
 repository. -->
 
+### Conan
+
+You can download and install {fmt} using the [Conan](https://conan.io/) package manager:
+
+    conan install -r conancenter --requires="fmt/[*]" --build=missing
+
+<!-- The {fmt} package in Conan Center is maintained by
+[ConanCenterIndex](https://github.com/conan-io/conan-center-index) community.
+If the version is out of date or the package does not work,
+please create an issue or pull request on the Conan Center Index repository. -->
+
 ## Building from Source
 
 CMake works by generating native makefiles or project files that can be


### PR DESCRIPTION
Greetings!

As you may know, the `{fmt}` project has been available on the Conan Center for years.

I opened this PR to expose the chance of users being able to get informed on how to install `{fmt}` using Conan. 

The pattern `fmt/[*]` indicates "the latest version available".

Regards! 
