### PR TITLE
Suppress GCC 16 incomplete type warning

### DIFF
--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -2649,6 +2649,9 @@ TEST(incomplete_type_test, format) {
   EXPECT_EQ(fmt::format("{}", external_instance), "42");
 }
 
+#if FMT_GCC_VERSION >= 1600
+FMT_PRAGMA_GCC(diagnostic ignored "-Wsfinae-incomplete")
+#endif
 struct incomplete_type {};
 const incomplete_type& external_instance = {};
 


### PR DESCRIPTION
 GCC 16 emits `-Wsfinae-incomplete` when the incomplete type used by
  `incomplete_type_test` is later defined.

  The pattern is intentional because the test verifies formatting a type while
  it is still incomplete. Suppress the GCC 16 diagnostic narrowly around the
  definition so the test retains its coverage without producing a warning.

  Tested with GCC 16.2.1:

  - Full build succeeded
  - 21/21 tests passed
  - `git diff --check` passed