### PR TITLE
Mark static arrays as constexpr for consistency

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -92,8 +92,8 @@ FMT_FUNC void format_error_code(detail::buffer<char>& out, int error_code,
   // Report error code making sure that the output fits into inline_buffer_size
   // to avoid dynamic memory allocation and potential bad_alloc.
   out.try_resize(0);
-  static const char SEP[] = ": ";
-  static const char ERROR_STR[] = "error ";
+  static constexpr char SEP[] = ": ";
+  static constexpr char ERROR_STR[] = "error ";
   // Subtract 2 to account for terminating null characters in SEP and ERROR_STR.
   size_t error_code_size = sizeof(SEP) + sizeof(ERROR_STR) - 2;
   auto abs_value = static_cast<uint32_or_64_or_128_t<int>>(error_code);

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1071,7 +1071,7 @@ using uint64_or_128_t = conditional_t<num_bits<T>() <= 64, uint64_t, uint128_t>;
 inline auto digits2(size_t value) noexcept -> const char* {
   // Align data since unaligned access may be slower when crossing a
   // hardware-specific boundary.
-  alignas(2) static const char data[] =
+  alignas(2) static constexpr char data[] =
       "0001020304050607080910111213141516171819"
       "2021222324252627282930313233343536373839"
       "4041424344454647484950515253545556575859"
@@ -1084,7 +1084,7 @@ inline auto digits2(size_t value) noexcept -> const char* {
 // the decimal point of i / 100 in base 2, the first 2 bytes
 // after digits2_i(x) is the string representation of i.
 inline auto digits2_i(size_t value) noexcept -> const char* {
-  alignas(2) static const char data[] =
+  alignas(2) static constexpr char data[] =
       "00010203  0405060707080910  1112"
       "131414151617  18192021  222324  "
       "25262728  2930313232333435  3637"


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
I realized from my a PR a few months ago.
1. These static arrays could be marked as constexpr
2. Doing so makes should decrease compile time and ~allow the linker to better de-duplicate across translation units (reducing binary size)~ (Modern compilers are pretty good, so they were able to auto-constexpr it anyway). No size difference on LLVM, approximately noise size different on gcc using LD linker).
3. It should be compatible with c++11, which is the minimum we target.
4. Allows sizeof to be constexpr when called on them, which will improve some constant folding in the library
