### PR TITLE
docs: add link to a live browser demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ fmt](https://stackoverflow.com/questions/tagged/fmt).
 
 Try {fmt} in [Compiler Explorer](https://godbolt.org/z/8Mx1EW73v).
 
+[![Live demo by Demoshell](https://build.demoshell.com/v1/embed/badge.svg)](https://build.demoshell.com/launch?snapshot=demoshell%2Ftools%3Afmt)
+
 # Features
 
 - Simple [format API](https://fmt.dev/latest/api/) with positional


### PR DESCRIPTION
Adds a "Live demo" link to the README that points to an emulated Linux VM (WebAssembly) with example of fmt usage in it. The image rebuilds automatically when a new release is published.

Disclosure: I run the service behind this (Demoshell). The demo and hosting are free for open-source projects (the badge carries a small attribution). 

The demo page also allows the maintainer to claim that VM if you'd like to support it. Otherwise I'll keep taking care of it. 