### PR TITLE
Add .gradle directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.so*
 *.xcodeproj
 *~
+*.gradle/
 .vscode/
 .cache/
 .vs/


### PR DESCRIPTION
When building the project with java/gradle, it generates a .gradle folder in directories, these are used by gradle to keep track of file hashes, cache and other stuff, so not needed to track and should be ignored by git