### PR TITLE
Fix typo: format-benchmarks -> format-benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ library](https://fmt.dev/latest/get-started/#building-from-source) for
 instructions on how to build the library and run the unit tests.
 
 Benchmarks reside in a separate repository,
-[format-benchmarks](https://github.com/fmtlib/format-benchmark), so to
+[format-benchmark](https://github.com/fmtlib/format-benchmark), so to
 run the benchmarks you first need to clone this repository and generate
 Makefiles with CMake:
 


### PR DESCRIPTION
Fix typo: repository name is "format-benchmark" (singular), not "format-benchmarks".

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
