### PR TITLE
Provide reasonable default definition for is_contiguous

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -587,8 +587,21 @@ using string_view = basic_string_view<char>;
 template <typename T> class basic_appender;
 using appender = basic_appender<char>;
 
+namespace detail {
+
 // Checks whether T is a container with contiguous storage.
-template <typename T> struct is_contiguous : std::false_type {};
+template <typename T>
+auto is_contiguous_helper(int)
+    -> decltype(std::declval<T&>().data(), std::declval<T&>().size(),
+                std::declval<T&>().resize(size_t{}),
+                std::declval<T&>()[size_t{}], std::true_type{});
+
+template <typename T> auto is_contiguous_helper(...) -> std::false_type;
+
+}  // namespace detail
+
+template <typename T>
+struct is_contiguous : decltype(detail::is_contiguous_helper<T>(0)) {};
 
 class context;
 template <typename OutputIt, typename Char> class generic_context;


### PR DESCRIPTION
Another attempt at https://github.com/fmtlib/fmt/pull/4716 . Compiling `base-test.cc` takes around 10 seconds (both before and after), probably is fine. (not sure what else to measure.)

Instead of using [`contiguous_iterator`](https://en.cppreference.com/w/cpp/iterator/contiguous_iterator.html), I just check whether `.data()` can be called on it; if it can be called, the container is likely contiguous. Opinion?

[Some code](https://github.com/fmtlib/fmt/blob/602df7dab8c795777c82d30dc5c3b3a60364134c/include/fmt/format.h#L468-L482) assumes that if it's contiguous, `.resize()` exists, so it won't work for e.g. `std::array` even though that one is contiguous. But then `back_insert_iterator` doesn't work on `std::array` either.

Directly define a partial specialization of `is_contiguous` with `typename = void` leads to ambiguous overload errors, which is backwards incompatible if someone else special-case `is_contiguous`. See for example https://github.com/user202729/fmt/actions/runs/24015836992/job/70035092887