### PR TITLE
Suppress unused parameter warnings with FMT_USE_LOCALE=0

### DIFF
--- a/include/fmt/xchar.h
+++ b/include/fmt/xchar.h
@@ -53,6 +53,7 @@ inline auto write_loc(basic_appender<wchar_t> out, loc_value value,
   if (!grouping.empty()) separator = std::wstring(1, numpunct.thousands_sep());
   return value.visit(loc_writer<wchar_t>{out, specs, separator, grouping, {}});
 #endif
+  ignore_unused(out, value, specs, loc);
   return false;
 }
 


### PR DESCRIPTION
`write_loc` leaves all four parameters unused when `FMT_USE_LOCALE` is 0, so the header does not compile with `-Wunused-parameter -Werror`:

```
$ echo '#include <fmt/xchar.h>' > t.cc
$ clang++ -std=c++17 -DFMT_USE_LOCALE=0 -Wunused-parameter -Werror -Iinclude -fsyntax-only t.cc
include/fmt/xchar.h:46:47: error: unused parameter 'out' [-Werror,-Wunused-parameter]
include/fmt/xchar.h:46:62: error: unused parameter 'value' [-Werror,-Wunused-parameter]
include/fmt/xchar.h:47:43: error: unused parameter 'specs' [-Werror,-Wunused-parameter]
include/fmt/xchar.h:47:61: error: unused parameter 'loc' [-Werror,-Wunused-parameter]
```

These are the only diagnostics in the `xchar.h` include chain, so the one line makes that configuration build clean.

No `#else` needed: the `FMT_USE_LOCALE` branch returns, so the call is reached only when the parameters really are unused. Same placement as `ignore_unused(f)` in `ostream.h`.

Checked with `-Wall -Wextra -Werror` at `FMT_USE_LOCALE=0` and `1`, and with `-Wunreachable-code`.
