### PR TITLE
zoned_time

### DIFF
--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -1021,3 +1021,30 @@ TEST(chrono_test, year_month_day) {
     EXPECT_THAT(months, Contains(fmt::format(loc, "{:L%b}", month)));
   }
 }
+
+#if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 201907L
+TEST(chrono_test, zoned_time) {
+   const static std::map<std::string, std::pair<std::string, std::string>> map_to_test{
+    {"Africa/Cairo", {"EET", "+0200"}},
+    {"Africa/Johannesburg", {"SAST", "+0200"}},
+    {"America/Chicago", {"CST", "-0600"}},
+    {"America/Denver", {"MST", "-0700"}},
+    {"America/Los_Angeles", {"PST", "-0800"}},
+    {"America/New_York", {"EST", "-0500"}},
+    {"Asia/Kolkata", {"IST", "+0530"}},
+    {"Asia/Riyadh", {"+03", "+0300"}},
+    {"Asia/Shanghai", {"CST", "+0800"}},
+    {"Asia/Tokyo", {"JST", "+0900"}},
+    {"Australia/Sydney", {"AEDT", "+1100"}},
+    {"Europe/Berlin", {"CET", "+0100"}},
+    {"Europe/London", {"GMT", "+0000"}},
+    {"Europe/Paris", {"CET", "+0100"}},
+    {"Pacific/Auckland", {"NZDT", "+1300"}}};
+   for (const auto& entry : map_to_test) {
+     const std::chrono::zoned_time entry_to_test{std::chrono::locate_zone(entry.first),
+     std::chrono::system_clock::now()};
+     EXPECT_EQ(fmt::format("{:%Z}", entry_to_test), entry.second.first);
+     EXPECT_EQ(fmt::format("{:%z}", entry_to_test), entry.second.second);
+    }
+}
+#endif


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
Hi @vitaut , this PR provides zoned_time formatter.

----

```c++
#include <fmt/chrono.h>  
#include <spdlog/spdlog.h>  

using namespace std::chrono;  

int main(int argc, char* argv[]) {
  const std::chrono::zoned_time now{locate_zone("America/Chicago"),
                       floor<seconds>(system_clock::now())};
  std::string fmt_result{fmt::format("{:%H:%M %Z %z}", now)};
  std::string std_result{std::format("{:%H:%M %Z %z}", now)};

  spdlog::info("\nfmt_result: {}\nstd_result: {}", fmt_result, std_result);
  return 0;
}
```
With the result:
```sh
[2026-01-09 02:09:56.643] [info] 
fmt_result: 17:09 CST -0600
std_result: 17:09 CST -0600
```