### PR TITLE
Document that hexfloat 'a'/'A' always emits the 0x prefix

### DIFF
--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -251,7 +251,7 @@ fmt::format("{:#06x}", 0xfe);  // # adds the prefix, 06 zero-pads to width 6
 
 | Type | Effect                                                              |
 |------|---------------------------------------------------------------------|
-| `a`  | Hexadecimal-significand form (e.g. `1.8p+1`). Lower-case digits and a lower-case `p` for the binary exponent. The `#` flag adds a `0x` prefix. |
+| `a`  | Hexadecimal-significand form (e.g. `0x1.8p+1`). Lower-case digits and a lower-case `p` for the binary exponent. The `0x` prefix is always emitted, matching printf's `%a`. The `#` flag forces a decimal point (e.g. `0x1.p+1`).
 | `A`  | Same as `a`, but upper-case throughout.                             |
 | `e`  | Scientific notation with a lower-case `e` for the decimal exponent. |
 | `E`  | Scientific notation with an upper-case `E`.                         |


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
## Problem

The documentation for the `a`/`A` (hexfloat) type in `doc/syntax.md` is inaccurate in two ways:

1. The example is shown as `1.8p+1`, without the `0x` prefix.
2. It states that the `#` flag "adds a `0x` prefix".

Both are wrong. In practice fmt always emits the `0x` prefix (matching printf's `%a`), regardless of `#`.

## Reproduction

```cpp
#include <fmt/format.h>
#include 
#include 
int main() {
  fmt::print("fmt   : [{:a}]\n", 3.0);
  fmt::print("fmt # : [{:#a}]\n", 3.0);
  fmt::print("fmt   : [{:a}]\n", 2.0);
  fmt::print("fmt # : [{:#a}]\n", 2.0);
  std::printf("std   : [%s]\n", std::format("{:a}", 3.0).c_str());
}
```

Output:
fmt   : [0x1.8p+1]
fmt # : [0x1.8p+1]     // 0x present with and without #
fmt   : [0x1p+1]
fmt # : [0x1.p+1]      // # forces a decimal point, not the prefix
std   : [1.8p+1]       // std::format omits the prefix

So:
- The `0x` prefix is **always** emitted, like printf's `%a` (and unlike `std::format`).
- The `#` flag forces a decimal point, not the prefix.

## Fix

Update the `a` row to use the example `0x1.8p+1`, note that the `0x` prefix is always emitted, and correct the description of `#`. The implementation is correct; only the docs are updated to match it.

Fixes #4657