### PR TITLE
Right-align inf and nan with a bare width

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2402,12 +2402,11 @@ FMT_CONSTEXPR20 auto write_nonfinite(OutputIt out, bool isnan,
   const bool is_zero_fill =
       specs.fill_size() == 1 && specs.fill_unit<Char>() == '0';
   if (is_zero_fill) specs.set_fill(' ');
-  return write_padded<Char>(out, specs, size,
-                            [=](reserve_iterator<OutputIt> it) {
-                              if (s != sign::none)
-                                *it++ = detail::getsign<Char>(s);
-                              return copy<Char>(str, str + str_size, it);
-                            });
+  return write_padded<Char, align::right>(
+      out, specs, size, [=](reserve_iterator<OutputIt> it) {
+        if (s != sign::none) *it++ = detail::getsign<Char>(s);
+        return copy<Char>(str, str + str_size, it);
+      });
 }
 
 // A decimal floating-point number significand * pow(10, exp).

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1622,6 +1622,7 @@ TEST(format_test, format_nan) {
   EXPECT_EQ(fmt::format("{:<7}", nan), "nan    ");
   EXPECT_EQ(fmt::format("{:^7}", nan), "  nan  ");
   EXPECT_EQ(fmt::format("{:>7}", nan), "    nan");
+  EXPECT_EQ(fmt::format("{:7}", nan), "    nan");
 }
 
 TEST(format_test, format_infinity) {
@@ -1639,6 +1640,7 @@ TEST(format_test, format_infinity) {
   EXPECT_EQ(fmt::format("{:<7}", inf), "inf    ");
   EXPECT_EQ(fmt::format("{:^7}", inf), "  inf  ");
   EXPECT_EQ(fmt::format("{:>7}", inf), "    inf");
+  EXPECT_EQ(fmt::format("{:7}", inf), "    inf");
 }
 
 TEST(format_test, format_long_double) {


### PR DESCRIPTION
Fixes #4894.

The nonfinite path in `write_float` takes the string default alignment rather than the numeric one, so `inf` and `nan` come out left-aligned while finite values with the same spec come out right-aligned.

```cpp
fmt::print("[{:10}]\n", 1.5);   // [       1.5]
fmt::print("[{:10}]\n", inf);   // [inf       ]
```

After the change both are right-aligned, matching `std::format` and the documented default. An explicit alignment is unaffected.

`format-test.cc` gains cases for `inf` and `nan` under a bare width. The assertion next to them already expected the new string for a signed nonfinite, so it was passing for the wrong reason.
