### PR TITLE
Fix std.h/ranges.h ambiguity for optional in c++26 (fmtlib#4760)

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -14,6 +14,13 @@
 #  include <tuple>
 #  include <type_traits>
 #  include <utility>
+
+// Check FMT_CPLUSPLUS to suppress a bogus warning in MSVC.
+#  if FMT_CPLUSPLUS >= 201703L
+#    if FMT_HAS_INCLUDE(<optional>)
+#      include <optional>
+#    endif
+#  endif
 #endif
 
 #include "format.h"
@@ -486,6 +493,12 @@ struct range_format_kind
     : conditional_t<
           is_range<T, Char>::value, detail::range_format_kind_<T>,
           std::integral_constant<range_format, range_format::disabled>> {};
+
+#if defined(__cpp_lib_optional_range_support)
+template <typename T, typename Char>
+struct range_format_kind<std::optional<T>, Char>
+    : std::integral_constant<range_format, range_format::disabled> {};
+#endif
 
 template <typename R, typename Char>
 struct formatter<

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -20,6 +20,10 @@
 #  include <ranges>
 #endif
 
+#if FMT_CPLUSPLUS > 201703L && FMT_HAS_INCLUDE(<optional>)
+#  include <optional>
+#endif
+
 #include "fmt/format.h"
 #include "gtest/gtest.h"
 
@@ -270,6 +274,14 @@ TEST(ranges_test, disabled_range_formatting_of_path) {
   EXPECT_EQ((fmt::range_format_kind<path_like<wchar_t>, char>::value),
             fmt::range_format::disabled);
 }
+
+# if defined(__cpp_lib_optional_range_support)
+TEST(ranges_test, disabled_range_formatting_of_optional) {
+  // Range format of optional is disabled to avoid ambiguity with fmt/std.h.
+  EXPECT_EQ((fmt::range_format_kind<std::optional<int>, char>::value),
+            fmt::range_format_disabled);
+}
+#endif
 
 struct vector_string : std::vector<char> {
   using base = std::vector<char>;


### PR DESCRIPTION
C++26 adds range support for `std::optional` which causes ambiguity when including both `fmt/std.h` and `fmt/ranges.h`.

This PR specifically disables optional in `fmt/ranges.h`

See #4760 .