### PR TITLE
Fix debug format width calculation by clarifying maximum buffer size.

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -2061,11 +2061,19 @@ template <typename Char, typename OutputIt>
 FMT_CONSTEXPR auto write_char(OutputIt out, Char value,
                               const format_specs& specs) -> OutputIt {
   bool is_debug = specs.type() == presentation_type::debug;
-  return write_padded<Char>(out, specs, 1, [=](reserve_iterator<OutputIt> it) {
-    if (is_debug) return write_escaped_char(it, value);
-    *it++ = value;
-    return it;
-  });
+
+  const int max_buffer_size = 12;
+  Char buf[max_buffer_size];
+  auto* begin = buf;
+  auto* end = (is_debug) ? write_escaped_char(begin, value) : begin;
+  size_t size = (is_debug) ? to_unsigned(end - begin) : 1;
+
+  return write_padded<Char>(out, specs, size,
+                            [=](reserve_iterator<OutputIt> it) {
+                              if (is_debug) return copy<Char>(begin, end, it);
+                              *it++ = value;
+                              return it;
+                            });
 }
 
 template <typename Char> class digit_grouping {
@@ -2422,6 +2430,11 @@ FMT_CONSTEXPR auto write(OutputIt out, basic_string_view<Char> s,
 
     return false;
   });
+
+  if (is_debug && s.size() == 0 && specs.precision != 0 && display_width < display_width_limit) {
+    ++display_width;
+    ++size;
+  }
 
   struct bounded_output_iterator {
     reserve_iterator<OutputIt> underlying_iterator;

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1007,6 +1007,9 @@ TEST(format_test, width) {
 TEST(format_test, debug_presentation) {
   EXPECT_EQ(fmt::format("{:?}", ""), R"("")");
 
+  EXPECT_EQ(fmt::format("{:1?}", ""), R"("")");
+  EXPECT_EQ(fmt::format("{:6?}", 'a'), "'a'   ");
+
   EXPECT_EQ(fmt::format("{:*<5.0?}", "\n"), R"(*****)");
   EXPECT_EQ(fmt::format("{:*<5.1?}", "\n"), R"("****)");
   EXPECT_EQ(fmt::format("{:*<5.2?}", "\n"), R"("\***)");

--- a/test/xchar-test.cc
+++ b/test/xchar-test.cc
@@ -299,6 +299,15 @@ TEST(xchar_test, escape_string) {
 
 TEST(xchar_test, to_wstring) { EXPECT_EQ(L"42", fmt::to_wstring(42)); }
 
+TEST(xchar_test, astral_codepoint_width) {
+  // U+E0001 (LANGUAGE TAG) is non-printable, so it takes the \Uxxxxxxxx
+  // escape path: quote + '\' + 'U' + 8 hex digits + quote = 12 code units,
+  char32_t cp = 0xE0001;
+  EXPECT_EQ(fmt::format(U"{:11?}", cp).size(), 12u);  // width < size: no pad
+  EXPECT_EQ(fmt::format(U"{:12?}", cp).size(), 12u);  // width == size: exact
+  EXPECT_EQ(fmt::format(U"{:13?}", cp).size(), 13u);  // width > size: 1 pad
+}
+
 #ifndef FMT_STATIC_THOUSANDS_SEPARATOR
 
 template <typename Char> struct numpunct : std::numpunct<Char> {


### PR DESCRIPTION
Width for debug-escaped chars/strings was computed from the unescaped size, causing incorrect padding and, for empty strings, a dropped closing quote. Removes magic number by assigning 12 to `max_buffer_size`. Fixes #4901 and adds additional test coverage for non-printing characters that exceed the maximum. 

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->
