### PR TITLE
chore(IWYU): Remove some redundant includes

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -13,10 +13,7 @@
 
 #  include <algorithm>
 #  include <cerrno>  // errno
-#  include <climits>
-#  include <cmath>
-#  include <exception>
-#  include <new>  // std::bad_alloc
+#  include <new>     // std::bad_alloc
 #endif
 
 #if defined(_WIN32) && !defined(FMT_USE_WRITE_CONSOLE)

--- a/src/os.cc
+++ b/src/os.cc
@@ -13,7 +13,6 @@
 #include "fmt/os.h"
 
 #ifndef FMT_MODULE
-#  include <climits>
 
 #  if FMT_USE_FCNTL
 #    include <sys/stat.h>
@@ -35,6 +34,8 @@
 
 #  ifdef _WIN32
 #    include <windows.h>
+
+#    include <climits>  // CHAR_BIT
 #  endif
 #endif
 

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -13,7 +13,6 @@
 
 #include "fmt/format.h"
 #include "gmock/gmock.h"
-#include "util.h"
 
 using fmt::detail::bigint;
 using fmt::detail::fp;

--- a/test/posix-mock-test.cc
+++ b/test/posix-mock-test.cc
@@ -15,19 +15,19 @@
 #include <errno.h>
 #include <fcntl.h>
 
-#include <climits>
 #include <memory>
 
 #include "../src/os.cc"
 
 #ifdef _WIN32
 #  include <io.h>
+
+#  include <climits>  // UINT_MAX
 #  undef max
 #endif
 
 #include "gmock/gmock.h"
 #include "gtest-extra.h"
-#include "util.h"
 
 using fmt::buffered_file;
 


### PR DESCRIPTION
Checked header dependencies using `IWYU` and removed includes identified as redundant. I check potential false positives and some warnings were addressed here — not all. 

`fmt` project has platform-specific guards and backward-compatibility build paths that's why I tried to approach it as minimally as possible.

I am marking this PR draft. I want analyze CI results and check again this changes.