### PR TITLE
fix: error: invalid 'static_cast' from type 'fmt::v12::locale_ref' to type 'bool'

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -930,6 +930,9 @@ class locale_ref {
   }
 
   inline explicit operator bool() const noexcept { return locale_ != nullptr; }
+#else
+ public:
+  inline explicit operator bool() const noexcept { return false; }
 #endif  // FMT_USE_LOCALE
 
  public:


### PR DESCRIPTION
Hi,

i tried to use `fmt::gmtime` with locale support disabled `#define FMT_USE_LOCALE 0`.

During compilation I get the following error:

`error: invalid 'static_cast' from type 'fmt::v12::locale_ref' to type 'bool'`

This error can be fixed by adding a bool operator to `locale_ref`. I'm not sure if my implementation is correct. At least I can see that `fmt::format("{:%Y-%m-%d %H:%M:%S}", fmt::gmtime(time))` returns the correct time string.