### PR TITLE
Make fmt::as_identifiers a struct instead of a variable

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -566,7 +566,7 @@ enumerator matching the formatted value:
 
     #include <fmt/enum.h>
 
-    enum class [[=fmt::as_identifiers]] color { red, green, blue };
+    enum class [[=fmt::as_identifiers()]] color { red, green, blue };
 
     fmt::print("{}", color::green);
     // Output: green

--- a/include/fmt/enum.h
+++ b/include/fmt/enum.h
@@ -33,21 +33,18 @@ FMT_BEGIN_NAMESPACE
 
 #if FMT_USE_REFLECTION
 
-/// The type of the `fmt::as_identifiers` annotation.
-FMT_EXPORT struct as_identifiers_t {};
-
 /**
  * An annotation that makes an enum format as identifiers of its enumerators.
  *
  * **Example**:
  *
- *     enum class [[=fmt::as_identifiers]] color { red, green, blue };
+ *     enum class [[=fmt::as_identifiers()]] color { red, green, blue };
  *     auto s = fmt::format("{}", color::green);  // s == "green"
  *
  * A value that doesn't match any enumerator is represented as its underlying
  * value in decimal before applying string formatting.
  */
-FMT_EXPORT inline constexpr auto as_identifiers = as_identifiers_t();
+FMT_EXPORT struct as_identifiers {};
 
 namespace detail {
 
@@ -57,8 +54,7 @@ consteval auto use_identifiers() -> bool {
   if constexpr (!std::is_enum<U>::value) {
     return false;
   } else {
-    return !std::meta::annotations_of_with_type(^^U, ^^as_identifiers_t)
-                .empty();
+    return !std::meta::annotations_of_with_type(^^U, ^^as_identifiers).empty();
   }
 }
 

--- a/test/enum-test.cc
+++ b/test/enum-test.cc
@@ -21,56 +21,61 @@ TEST(enum_test, no_reflection) {
 
 // clang-format doesn't support annotations yet.
 // clang-format off
-enum class [[=fmt::as_identifiers]] color { red, green, blue };
+enum class [[=fmt::as_identifiers()]] color { red, green, blue };
 enum class color_without_annotation { red, green, blue };
-enum [[=fmt::as_identifiers]] unscoped_color { unscoped_red, unscoped_green };
-enum class [[=fmt::as_identifiers]] level : unsigned char { low = 1, high = 2 };
-enum class [[=fmt::as_identifiers]] byte_enum : char { one = 1 };
-enum class [[=fmt::as_identifiers]] signed_byte_enum : signed char { minus_one = -1 };
-enum class [[=fmt::as_identifiers]] bool_enum : bool { off = false };
-enum class [[=fmt::as_identifiers]] alias { one = 1, uno = 1 };
-enum class [[=fmt::as_identifiers]] empty_enum {};
+enum [[=fmt::as_identifiers()]] unscoped_color { unscoped_red, unscoped_green };
+enum class [[=fmt::as_identifiers()]] level : unsigned char {
+  low = 1,
+  high = 2
+};
+enum class [[=fmt::as_identifiers()]] byte_enum : char { one = 1 };
+enum class [[=fmt::as_identifiers()]] signed_byte_enum : signed char {
+  minus_one = -1
+};
+enum class [[=fmt::as_identifiers()]] bool_enum : bool { off = false };
+enum class [[=fmt::as_identifiers()]] alias { one = 1, uno = 1 };
+enum class [[=fmt::as_identifiers()]] empty_enum {};
 
 // Dense values: formatted via a lookup table.
-enum class [[=fmt::as_identifiers]] dense { d0, d1, d2, d3, d4 };
+enum class [[=fmt::as_identifiers()]] dense { d0, d1, d2, d3, d4 };
 // 3 holes out of 10: the sparsest case that still uses a lookup table.
-enum class [[=fmt::as_identifiers]] holey {
+enum class [[=fmt::as_identifiers()]] holey {
   h0, h1, h2, h3, h4, h5, h6 = 9
 };
 // 4 holes out of 11: just too sparse, formatted via a hash table.
-enum class [[=fmt::as_identifiers]] sparse {
+enum class [[=fmt::as_identifiers()]] sparse {
   s0, s1, s2, s3, s4, s5, s6 = 10
 };
 // Values spanning both signs and the extremes of the underlying type.
-enum class [[=fmt::as_identifiers]] signed_enum {
+enum class [[=fmt::as_identifiers()]] signed_enum {
   minus_two = -2,
   minus_one = -1,
   one = 1
 };
 // Many scattered values, exercising collisions in the hash table.
-enum class [[=fmt::as_identifiers]] scattered {
+enum class [[=fmt::as_identifiers()]] scattered {
   a = 1, b = 17, c = 33, d = 49, e = 65, f = 81,
   g = 97, h = 113, i = 129, j = 145, k = 161, l = 177
 };
 // Values that collide in the hash table: c0, c7 and c15 share a slot, and c6
 // occupies the next one, so probing for c7 and c15 has to step over it.
-enum class [[=fmt::as_identifiers]] collision {
+enum class [[=fmt::as_identifiers()]] collision {
   c0 = 0, c6 = 6, c7 = 7, c15 = 15
 };
 // Values that collide in the last slot of the hash table, so the probe
 // sequence wraps around to the beginning.
-enum class [[=fmt::as_identifiers]] wrapping_collision {
+enum class [[=fmt::as_identifiers()]] wrapping_collision {
   w8 = 8, w16 = 16, w24 = 24
 };
 // Aliased values in an enum that is too sparse for a lookup table.
-enum class [[=fmt::as_identifiers]] sparse_alias {
+enum class [[=fmt::as_identifiers()]] sparse_alias {
   one = 1, dup = 1, far = 1000
 };
-enum class [[=fmt::as_identifiers]] extremes : int {
+enum class [[=fmt::as_identifiers()]] extremes : int {
   lowest = INT_MIN,
   highest = INT_MAX
 };
-enum class [[=fmt::as_identifiers]] big : unsigned long long {
+enum class [[=fmt::as_identifiers()]] big : unsigned long long {
   huge = ULLONG_MAX
 };
 // clang-format on

--- a/test/module-test.cc
+++ b/test/module-test.cc
@@ -377,7 +377,7 @@ TEST(module_test, compile_format_string) {
     defined(__cpp_lib_define_static)
 // clang-format doesn't support annotations yet.
 // clang-format off
-enum class [[=fmt::as_identifiers]] color { red, green, blue };
+enum class [[=fmt::as_identifiers()]] color { red, green, blue };
 // clang-format on
 
 TEST(module_test, format_enum) {


### PR DESCRIPTION
The annotation was a constant of an empty type, which left no room for options. Make the annotation type itself, fmt::as_identifiers, the thing users write, so it is now spelled

  enum class [[=fmt::as_identifiers()]] color { red, green, blue };

and options can later be added as constructor arguments.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
