### PR TITLE
Avoid MSVC C4702 unreachable code warning in print/println

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -2898,8 +2898,9 @@ FMT_INLINE void print(format_string<T...> fmt, T&&... args) {
   vargs<T...> va = {{args...}};
   if FMT_CONSTEXPR20 (!detail::use_utf8)
     return detail::vprint_mojibake(stdout, fmt.str, va, false);
-  detail::is_locking<T...>() ? vprint_buffered(stdout, fmt.str, va)
-                             : vprint(fmt.str, va);
+  else
+    detail::is_locking<T...>() ? vprint_buffered(stdout, fmt.str, va)
+                               : vprint(fmt.str, va);
 }
 
 /**
@@ -2915,8 +2916,9 @@ FMT_INLINE void print(FILE* f, format_string<T...> fmt, T&&... args) {
   vargs<T...> va = {{args...}};
   if FMT_CONSTEXPR20 (!detail::use_utf8)
     return detail::vprint_mojibake(f, fmt.str, va, false);
-  detail::is_locking<T...>() ? vprint_buffered(f, fmt.str, va)
-                             : vprint(f, fmt.str, va);
+  else
+    detail::is_locking<T...>() ? vprint_buffered(f, fmt.str, va)
+                               : vprint(f, fmt.str, va);
 }
 
 /// Formats `args` according to specifications in `fmt` and writes the output
@@ -2925,7 +2927,7 @@ template <typename... T>
 FMT_INLINE void println(FILE* f, format_string<T...> fmt, T&&... args) {
   vargs<T...> va = {{args...}};
   if FMT_CONSTEXPR20 (detail::use_utf8) return vprintln(f, fmt.str, va);
-  detail::vprint_mojibake(f, fmt.str, va, true);
+  else detail::vprint_mojibake(f, fmt.str, va, true);
 }
 
 /// Formats `args` according to specifications in `fmt` and writes the output


### PR DESCRIPTION
## Problem

`fmt::print` and `fmt::println` in `base.h` dispatch on the compile-time
constant `detail::use_utf8`:

```cpp
if FMT_CONSTEXPR20 (detail::use_utf8) return vprintln(f, fmt.str, va);
detail::vprint_mojibake(f, fmt.str, va, true);
```

When the condition is constant the `if` branch always returns, so the
trailing statement is unreachable. In C++20 `FMT_CONSTEXPR20` expands to
`constexpr`, and MSVC reports the dead statement as warning **C4702
(unreachable code)** at high warning levels.

Reproducer from #4810 (MSVC 19.51, `/std:c++20 /Wall`, header-only):

```
fmt\base.h(2927) : warning C4702: unreachable code
```

Depending on the value of `use_utf8` for a given build, the same pattern
also affects the two `print` overloads.

## Fix

Move the fallthrough statement into an `else` branch so it becomes part of
the discarded `if constexpr` branch, which MSVC does not flag. Behavior is
unchanged — exactly one branch ran before and runs now.

## Testing

No compiler with MSVC was available locally, but the change was verified
to compile cleanly and behave correctly with GCC 15.2 under
`-Wall -Wextra -Werror` in C++17 (plain `if`/`else`), C++20, and C++23
(`if constexpr`/`else`), including the wide-char path via `fmt/xchar.h`.
The `else` form is the standard idiom for suppressing C4702 in a discarded
`if constexpr` branch.

Closes #4810