### PR TITLE
Fix locale_ref should report invalid when locale is disabled

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -931,6 +931,8 @@ class locale_ref {
   }
 
   inline explicit operator bool() const noexcept { return locale_ != nullptr; }
+#else
+  inline explicit operator bool() const noexcept { return false; }
 #endif  // FMT_USE_LOCALE
 
  public:


### PR DESCRIPTION
Fixes this error when calling `fmt::format("{:%F %T}", std::chrono::system_clock::now())`

```
fmt/include/fmt/chrono.h:2150:28: error: invalid 'static_cast' from type 'fmt::v12::locale_ref' to type 'bool'
 2150 |     detail::get_locale loc(static_cast<bool>(loc_ref), loc_ref);
      |
```

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
