### PR TITLE
Fix formatting std::tm with null tm_zone

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -1192,6 +1192,7 @@ class tm_writer {
 
   template <typename T, FMT_ENABLE_IF(has_tm_zone<T>::value)>
   void format_tz_name(const T& tm) {
+    if (!tm.tm_zone) FMT_THROW(format_error("no timezone"));
     out_ = write_tm_str<Char>(out_, tm.tm_zone, loc_);
   }
   template <typename T, FMT_ENABLE_IF(!has_tm_zone<T>::value)>

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -358,6 +358,9 @@ TEST(chrono_test, tm) {
   char tz[] = "EET";
   if (fmt::detail::set_tm_zone(time, tz)) {
     EXPECT_EQ(fmt::format(fmt::runtime("{:%Z}"), time), "EET");
+    fmt::detail::set_tm_zone(time, nullptr);
+    EXPECT_THROW_MSG((void)fmt::format(fmt::runtime("{:%Z}"), time),
+                     fmt::format_error, "no timezone");
   } else {
     EXPECT_THROW_MSG((void)fmt::format(fmt::runtime("{:%Z}"), time),
                      fmt::format_error, "no timezone");


### PR DESCRIPTION
This fixes formatting `%Z` for a `std::tm` whose platform `tm_zone` field exists but is null. The syntax documentation says that unavailable timezone information should result in `format_error`; currently this path passes `tm_zone` directly to string formatting and can dereference a null C string.

The change reports the existing `no timezone` error for a null `tm_zone` and adds a chrono regression test.

Tests:
- `/tmp/fmt-pr-build/bin/chrono-test`
- `ctest --test-dir /tmp/fmt-pr-build --output-on-failure -j$(nproc)`