### PR TITLE
Fix fallback uint128 bitwise not for 32-bit builds

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -326,6 +326,9 @@ class uint128 {
       -> uint128 {
     return {lhs.hi_ & rhs.hi_, lhs.lo_ & rhs.lo_};
   }
+  friend constexpr auto operator~(const uint128& n) -> uint128 {
+    return {~n.hi_, ~n.lo_};
+  }
   friend FMT_CONSTEXPR auto operator+(const uint128& lhs, const uint128& rhs)
       -> uint128 {
     auto result = uint128(lhs);

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -82,6 +82,11 @@ TEST(uint128_test, minus) {
   EXPECT_EQ(n - 2, 40);
 }
 
+TEST(uint128_test, bitwise_not) {
+  auto n = ~uint128(0x123456789abcdef0, 0x0fedcba987654321);
+  EXPECT_EQ(n, uint128(0xedcba9876543210f, 0xf0123456789abcde));
+}
+
 TEST(uint128_test, plus_assign) {
   auto n = uint128(32);
   n += uint128(10);


### PR DESCRIPTION
Fixes #4811.

The fallback `detail::uint128` implementation is used when native `__int128` is unavailable, including i686 builds.

`format_hexfloat` masks rounded bits with `~(inc - 1)`, but the fallback type did not define unary `operator~`, causing 32-bit builds to fail.

This change restores the missing bitwise-not operator and adds regression coverage for the fallback `uint128` implementation.

Tested:

* x86_64 build
* i686 build
* `format-test --gtest_filter=uint128_test.*`
