### PR TITLE
Fix module fmt::join<string_view>

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -40,6 +40,12 @@
 
 #include "base.h"
 
+// libc++ supports string_view in pre-c++17.
+#if FMT_HAS_INCLUDE(<string_view>) && \
+    (FMT_CPLUSPLUS >= 201703L || defined(_LIBCPP_VERSION))
+#  define FMT_USE_STRING_VIEW
+#endif
+
 #ifndef FMT_MODULE
 #  include <stdlib.h>  // malloc, free
 
@@ -62,11 +68,8 @@
 #    include <bit>  // std::bit_cast
 #  endif
 
-// libc++ supports string_view in pre-c++17.
-#  if FMT_HAS_INCLUDE(<string_view>) && \
-      (FMT_CPLUSPLUS >= 201703L || defined(_LIBCPP_VERSION))
+#  if defined(FMT_USE_STRING_VIEW)
 #    include <string_view>
-#    define FMT_USE_STRING_VIEW
 #  endif
 
 #  if FMT_MSC_VERSION


### PR DESCRIPTION
`FMT_USE_STRING_VIEW` define was incorrectly not being defined when using modules, so there was no appropriate formatter specialization for std::string_view. Fix is to move define out of `#ifndef FMT_MODULE` block

Fixes #4379

I'm using linux/clang/ninja, couldn't see how to compile module-test.cc from a quick look, happy to add a test in there if you can give me a pointer how I should build it and you prefer.

Test would just be like the original bug filed, eg.:
```cpp
    std::vector<std::string_view> svs;
    fmt::format("{}\n", fmt::join(svs, ", ")); // Actual values
```