### PR TITLE
Fix write_significand buffer size for GCC 16 LTO warnings

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2452,8 +2452,8 @@ template <typename OutputIt, typename UInt, typename Char,
 inline auto write_significand(OutputIt out, UInt significand,
                               int significand_size, int integral_size,
                               Char decimal_point) -> OutputIt {
-  // Buffer is large enough to hold digits (digits10 + 1) and a decimal point.
-  Char buffer[digits10<UInt>() + 2];
+  // Buffer is large enough to hold digits (digits10 + 2) and a decimal point.
+  Char buffer[digits10<UInt>() + 3];
   auto end = write_significand(buffer, significand, significand_size,
                                integral_size, decimal_point);
   return detail::copy_noinline<Char>(buffer, end, out);


### PR DESCRIPTION
## Summary

Fixes #4767.

GCC 16 with LTO reports `-Wstringop-overflow` in `write_fixed` because the stack buffer in the `write_significand` OutputIt overload was sized as `digits10<UInt>() + 2`, while `significand_size` can be `digits10 + 1` and the write path uses offset `significand_size + 1`.

Increase the buffer to `digits10<UInt>() + 3` so all digit writes and the decimal point fit.

## Test plan

- [ ] Reproduce with GCC 16 + `-flto` as described in the issue (FetchContent fmt, link with IPO)
- [ ] Confirm the LTO link stage no longer emits `-Wstringop-overflow` for `format.h`