### PR TITLE
Skip VERSION/SOVERSION/DEBUG_POSTFIX on the header-only INTERFACE target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,10 +258,10 @@ function (setup_target target kind)
 
   if (NOT "${kind}" STREQUAL "INTERFACE")
     set_target_properties(
-            ${target}
-            PROPERTIES VERSION ${FMT_VERSION}
-            SOVERSION ${CPACK_PACKAGE_VERSION_MAJOR}
-            DEBUG_POSTFIX "${FMT_DEBUG_POSTFIX}")
+      ${target}
+      PROPERTIES VERSION ${FMT_VERSION}
+                 SOVERSION ${CPACK_PACKAGE_VERSION_MAJOR}
+                 DEBUG_POSTFIX "${FMT_DEBUG_POSTFIX}")
   endif ()
 endfunction ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,11 +256,13 @@ function (setup_target target kind)
     target_compile_definitions(${target} ${kind} FMT_UNICODE=0)
   endif ()
 
-  set_target_properties(
-    ${target}
-    PROPERTIES VERSION ${FMT_VERSION}
-               SOVERSION ${CPACK_PACKAGE_VERSION_MAJOR}
-               DEBUG_POSTFIX "${FMT_DEBUG_POSTFIX}")
+  if (NOT "${kind}" STREQUAL "INTERFACE")
+    set_target_properties(
+            ${target}
+            PROPERTIES VERSION ${FMT_VERSION}
+            SOVERSION ${CPACK_PACKAGE_VERSION_MAJOR}
+            DEBUG_POSTFIX "${FMT_DEBUG_POSTFIX}")
+  endif ()
 endfunction ()
 
 set(FMT_HEADERS)


### PR DESCRIPTION
Closes #4818 

Skip that `set_target_properties()` call when `kind` is `INTERFACE`. These properties have no effect on a header-only target on *any* CMake version (there's no binary artifact to version or suffix), so this is a no-op change for the actual compiled `fmt`/`fmt-c` targets and only removes a call that was never doing anything useful for `fmt-header-only`.

Originating manily from ....
`setup_target(target kind)` is called for both compiled targets (`PUBLIC`/`PRIVATE` kind) and the header-only `fmt-header-only` target (`INTERFACE` kind, line 418). It unconditionally calls `set_target_properties(... VERSION ... SOVERSION ... DEBUG_POSTFIX ...)`.