### PR TITLE
Fix FMT_COMPILE failure with format_as mapped types  (Issue #4794)

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -168,14 +168,6 @@ constexpr auto get_arg_checked(const Args&... args) -> const T& {
 template <typename Char>
 struct is_compiled_format<code_unit<Char>> : std::true_type {};
 
-
-template <typename T, typename = void>
-struct compile_has_format_as : std::false_type {};
-
-template <typename T>
-struct compile_has_format_as<T, void_t<decltype(format_as(std::declval<const T&>()))>> : std::true_type {};
-
-
 template <typename Char, typename V, int N> struct field {
   using char_type = Char;
 
@@ -194,11 +186,6 @@ template <typename Char, typename V, int N> struct field {
     }
   }
 };
-
-
-
-
-
 
 template <typename Char, typename T, int N>
 struct is_compiled_format<field<Char, T, N>> : std::true_type {};

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -168,6 +168,7 @@ constexpr auto get_arg_checked(const Args&... args) -> const T& {
 template <typename Char>
 struct is_compiled_format<code_unit<Char>> : std::true_type {};
 
+// A replacement field that refers to argument N.
 template <typename Char, typename V, int N> struct field {
   using char_type = Char;
 
@@ -177,9 +178,9 @@ template <typename Char, typename V, int N> struct field {
     if constexpr (std::is_convertible<V, basic_string_view<Char>>::value) {
       auto s = basic_string_view<Char>(arg);
       return copy<Char>(s.begin(), s.end(), out);
-    } else if constexpr (detail::use_format_as<V>::value) {
+    } else if constexpr (use_format_as<V>::value) {
       return write<Char>(out, format_as(arg));
-    } else if constexpr (detail::use_format_as_member<V>::value) {
+    } else if constexpr (use_format_as_member<V>::value) {
       return write<Char>(out, formatter<V>::format_as(arg));
     } else {
       return write<Char>(out, arg);

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -175,6 +175,7 @@ struct compile_has_format_as : std::false_type {};
 template <typename T>
 struct compile_has_format_as<T, void_t<decltype(format_as(std::declval<const T&>()))>> : std::true_type {};
 
+
 template <typename Char, typename V, int N> struct field {
   using char_type = Char;
 
@@ -184,13 +185,20 @@ template <typename Char, typename V, int N> struct field {
     if constexpr (std::is_convertible<V, basic_string_view<Char>>::value) {
       auto s = basic_string_view<Char>(arg);
       return copy<Char>(s.begin(), s.end(), out);
-    } else if constexpr (compile_has_format_as<V>::value) {
+    } else if constexpr (detail::use_format_as<V>::value) {
       return write<Char>(out, format_as(arg));
+    } else if constexpr (detail::use_format_as_member<V>::value) {
+      return write<Char>(out, formatter<V>::format_as(arg));
     } else {
       return write<Char>(out, arg);
     }
   }
 };
+
+
+
+
+
 
 template <typename Char, typename T, int N>
 struct is_compiled_format<field<Char, T, N>> : std::true_type {};

--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -168,7 +168,13 @@ constexpr auto get_arg_checked(const Args&... args) -> const T& {
 template <typename Char>
 struct is_compiled_format<code_unit<Char>> : std::true_type {};
 
-// A replacement field that refers to argument N.
+
+template <typename T, typename = void>
+struct compile_has_format_as : std::false_type {};
+
+template <typename T>
+struct compile_has_format_as<T, void_t<decltype(format_as(std::declval<const T&>()))>> : std::true_type {};
+
 template <typename Char, typename V, int N> struct field {
   using char_type = Char;
 
@@ -178,6 +184,8 @@ template <typename Char, typename V, int N> struct field {
     if constexpr (std::is_convertible<V, basic_string_view<Char>>::value) {
       auto s = basic_string_view<Char>(arg);
       return copy<Char>(s.begin(), s.end(), out);
+    } else if constexpr (compile_has_format_as<V>::value) {
+      return write<Char>(out, format_as(arg));
     } else {
       return write<Char>(out, arg);
     }

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -479,3 +479,17 @@ TEST(compile_test, constexpr_string_format) {
   EXPECT_TRUE(big);
 }
 #endif  // FMT_USE_CONSTEXPR_STRING
+
+
+
+
+namespace {
+struct CompileFormatAsType {
+  int value;
+};
+int format_as(CompileFormatAsType f) { return f.value; }
+} // namespace
+
+TEST(CompileTest, FormatAs) {
+  EXPECT_EQ("42", fmt::format(FMT_COMPILE("{}"), CompileFormatAsType{42}));
+}

--- a/test/compile-test.cc
+++ b/test/compile-test.cc
@@ -480,16 +480,12 @@ TEST(compile_test, constexpr_string_format) {
 }
 #endif  // FMT_USE_CONSTEXPR_STRING
 
-
-
-
 namespace {
-struct CompileFormatAsType {
+struct compile_format_as_type {
   int value;
 };
-int format_as(CompileFormatAsType f) { return f.value; }
-} // namespace
-
-TEST(CompileTest, FormatAs) {
-  EXPECT_EQ("42", fmt::format(FMT_COMPILE("{}"), CompileFormatAsType{42}));
+int format_as(compile_format_as_type f) { return f.value; }
+} 
+TEST(compile_test, format_as) {
+  EXPECT_EQ("42", fmt::format(FMT_COMPILE("{}"), compile_format_as_type{42}));
 }


### PR DESCRIPTION
This PR fixes an issue where `FMT_COMPILE` fails to compile when used with user-defined types formatted via `format_as`. 

**The Changes:**

* Introduced `compile_has_format_as` to check for `format_as` overloads at compile time via ADL.

* Updated the `format` method inside `detail::field` in `compile.h` to branch using `if constexpr`, casting the argument via `format_as` if the type supports it.

* Added a regression test to `test/compile-test.cc` to ensure compile-time `format_as` evaluation works as expected.

Closes #4794