### PR TITLE
Add `fmt_print` to C API

### DIFF
--- a/include/fmt/fmt-c.h
+++ b/include/fmt/fmt-c.h
@@ -181,11 +181,14 @@ typedef enum {} fmt_signed_char;
     (fmt_arg[]) { FMT_MAP(FMT_MAKE_ARG, ##__VA_ARGS__) }
 #  define FMT_EXPAND(v) v
 
-#  define fmt_format(buffer, size, fmt, ...)                              \
-    fmt_vformat((buffer), (size), (fmt),                                  \
-                FMT_EXPAND(FMT_VA_SELECT(FMT_MAKE_NULL, FMT_MAKE_ARGLIST, \
-                                         ##__VA_ARGS__)(__VA_ARGS__)),    \
-                FMT_NARG(, ##__VA_ARGS__))
+#  define FMT_FORMAT_ARGS(fmt, ...)                               \
+    (fmt),                                                        \
+        FMT_EXPAND(FMT_VA_SELECT(FMT_MAKE_NULL, FMT_MAKE_ARGLIST, \
+                                 ##__VA_ARGS__)(__VA_ARGS__)),    \
+        FMT_NARG(, ##__VA_ARGS__)
+
+#  define fmt_format(buffer, size, fmt, ...) \
+    fmt_vformat((buffer), (size), FMT_FORMAT_ARGS((fmt), ##__VA_ARGS__))
 
 #endif  // __cplusplus
 

--- a/include/fmt/fmt-c.h
+++ b/include/fmt/fmt-c.h
@@ -10,6 +10,7 @@
 
 #include <stdbool.h>  // bool
 #include <stddef.h>   // size_t
+#include <stdio.h>    // FILE
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,6 +47,8 @@ enum { fmt_error = -1, fmt_error_invalid_arg = -2 };
 
 int fmt_vformat(char* buffer, size_t size, const char* fmt, const fmt_arg* args,
                 size_t num_args);
+int fmt_vprint(FILE* stream, const char* fmt, const fmt_arg* args,
+               size_t num_args);
 
 #ifdef __cplusplus
 }
@@ -189,6 +192,9 @@ typedef enum {} fmt_signed_char;
 
 #  define fmt_format(buffer, size, fmt, ...) \
     fmt_vformat((buffer), (size), FMT_FORMAT_ARGS((fmt), ##__VA_ARGS__))
+
+#  define fmt_print(stream, fmt, ...) \
+    fmt_vprint((stream), FMT_FORMAT_ARGS((fmt), ##__VA_ARGS__))
 
 #endif  // __cplusplus
 

--- a/src/fmt-c.cc
+++ b/src/fmt-c.cc
@@ -9,12 +9,12 @@
 
 #include <fmt/base.h>
 
-extern "C" int fmt_vformat(char* buffer, size_t size, const char* fmt,
-                           const fmt_arg* args, size_t num_args) {
-  constexpr size_t max_args = 16;
-  if (num_args > max_args) return fmt_error_invalid_arg;
+constexpr size_t max_c_format_args = 16;
+static int convert_c_format_args(
+    fmt::basic_format_arg<fmt::format_context>* format_args,
+    const fmt_arg* args, size_t num_args) {
+  if (num_args > max_c_format_args) return fmt_error_invalid_arg;
 
-  fmt::basic_format_arg<fmt::format_context> format_args[max_args];
   for (size_t i = 0; i < num_args; ++i) {
     switch (args[i].type) {
     case fmt_int:    format_args[i] = args[i].value.int_value; break;
@@ -31,11 +31,35 @@ extern "C" int fmt_vformat(char* buffer, size_t size, const char* fmt,
     default:          return fmt_error_invalid_arg;
     }
   }
+  return 0;
+}
+
+extern "C" int fmt_vformat(char* buffer, size_t size, const char* fmt,
+                           const fmt_arg* args, size_t num_args) {
+  fmt::basic_format_arg<fmt::format_context> format_args[max_c_format_args];
+  int error = convert_c_format_args(format_args, args, num_args);
+  if (error != 0) return error;
+
   FMT_TRY {
     auto result = fmt::vformat_to_n(
         buffer, size, fmt,
         fmt::format_args(format_args, static_cast<int>(num_args)));
     return static_cast<int>(result.size);
+  }
+  FMT_CATCH(...) {}
+  return fmt_error;
+}
+
+extern "C" int fmt_vprint(FILE* stream, const char* fmt, const fmt_arg* args,
+                          size_t num_args) {
+  fmt::basic_format_arg<fmt::format_context> format_args[max_c_format_args];
+  int error = convert_c_format_args(format_args, args, num_args);
+  if (error != 0) return error;
+
+  FMT_TRY {
+    fmt::vprint(stream, fmt,
+                fmt::format_args(format_args, static_cast<int>(num_args)));
+    return 0;
   }
   FMT_CATCH(...) {}
   return fmt_error;


### PR DESCRIPTION
This PR introduces a `fmt_print()` macro to the C API, which print to a `FILE*` stream using `fmt::vprint(stream, fmt, format_args)`.

Additionally, this PR introduces the following helpers in `fmt-c.h`:

- a helper macro `FMT_FORMAT_ARGS(fmt, ...)` that abstracts away the macro magic necessary to produce the `fmt_arg` array, useful for avoiding duplicated logic when declaring additional wrapper macros that expand to calls to `fmt_vformat` or similar
- a `fmt_vprint()` function used to implement the `fmt_print()` macro