### PR TITLE
Remove FMT_API from ostream class to members

### DIFF
--- a/include/fmt/os.h
+++ b/include/fmt/os.h
@@ -365,17 +365,17 @@ FMT_INLINE_VARIABLE constexpr auto buffer_size = detail::buffer_size();
 
 /// A fast buffered output stream for writing from a single thread. Writing from
 /// multiple threads without external synchronization may result in a data race.
-class FMT_API ostream : private detail::buffer<char> {
+class ostream : private detail::buffer<char> {
  private:
   file file_;
 
-  ostream(cstring_view path, const detail::ostream_params& params);
+  FMT_API ostream(cstring_view path, const detail::ostream_params& params);
 
-  static void grow(buffer<char>& buf, size_t);
+  FMT_API static void grow(buffer<char>& buf, size_t);
 
  public:
-  ostream(ostream&& other) noexcept;
-  ~ostream();
+  FMT_API ostream(ostream&& other) noexcept;
+  FMT_API ~ostream();
 
   operator writer() {
     detail::buffer<char>& buf = *this;


### PR DESCRIPTION
Putting FMT_API on the class definition propagates it to the base class detail::buffer<char>'s members. However, MSVC not emit definitions for inline members unless it sees the symbols as FMT_API when compiling.

This fix removes the FMT_API declaration from the class itself and marks individual non-inline members as FMT_API to address the issue.

Fixes https://github.com/fmtlib/fmt/issues/4576