### PR TITLE
Clean up a couple of CMake includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,8 +326,6 @@ if (FMT_SAFE_DURATION_CAST)
   target_compile_definitions(fmt PUBLIC FMT_SAFE_DURATION_CAST)
 endif ()
 
-include(CMakeParseArguments)
-
 # Adds a library compiled with C++20 module support.
 #
 # Usage:
@@ -549,7 +547,6 @@ function (add_doc_target)
       --site-dir ${CMAKE_CURRENT_BINARY_DIR}/doc-html --no-directory-urls
     SOURCES ${sources})
 
-  include(GNUInstallDirs)
   install(
     DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc-html/
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/fmt


### PR DESCRIPTION
CMakeParseArguments is a no-op since CMake 3.5 and the minimum version {fmt} supports is 3.8:
    https://cmake.org/cmake/help/latest/module/CMakeParseArguments.html

GNUInstallDirs is already unconditionally included earlier in the file:
https://github.com/fmtlib/fmt/blob/2b4eb7df478a0a2ec319cf192292d2fc7b6acab2/CMakeLists.txt#L100