### PR TITLE
Add FMT_USE_FLOCKFILE macro to force has_flockfile trait to false

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1489,12 +1489,16 @@ template <typename F> auto getc_unlocked(F* f) -> decltype(_fgetc_nolock(f)) {
 }
 #endif
 
+#ifndef FMT_USE_FLOCKFILE
+#  define FMT_USE_FLOCKFILE 1
+#endif
+
 template <typename F = FILE, typename Enable = void>
 struct has_flockfile : std::false_type {};
 
 template <typename F>
 struct has_flockfile<F, void_t<decltype(flockfile(&std::declval<F&>()))>>
-    : std::true_type {};
+    : bool_constant<FMT_USE_FLOCKFILE != 0> {};
 
 // A FILE wrapper. F is FILE defined as a template parameter to make system API
 // detection work.


### PR DESCRIPTION
Fixes fmtlib/fmt#4646

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
