### PR TITLE
fix: use logical AND instead of bitwise AND in endpoint check

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1338,7 +1338,7 @@ template <typename T> auto to_decimal(T x) noexcept -> decimal_fp<T> {
 
   if (r < deltai) {
     // Exclude the right endpoint if necessary.
-    if (r == 0 && (z_mul.is_integer & !include_right_endpoint)) {
+    if (r == 0 && (z_mul.is_integer && !include_right_endpoint)) {
       --ret_value.significand;
       r = float_info<T>::big_divisor;
       goto small_divisor_case_label;


### PR DESCRIPTION
While configuring CodeQL for my own project, it flagged a warning about mixing a logical NOT with a bitwise operator in the endpoint check: if (r == 0 && (z_mul.is_integer & !include_right_endpoint)). 

After looking into the code, I verified that both operands are bool types, which means the current logic happens to work fine due to implicit type promotion. 

I've changed it to a logical && to restore standard boolean behavior, future-proof the code, and clear the alert.

warning: https://github.com/OpenAtom-Linyaps/linyaps-box/security/code-scanning/1