### PR TITLE
Generate CMake export set regardless of FMT_INSTALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,16 @@ add_library(fmt::fmt-c ALIAS fmt-c)
 set_target_properties(fmt-c PROPERTIES PUBLIC_HEADER include/fmt/fmt-c.h)
 
 # Install targets.
+set(targets_export_name fmt-targets)
+set(INSTALL_TARGETS fmt fmt-header-only fmt-c)
+
+if (FMT_MODULE)
+  list(APPEND INSTALL_TARGETS fmt-module)
+  if (FMT_USE_CMAKE_MODULES)
+    set(INSTALL_FILE_SET FILE_SET fmt DESTINATION ${FMT_INC_DIR}/fmt)
+  endif ()
+endif ()
+
 if (FMT_INSTALL)
   include(CMakePackageConfigHelpers)
   set_verbose(
@@ -454,7 +464,6 @@ if (FMT_INSTALL)
   set(version_config ${PROJECT_BINARY_DIR}/fmt-config-version.cmake)
   set(project_config ${PROJECT_BINARY_DIR}/fmt-config.cmake)
   set(pkgconfig ${PROJECT_BINARY_DIR}/fmt.pc)
-  set(targets_export_name fmt-targets)
 
   set_verbose(
     FMT_LIB_DIR ${CMAKE_INSTALL_LIBDIR} CACHE STRING
@@ -485,15 +494,6 @@ if (FMT_INSTALL)
     ${PROJECT_SOURCE_DIR}/support/cmake/fmt-config.cmake.in ${project_config}
     INSTALL_DESTINATION ${FMT_CMAKE_DIR})
 
-  set(INSTALL_TARGETS fmt fmt-header-only fmt-c)
-
-  if (FMT_MODULE)
-    list(APPEND INSTALL_TARGETS fmt-module)
-    if (FMT_USE_CMAKE_MODULES)
-      set(INSTALL_FILE_SET FILE_SET fmt DESTINATION ${FMT_INC_DIR}/fmt)
-    endif ()
-  endif ()
-
   # Install the library and headers.
   install(
     TARGETS ${INSTALL_TARGETS}
@@ -503,13 +503,6 @@ if (FMT_INSTALL)
     ARCHIVE DESTINATION ${FMT_LIB_DIR}
     PUBLIC_HEADER DESTINATION ${FMT_INC_DIR}/fmt
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} ${INSTALL_FILE_SET})
-
-  # Use a namespace because CMake provides better diagnostics for namespaced
-  # imported targets.
-  export(
-    TARGETS ${INSTALL_TARGETS}
-    NAMESPACE fmt::
-    FILE ${PROJECT_BINARY_DIR}/${targets_export_name}.cmake)
 
   # Install version, config and target files.
   install(
@@ -527,6 +520,15 @@ if (FMT_INSTALL)
     DESTINATION "${FMT_PKGCONFIG_DIR}"
     COMPONENT fmt_core)
 endif ()
+
+# Generate an export file in the build tree so that fmt can be used by
+# add_subdirectory() or FetchContent without being installed. Use a
+# namespace because CMake provides better diagnostics for namespaced
+# imported targets.
+export(
+  TARGETS ${INSTALL_TARGETS}
+  NAMESPACE fmt::
+  FILE ${PROJECT_BINARY_DIR}/${targets_export_name}.cmake)
 
 function (add_doc_target)
   find_program(DOXYGEN doxygen PATHS "$ENV{ProgramFiles}/doxygen/bin"

--- a/test/add-subdirectory-test/CMakeLists.txt
+++ b/test/add-subdirectory-test/CMakeLists.txt
@@ -15,3 +15,12 @@ if (TARGET fmt::fmt-header-only)
   target_compile_options(header-only-test PRIVATE ${PEDANTIC_COMPILE_FLAGS})
   target_link_libraries(header-only-test fmt::fmt-header-only)
 endif ()
+
+# Test that a target publicly depending on fmt can itself be exported even
+# though fmt is added via add_subdirectory and FMT_INSTALL is off (#4806).
+add_library(export-test STATIC export-lib.cc)
+target_link_libraries(export-test PUBLIC fmt::fmt)
+export(
+  TARGETS export-test
+  NAMESPACE test::
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/export-test-targets.cmake)

--- a/test/add-subdirectory-test/export-lib.cc
+++ b/test/add-subdirectory-test/export-lib.cc
@@ -1,0 +1,3 @@
+#include "fmt/base.h"
+
+void greet(const char* name) { fmt::print("Hello, {}!\n", name); }


### PR DESCRIPTION
Closes #4806

`export(TARGETS ...)` is currently scoped inside `if (FMT_INSTALL)`, so a project that pulls in fmt via `add_subdirectory()`/`FetchContent` without also installing it never gets the `fmt::*` import targets in its build tree. If that project then tries to `export()` one of its own targets that depends on fmt, CMake fails with:

```
CMake Error: export("MyLibTargets" ...) includes target "mylib" which requires target "fmt" that is not in any export set.
```

This moves the `export()` call, along with the `INSTALL_TARGETS`/`targets_export_name` it needs, outside the `FMT_INSTALL` guard so it always runs. Everything that's actually install-specific (config/version files, pkg-config, `install(EXPORT ...)`) stays behind the guard, so installed behavior is unchanged — confirmed that `fmt-config.cmake`, `fmt-config-version.cmake` and `fmt.pc` are still only produced with `FMT_INSTALL=ON`.

Extended `test/add-subdirectory-test` with a small static library that publicly links `fmt::fmt` and exports itself. This reproduces the exact failure from the issue when `FMT_INSTALL` is off (the default when fmt is a subproject) and passes with this fix.
