### PR TITLE
Format zero as 0x0p+0 in hexfloat

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3116,6 +3116,11 @@ FMT_CONSTEXPR20 void format_hexfloat(Float value, format_specs specs,
   f.e += num_float_significand_bits;
   if (!has_implicit_bit<Float>()) --f.e;
 
+  // basic_fp maps a zero biased exponent to the minimum subnormal exponent,
+  // which is correct for subnormals but not for zero: printf prints zero as
+  // 0x0p+0. A zero significand can only come from +-0, so reset the exponent.
+  if (f.f == 0) f.e = 0;
+
   const auto num_fraction_bits =
       num_float_significand_bits + (has_implicit_bit<Float>() ? 1 : 0);
   const auto num_xdigits = (num_fraction_bits + 3) / 4;

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1539,6 +1539,13 @@ TEST(format_test, format_double) {
 
     d = std::numeric_limits<double>::denorm_min();
     EXPECT_EQ(fmt::format("{:a}", d), "0x0.0000000000001p-1022");
+
+    // Zero has no subnormal exponent: printf prints it as 0x0p+0.
+    EXPECT_EQ(fmt::format("{:a}", 0.0), "0x0p+0");
+    EXPECT_EQ(fmt::format("{:a}", -0.0), "-0x0p+0");
+    EXPECT_EQ(fmt::format("{:A}", 0.0), "0X0P+0");
+    EXPECT_EQ(fmt::format("{:#a}", 0.0), "0x0.p+0");
+    EXPECT_EQ(fmt::format("{:.3a}", 0.0), "0x0.000p+0");
   }
 
   if (std::numeric_limits<long double>::digits == 64) {


### PR DESCRIPTION
`fmt::format("{:a}", 0.0)` gives `0x0p-1022` where `printf("%a", 0.0)` gives `0x0p+0`:

```
value   printf         fmt
0.0     0x0p+0         0x0p-1022
-0.0    -0x0p+0        -0x0p-1022
```

Same for `{:A}`, `{:#a}` and any explicit precision. Non-zero values already agree.

### Cause

`basic_fp::assign` maps a zero biased exponent to 1:

```cpp
if (biased_e == 0)
  biased_e = 1;  // Subnormals use biased exponent 1 (min exponent).
```

That is right for subnormals, but zero shares the same biased exponent and is not a subnormal, so `format_hexfloat` ends up printing the minimum subnormal exponent for a value whose significand carries no information.

The fix resets the exponent in `format_hexfloat` rather than in `assign`, since the decimal path shares `assign` and relies on the subnormal mapping.

### Scope

A zero significand can only come from ±0 — normals get the implicit bit added, and a subnormal has a nonzero significand by definition — so the guard cannot affect any other value. I checked the neighbours explicitly: `denorm_min`, `min`, `max`, `±inf` and `nan` are byte-identical before and after, and `denorm_min` keeps fmt's existing denormalized form `0x0.0000000000001p-1022` that `format_double` already asserts.

### Testing

The five new expectations were taken from `printf` output rather than derived by hand. All five fail without the change, with exactly the old values:

```
Which is: "0x0p-1022"
Which is: "-0x0p-1022"
Which is: "0X0P-1022"
Which is: "0x0.p-1022"
Which is: "0x0.000p-1022"
```

With it, `ctest` is 21/21 (Debug, macOS arm64, Apple clang 17). `clang-format --dry-run -Werror` is clean on both files. No existing test asserted the hexfloat form of zero, so nothing had to be updated.

I took printf as the reference because of your comments on #4657 — "the reference implementation of `std::format` always printed `0x` like pretty much every other facility" — and LWG 4515. If you would rather keep zero consistent with how fmt prints subnormals instead, say so and I will close this.
