### PR TITLE
fix GCC PCH Breakage Triggered by fmt Scoped `#pragma GCC optimize("0g")`

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -226,7 +226,7 @@
 
 // Enable minimal optimizations for more compact code in debug mode.
 FMT_PRAGMA_GCC(push_options)
-#if !defined(__OPTIMIZE__) && !defined(__CUDACC__) && !defined(FMT_MODULE)
+#if !defined(FMT_DISABLE_DEBUG_OPTIMIZE_PRAGMA) && !defined(__OPTIMIZE__) && !defined(__CUDACC__) && !defined(FMT_MODULE)
 FMT_PRAGMA_GCC(optimize("Og"))
 #endif
 


### PR DESCRIPTION
## Issue

Issue: #4757

## Changes

Added a preprocessor flag `FMT_DISABLE_DEBUG_OPTIMIZE_PRAGMA` that if set prevents `FMT_PRAGMA_GCC(optimize("0g"))` flag from being set, preventing the gcc compiler option leak.

## Testing

Verified fix works on Fedora 36/44 with gcc 12/16 with the following Dockerfile:

```
FROM --platform=linux/amd64 fedora:44

RUN dnf install -y gcc-c++ && dnf clean all

WORKDIR /fmt
COPY . .

# create bug repro files
# (include base.h in pch header and some user code in main.cpp that will trigger error)
RUN mkdir -p /repro && \
    printf '#include <fmt/base.h>\n' > /repro/pch.h && \
    printf '#include <emmintrin.h>\nint shift_right(__m128i x) {\n    __m128i result = _mm_srli_si128(x, 2);\n    return _mm_cvtsi128_si32(result);\n}\n' > /repro/main.cpp

# Compiles project twice
# [1/2] - compile code without fix (should print FAILED)
# [2/2] - compile code with fix (should print OK - fix works)
RUN printf '#!/bin/bash\n\
echo "GCC: $(g++ --version | head -1)"\n\
echo ""\n\
echo "[1] Precompiling PCH without fix..."\n\
g++ -msse2 -g -O0 -I/fmt/include -x c++-header /repro/pch.h -o /repro/pch.h.gch\n\
echo "[2] Compiling WITHOUT fix (should fail):"\n\
if g++ -msse2 -g -O0 -I/fmt/include -include /repro/pch.h -c /repro/main.cpp -o /dev/null 2>&1; then\n\
    echo "    OK (bug not triggered)"\n\
else\n\
    echo "    FAILED - bug confirmed"\n\
fi\n\
echo ""\n\
echo "[3] Precompiling PCH WITH fix..."\n\
g++ -msse2 -g -O0 -I/fmt/include -DFMT_DISABLE_DEBUG_OPTIMIZE_PRAGMA -x c++-header /repro/pch.h -o /repro/pch.h.gch\n\
echo "[4] Compiling WITH fix (should succeed):"\n\
if g++ -msse2 -g -O0 -I/fmt/include -DFMT_DISABLE_DEBUG_OPTIMIZE_PRAGMA -include /repro/pch.h -c /repro/main.cpp -o /dev/null 2>&1; then\n\
    echo "    OK - fix works!"\n\
else\n\
    echo "    FAILED - fix did not work"\n\
fi\n\
' > /repro/run.sh && chmod +x /repro/run.sh

CMD ["/repro/run.sh"]

```