### PR TITLE
Fixed producing unusual warnings from MSVC like compilers, enable support for noreturn for them, and cleanup crutches.

### DIFF
--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -188,14 +188,6 @@
 #  define FMT_FALLTHROUGH
 #endif
 
-#if FMT_MSC_VERSION || defined(__NVCC__)
-// Disable unusual warning on MSVC/NVCC because of bogus unreachable code
-// warnings in many places.
-#  pragma warning(disable : 4702)
-// Disable because don't need to check
-#  pragma warning(disable : 26495)
-#endif
-
 #if FMT_HAS_CPP_ATTRIBUTE(noreturn)
 #  define FMT_NORETURN [[noreturn]]
 #else
@@ -1773,9 +1765,13 @@ template <typename T> class buffer {
   grow_fun grow_;
 
  protected:
+FMT_PRAGMA_MSVC(warning(push))
+FMT_PRAGMA_MSVC(warning(disable : 26495))
   // Don't initialize ptr_ since it is not accessed to save a few cycles.
   FMT_CONSTEXPR buffer(grow_fun grow, size_t sz) noexcept
-      : size_(sz), capacity_(sz), grow_(grow) {}
+      : size_(sz), capacity_(sz), grow_(grow) {
+  }
+FMT_PRAGMA_MSVC(warning(pop))
 
   constexpr buffer(grow_fun grow, T* p = nullptr, size_t sz = 0,
                    size_t cap = 0) noexcept

--- a/include/fmt/base.h
+++ b/include/fmt/base.h
@@ -188,8 +188,15 @@
 #  define FMT_FALLTHROUGH
 #endif
 
-// Disable [[noreturn]] on MSVC/NVCC because of bogus unreachable code warnings.
-#if FMT_HAS_CPP_ATTRIBUTE(noreturn) && !FMT_MSC_VERSION && !defined(__NVCC__)
+#if FMT_MSC_VERSION || defined(__NVCC__)
+// Disable unusual warning on MSVC/NVCC because of bogus unreachable code
+// warnings in many places.
+#  pragma warning(disable : 4702)
+// Disable because don't need to check
+#  pragma warning(disable : 26495)
+#endif
+
+#if FMT_HAS_CPP_ATTRIBUTE(noreturn)
 #  define FMT_NORETURN [[noreturn]]
 #else
 #  define FMT_NORETURN
@@ -1768,9 +1775,7 @@ template <typename T> class buffer {
  protected:
   // Don't initialize ptr_ since it is not accessed to save a few cycles.
   FMT_CONSTEXPR buffer(grow_fun grow, size_t sz) noexcept
-      : size_(sz), capacity_(sz), grow_(grow) {
-    if (FMT_MSC_VERSION != 0) ptr_ = nullptr;  // Suppress warning 26495.
-  }
+      : size_(sz), capacity_(sz), grow_(grow) {}
 
   constexpr buffer(grow_fun grow, T* p = nullptr, size_t sz = 0,
                    size_t cap = 0) noexcept

--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -155,12 +155,6 @@ FMT_FUNC auto write_loc(appender out, loc_value value,
 }  // namespace detail
 
 FMT_FUNC void report_error(const char* message) {
-#if FMT_MSC_VERSION || defined(__NVCC__)
-  // Silence unreachable code warnings in MSVC and NVCC because these
-  // are nearly impossible to fix in a generic code.
-  volatile bool b = true;
-  if (!b) return;
-#endif
   FMT_THROW(format_error(message));
 }
 

--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -147,6 +147,10 @@
 #  define FMT_CONSTEXPR_STRING
 #endif
 
+// msvc produces unusable warnings if noreturn enabled.
+FMT_PRAGMA_MSVC(warning(push))
+FMT_PRAGMA_MSVC(warning(disable : 4702))
+
 // GCC 4.9 doesn't support qualified names in specializations.
 namespace std {
 template <typename T> struct iterator_traits<fmt::basic_appender<T>> {
@@ -4424,6 +4428,9 @@ FMT_END_NAMESPACE
 #  define FMT_FUNC inline
 #  include "format-inl.h"
 #endif
+
+// Restore msvc warning state.
+FMT_PRAGMA_MSVC(warning(pop))
 
 // Restore _LIBCPP_REMOVE_TRANSITIVE_INCLUDES.
 #ifdef FMT_REMOVE_TRANSITIVE_INCLUDES


### PR DESCRIPTION
I use my pet project https://github.com/IRainman/Calc with the warning level on MSVC 4+ and it shows many unusual warnings on fmt. 