### PR TITLE
feat: add formatter for std::exception_ptr (#4808)

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -649,6 +649,25 @@ struct formatter<
   }
 };
 
+template <> struct formatter<std::exception_ptr> : formatter<std::exception> {
+  template <typename FormatContext>
+  auto format(const std::exception_ptr& ex_ptr, FormatContext& ctx) const
+      -> decltype(ctx.out()) {
+    if (!ex_ptr) {
+      return detail::write(ctx.out(), string_view("nullptr"));
+    }
+
+    try {
+      std::rethrow_exception(ex_ptr);
+    } catch (const std::exception& e) {
+      // Reuses the base formatter<std::exception>::format behavior perfectly
+      return formatter<std::exception>::format(e, ctx);
+    } catch (...) {
+      return detail::write(ctx.out(), string_view("unknown exception"));
+    }
+  }
+};
+
 template <int N, typename Char>
 struct formatter<detail::bitint<N>, Char> : formatter<long long, Char> {
   static_assert(N <= 64, "unsupported _BitInt");

--- a/test/std-test.cc
+++ b/test/std-test.cc
@@ -404,6 +404,26 @@ TEST(std_test, exception) {
 #endif
 }
 
+TEST(std_test, exception_ptr) {
+  std::exception_ptr p1 = nullptr;
+  std::exception_ptr p2;
+
+  try {
+    using namespace my_ns1::my_ns2;
+    throw my_exception("My Exception");
+  } catch (...) {
+    p2 = std::current_exception();
+  }
+
+  EXPECT_EQ(fmt::format("{}", p1), "nullptr");
+  EXPECT_EQ(fmt::format("{}", p2), "My Exception");
+
+#if FMT_USE_RTTI
+  EXPECT_EQ(fmt::format("{:t}", p2),
+            "my_ns1::my_ns2::my_exception: My Exception");
+#endif
+}
+
 #if FMT_USE_RTTI
 TEST(std_test, type_info) {
   EXPECT_EQ(fmt::format("{}", typeid(std::runtime_error)),


### PR DESCRIPTION
### Description
This PR adds a `fmt::formatter` specialization for `std::exception_ptr` to `fmt/std.h`, resolving the feature request in #4808. 

It safely handles `nullptr` cases, extracts the message via `e.what()` for standard exceptions, and provides a fallback for unknown types.

### Related Issue
Closes #4808

### Checklist
- [x] Formatter implemented in `include/fmt/std.h`
- [x] Unit tests added to `test/std-test.cc`
- [x] All tests passing locally