### PR TITLE
add include_guard (GLOBAL) to allow usage in multiple submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8...3.28)
-include_guard (GLOBAL)
+include_guard(GLOBAL)
 
 # Fallback for using newer policies on CMake <3.12.
 if (${CMAKE_VERSION} VERSION_LESS 3.12)


### PR DESCRIPTION
added `include_guard (GLOBAL)` to allow usage of this cmake file via add_subdirectory() from multiple submodules