### PR TITLE
Fix leaky `diagnostic ignored` pragma

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -236,6 +236,7 @@ FMT_PRAGMA_GCC(optimize("Og"))
 #  define FMT_GCC_OPTIMIZED
 #endif
 FMT_PRAGMA_CLANG(diagnostic push)
+FMT_PRAGMA_GCC(diagnostic push)
 
 #ifdef FMT_ALWAYS_INLINE
 // Use the provided definition.
@@ -2997,6 +2998,7 @@ FMT_INLINE void println(format_string<T...> fmt, T&&... args) {
   return fmt::println(stdout, fmt, static_cast<T&&>(args)...);
 }
 
+FMT_PRAGMA_GCC(diagnostic pop)
 FMT_PRAGMA_CLANG(diagnostic pop)
 FMT_PRAGMA_GCC(pop_options)
 FMT_END_EXPORT


### PR DESCRIPTION
Ignoring the `-Wconversion` diagnostic in `make_format_args` was leaking out of the header, resulting in that warning being ignored in downstream code that includes `fmt/base.h`:

https://github.com/fmtlib/fmt/blob/9395ef5fcb817c6145c7f0d274be87629c360bf2/include/fmt/base.h#L2823-L2828

We should `push`/`pop` the diagnostics to ensure this is cleaned up (as is done for clang and for GCC options).

See this [Compiler Explorer reproducer](https://godbolt.org/z/jMo4EWr4M) for the problem. You can see that gcc doesn't raise a warning while clang does. Commenting out the `#include <fmt/base.h>` restores the correct behaviour.
