### PR TITLE
Speed up do_format_decimal

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1249,7 +1249,7 @@ FMT_CONSTEXPR20 auto do_format_decimal(Char* out, UInt value, int size)
   while (value >= 100) {
     n -= 2;
     if (!is_constant_evaluated() && sizeof(UInt) == 4) {
-      auto p = value * ((1ull << 39) / 100 + 1);
+      auto p = value * static_cast<uint64_t>((1ull << 39) / 100 + 1);
       write2digits_i(out + n, p >> (39 - 7) & ((1 << 7) - 1));
       value = static_cast<UInt>(p >> 39) +
               (static_cast<UInt>(value >= (100u << 25)) << 25);


### PR DESCRIPTION
Minor speedup.
Before (using https://github.com/fmtlib/format-benchmark):

```

--------------------------------------------------------------------------------
Benchmark                      Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------
fmt_format_to_compile   13785856 ns     13748336 ns           50 items_per_second=72.7361M/s
fmt_format_int          13560583 ns     13522664 ns           51 items_per_second=73.9499M/s
```

After:

```
--------------------------------------------------------------------------------
Benchmark                      Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------
fmt_format_to_compile   13448662 ns     13411962 ns           52 items_per_second=74.5603M/s
fmt_format_int          13132046 ns     13090029 ns           53 items_per_second=76.394M/s
```

The idea is to avoid the modulo (which gets compiled to a `imul` and a `sub`) by looking at the 7 bits after the decimal point of `value / 100`.

This adds 256+1 bytes worth of lookup table (the old lookup table still need to stay there, unfortunately). Although technically the null terminator and the last 2 spaces are unused.

Correctness is shown by exhaustively search through the whole range of 32-bit integers and ensure that for all `i`, `(i * ((1ull<<39)/100+1)) >> (39 - 7) & ((1<<7) - 1)` uniquely determines the value of `i % 100` and `((i * ((1ull<<39)/100+1)) >> 39) + ((i>=(100u<<25))<<25)` is exactly equal to `i / 100`.

The check `sizeof(UInt) == 4` implicitly assumes `CHAR_BIT == 8` (is it worth being spelled out?)

<details>
<summary>Source code of brute force checker</summary>

```cpp
using ull = unsigned long long;
int main(){
	int lookup [1<<7];
	for (int i = 1<<7; i-->0;){
		lookup[i] = -1;
	}
	for(unsigned i=0;;){
		auto& l = lookup[(i * ((1ull<<39)/100+1)) >> (39 - 7) & ((1<<7) - 1)];
		if(l<0) l = i % 100;
		if(l != (i % 100))
			__builtin_printf("%u\n", i);
		if(((i * ((1ull<<39)/100+1)) >> 39) + ((i>=(100u<<25))<<25) != i / 100)
			__builtin_printf(">%u %u %u\n", i, i/100, unsigned((i * ((1ull<<39)/100+1)) >> 39));
		if(++i==0) break;
	}
	for(unsigned i=0; i<sizeof(lookup)/sizeof(lookup[0]); ++i) {
		if (i % 16 == 0) __builtin_printf("\"");
		if (lookup[i] < 0)
			__builtin_printf("  ");
		else
			__builtin_printf("%02d", lookup[i]);
		if ((i+1) % 16 == 0) __builtin_printf("\"\n");
	}
}
```
</details>

Future work:

- adapt to `write_significand`
- generalize algorithm to work with 64-bit input (will need `__int128`).

------

note:

- `digits2_i` is not constexpr (before C++20)
- `write2digits_i` is not constexpr either, so there's no need for the `std::is_constant_evaluated`
- I don't understand why we don't want `memcpy` if `FMT_OPTIMIZE_SIZE` is true, but `write2digits` do that.
- apparently gcc cannot compile two char load/store into one short load/store (even with both load to a temporary then store back, so no concern of aliasing here).
- the benchmark has a very large proportion of values with at most 4 digits, which is why parallel multiplication such as in [`hofman_fun`](https://stackoverflow.com/a/4364057/5267751) will _always_ be slower.