### PR TITLE
Avoid dropping null byte in format string

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2690,16 +2690,16 @@ template <typename... T> struct fstring {
     static_assert(count<(is_view<remove_cvref_t<T>>::value &&
                          std::is_reference<T>::value)...>() == 0,
                   "passing views as lvalues is disallowed");
-    if (FMT_USE_CONSTEVAL) parse_format_string<char>(s, checker(s, arg_pack()));
+    if (FMT_USE_CONSTEVAL)
+      parse_format_string<char>(str, checker(str, arg_pack()));
     constexpr bool unused = detail::enforce_compile_checks<sizeof(s) != 0>();
     (void)unused;
   }
   template <typename S,
             FMT_ENABLE_IF(std::is_convertible<const S&, string_view>::value)>
   FMT_CONSTEVAL FMT_ALWAYS_INLINE fstring(const S& s) : str(s) {
-    auto sv = string_view(str);
     if (FMT_USE_CONSTEVAL)
-      detail::parse_format_string<char>(sv, checker(sv, arg_pack()));
+      detail::parse_format_string<char>(str, checker(str, arg_pack()));
     constexpr bool unused = detail::enforce_compile_checks<sizeof(s) != 0>();
     (void)unused;
   }

--- a/test/compile-error-test/CMakeLists.txt
+++ b/test/compile-error-test/CMakeLists.txt
@@ -239,6 +239,16 @@ if (CMAKE_CXX_STANDARD GREATER_EQUAL 20)
   #endif
     "
     ERROR)
+  expect_compile(
+    format-string-embedded-nul-error
+    "
+    #if FMT_USE_CONSTEVAL
+      fmt::format(\"a\\0{}\");
+    #else
+      #error
+    #endif
+    "
+    ERROR)
 
   # Compile-time argument name check
   expect_compile(


### PR DESCRIPTION
Consider

```cpp
fmt::format("a\0{}");
fmt::format("{}\0a");
```
Both ought to raise a compile-time error because of missing format argument, but before this change, only the second one will. This is because previously `s` instead of `str` was passed in the checking function, which uses the following constructor overload

```cpp
#if FMT_GCC_VERSION
  FMT_ALWAYS_INLINE
#endif
  FMT_CONSTEXPR basic_string_view(const Char* s) : data_(s) {
#if FMT_HAS_BUILTIN(__builtin_strlen) || FMT_GCC_VERSION || FMT_CLANG_VERSION
    if (std::is_same<Char, char>::value && !detail::is_constant_evaluated()) {
      size_ = __builtin_strlen(detail::narrow(s));  // strlen is not constexpr.
      return;
    }
#endif
    size_t len = 0;
    while (*s++) ++len;
    size_ = len;
  }
```

and drop everything after the null byte.

Also simplify the other constructor since `str`'s type is already `string_view`.