### PR TITLE
support `std::optional` holding cv-qualified types

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -353,7 +353,7 @@ template <typename T, typename Char>
 struct formatter<std::optional<T>, Char,
                  std::enable_if_t<is_formattable<T, Char>::value>> {
  private:
-  formatter<T, Char> underlying_;
+  formatter<std::remove_cv_t<T>, Char> underlying_;
   static constexpr basic_string_view<Char> optional =
       detail::string_literal<Char, 'o', 'p', 't', 'i', 'o', 'n', 'a', 'l',
                              '('>{};

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -145,6 +145,7 @@ TEST(std_test, optional) {
   EXPECT_FALSE((fmt::is_formattable<unformattable>::value));
   EXPECT_FALSE((fmt::is_formattable<std::optional<unformattable>>::value));
   EXPECT_TRUE((fmt::is_formattable<std::optional<int>>::value));
+  EXPECT_TRUE((fmt::is_formattable<std::optional<const int>>::value));
 #endif
 }
 


### PR DESCRIPTION
Fixes #4561
