### PR TITLE
Update GCC version requirement in CMake module comment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ project(FMT CXX)
 # Determine support for the C++ module scanning and CXX_MODULE File_Sets
 # Requires C++20, CMake >= 3.28 and
 # Generators(Ninja >= 1.11 OR Visual Studio >= 17.4).
-# Compilers GCC>=14, Clang>=16 or MSVC >= 17.4
+CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 15
 # Source: https://cmake.org/cmake/help/latest/manual/cmake-cxxmodules.7.html
 set(FMT_USE_CMAKE_MODULES FALSE)
 if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.28 AND CMAKE_CXX_STANDARD


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

## Summary

Updates the comment describing the minimum supported compiler versions for CMake module support.

The implementation currently checks for GCC 15 or later:

```cmake
CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 15
