### PR TITLE
Fix out-of-bounds read in vprintf with trailing '%'

### DIFF
--- a/include/fmt/printf.h
+++ b/include/fmt/printf.h
@@ -438,6 +438,8 @@ void vprintf(buffer<Char>& buf, basic_string_view<Char> format,
     }
     write(out, basic_string_view<Char>(start, to_unsigned(it - 1 - start)));
 
+    if (it == end) report_error("invalid format string");
+
     auto specs = format_specs();
     specs.set_align(align::right);
 

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -46,6 +46,14 @@ auto test_sprintf(fmt::basic_string_view<wchar_t> format, const Args&... args)
 
 TEST(printf_test, no_args) { EXPECT_EQ("test", test_sprintf("test")); }
 
+TEST(printf_test, trailing_percent) {
+  EXPECT_THROW_MSG(test_sprintf("%"), format_error, "invalid format string");
+  EXPECT_THROW_MSG(test_sprintf("hello%"), format_error,
+                   "invalid format string");
+  EXPECT_THROW_MSG(test_sprintf("%1$d%", 1, 2), format_error,
+                   "invalid format string");
+}
+
 TEST(printf_test, escape) {
   EXPECT_EQ("%", test_sprintf("%%"));
   EXPECT_EQ("before %", test_sprintf("before %%"));
@@ -76,8 +84,6 @@ TEST(printf_test, number_is_too_big_in_arg_index) {
 }
 
 TEST(printf_test, switch_arg_indexing) {
-  EXPECT_THROW_MSG(test_sprintf("%1$d%", 1, 2), format_error,
-                   "cannot switch from manual to automatic argument indexing");
   EXPECT_THROW_MSG(test_sprintf(format("%1$d%{}d", big_num), 1, 2),
                    format_error, "number is too big");
   EXPECT_THROW_MSG(test_sprintf("%1$d%d", 1, 2), format_error,


### PR DESCRIPTION
This was originally found in ClickHouse's [fuzzing CI](https://s3.amazonaws.com/clickhouse-test-reports/PRs/102391/f9e7727745c52b516a482598b741a086e97b9ba2/unit_tests_msan/job.log) and simplified in https://github.com/fmtlib/fmt/issues/4741.

Closes https://github.com/fmtlib/fmt/issues/4741

I'm not super happy about having to move the `switch_arg_indexing` test but this one now triggers the new check, which I think it's preferable. The rest of the tests in the block are covering all other uses cases, so I think it's fine "removing it"