### PR TITLE
doc extension concerning format_as and general implementations

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -475,7 +475,7 @@ Using `fmt::join`, you can separate tuple elements with a custom separator:
 - [`std::tm`](https://en.cppreference.com/w/cpp/chrono/c/tm)
 
 The format syntax is described in [Chrono Format Specifications](syntax.md#
-chrono-format-spec).
+chrono-format-specifications).
 
 **Example**:
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -92,6 +92,9 @@ Use `format_as` if you want to make your type formattable as some other
 type with the same format specifiers. The `format_as` function should
 take an object of your type and return an object of a formattable type.
 It should be defined in the same namespace as your type.
+Note that `format_as` is not suitable for user-defined types which are already
+formattable due to one of the general implementations (e.g. in
+[`fmt/ranges.h`](#ranges-api)), specialize `formatter` explicitly in these cases.
 
 Example ([run](https://godbolt.org/z/nvME4arz8)):
 
@@ -472,7 +475,7 @@ Using `fmt::join`, you can separate tuple elements with a custom separator:
 - [`std::tm`](https://en.cppreference.com/w/cpp/chrono/c/tm)
 
 The format syntax is described in [Chrono Format Specifications](syntax.md#
-chrono-format-specifications).
+chrono-format-spec).
 
 **Example**:
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -92,9 +92,10 @@ Use `format_as` if you want to make your type formattable as some other
 type with the same format specifiers. The `format_as` function should
 take an object of your type and return an object of a formattable type.
 It should be defined in the same namespace as your type.
-Note that `format_as` is not suitable for user-defined types which are already
-formattable due to one of the general implementations (e.g. in
-[`fmt/ranges.h`](#ranges-api)), specialize `formatter` explicitly in these cases.
+`format_as` cannot be used when a type also matches another `formatter`
+specialization, such as the range `formatter`, because the specializations
+would be ambiguous. Disable the conflicting specialization, if possible,
+or provide an explicit `formatter` specialization instead.
 
 Example ([run](https://godbolt.org/z/nvME4arz8)):
 


### PR DESCRIPTION
add a sentence about the possible interaction of format_as and general implementations

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
