### PR TITLE
Revert "Suppress a false positive in clang-tidy"

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1599,7 +1599,7 @@ template <typename F> class apple_file : public file_base<F> {
   void init_buffer() {
     if (this->file_->_p) return;
     // Force buffer initialization by placing and removing a char in a buffer.
-    if (!FMT_CLANG_ANALYZER) putc_unlocked(0, this->file_);
+    putc_unlocked(0, this->file_);
     --this->file_->_p;
     ++this->file_->_w;
   }

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -167,12 +167,6 @@ template <typename T> struct iterator_traits<fmt::basic_appender<T>> {
 #  define FMT_THROW(x) ::fmt::assert_fail(__FILE__, __LINE__, (x).what())
 #endif
 
-#ifdef __clang_analyzer__
-#  define FMT_CLANG_ANALYZER 1
-#else
-#  define FMT_CLANG_ANALYZER 0
-#endif
-
 // Defining FMT_REDUCE_INT_INSTANTIATIONS to 1, will reduce the number of
 // integer formatter template instantiations to just one by only using the
 // largest integer type. This results in a reduction in binary size but will
@@ -4262,26 +4256,21 @@ class format_int {
   inline auto str() const -> std::string { return {str_, size()}; }
 };
 
-#if FMT_CLANG_ANALYZER
-#  define FMT_STRING_IMPL(s, base) s
-#else
-#  define FMT_STRING_IMPL(s, base)                                           \
-    [] {                                                                     \
-      /* Use the hidden visibility as a workaround for a GCC bug (#1973). */ \
-      /* Use a macro-like name to avoid shadowing warnings. */               \
-      struct FMT_VISIBILITY("hidden") FMT_COMPILE_STRING : base {            \
-        using char_type = fmt::remove_cvref_t<decltype(s[0])>;               \
-        constexpr explicit operator fmt::basic_string_view<char_type>()      \
-            const {                                                          \
-          return fmt::detail::compile_string_to_view<char_type>(s);          \
-        }                                                                    \
-      };                                                                     \
-      using FMT_STRING_VIEW =                                                \
-          fmt::basic_string_view<typename FMT_COMPILE_STRING::char_type>;    \
-      fmt::detail::ignore_unused(FMT_STRING_VIEW(FMT_COMPILE_STRING()));     \
-      return FMT_COMPILE_STRING();                                           \
-    }()
-#endif  // FMT_CLANG_ANALYZER
+#define FMT_STRING_IMPL(s, base)                                              \
+  [] {                                                                        \
+    /* Use the hidden visibility as a workaround for a GCC bug (#1973). */    \
+    /* Use a macro-like name to avoid shadowing warnings. */                  \
+    struct FMT_VISIBILITY("hidden") FMT_COMPILE_STRING : base {               \
+      using char_type = fmt::remove_cvref_t<decltype(s[0])>;                  \
+      constexpr explicit operator fmt::basic_string_view<char_type>() const { \
+        return fmt::detail::compile_string_to_view<char_type>(s);             \
+      }                                                                       \
+    };                                                                        \
+    using FMT_STRING_VIEW =                                                   \
+        fmt::basic_string_view<typename FMT_COMPILE_STRING::char_type>;       \
+    fmt::detail::ignore_unused(FMT_STRING_VIEW(FMT_COMPILE_STRING()));        \
+    return FMT_COMPILE_STRING();                                              \
+  }()
 
 /**
  * Constructs a legacy compile-time format string from a string literal `s`.


### PR DESCRIPTION
This reverts commit 619b3a5aa031a25e8d06fec1e03992e5e727c5a5.

The original commit may have addressed a clang-tidy false positive, but it also introduced one, as described in #4871.
Merging this PR will fix that issue.

Builds, passes all tests, produces the expected output in gcc and clang, and does not error in clang-tidy.