### PR TITLE
Replace `try` and `catch` with the `FMT_TRY` and `FMT_CATCH` macros

### DIFF
--- a/src/fmt-c.cc
+++ b/src/fmt-c.cc
@@ -31,12 +31,12 @@ extern "C" int fmt_vformat(char* buffer, size_t size, const char* fmt,
     default:          return fmt_error_invalid_arg;
     }
   }
-  try {
+  FMT_TRY {
     auto result = fmt::vformat_to_n(
         buffer, size, fmt,
         fmt::format_args(format_args, static_cast<int>(num_args)));
     return static_cast<int>(result.size);
-  } catch (...) {
+  } FMT_CATCH (...) {
   }
   return fmt_error;
 }

--- a/src/fmt-c.cc
+++ b/src/fmt-c.cc
@@ -36,7 +36,7 @@ extern "C" int fmt_vformat(char* buffer, size_t size, const char* fmt,
         buffer, size, fmt,
         fmt::format_args(format_args, static_cast<int>(num_args)));
     return static_cast<int>(result.size);
-  } FMT_CATCH (...) {
   }
+  FMT_CATCH(...) {}
   return fmt_error;
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
