### PR TITLE
Allow to use fmt::println with colors and formatting

### DIFF
--- a/include/fmt/color.h
+++ b/include/fmt/color.h
@@ -528,6 +528,42 @@ void print(text_style ts, format_string<T...> fmt, T&&... args) {
   return print(stdout, ts, fmt, std::forward<T>(args)...);
 }
 
+inline void vprintln(FILE* f, text_style ts, string_view fmt,
+                     format_args args) {
+  auto buf = memory_buffer();
+  detail::vformat_to(buf, ts, fmt, args);
+  buf.push_back('\n');
+  print(f, FMT_STRING("{}"), string_view(buf.begin(), buf.size()));
+}
+
+/**
+ * Formats a string and prints it to the specified file stream followed by a
+ * newline, using ANSI escape sequences to specify text formatting.
+ *
+ * **Example**:
+ *
+ *     fmt::println(fmt::emphasis::bold | fg(fmt::color::red),
+ *                  "Elapsed time: {0:.2f} seconds", 1.23);
+ */
+template <typename... T>
+void println(FILE* f, text_style ts, format_string<T...> fmt, T&&... args) {
+  vprintln(f, ts, fmt.str, vargs<T...>{{args...}});
+}
+
+/**
+ * Formats a string and prints it to stdout followed by a newline, using ANSI
+ * escape sequences to specify text formatting.
+ *
+ * **Example**:
+ *
+ *     fmt::println(fmt::emphasis::bold | fg(fmt::color::red),
+ *                  "Elapsed time: {0:.2f} seconds", 1.23);
+ */
+template <typename... T>
+void println(text_style ts, format_string<T...> fmt, T&&... args) {
+  return println(stdout, ts, fmt, std::forward<T>(args)...);
+}
+
 inline auto vformat(text_style ts, string_view fmt, format_args args)
     -> std::string {
   auto buf = memory_buffer();

--- a/test/color-test.cc
+++ b/test/color-test.cc
@@ -136,3 +136,15 @@ TEST(color_test, print) {
   EXPECT_WRITE(stdout, fmt::print(fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30)"),
                "\x1b[38;2;255;020;030mrgb(255,20,30)\x1b[0m");
 }
+
+TEST(color_test, println) {
+  EXPECT_WRITE(stdout,
+               fmt::println(fg(fmt::rgb(255, 20, 30)), "rgb(255,20,30)"),
+               "\x1b[38;2;255;020;030mrgb(255,20,30)\x1b[0m\n");
+  EXPECT_WRITE(stdout, fmt::println(fmt::emphasis::bold, "bold"),
+               "\x1b[1mbold\x1b[0m\n");
+  EXPECT_WRITE(
+      stdout,
+      fmt::println(fg(fmt::color::blue) | fmt::emphasis::bold, "blue/bold"),
+      "\x1b[1m\x1b[38;2;000;000;255mblue/bold\x1b[0m\n");
+}


### PR DESCRIPTION
Hi,
This PR simply adds the possibility to add colors and formatting while using `fmt::println`.
Example:
```c++
fmt::println(fmt::emphasis::bold | fg(fmt::color::red), "Hi!");
```

godbolt: https://godbolt.org/z/Ws511KPTz