### PR TITLE
Moved named_arg to public API

### DIFF
--- a/include/fmt/args.h
+++ b/include/fmt/args.h
@@ -113,8 +113,7 @@ FMT_EXPORT template <typename Context> class dynamic_format_arg_store {
     data_.emplace_back(arg);
   }
 
-  template <typename T>
-  void emplace_arg(const detail::named_arg<T, char_type>& arg) {
+  template <typename T> void emplace_arg(const named_arg<T, char_type>& arg) {
     if (named_info_.empty())
       data_.insert(data_.begin(), basic_format_arg<Context>(nullptr, 0));
     data_.emplace_back(detail::unwrap(arg.value));
@@ -183,8 +182,7 @@ FMT_EXPORT template <typename Context> class dynamic_format_arg_store {
    * formatting function. `std::reference_wrapper` is supported to avoid
    * copying of the argument. The name is always copied into the store.
    */
-  template <typename T>
-  void push_back(const detail::named_arg<T, char_type>& arg) {
+  template <typename T> void push_back(const named_arg<T, char_type>& arg) {
     const char_type* arg_name =
         dynamic_args_.push<std::basic_string<char_type>>(arg.name).c_str();
     if FMT_CONSTEXPR20 (need_copy<T>::value) {

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2342,6 +2342,9 @@ inline void vprint_mojibake(FILE*, string_view, const format_args&, bool) {}
 
 // The main public API.
 
+template <typename T, typename Char = char>
+using named_arg = detail::named_arg<T, Char>;
+
 template <typename Char>
 FMT_CONSTEXPR void parse_context<Char>::do_check_arg_id(int arg_id) {
   // Argument id is only checked at compile time during parsing because
@@ -2718,7 +2721,7 @@ using vargs =
  * sufficiently new compilers. See `operator""_a()`.
  */
 template <typename T>
-inline auto arg(const char* name, const T& arg) -> detail::named_arg<T> {
+inline auto arg(const char* name, const T& arg) -> named_arg<T> {
   return {name, arg};
 }
 

--- a/include/fmt/xchar.h
+++ b/include/fmt/xchar.h
@@ -137,7 +137,7 @@ inline auto operator""_a(const wchar_t* s, size_t) -> detail::udl_arg<wchar_t> {
 #endif
 
 template <typename T>
-auto arg(const wchar_t* name, const T& arg) -> detail::named_arg<T, wchar_t> {
+auto arg(const wchar_t* name, const T& arg) -> named_arg<T, wchar_t> {
   return {name, arg};
 }
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
I have moved `named_arg` to the public API and fixed the affected files. Local tests have passed.
Close #4683 