### PR TITLE
Remove the '0' chrono padding modifier from the docs

### DIFF
--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -300,7 +300,7 @@ chrono_specs       ::= conversion_spec |
                        chrono_specs (conversion_spec | literal_char)
 conversion_spec    ::= "%" [padding_modifier] [locale_modifier] chrono_type
 literal_char       ::= &lt;a character other than '{', '}' or '%'>
-padding_modifier   ::= "-" | "_"  | "0"
+padding_modifier   ::= "-" | "_"
 locale_modifier    ::= "E" | "O"
 chrono_type        ::= "a" | "A" | "b" | "B" | "c" | "C" | "d" | "D" | "e" |
                        "F" | "g" | "G" | "h" | "H" | "I" | "j" | "m" | "M" |
@@ -594,13 +594,13 @@ The available presentation types (*chrono_type*) are:
 Specifiers that have a calendaric component such as `'d'` (the day of month)
 are valid only for `std::tm` and time points but not durations.
 
-The available padding modifiers (*padding_modifier*) are:
+Numeric results are padded with zeros by default. The available padding
+modifiers (*padding_modifier*) are:
 
 | Type  | Meaning                                 |
 |-------|-----------------------------------------|
 | `'_'` | Pad a numeric result with spaces.       |
 | `'-'` | Do not pad a numeric result string.     |
-| `'0'` | Pad a numeric result string with zeros. |
 
 These modifiers are only supported for the `'H'`, `'I'`, `'M'`, `'S'`, `'U'`,
 `'V'`, `'W'`, `'Y'`, `'d'`, `'j'` and `'m'` presentation types.


### PR DESCRIPTION
`doc/syntax.md` documents a chrono padding modifier that the parser rejects.

The grammar says `padding_modifier ::= "-" | "_" | "0"` and the table below it
lists a `'0'` row, for the 11 presentation types the same section names
(`H I M S U V W Y d j m`). But `parse_chrono_format` only has cases for `'_'`
and `'-'`, so every `%0` spelling throws `format_error: invalid format`.

Measured on `main` (bc82c40), all 11 documented types, `std::tm` and
`std::chrono::seconds`, 44 cells:

| modifier | OK | error |
|---|---|---|
| (none) | 11 | 0 |
| `-` | 11 | 0 |
| `_` | 11 | 0 |
| `0` | 0 | **11** |

```c++
fmt::format("{:%H}",  tm);  // "03"
fmt::format("{:%-H}", tm);  // "3"
fmt::format("{:%_H}", tm);  // " 3"
fmt::format("{:%0H}", tm);  // throws: invalid format
```

The docs are the stale side, not the code. `ca8eeb09` (#3976, 2024-05-30)
added the `'0'` grammar and table row; `7bd11b5c` (2024-06-08, nine days
later) removed `case '0'` and its tests under *"Remove a redundant extension
to reduce divergence from std::format"*, touching only `chrono.h` and
`chrono-test.cc`. Zero padding is the default, so it was redundant — this
just drops the two stale mentions and notes the default.

Docs-only. The "only supported for" list is accurate: all 11 do honor `-`
and `_`, checked with values short enough to discriminate.

Drafted with Claude Code (`claude-opus-5`); measurements and archaeology run
and reviewed by me.
