### PR TITLE
Add const qualifiers and use std::move for improved const-correctness

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3944,8 +3944,8 @@ template <typename Locale> class format_facet : public Locale::facet {
   explicit format_facet(string_view sep = "", std::string grouping = "\3",
                         std::string decimal_point = ".")
       : separator_(sep.data(), sep.size()),
-        grouping_(grouping),
-        decimal_point_(decimal_point) {}
+        grouping_(std::move(grouping)),
+        decimal_point_(std::move(decimal_point)) {}
 
   auto put(appender out, loc_value val, const format_specs& specs) const
       -> bool {


### PR DESCRIPTION
Hello,

This pull request resolves several static analysis findings and improves code quality through ~`const-correctness` and~ move semantics.

### Static Analysis Findings (cppcheck)

| File | Finding |
|------|---------|
| ~`include/fmt/args.h:60`~ | ~`constVariableReference` - Variable 'value' can be declared as reference to const~ |
| ~`include/fmt/chrono.h:512`~ | ~`constParameterPointer` - Parameter 'tm' can be declared as pointer to const~ |
| ~`include/fmt/chrono.h:523`~ | ~`constVariablePointer` - Variable 'tm' can be declared as pointer to const~ |
| `include/fmt/format.h:3945` | `passedByValue` - Function parameter 'decimal_point' should be passed by const reference |

This is my first pull request to this project. I've read [CONTRIBUTING.md](https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md), all `ctest` pass and code formatted `clang*format` but please let me know if anything needs adjustment. I'd be happy to help.

Regards.