### PR TITLE
Add IWYU pragma to base.h

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -8,6 +8,8 @@
 #ifndef FMT_BASE_H_
 #define FMT_BASE_H_
 
+// IWYU pragma: private, include "fmt/format.h"
+
 #if defined(FMT_IMPORT_STD) && !defined(FMT_MODULE)
 #  define FMT_MODULE
 #endif


### PR DESCRIPTION
So clang-tidy is happy if you include <fmt/format.h> for fmt::formatter<T>.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
