### PR TITLE
Fix doc CSS to display white-space properly

### DIFF
--- a/doc/fmt.css
+++ b/doc/fmt.css
@@ -20,6 +20,7 @@
   margin-left: 1em;
 }
 
+code,
 pre > code.decl {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
See fmtlib/fmt.dev#25

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
