### PR TITLE
fix out-of-range float to int conversion in to_nonnegative_int

### DIFF
--- a/include/fmt/chrono.h
+++ b/include/fmt/chrono.h
@@ -934,10 +934,9 @@ inline auto to_nonnegative_int(T value, Int upper) -> Int {
 }
 template <typename T, typename Int, FMT_ENABLE_IF(!std::is_integral<T>::value)>
 inline auto to_nonnegative_int(T value, Int upper) -> Int {
-  auto int_value = static_cast<Int>(value);
-  if (int_value < 0 || value > static_cast<T>(upper))
+  if (value < 0 || value >= static_cast<T>(upper) + 1)
     FMT_THROW(format_error("invalid value"));
-  return int_value;
+  return static_cast<Int>(value);
 }
 
 constexpr auto pow10(std::uint32_t n) -> long long {

--- a/test/chrono-test.cc
+++ b/test/chrono-test.cc
@@ -989,6 +989,9 @@ TEST(chrono_test, glibc_extensions) {
 TEST(chrono_test, out_of_range) {
   auto d = std::chrono::duration<unsigned long, std::giga>(538976288);
   EXPECT_THROW((void)fmt::format("{:%j}", d), fmt::format_error);
+  // A floating-point day count that doesn't fit in int.
+  auto fd = std::chrono::duration<double>(1e300);
+  EXPECT_THROW((void)fmt::format("{:%j}", fd), fmt::format_error);
 }
 
 TEST(chrono_test, year_month_day) {


### PR DESCRIPTION
The floating-point overload of `detail::to_nonnegative_int` casts `value` to `Int` before range-checking it, so the cast itself runs on out-of-range values.

Repro (header-only, clang -std=c++17 -fsanitize=undefined):

```c++
fmt::format("{:%j}", std::chrono::duration<double>(1e300));
```

```
include/fmt/chrono.h:937:37: runtime error: 1.15741e+295 is outside the range of representable values of type 'int'
```

Path: `on_day_of_year` -> `write(days(), ...)` -> `to_nonnegative_int(days(), INT_MAX)`. Observation: `static_cast<Int>(value)` is evaluated first and the range check only sees the already-converted value, so the behaviour is undefined before the throw can happen.

Fix: do the range check first, comparing against `static_cast<T>(upper) + 1`. The `+ 1` matters at the float boundary: `static_cast<float>(INT_MAX)` rounds up to 2^31, so `value > static_cast<T>(upper)` would let a value equal to 2^31 through and the cast would still overflow. With `>= upper + 1` both the comparison and the conversion are well defined.

Found while running the chrono formatters under UBSan. Added a regression test to `chrono_test.out_of_range`; all chrono tests pass.
