### PR TITLE
Fix bug re: return type of `f(un)lockfile` wrappers for Windows

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1477,10 +1477,10 @@ template <typename T> struct span {
 };
 
 template <typename F> auto flockfile(F* f) -> decltype(_lock_file(f)) {
-  _lock_file(f);
+  return _lock_file(f);
 }
 template <typename F> auto funlockfile(F* f) -> decltype(_unlock_file(f)) {
-  _unlock_file(f);
+  return _unlock_file(f);
 }
 
 #ifndef getc_unlocked


### PR DESCRIPTION
Just a tiny bugfix I spotted: The `f(un)lockfile` wrappers in `format-inl.h` that wrap Windows's `_(un)lock_file` methods are defined with a trailing return type derived by using decltype on a hypothetical call to the underlying functions.

The wrappers don't contain a `return` in their bodies, however, so if the return type of the underlying functions were to ever change from `void`, there would be a compile error.

~~IIRC, the ability to write `return [other function returning void]();` in a function returning `void` is a new-ish addition to the standard (no idea when). Since these functions aren't public-facing, and no library code ever attempts to use their return values, I opted to just declare them `void` instead of adding `return`s.~~

This just adds `return` to each function.
