### PR TITLE
base.h: `_BitInt` is not available when Clang is used as a host compiler for NVCC

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -417,7 +417,11 @@ inline auto map(uint128_opt) -> monostate { return {}; }
 #endif
 
 #ifndef FMT_USE_BITINT
-#  define FMT_USE_BITINT (FMT_CLANG_VERSION >= 1500 && !defined(__CUDACC__))
+#  if FMT_CLANG_VERSION >= 1500 && !defined(__CUDACC__)
+#    define FMT_USE_BITINT 1
+#  else
+#    define FMT_USE_BITINT 0
+#  endif
 #endif
 
 #if FMT_USE_BITINT

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -417,7 +417,7 @@ inline auto map(uint128_opt) -> monostate { return {}; }
 #endif
 
 #ifndef FMT_USE_BITINT
-#  define FMT_USE_BITINT (FMT_CLANG_VERSION >= 1500)
+#  define FMT_USE_BITINT (FMT_CLANG_VERSION >= 1500 && !defined(__CUDACC__))
 #endif
 
 #if FMT_USE_BITINT


### PR DESCRIPTION
When using NVCC with Clang as the host compiler (`nvcc -ccbin=clang-17`), including fmt currently fails (at least on Linux) with
```
include/fmt/base.h(423): error: identifier "_BitInt" is undefined
  template <int N> using bitint = _BitInt(N);
```
This PR disables the use of _BitInt in that case.

I was thinking it might be related to NVCC requiring the use of libstdc++ and prohibiting libc++ in most cases, but forcing libc++ with `-Xcompiler=-stdlib=libc++ -D_ALLOW_UNSUPPORTED_LIBCPP` did not get rid of the error.

I'm guessing it has not cropped up earlier due the use of fmt with CUDA code probably not being too common and Nvidia generally recommending GCC over Clang as the host compiler.