### PR TITLE
docs: use HTTPS Doxygen link in get-started.md

### DIFF
--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -136,7 +136,7 @@ To build the documentation you need the following software installed on
 your system:
 
 - [Python](https://www.python.org/)
-- [Doxygen](http://www.stack.nl/~dimitri/doxygen/)
+- [Doxygen](https://www.doxygen.nl/)
 - [MkDocs](https://www.mkdocs.org/) with `mkdocs-material`, `mkdocstrings`,
   `pymdown-extensions` and `mike`
 


### PR DESCRIPTION
## Summary

Updates the Doxygen prerequisite link in `doc/get-started.md` from the legacy `http://www.stack.nl/...` URL to `https://www.doxygen.nl/`.

## Test plan

- [x] Documentation only

Made with [Cursor](https://cursor.com)