### PR TITLE
docs: update Doxygen link in get-started guide

### DIFF
--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -136,7 +136,7 @@ To build the documentation you need the following software installed on
 your system:
 
 - [Python](https://www.python.org/)
-- [Doxygen](http://www.stack.nl/~dimitri/doxygen/)
+- [Doxygen](https://www.doxygen.org/)
 - [MkDocs](https://www.mkdocs.org/) with `mkdocs-material`, `mkdocstrings`,
   `pymdown-extensions` and `mike`
 


### PR DESCRIPTION
## Summary
Replace the deprecated `stack.nl` Doxygen URL with the current official site `https://www.doxygen.org/` in `doc/get-started.md`.

## Test plan
- [ ] Docs build unchanged aside from link target