### PR TITLE
fix: explicitly check `operator[]` in `is_contiguous`

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -493,9 +493,10 @@ inline FMT_CONSTEXPR auto get_container(OutputIt it) ->
 template <typename T, typename Enable = void>
 struct is_contiguous : std::false_type {};
 template <typename T>
-struct is_contiguous<T, void_t<decltype(std::declval<T&>().data()),
-                               decltype(std::declval<T&>().size()),
-                               decltype(std::declval<T&>()[size_t()])>>
+struct is_contiguous<T,
+                     void_t<decltype(std::declval<T&>().data()),
+                            decltype(std::declval<T&>().size()),
+                            decltype(std::declval<T&>().operator[](size_t()))>>
     : std::true_type {};
 }  // namespace detail
 

--- a/test/base-test.cc
+++ b/test/base-test.cc
@@ -874,6 +874,25 @@ struct custom_container {
   auto operator[](size_t) -> char& { return data; }
 };
 
+struct phantom_subscript_operator_container
+{
+  std::vector<char> buffer_;
+
+  using value_type = char;
+
+  FMT_NODISCARD auto size() const noexcept -> size_t { return buffer_.size(); }
+
+  FMT_NODISCARD auto data() noexcept -> char* { return buffer_.data(); }
+
+  FMT_NODISCARD auto data() const noexcept -> char const* { return buffer_.data(); }
+
+  void resize(size_t n) { buffer_.resize(n); }
+
+  void push_back(char const& value) { buffer_.push_back(value); }
+
+  FMT_NODISCARD operator char const*() const noexcept { return data(); }
+};
+
 FMT_BEGIN_NAMESPACE
 template <> struct is_contiguous<custom_container> : std::true_type {};
 FMT_END_NAMESPACE
@@ -884,6 +903,7 @@ TEST(base_test, is_contiguous) {
   EXPECT_TRUE((fmt::is_contiguous<fmt::string_view>::value));
   EXPECT_TRUE((fmt::is_contiguous<std::vector<char>>::value));
   EXPECT_FALSE((fmt::is_contiguous<std::list<char>>::value));
+  EXPECT_FALSE((fmt::is_contiguous<phantom_subscript_operator_container>::value));
 }
 
 TEST(base_test, format_to_custom_container) {

--- a/test/base-test.cc
+++ b/test/base-test.cc
@@ -874,23 +874,22 @@ struct custom_container {
   auto operator[](size_t) -> char& { return data; }
 };
 
-struct phantom_subscript_operator_container
-{
+struct phantom_subscript_operator_container {
   std::vector<char> buffer_;
 
   using value_type = char;
 
-  FMT_NODISCARD auto size() const noexcept -> size_t { return buffer_.size(); }
+  auto size() const noexcept -> size_t { return buffer_.size(); }
 
-  FMT_NODISCARD auto data() noexcept -> char* { return buffer_.data(); }
+  auto data() noexcept -> char* { return buffer_.data(); }
 
-  FMT_NODISCARD auto data() const noexcept -> char const* { return buffer_.data(); }
+  auto data() const noexcept -> const char* { return buffer_.data(); }
 
   void resize(size_t n) { buffer_.resize(n); }
 
-  void push_back(char const& value) { buffer_.push_back(value); }
+  void push_back(const char& value) { buffer_.push_back(value); }
 
-  FMT_NODISCARD operator char const*() const noexcept { return data(); }
+  operator const char*() const noexcept { return data(); }
 };
 
 FMT_BEGIN_NAMESPACE

--- a/test/base-test.cc
+++ b/test/base-test.cc
@@ -875,19 +875,19 @@ struct custom_container {
 };
 
 struct phantom_subscript_operator_container {
-  std::vector<char> buffer_;
+  std::vector<char> buffer;
 
   using value_type = char;
 
-  auto size() const noexcept -> size_t { return buffer_.size(); }
+  auto size() const noexcept -> size_t { return buffer.size(); }
 
-  auto data() noexcept -> char* { return buffer_.data(); }
+  auto data() noexcept -> char* { return buffer.data(); }
 
-  auto data() const noexcept -> const char* { return buffer_.data(); }
+  auto data() const noexcept -> const char* { return buffer.data(); }
 
-  void resize(size_t n) { buffer_.resize(n); }
+  void resize(size_t n) { buffer.resize(n); }
 
-  void push_back(const char& value) { buffer_.push_back(value); }
+  void push_back(const char& value) { buffer.push_back(value); }
 
   operator const char*() const noexcept { return data(); }
 };


### PR DESCRIPTION
Prevent false positives when the container itself does not have `operator[](size_t)`, but the target type of one of the non-explicit user-defined conversion functions ~~does~~ has a built-in subscript operator. Edit: corrected wording

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

Example: https://godbolt.org/z/53bqcn97W

<details>
<summary>Error message</summary>

```
In file included from /opt/compiler-explorer/libs/fmt/trunk/include/fmt/format.h:41,
                 from <source>:3:
/opt/compiler-explorer/libs/fmt/trunk/include/fmt/base.h: In instantiation of 'static constexpr void fmt::v12::detail::container_buffer<Container>::grow(fmt::v12::detail::buffer<typename Container::value_type>&, size_t) [with Container = MyBuf<char, 256>; typename Container::value_type = char; size_t = long unsigned int]':
/opt/compiler-explorer/libs/fmt/trunk/include/fmt/base.h:2029:56:   required from 'fmt::v12::detail::container_buffer<Container>::container_buffer(Container&) [with Container = MyBuf<char, 256>]'
 2029 |       : buffer<value_type>(grow, c.size()), container(c) {}
      |                                                        ^
/opt/compiler-explorer/libs/fmt/trunk/include/fmt/base.h:2046:32:   required from 'fmt::v12::detail::iterator_buffer<OutputIt, typename std::enable_if<(fmt::v12::detail::is_back_insert_iterator<OutputIt>::value && fmt::v12::detail::is_contiguous<typename OutputIt::container_type>::value), typename OutputIt::container_type::value_type>::type>::iterator_buffer(OutputIt, size_t) [with OutputIt = std::back_insert_iterator<MyBuf<char, 256> >; typename std::enable_if<(fmt::v12::detail::is_back_insert_iterator<OutputIt>::value && fmt::v12::detail::is_contiguous<typename OutputIt::container_type>::value), typename OutputIt::container_type::value_type>::type = char; typename OutputIt::container_type = MyBuf<char, 256>; typename OutputIt::container_type::value_type = char; class OutputIt::container_type = MyBuf<char, 256>; size_t = long unsigned int]'
 2046 |       : base(get_container(out)) {}
      |                                ^
/opt/compiler-explorer/libs/fmt/trunk/include/fmt/base.h:2089:10:   required from 'fmt::v12::detail::iterator_buffer<OutputIt, T> fmt::v12::detail::get_buffer(OutputIt) [with T = char; OutputIt = std::back_insert_iterator<MyBuf<char, 256> >; typename std::enable_if<(! is_buffer_appender<OutputIt>::value), int>::type <anonymous> = 0]'
 2089 |   return iterator_buffer<OutputIt, T>(out);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/compiler-explorer/libs/fmt/trunk/include/fmt/base.h:2797:40:   required from 'fmt::v12::remove_cvref_t<T> fmt::v12::vformat_to(OutputIt&&, string_view, format_args) [with OutputIt = std::back_insert_iterator<MyBuf<char, 256> >&; typename std::enable_if<detail::is_output_iterator<typename std::remove_cv<typename std::remove_reference<_Tp>::type>::type, char>::value, int>::type <anonymous> = 0; remove_cvref_t<T> = std::back_insert_iterator<MyBuf<char, 256> >; string_view = basic_string_view<char>; format_args = basic_format_args<context>]'
 2797 |   auto&& buf = detail::get_buffer<char>(out);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/opt/compiler-explorer/libs/fmt/trunk/include/fmt/base.h:2817:20:   required from 'fmt::v12::remove_cvref_t<T> fmt::v12::format_to(OutputIt&&, format_string<T ...>, T&& ...) [with OutputIt = std::back_insert_iterator<MyBuf<char, 256> >; T = {const char (&)[5]}; typename std::enable_if<detail::is_output_iterator<typename std::remove_cv<typename std::remove_reference<_Tp>::type>::type, char>::value, int>::type <anonymous> = 0; remove_cvref_t<T> = std::back_insert_iterator<MyBuf<char, 256> >; format_string<T ...> = fstring<const char (&)[5]>]'
 2817 |   return vformat_to(out, fmt.str, vargs<T...>{{args...}});
      |          ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<source>:50:19:   required from here
   50 |     fmt::format_to(std::back_inserter(buf), "{}", "test");
      |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/compiler-explorer/libs/fmt/trunk/include/fmt/base.h:2022:14: error: invalid conversion from 'const char*' to 'char*' [-fpermissive]
 2022 |     self.set(&self.container[0], capacity);
      |              ^~~~~~~~~~~~~~~~
      |              |
      |              const char*
/opt/compiler-explorer/libs/fmt/trunk/include/fmt/base.h:1770:29: note: initializing argument 1 of 'constexpr void fmt::v12::detail::buffer<T>::set(T*, size_t) [with T = char; size_t = long unsigned int]'
 1770 |   FMT_CONSTEXPR void set(T* buf_data, size_t buf_capacity) noexcept {
      |                          ~~~^~~~~~~~
Compiler returned: 1
```

</details>
