### PR TITLE
docs: note std::format hex float 0x prefix difference

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -715,6 +715,10 @@ following differences:
   (ignoring redundant digits and sign in exponent) and may produce more
   decimal digits than necessary.
 
+- For the hexadecimal floating-point presentation types (`'a'`/`'A'`),
+  {fmt} includes a `0x`/`0X` prefix (similar to `printf`'s `%a`), while
+  `std::format` follows `std::to_chars` and omits the prefix.
+
 ## Configuration Options
 
 {fmt} provides configuration via CMake options and preprocessor macros to


### PR DESCRIPTION
## Summary

Documents a behavioral difference between {fmt} and `std::format` for hexadecimal floating-point formatting (`'a'`/`'A'`): {fmt} includes a `0x`/`0X` prefix (like `printf` `%a`), while `std::format` (via `std::to_chars`) does not.

Fixes #4657.

## Test plan

- [x] Documentation-only change; verified wording against Godbolt example in the issue.