### PR TITLE
Document C++20 module usage with CMake

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,10 @@
   `fmt::ostream_formatter`) and `fmt::streamed` from the C++20 module
   (https://github.com/fmtlib/fmt/pull/4861). Thanks @avikivity.
 
+- Documented how to use the C++20 module with CMake, including the
+  `fmt::fmt-module` target and compiler requirements
+  (https://github.com/fmtlib/fmt/issues/4237).
+
 - Optimized 128-bit integer formatting by reducing the value to 64-bit
   chunks instead of doing repeated 128-bit division, giving a ~5x speedup
   on full-range values.

--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -47,6 +47,22 @@ In order to use the header-only target or the module target, simply substitute t
 `fmt::fmt` in the above steps with `fmt::fmt-header-only` or `fmt::fmt-module` 
 accordingly.
 
+### Using the C++20 Module
+
+Link your target to `fmt::fmt-module` and import `fmt` instead of including a
+{fmt} header:
+
+    target_link_libraries(<your-target> PRIVATE fmt::fmt-module)
+
+    import fmt;
+
+    int main() {
+      fmt::print("Hello, world!\\n");
+    }
+
+The module target requires C++20 module support in CMake and the compiler. For
+GCC, use CMake 3.28 or newer, Ninja 1.11 or newer, and GCC 15 or newer.
+
 ## Installation
 
 ### Debian/Ubuntu

--- a/doc/get-started.md
+++ b/doc/get-started.md
@@ -8,10 +8,11 @@ with CMake, while the [Build Systems](#build-systems) section covers the rest.
 
 ## CMake
 
-{fmt} provides three CMake targets: `fmt::fmt` for the standard compiled library,
-`fmt::fmt-module` for the C++ module library and `fmt::fmt-header-only` for the
-header-only library. It is recommended to use the compiled library or the module 
-library for improved build times. 
+{fmt} provides CMake targets: `fmt::fmt` for the standard compiled library,
+`fmt::fmt-header-only` for the header-only library, and optionally
+`fmt::fmt-module` for the C++ module library when the `FMT_MODULE` option is
+enabled. It is recommended to use the compiled library or the module library for
+improved build times. 
 
 There are three primary ways to use {fmt} with CMake:
 
@@ -49,6 +50,12 @@ accordingly.
 
 ### Using the C++20 Module
 
+The `fmt::fmt-module` target is only available when the `FMT_MODULE` CMake
+option is enabled. Enable it by passing `-DFMT_MODULE=ON` when configuring your
+project before adding {fmt}, or set `CMAKE_CXX_STANDARD` to at least 20 before
+adding {fmt} which will enable module support automatically when supported by
+the toolchain.
+
 Link your target to `fmt::fmt-module` and import `fmt` instead of including a
 {fmt} header:
 
@@ -57,11 +64,12 @@ Link your target to `fmt::fmt-module` and import `fmt` instead of including a
     import fmt;
 
     int main() {
-      fmt::print("Hello, world!\\n");
+      fmt::print("Hello, world!\n");
     }
 
-The module target requires C++20 module support in CMake and the compiler. For
-GCC, use CMake 3.28 or newer, Ninja 1.11 or newer, and GCC 15 or newer.
+When using CMake's native C++ module support, you need CMake 3.28 or newer,
+Ninja 1.11 or newer (with the Ninja generator), and GCC 15 or newer (with GCC).
+{fmt} also provides a fallback build path for other toolchains.
 
 ## Installation
 


### PR DESCRIPTION
Adds CMake guidance for using {fmt} as a C++20 module.

- Enable `FMT_MODULE` before adding {fmt} as a subdirectory
- Link against `fmt::fmt`
- Use `import fmt;` in consumer source files
- Document the CMake 3.28+ and Ninja requirement for GCC module dependency scanning

Fixes #4237.
