### PR TITLE
Make FMT_STRING redundant when FMT_USE_CONSTEVAL is enabled

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -4228,7 +4228,7 @@ class format_int {
   inline auto str() const -> std::string { return {str_, size()}; }
 };
 
-#if FMT_USE_CONSTEVAL || FMT_CLANG_ANALYZER
+#if FMT_CLANG_ANALYZER
 #  define FMT_STRING_IMPL(s, base) s
 #else
 #  define FMT_STRING_IMPL(s, base)                                           \
@@ -4257,7 +4257,11 @@ class format_int {
  *     // A compile-time error because 'd' is an invalid specifier for strings.
  *     std::string s = fmt::format(FMT_STRING("{:d}"), "foo");
  */
-#define FMT_STRING(s) FMT_STRING_IMPL(s, fmt::detail::compile_string)
+#if FMT_USE_CONSTEVAL
+#  define FMT_STRING(s) s
+#else
+#  define FMT_STRING(s) FMT_STRING_IMPL(s, fmt::detail::compile_string)
+#endif  // FMT_USE_CONSTEVAL
 
 FMT_API auto vsystem_error(int error_code, string_view fmt, format_args args)
     -> std::system_error;


### PR DESCRIPTION
Closes #4611.

As discussed in that issue, `FMT_STRING(s)` has been made to simply expand to `s` when `FMT_USE_CONSTEVAL` is enabled.

This fixes the issue with formatting chrono durations.