### PR TITLE
Fix ambigious call to fprintf when compiling as a C++20 module

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -36,7 +36,7 @@ FMT_BEGIN_NAMESPACE
 FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
   // Use unchecked std::fprintf to avoid triggering another assertion when
   // writing to stderr fails.
-  fprintf(stderr, "%s:%d: assertion failed: %s", file, line, message);
+  std::fprintf(stderr, "%s:%d: assertion failed: %s", file, line, message);
   abort();
 }
 #endif


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

Fixes the following error when compiling with Clang and `-DFMT_MODULE=ON`:

```
In file included from <fmt>/src/fmt.cc:147:
In file included from <fmt>/src/format.cc:8:
<fmt>/include/fmt/format-inl.h:39:3: error: call to 'fprintf' is ambiguous
   39 |   fprintf(stderr, "%s:%d: assertion failed: %s", file, line, message);
      |   ^~~~~~~
/usr/include/stdio.h:360:12: note: candidate function
  360 | extern int fprintf (FILE *__restrict __stream,
      |            ^
<fmt>/include/fmt/printf.h:599:13: note: candidate function [with T = <const char *, int, const char *>]
  599 | inline auto fprintf(std::FILE* f, string_view fmt, const T&... args) -> int {
      |             ^

```

Compiling with GCC produces a warning instead
