### PR TITLE
Add a missing include for the C++ module build

### DIFF
--- a/src/fmt.cc
+++ b/src/fmt.cc
@@ -19,6 +19,7 @@ module;
 // to prevent attachment to this module.
 #ifndef FMT_IMPORT_STD
 #  include <algorithm>
+#  include <atomic>
 #  include <bitset>
 #  include <chrono>
 #  include <cmath>


### PR DESCRIPTION
The std.h header uses types such as std::atomic and std::atomic_flag. For the normal build mode, this header does include all the headers it needs, such as <atomic>.

However when building the C++ module of {fmt}, the std.h header omits such includes, and instead expects them to be included beforehand by fmt.cc - which lacked including <atomic>.

This fixes building the C++ module with libc++ 23, which has removed a number of unnecessary transitive includes.

