### PR TITLE
Vulnerability fix: uninitialized value access in basic_format_args::get()

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2645,6 +2645,7 @@ template <typename Context> class basic_format_args {
   /// Returns the argument with the specified id.
   FMT_CONSTEXPR auto get(int id) const -> format_arg {
     auto arg = format_arg();
+    arg.value_.no_value = {};
     if (!is_packed()) {
       if (id < max_size()) arg = args_[id];
       return arg;


### PR DESCRIPTION
## Summary
Fixes uninitialized variable usage flagged by Polaris in `basic_format_args::get()` method.

## Problem
- **Details:**  `High vulnerability` due to use of uninitialized variable
- **Reported by:** Polaris
- **Description:** `Using uninitialized variable 'arg'. Field 'arg.value_' is uninitialized`
- **Location in code:** Inside `basic_format_args::get()` method in `base.h`
- **Reason:** When creating a default `format_arg` object, the union member `value_` was not explicitly initialized.

## Scan snapshot
<img width="616" height="318" alt="image" src="https://github.com/user-attachments/assets/a37939aa-72c7-4130-b510-5e3d4432790e" />

## Solution
Added explicit initialization of `value_.no_value` after creating the default `format_arg` object: