### PR TITLE
fix out-of-bounds read in basic_format_args::get

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2593,7 +2593,7 @@ template <typename Context> class basic_format_args {
   FMT_CONSTEXPR auto get(int id) const -> format_arg {
     auto arg = format_arg();
     if (!is_packed()) {
-      if (id < max_size()) arg = args_[id];
+      if (unsigned(id) < unsigned(max_size())) arg = args_[id];
       return arg;
     }
     if (unsigned(id) >= detail::max_packed_args) return arg;

--- a/test/printf-test.cc
+++ b/test/printf-test.cc
@@ -116,6 +116,17 @@ TEST(printf_test, invalid_arg_index) {
                    "argument not found");
 }
 
+TEST(printf_test, zero_positional_width_precision) {
+  // A '0' positional index for a '*' width or precision must be rejected. Use
+  // enough arguments to exercise the unpacked argument storage path.
+  EXPECT_THROW_MSG(test_sprintf("%*0$d", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                13, 14, 15, 16),
+                   format_error, "argument not found");
+  EXPECT_THROW_MSG(test_sprintf("%.*0$d", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+                                13, 14, 15, 16),
+                   format_error, "argument not found");
+}
+
 TEST(printf_test, default_align_right) {
   EXPECT_PRINTF("   42", "%5d", 42);
   EXPECT_PRINTF("  abc", "%5s", "abc");


### PR DESCRIPTION
Spotted this while poking at the printf layer with positional arguments.

    ./a.out '%*0$d'   # 16 int args, positional width index 0$
    args at 0x1044c8000, args[-1] at 0x1044c7fe0
    [1]  bus error (SIGBUS)

printf indices are 1-based, so the `get_arg` lambda in `vprintf` decrements the parsed index to 0-based before fetching. A `0$` width or precision parses to 0 and decrements to -1. The main-argument path rejects a 0 index, but the `*` width and precision paths do not, so -1 reaches `basic_format_args::get`.

The packed branch of `get` already rejects a negative id (`unsigned(id) >= max_packed_args`). The unpacked branch, taken once there are more than 15 arguments, compares `id < max_size()` as signed, so -1 passes and reads `args_[-1]`.

I put the arguments array right behind a guard page to make the read fault deterministically. `%*0$d` and `%.*0$d` both land on `args_[-1]`; valid indices stay in bounds. Making the unpacked branch use the same unsigned comparison as the packed one closes it.
