### PR TITLE
restore 'inline' for normalize_libcxx_inline_namespaces

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -139,8 +139,8 @@ template <typename Variant, typename Char> class is_variant_formattable {
 #endif  // FMT_CPP_LIB_VARIANT
 
 #if FMT_USE_RTTI
-inline string_view normalize_libcxx_inline_namespaces(string_view demangled_name_view,
-                                               char* begin) {
+inline string_view normalize_libcxx_inline_namespaces(
+    string_view demangled_name_view, char* begin) {
   // Normalization of stdlib inline namespace names.
   // libc++ inline namespaces.
   //  std::__1::*       -> std::*


### PR DESCRIPTION
fixes #4568 

make normalize_libcxx_inline_namespaces inline to avoid multiple definitions error.