### PR TITLE
docs: note std::format vs fmt difference for 'a' format

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -715,6 +715,11 @@ following differences:
   (ignoring redundant digits and sign in exponent) and may produce more
   decimal digits than necessary.
 
+- For the `'a'`/`'A'` presentation types, {fmt} includes the `0x`/`0X`
+  prefix in the output (like `printf`'s `%a`), while `std::format` output
+  for hexadecimal floating-point values is specified in terms of
+  `std::to_chars` and does not include that prefix.
+
 ## Configuration Options
 
 {fmt} provides configuration via CMake options and preprocessor macros to


### PR DESCRIPTION
Fixes #4657

Adds a bullet to the "differences from `std::format`" section in `doc/api.md` explaining that `'a'`/`'A'` output in {fmt} includes the `0x`/`0X` prefix (like `printf` `%a`), while `std::format` hexadecimal floating-point formatting via `std::to_chars` does not.

Example: https://godbolt.org/z/TaK4s5YTM

Made with [Cursor](https://cursor.com)