### PR TITLE
value-initialise the buffer array member of detail::ansi_color_escape for constexpr use

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -429,7 +429,7 @@ template <typename Char> struct ansi_color_escape {
 
  private:
   static constexpr size_t num_emphases = 8;
-  Char buffer[7u + 4u * num_emphases];
+  Char buffer[7u + 4u * num_emphases] = {};
   size_t size = 0;
 
   static FMT_CONSTEXPR void to_esc(uint8_t c, Char* out,


### PR DESCRIPTION
I am using `make_foreground_color<>` in some code to generate the colouring escape sequence upfront (I realise I'm using things in client code from the `detail` namespace which might preclude me from asking for this to be fixed :) )

eg,

```
static constexpr auto foreground1 = fmt::detail::make_foreground_color<char>( _fg1 );
```

MSVC will refuse to compile this without the included patch, due to incomplete initialisation of the members in `ansi_color_escape`

```
... error C2131: expression did not evaluate to a constant
... failure was caused by a read of an uninitialized symbol
... see usage of 'fmt::v12::detail::ansi_color_escape<char>::buffer'
```

adding simple value-init to the `buffer` member satisfies the compiler. Does not change the outcome of any existing code.