### PR TITLE
Fix C++20 concept detection

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2803,7 +2803,7 @@ template <typename T, typename Char = char>
 using is_formattable = bool_constant<!std::is_same<
     detail::mapped_t<conditional_t<std::is_void<T>::value, int*, T>, Char>,
     void>::value>;
-#ifdef __cpp_concepts
+#if defined(__cpp_concepts) && __cpp_concepts >= 201907L
 template <typename T, typename Char = char>
 concept formattable = is_formattable<remove_reference_t<T>, Char>::value;
 #endif


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
Fix compilation on GCC < 8.4 with `-fconcepts`.

~From GCC 8.4 onwards, ISO-19217 concepts `-fconcepts` are compatible with C++20 concepts thanks to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88075.~ Edit: Irrelevant

Repro of what I'm trying to fix: https://godbolt.org/z/vv179vWGe