### PR TITLE
Add pkgconfig file for fmt-c library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,14 @@ setup_target(fmt-header-only INTERFACE)
 
 add_library(fmt-c src/fmt-c.cc)
 target_compile_features(fmt-c INTERFACE c_std_11)
+
+# Set FMT_C_LIB_NAME for pkg-config fmt-c.pc. We cannot use the OUTPUT_NAME
+# target property because it's not set by default.
+set(FMT_C_LIB_NAME fmt-c)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(FMT_C_LIB_NAME ${FMT_C_LIB_NAME}${FMT_DEBUG_POSTFIX})
+endif ()
+
 if (BUILD_SHARED_LIBS)
   target_compile_definitions(
     fmt-c
@@ -462,6 +470,7 @@ if (FMT_INSTALL)
   set(version_config ${PROJECT_BINARY_DIR}/fmt-config-version.cmake)
   set(project_config ${PROJECT_BINARY_DIR}/fmt-config.cmake)
   set(pkgconfig ${PROJECT_BINARY_DIR}/fmt.pc)
+  set(pkgconfig_c ${PROJECT_BINARY_DIR}/fmt-c.pc)
 
   set_verbose(
     FMT_LIB_DIR ${CMAKE_INSTALL_LIBDIR} CACHE STRING
@@ -488,6 +497,8 @@ if (FMT_INSTALL)
 
   configure_file("${PROJECT_SOURCE_DIR}/support/cmake/fmt.pc.in" "${pkgconfig}"
                  @ONLY)
+  configure_file("${PROJECT_SOURCE_DIR}/support/cmake/fmt-c.pc.in"
+                 "${pkgconfig_c}" @ONLY)
   configure_package_config_file(
     ${PROJECT_SOURCE_DIR}/support/cmake/fmt-config.cmake.in ${project_config}
     INSTALL_DESTINATION ${FMT_CMAKE_DIR})
@@ -517,7 +528,7 @@ if (FMT_INSTALL)
     COMPONENT fmt_core)
 
   install(
-    FILES "${pkgconfig}"
+    FILES "${pkgconfig}" "${pkgconfig_c}"
     DESTINATION "${FMT_PKGCONFIG_DIR}"
     COMPONENT fmt_core)
 endif ()

--- a/support/cmake/fmt-c.pc.in
+++ b/support/cmake/fmt-c.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
+
+Name: fmt-c
+Description: C interface for fmt, a modern formatting library
+Version: @FMT_VERSION@
+Libs: -L${libdir} -l@FMT_C_LIB_NAME@
+Cflags: -I${includedir}
+Requires.private: fmt = @FMT_VERSION@


### PR DESCRIPTION
This PR adds a pkgconfig file for the `fmt-c` library, allowing the C API to be found and linked via pkgconfig. The CMake package already exports `fmt::fmt-c`, so that doesn't need changes.

The only thing I was unsure of was if `fmt-c.pc` should explicitly link `-lfmt` as well, or if the implicit transitive linkage is enough. For now I have added it, since the `fmt::fmt-c` CMake target explicitly lists `fmt::fmt` as a linked library as well, but it can be removed if not needed.

Also, currently the `fmt::fmt-c` target is part of the `fmt_core` CMake package component, so I added the `fmt_c.pc` file to `fmt_core` as well. Maybe that could be changed to a `fmt_c` or `fmt_c_api` component.