### PR TITLE
Fix debug format width calculation

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -1907,11 +1907,22 @@ template <typename Char, typename OutputIt>
 FMT_CONSTEXPR auto write_char(OutputIt out, Char value,
                               const format_specs& specs) -> OutputIt {
   bool is_debug = specs.type() == presentation_type::debug;
-  return write_padded<Char>(out, specs, 1, [=](reserve_iterator<OutputIt> it) {
-    if (is_debug) return write_escaped_char(it, value);
-    *it++ = value;
-    return it;
-  });
+  Char buf[12];
+  auto* begin = buf;
+  auto* end = begin;
+  size_t size = 1;
+
+  if (is_debug) {
+    end = write_escaped_char(begin, value);
+    size = to_unsigned(end - begin);
+  }
+
+  return write_padded<Char>(out, specs, size,
+                            [=](reserve_iterator<OutputIt> it) {
+                              if (is_debug) return copy<Char>(begin, end, it);
+                              *it++ = value;
+                              return it;
+                            });
 }
 
 template <typename Char> class digit_grouping {
@@ -2268,6 +2279,12 @@ FMT_CONSTEXPR auto write(OutputIt out, basic_string_view<Char> s,
 
     return false;
   });
+
+  if (is_debug && s.size() == 0 && specs.precision != 0 &&
+      display_width < display_width_limit) {
+    ++display_width;
+    ++size;
+  }
 
   struct bounded_output_iterator {
     reserve_iterator<OutputIt> underlying_iterator;

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -941,6 +941,7 @@ TEST(format_test, width) {
 
 TEST(format_test, debug_presentation) {
   EXPECT_EQ(fmt::format("{:?}", ""), R"("")");
+  EXPECT_EQ(fmt::format("{:1?}", ""), R"("")");
 
   EXPECT_EQ(fmt::format("{:*<5.0?}", "\n"), R"(*****)");
   EXPECT_EQ(fmt::format("{:*<5.1?}", "\n"), R"("****)");
@@ -1683,6 +1684,7 @@ TEST(format_test, format_char) {
 
   EXPECT_EQ(fmt::format("{}", '\n'), "\n");
   EXPECT_EQ(fmt::format("{:?}", '\n'), "'\\n'");
+  EXPECT_EQ(fmt::format("{:6?}", 'a'), "'a'   ");
   EXPECT_EQ(fmt::format("{:x}", '\xff'), "ff");
 }
 


### PR DESCRIPTION
Fixes #4901.

The width calculation for debug-formatted characters and strings was based on the unescaped output size. This caused incorrect padding for debug characters and could truncate the closing quote for empty debug strings.

This change:

* Calculates the formatted size of debug characters using the escaped representation.
* Correctly accounts for the closing quote of an empty debug string when width/precision permits it.
* Adds regression tests for both cases.

All tests pass locally.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
