### PR TITLE
style: Correct indentation in locale initialization

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1598,7 +1598,7 @@ class get_locale {
     ignore_unused(loc);
     ::new (&locale_) std::locale(
 #if FMT_USE_LOCALE
-      loc.template get<std::locale>()
+        loc.template get<std::locale>()
 #endif
     );
   }


### PR DESCRIPTION
Commit 5f66e07 introduced a linting error due to incorrect indentation in the locale initialization code.

This PR corrects the indentation to resolve the issue.