### PR TITLE
Add missing FMT_CONSTEXPR specifier on static_format_result members.

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -559,8 +559,8 @@ template <size_t N> class static_format_result {
     *fmt::format_to(data, fmt, std::forward<T>(args)...) = '\0';
   }
 
-  auto str() const -> fmt::string_view { return {data, N - 1}; }
-  auto c_str() const -> const char* { return data; }
+  FMT_CONSTEXPR auto str() const -> fmt::string_view { return {data, N - 1}; }
+  FMT_CONSTEXPR auto c_str() const -> const char* { return data; }
 };
 
 /**


### PR DESCRIPTION
```cpp
file.cpp:36:27: error: constexpr variable 'string_view' must be initialized by a constant expression
   36 |     constexpr static auto string_view = str.str();
      |                           ^             ~~~~~~~~~
```

This error goes away when annotating the member function with FMT_CONSTEXPR