### PR TITLE
Fix fmt-c.h not being installed with fmt-c library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,9 @@ endif ()
 target_link_libraries(fmt-c PUBLIC fmt::fmt)
 add_library(fmt::fmt-c ALIAS fmt-c)
 
+set_target_properties(fmt-c PROPERTIES
+  PUBLIC_HEADER include/fmt/fmt-c.h)
+
 # Install targets.
 if (FMT_INSTALL)
   include(CMakePackageConfigHelpers)


### PR DESCRIPTION
This PR fixes the C API header not being installed on `cmake --install <BUILDDIR>` by setting the `PUBLIC_HEADER` target property on `fmt-c`.

This also adds the other properties set on the `fmt` target except for the VS2017 workaround since I don't know what needs to change for the C library. Feel free to add it or tell me what needs to change.

Fixes #4693.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
