### PR TITLE
Fix default alignment for inf/nan

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2402,12 +2402,11 @@ FMT_CONSTEXPR20 auto write_nonfinite(OutputIt out, bool isnan,
   const bool is_zero_fill =
       specs.fill_size() == 1 && specs.fill_unit<Char>() == '0';
   if (is_zero_fill) specs.set_fill(' ');
-  return write_padded<Char>(out, specs, size,
-                            [=](reserve_iterator<OutputIt> it) {
-                              if (s != sign::none)
-                                *it++ = detail::getsign<Char>(s);
-                              return copy<Char>(str, str + str_size, it);
-                            });
+  return write_padded<Char, align::right>(
+      out, specs, size, [=](reserve_iterator<OutputIt> it) {
+        if (s != sign::none) *it++ = detail::getsign<Char>(s);
+        return copy<Char>(str, str + str_size, it);
+      });
 }
 
 // A decimal floating-point number significand * pow(10, exp).

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1622,6 +1622,7 @@ TEST(format_test, format_nan) {
   EXPECT_EQ(fmt::format("{:<7}", nan), "nan    ");
   EXPECT_EQ(fmt::format("{:^7}", nan), "  nan  ");
   EXPECT_EQ(fmt::format("{:>7}", nan), "    nan");
+  EXPECT_EQ(fmt::format("{:7}", nan), "    nan");
 }
 
 TEST(format_test, format_infinity) {
@@ -1639,6 +1640,7 @@ TEST(format_test, format_infinity) {
   EXPECT_EQ(fmt::format("{:<7}", inf), "inf    ");
   EXPECT_EQ(fmt::format("{:^7}", inf), "  inf  ");
   EXPECT_EQ(fmt::format("{:>7}", inf), "    inf");
+  EXPECT_EQ(fmt::format("{:7}", inf), "    inf");
 }
 
 TEST(format_test, format_long_double) {


### PR DESCRIPTION
Fixes #4894

As per #4894, `inf` and `nan` are left-aligned with a bare width, while finite values are right-aligned. This PR fixes the default alignment for nonfinite values to be right-aligned.