### PR TITLE
fix: add copyright notice to src/fmt.cc

### DIFF
--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -1,3 +1,10 @@
+// Formatting library for C++ - module implementation
+//
+// Copyright (c) 2012 - present, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
 module;
 
 #define FMT_MODULE


### PR DESCRIPTION
## Summary

Adds the standard {fmt} file header (copyright + license reference) to `src/fmt.cc`, matching `src/format.cc` and `src/os.cc`. This addresses SBOM / dependency scanner warnings reported in #4781.

Fixes #4781

## Test plan

- [x] Comment-only header addition before the `module;` directive
- [ ] CI

Made with [Cursor](https://cursor.com)