### PR TITLE
Fix missing named argument validation in FMT_COMPILE

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -416,7 +416,11 @@ constexpr auto compile_format_string(S fmt) {
               decltype(get_type<arg_index, Args>::value), Args, arg_id_end_pos,
               arg_index, next_id>(fmt);
         } else if constexpr (c == '}') {
-          return parse_tail<Args, arg_id_end_pos + 1, ID>(
+            if constexpr (std::is_same_v<Args, type_list<>>) {
+                static_assert(!std::is_same_v<Args, type_list<>>,
+                                  "named argument referenced in format string but no arguments provided");
+                   }
+            return parse_tail<Args, arg_id_end_pos + 1, ID>(
               runtime_named_field<char_type>{arg_id_result.arg_id.name}, fmt);
         } else if constexpr (c == ':') {
           return unknown_format();  // no type info for specs parsing


### PR DESCRIPTION
Fixes #4124 

## Problem 
When using `FMT_COMPILE` with named arguments, missing arguments do not cause compilation errors as they should.

```cpp
fmt::format(FMT_COMPILE("{x}"));  // Should fail to compile, but doesn't
```
While regular `fmt::format("{x}")` correctly fails with a compilation error, `FMT_COMPILE` silently falls back to runtime handling, potentially causing runtime errors instead.

## Solution
Added compile-time validation in the named argument handling path (around line 418 in compile.h). When a named argument is referenced but no arguments are provided (Args is `type_list<>)`, the code now triggers a `static_assert` with a clear error message.

## Changes

- Added check for empty argument list when named argument lookup fails
- Preserves existing behavior for valid runtime named arguments
- Provides clear compile-time error message: "named argument referenced in format string but no arguments provided"