### PR TITLE
[fix] error: module file CMakeFiles/__cmake_cxx23.dir/std.pcm cannot be loaded due to a configuration mismatch with the current compilation  #4279

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,15 @@ function(add_module_library name)
     # `std` is affected by CMake options and may be higher than C++20.
     get_target_property(std ${name} CXX_STANDARD)
 
+    # Respect CMAKE_CXX_EXTENSIONS when forming the -std flag used to
+    # precompile modules. A mismatch between -std=gnu++<ver> and -std=c++<ver>
+    # can cause "configuration mismatch" errors when loading .pcm files.
+    if (CMAKE_CXX_EXTENSIONS)
+      set(std_flag "-std=gnu++${std}")
+    else()
+      set(std_flag "-std=c++${std}")
+    endif()
+
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       set(pcms)
       foreach (src ${sources})
@@ -94,15 +103,15 @@ function(add_module_library name)
         # Use an absolute path to prevent target_link_libraries prepending -l
         # to it.
         set(pcms ${pcms} ${CMAKE_CURRENT_BINARY_DIR}/${pcm})
-        add_custom_command(
-          OUTPUT ${pcm}
-          COMMAND ${CMAKE_CXX_COMPILER}
-                  -std=c++${std} -x c++-module --precompile -c
-                  -o ${pcm} ${CMAKE_CURRENT_SOURCE_DIR}/${src}
-                  "-I$<JOIN:$<TARGET_PROPERTY:${name},INCLUDE_DIRECTORIES>,;-I>"
-          # Required by the -I generator expression above.
-          COMMAND_EXPAND_LISTS
-          DEPENDS ${src})
+  add_custom_command(
+    OUTPUT ${pcm}
+    COMMAND ${CMAKE_CXX_COMPILER}
+      ${std_flag} -x c++-module --precompile -c
+      -o ${pcm} ${CMAKE_CURRENT_SOURCE_DIR}/${src}
+      "-I$<JOIN:$<TARGET_PROPERTY:${name},INCLUDE_DIRECTORIES>,;-I>"
+    # Required by the -I generator expression above.
+    COMMAND_EXPAND_LISTS
+    DEPENDS ${src})
       endforeach ()
 
       # Add .pcm files as sources to make sure they are built before the library.
@@ -112,11 +121,12 @@ function(add_module_library name)
         set(obj ${pcm_we}.o)
         # Use an absolute path to prevent target_link_libraries prepending -l.
         set(sources ${sources} ${pcm} ${CMAKE_CURRENT_BINARY_DIR}/${obj})
-        add_custom_command(
-          OUTPUT ${obj}
-          COMMAND ${CMAKE_CXX_COMPILER} $<TARGET_PROPERTY:${name},COMPILE_OPTIONS>
-                  -c -o ${obj} ${pcm}
-          DEPENDS ${pcm})
+  add_custom_command(
+    OUTPUT ${obj}
+    COMMAND ${CMAKE_CXX_COMPILER} ${std_flag} -c -o ${obj} ${pcm}
+      "-I$<JOIN:$<TARGET_PROPERTY:${name},INCLUDE_DIRECTORIES>,;-I>"
+    COMMAND_EXPAND_LISTS
+    DEPENDS ${pcm})
       endforeach ()
     endif ()
     target_sources(${name} PRIVATE ${sources})


### PR DESCRIPTION
[fix] error: module file CMakeFiles/__cmake_cxx23.dir/std.pcm cannot be loaded due to a configuration mismatch with the current compilation  #4279
What I changed

Edited CMakeLists.txt in the add_module_library logic:
Compute a std_flag that honors CMAKE_CXX_EXTENSIONS:
If CMAKE_CXX_EXTENSIONS is ON, use -std=gnu++<ver>.
Otherwise use -std=c++<ver>.
Use ${std_flag} when invoking the compiler to precompile modules:
The precompile command previously used -std=c++<ver> unconditionally; now it uses ${std_flag}.
Use ${std_flag} (and the same include dirs) when compiling the .o from the .pcm to ensure a consistent compile configuration.

Why this helps

The "configuration mismatch" (PCM/PCH load failure) is typically caused by the PCM being produced with a different -std variant (e.g., -std=gnu++23) than the compile unit loading it (e.g., -std=c++23). On Clang the difference between gnu++ and c++ influences whether GNU extensions are enabled; that triggers the "GNU extensions was enabled in PCH file but is currently disabled" diagnostic.
Making the precompile and compile use the same -std avoids that mismatch.
The errors showing that types from std (enable_if, conditional, etc.) are missing are consistent with the compiler being in a different configuration or precompiled header context (modules/PCH broken), so fixing the PCM config mismatch should eliminate those follow-on errors.