### PR TITLE
Use contiguous_range when available

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -87,6 +87,10 @@
 #  define FMT_HAS_CPP_ATTRIBUTE(x) 0
 #endif
 
+#if FMT_HAS_INCLUDE(<ranges>)
+#  include <ranges>
+#endif
+
 #define FMT_HAS_CPP14_ATTRIBUTE(attribute) \
   (FMT_CPLUSPLUS >= 201402L && FMT_HAS_CPP_ATTRIBUTE(attribute))
 
@@ -588,7 +592,12 @@ template <typename T> class basic_appender;
 using appender = basic_appender<char>;
 
 // Checks whether T is a container with contiguous storage.
+#if defined(__cpp_lib_ranges)
+template <typename T>
+struct is_contiguous : std::bool_constant<std::ranges::contiguous_range<T>> {};
+#else
 template <typename T> struct is_contiguous : std::false_type {};
+#endif
 
 class context;
 template <typename OutputIt, typename Char> class generic_context;


### PR DESCRIPTION
This provides further 20% speedup for `vector<char>` when used on top of https://github.com/fmtlib/fmt/pull/4679 (with the linked benchmark that has since then been rejected, but for the purpose of measuring the code runtime, it works well enough), for understandable reasons.

If one wants support for faster format to `vector<char>` before C++20, it's possible to specialize `is_contiguous` for `vector`, `array` etc. But I don't think it's worth it. For example, such template specialization would not work with custom string types.

I don't know if `<ranges>` is too heavy for `base.h`. There is `contiguous_iterator` instead in `<iterator>`. https://en.cppreference.com/w/cpp/iterator/contiguous_iterator.html

------

Side note, thinking about it, since `base.h` defines `is_contiguous` to be always false, but `format.h` defines it to be true for `string`, wouldn't this lead to potential ODR?

- compilation unit `A` includes only `base.h` and use (something that uses) `is_contiguous<string>`.
- compilation unit `B` includes `format.h` and use (something that uses) `is_contiguous<string>`.

In practice, it's probably fine though.