### PR TITLE
test(scan): add basic float scan coverage

### DIFF
--- a/test/scan-test.cc
+++ b/test/scan-test.cc
@@ -58,6 +58,22 @@ TEST(scan_test, read_hex) {
       fmt::format_error, "number is too big");
 }
 
+TEST(scan_test, read_floats) {
+  auto float_result = fmt::scan<float>("3.14", "{}");
+  EXPECT_TRUE(float_result);
+  EXPECT_FLOAT_EQ(float_result->value(), 3.14f);
+
+  auto double_result = fmt::scan<double>("3.14", "{}");
+  EXPECT_TRUE(double_result);
+  EXPECT_DOUBLE_EQ(double_result->value(), 3.14);
+}
+
+TEST(scan_test, read_double_whitespace) {
+  auto result = fmt::scan<double>("   2.5   ", "{}");
+  EXPECT_TRUE(result);
+  EXPECT_DOUBLE_EQ(result->value(), 2.5);
+}
+
 TEST(scan_test, read_string) {
   EXPECT_EQ(fmt::scan<std::string>("foo", "{}")->value(), "foo");
 }


### PR DESCRIPTION
Adds basic test coverage for the experimental scan API’s floating-point handling, including simple float/double parsing and surrounding whitespace.

