### PR TITLE
[WIP] Detect presence of flockfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,8 @@ else ()
   message(WARNING "Feature cxx_std_11 is unknown for the CXX compiler")
 endif ()
 
-check_cxx_source_compiles([[
+check_cxx_source_compiles(
+  [[
     #include <stdio.h>
     int main() {
         // Use stdout just to prove we can pass a FILE* to it
@@ -316,9 +317,11 @@ check_cxx_source_compiles([[
         funlockfile(stdout);
         return 0;
     }
-]] HAVE_FLOCKFILE_COMPILE_TEST)
-target_compile_definitions(fmt PRIVATE
-  FMT_HAVE_FLOCKFILE_COMPILE_TEST=$<BOOL:HAVE_FLOCKFILE_COMPILE_TEST>)
+]]
+  HAVE_FLOCKFILE_COMPILE_TEST)
+target_compile_definitions(
+  fmt
+  PRIVATE FMT_HAVE_FLOCKFILE_COMPILE_TEST=$<BOOL:HAVE_FLOCKFILE_COMPILE_TEST>)
 
 # Set FMT_LIB_NAME for pkg-config fmt.pc. We cannot use the OUTPUT_NAME target
 # property because it's not set by default.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ endif ()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/support/cmake")
 
 include(CheckCXXCompilerFlag)
+include(CheckCXXSourceCompiles)
 include(JoinPaths)
 
 if (FMT_MASTER_PROJECT AND NOT DEFINED CMAKE_CXX_VISIBILITY_PRESET)
@@ -306,6 +307,18 @@ if (cxx_std_11 IN_LIST CMAKE_CXX_COMPILE_FEATURES)
 else ()
   message(WARNING "Feature cxx_std_11 is unknown for the CXX compiler")
 endif ()
+
+check_cxx_source_compiles([[
+    #include <stdio.h>
+    int main() {
+        // Use stdout just to prove we can pass a FILE* to it
+        flockfile(stdout);
+        funlockfile(stdout);
+        return 0;
+    }
+]] HAVE_FLOCKFILE_COMPILE_TEST)
+target_compile_definitions(fmt PRIVATE
+  FMT_HAVE_FLOCKFILE_COMPILE_TEST=$<BOOL:HAVE_FLOCKFILE_COMPILE_TEST>)
 
 # Set FMT_LIB_NAME for pkg-config fmt.pc. We cannot use the OUTPUT_NAME target
 # property because it's not set by default.

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1490,7 +1490,11 @@ template <typename F> auto getc_unlocked(F* f) -> decltype(_fgetc_nolock(f)) {
 #endif
 
 #ifndef FMT_USE_FLOCKFILE
-#  define FMT_USE_FLOCKFILE 1
+#  ifdef FMT_HAVE_FLOCKFILE_COMPILE_TEST
+#    define FMT_USE_FLOCKFILE FMT_HAVE_FLOCKFILE_COMPILE_TEST
+#  else
+#    define FMT_USE_FLOCKFILE 1
+#  endif
 #endif
 
 template <typename F = FILE, typename Enable = void>


### PR DESCRIPTION
@vitaut,

Wanted to continue the discussion from fmtlib/fmt#4646 since that's a closed issue..

> I think declaring functions without actually implementing them is really broken and should be fixed but I'm open to a PR to set `FMT_USE_FLOCKFILE` to 0 on newlib, provided that it's easy to detect.

@vitaut thanks for your understanding on this. I truly appreciate what you're saying, and it makes sense, but from what I've seen (and from the logistics I anticipate would be involved in not doing so), separating the declarations and implementations of low-level standard library functions in such a way that the former can't depend on the latter is SOP for bare-metal targets. (If you have any resources that suggest otherwise, I'm very open.)

A few clarifications:

How strongly wedded are you to using the presence of newlib _specifically_ as the deciding factor in setting `FMT_USE_FLOCKFILE`?

IMHO, the ideal solution would be to do something along the lines of what I've done in this PR, which directly tests if `flockfile` can be linked, especially if you're now okay making a small addition to the CMake script.  This involves as little fuss as possible and is 100% accurate, baring a mismatch in compile options between the compilation of this library and the software it is included in.

I'm realizing, however, that while your stated condition was that it be "easy to detect" and this implementation is certainly simple, it's possible you wanted me to just do this via a macro. I wanted to double check since you expressed reticence about doing this in CMake previously.

--------------------

Unfortunately, if we restrict ourselves to macros and/or detecting newlib, the accuracy of testing if `flockfile` works/links drops significantly:

It seems there is an official macro to test the presence of newlib (aptly named `__NEWLIB__`), but as I mentioned previously, the use of newlib isn't dispositive of `flockfile` being unimplemented. Newlib is just one `libc` implementation popular with bare-metal targets (others include `picolibc` and `LLVM libc`).  Further, some bare-metal platforms do, in fact, support filesystems (and, thus, `flockfile`).

If you're not convinced about using CMake to do the check, I'd be happy to address any concerns you have and figure out how to obviate them. 

<details>
<summary>
For sake of completeness, I've also included several macro-only solutions I've investigated here, with my assessment of each. As mentioned, they unfortunately all have (often major) downsides.
</summary>

1. Testing for a bare-metal target with `#if __STDC_HOSTED__ == 0`. 
  _Downside:_ This depends on the user or platform toolchain passing `-ffreestanding` to the compiler, which isn't always done.
2. Testing for the absence of any common OSes.  For example: `#if !defined(_WIN32) && !defined(__linux__) && !defined(__APPLE__) && !defined(__unix__) ...` 
  _Downside:_ this is brittle and would requires an exhaustive list of OSes with filesystems. Additionally, there are quite a few RTOS OSes where filesystem support is an optional feature.
3. Using macros make an educated guess as to if a target is bare-metal. For example: `#if (defined(__ELF__) && !defined(__linux__) && !defined(__unix__)) || defined(__ARM_EABI__)`
  _Downside:_ While this would likely be more accurate than the previous two at identifying bare-metal targets, it still can't tell if its being used on a bare-metal target with a filesystem, and is likely to miss many bare-metal targets anyway.
4. Testing if `#include <dirent.h>` works. While newlib doesn't have any macros to indicate filesystem support, one thing it does have is a default [`sys/dirent.h`](https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/include/sys/dirent.h;hb=HEAD) containing `#error` directive. If `<dirent.h>` is included and `sys/dirent.h` is not masked by a file of the same name in the platform's headers containing a real implementation, a compile-time error occurs.
  _Downside:_ this only works on newlib, plus there's no way to use this indicator without using CMake to assist, because the compiler will only know if it has an `#error` directive by `#include`ing it, at which point you've broken compilation.

</details>