### PR TITLE
feat: Allow fmt::join to accept rvalue tuples

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1598,7 +1598,7 @@ class get_locale {
     ignore_unused(loc);
     ::new (&locale_) std::locale(
 #if FMT_USE_LOCALE
-      loc.template get<std::locale>()
+        loc.template get<std::locale>()
 #endif
     );
   }

--- a/include/fmt/xchar.h
+++ b/include/fmt/xchar.h
@@ -156,9 +156,9 @@ auto join(std::initializer_list<T> list, wstring_view sep)
 }
 
 template <typename Tuple, FMT_ENABLE_IF(is_tuple_like<Tuple>::value)>
-auto join(const Tuple& tuple, basic_string_view<wchar_t> sep)
+auto join(Tuple&& tuple, basic_string_view<wchar_t> sep)
     -> tuple_join_view<Tuple, wchar_t> {
-  return {tuple, sep};
+  return {std::forward<Tuple>(tuple), sep};
 }
 
 template <typename Char, FMT_ENABLE_IF(!std::is_same<Char, char>::value)>

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -194,6 +194,11 @@ TEST(ranges_test, format_tuple) {
   EXPECT_TRUE((fmt::is_formattable<std::tuple<int, float>>::value));
 }
 
+TEST(ranges_test, format_tuple_rvalue) {
+  EXPECT_EQ(fmt::format("{}", std::make_tuple(42, 1.5f, "this is tuple", 'i')),
+            "(42, 1.5, \"this is tuple\", 'i')");
+}
+
 struct not_default_formattable {};
 struct bad_format {};
 


### PR DESCRIPTION
### Summary

This PR updates `fmt::join` and its underlying `tuple_join_view` to accept rvalue tuples. This enhances usability and fixes a critical lifetime issue, particularly when using `fmt::join` within `format_as` specializations.

### The Problem

Currently, `fmt::join` only accepts an lvalue reference to a tuple. This prevents passing a temporary tuple, such as one returned from `std::make_tuple` or `std::tie`, directly to the function.

This limitation is particularly dangerous when implementing a `format_as` overload. For example:

```cpp
struct SocketAddr {
  std::string addr;
  int port;
};

// This is unsafe with the current implementation.
auto format_as(const SocketAddr& s) {
  // std::tie returns a temporary (rvalue) tuple of references.
  return fmt::join(std::tie(s.addr, s.port), ":");
}
```

In the code above, the `tuple_join_view` returned by `fmt::join` holds a **dangling reference** to the temporary tuple created by `std::tie`, which is destroyed at the end of the `format_as` function. This leads to undefined behavior when the view is later used for formatting.

### The Solution

This PR resolves the issue by changing `fmt::join` to accept tuples via a forwarding reference (`T&&`).

- If an lvalue tuple is passed, it stores a reference as before.
- If an rvalue tuple is passed, it is moved or copied into the `tuple_join_view`, extending its lifetime and preventing dangling references.

With this change, the `format_as` implementation shown above becomes safe and works as intuitively expected. This makes `fmt::join` a much more powerful and safe tool for creating custom formatters for aggregate types.