### PR TITLE
Add support for building and testing fmt on Windows ARM64

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,6 +30,16 @@ jobs:
             toolset: v143
             build_type: Debug
             standard: 20
+          - os: windows-11-arm
+            platform: ARM64
+            toolset: v143
+            build_type: Debug
+            standard: 20
+          - os: windows-11-arm
+            platform: ARM64
+            toolset: v143
+            build_type: Release
+            standard: 20
 
     steps:
     - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0


### PR DESCRIPTION
**PR Description:**

- The PR adds CI support for building and testing fmt on Windows ARM64

**Changes Proposed:**

- Added Windows ARM64 build configurations in the workflow file[workflows/windows.yml].