### PR TITLE
Avoid -Wdangling-reference false positives in locale helpers

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -129,7 +129,8 @@ inline void fwrite_all(const void* ptr, size_t count, FILE* stream) {
 
 template <typename Char>
 FMT_FUNC auto thousands_sep_impl(locale_ref loc) -> thousands_sep_result<Char> {
-  auto&& facet = use_facet<numpunct<Char>>(loc.get<locale>());
+  auto loc_copy = loc.get<locale>();
+  auto&& facet = use_facet<numpunct<Char>>(loc_copy);
   auto grouping = facet.grouping();
   auto thousands_sep = grouping.empty() ? Char() : facet.thousands_sep();
   return {std::move(grouping), thousands_sep};

--- a/include/fmt/xchar.h
+++ b/include/fmt/xchar.h
@@ -46,8 +46,8 @@ using format_string_char_t = typename format_string_char<S>::type;
 inline auto write_loc(basic_appender<wchar_t> out, loc_value value,
                       const format_specs& specs, locale_ref loc) -> bool {
 #if FMT_USE_LOCALE
-  auto& numpunct =
-      std::use_facet<std::numpunct<wchar_t>>(loc.get<std::locale>());
+  auto loc_copy = loc.get<std::locale>();
+  auto& numpunct = std::use_facet<std::numpunct<wchar_t>>(loc_copy);
   auto separator = std::wstring();
   auto grouping = numpunct.grouping();
   if (!grouping.empty()) separator = std::wstring(1, numpunct.thousands_sep());


### PR DESCRIPTION
GCC 13/14 warns in two locale helpers when a precompiled header is used:

    include/fmt/format-inl.h:132: warning: possibly dangling reference to a temporary
      [-Wdangling-reference]
    include/fmt/xchar.h:49: same

It is a false positive: `locale_ref::get<std::locale>()` returns a copy, and the
reference returned by `std::use_facet` stays valid as long as any copy of that locale
exists. GCC only warns when the declaration comes from a precompiled header; with
`<locale>` included normally it stays quiet. Reproducible with plain `<locale>`,
no fmt involved:

    // t.cpp
    #include <locale>
    template <typename Char> auto f(const std::locale& l) -> Char {
      auto&& facet = std::use_facet<std::numpunct<Char>>(std::locale(l));
      return facet.decimal_point();
    }
    template char f<char>(const std::locale&);

    // pch.h
    #include <locale>

    g++ -Wdangling-reference -c t.cpp                    # quiet
    g++ -x c++-header pch.h -o pch.h.gch
    g++ -Wdangling-reference -include pch.h -c t.cpp     # warns

    (GCC 13.4; -Wdangling-reference comes with -Wextra there)


This patch binds the locale copy to a named variable at both call sites, so no reference
is bound to a temporary. Same single copy, no behaviour change, and the lifetime becomes
explicit instead of relying on the "valid while any copy exists" guarantee.

Checked with GCC 13.4: warnings gone when a PCH is in use, ctest passes 21/21, and
locale-aware output is unchanged

Originally filed against spdlog, which vendors these files (gabime/spdlog#3638), and
closed there with a pointer to this repository.
