### PR TITLE
Fix exception formatters with exceptions disabled

### DIFF
--- a/include/fmt/std.h
+++ b/include/fmt/std.h
@@ -665,7 +665,7 @@ struct formatter<
     }
 #endif  // FMT_USE_RTTI
     out = detail::write_bytes<char>(out, string_view(ex.what()));
-#if FMT_USE_RTTI
+#if FMT_USE_RTTI && FMT_USE_EXCEPTIONS
     // If the exception carries a nested exception (e.g. via
     // std::throw_with_nested), format the whole chain.
     if (auto* nested = dynamic_cast<const std::nested_exception*>(&ex)) {
@@ -680,7 +680,7 @@ struct formatter<
         }
       }
     }
-#endif  // FMT_USE_RTTI
+#endif  // FMT_USE_RTTI && FMT_USE_EXCEPTIONS
     return out;
   }
 };
@@ -690,6 +690,7 @@ template <> struct formatter<std::exception_ptr> : formatter<std::exception> {
   auto format(const std::exception_ptr& ep, FormatContext& ctx) const
       -> decltype(ctx.out()) {
     if (!ep) return this->write_padded(ctx, string_view("none"));
+#if FMT_USE_EXCEPTIONS
     try {
       std::rethrow_exception(ep);
     } catch (const std::exception& e) {
@@ -697,6 +698,9 @@ template <> struct formatter<std::exception_ptr> : formatter<std::exception> {
     } catch (...) {
       return this->write_padded(ctx, string_view("unknown exception"));
     }
+#else
+    return this->write_padded(ctx, string_view("unknown exception"));
+#endif  // FMT_USE_EXCEPTIONS
   }
 };
 


### PR DESCRIPTION
Fixes building with Clang 20 and older with -fno-exceptions, which treats try/catch usage as an error.

Fixes FEX builds: https://github.com/FEX-Emu/FEX/pull/5870