### PR TITLE
Negative integral to char overflow fix

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2127,7 +2127,7 @@ FMT_CONSTEXPR FMT_INLINE auto write_int(OutputIt out, write_int_arg<T> arg,
     // Handles negative cases on casts to smaller types using Two's complement
     // One example is int{-104} to char which std::format uses as 152
     if (sizeof(Char) < sizeof(abs_value) && (arg.prefix & 0xff) == '-')
-        abs_value = (1 << (8*sizeof(Char))) - abs_value;
+      abs_value = (1 << (8*sizeof(Char))) - abs_value;
     return write_char<Char>(out, static_cast<Char>(abs_value), specs);
   }
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2127,7 +2127,7 @@ FMT_CONSTEXPR FMT_INLINE auto write_int(OutputIt out, write_int_arg<T> arg,
     // Handles negative cases on casts to smaller types using Two's complement
     // One example is int{-104} to char which std::format uses as 152
     if (sizeof(Char) < sizeof(abs_value) && (arg.prefix & 0xff) == '-')
-      abs_value = (1 << (8*sizeof(Char))) - abs_value;
+      abs_value = ~abs_value + 1;
     return write_char<Char>(out, static_cast<Char>(abs_value), specs);
   }
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2124,6 +2124,10 @@ FMT_CONSTEXPR FMT_INLINE auto write_int(OutputIt out, write_int_arg<T> arg,
       prefix_append(prefix, unsigned(specs.upper() ? 'B' : 'b') << 8 | '0');
     break;
   case presentation_type::chr:
+    // Handles negative cases on casts to smaller types using Two's complement
+    // One example is int{-104} to char which std::format uses as 152
+    if (sizeof(Char) < sizeof(abs_value) && (arg.prefix & 0xff) == '-')
+        abs_value = (1 << (8*sizeof(Char))) - abs_value;
     return write_char<Char>(out, static_cast<Char>(abs_value), specs);
   }
 

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1334,6 +1334,7 @@ TEST(format_test, format_int) {
                    "invalid format specifier");
   check_unknown_types(42, "bBdoxXnLc", "integer");
   EXPECT_EQ(fmt::format("{:c}", static_cast<int>('x')), "x");
+  EXPECT_EQ(fmt::format("{:c}", int(-136)), "x");
 }
 
 TEST(format_test, format_bin) {

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1334,7 +1334,7 @@ TEST(format_test, format_int) {
                    "invalid format specifier");
   check_unknown_types(42, "bBdoxXnLc", "integer");
   EXPECT_EQ(fmt::format("{:c}", static_cast<int>('x')), "x");
-  EXPECT_EQ(fmt::format("{:c}", int(-136)), "x");
+  EXPECT_EQ(fmt::format("{:c}", -136), "x");
 }
 
 TEST(format_test, format_bin) {


### PR DESCRIPTION
Closes https://github.com/fmtlib/fmt/issues/4839
Fixed the negative integral overflow issue and added a test to check for 'x' in two's complement