### PR TITLE
Build nolocale-test with /utf-8 on MSVC

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -134,6 +134,8 @@ if (FMT_PEDANTIC)
                              PRIVATE ${PROJECT_SOURCE_DIR}/include)
   target_compile_definitions(nolocale-test
                              PRIVATE FMT_STATIC_THOUSANDS_SEPARATOR=1)
+  target_compile_options(nolocale-test
+                         PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/utf-8>)
 endif ()
 
 # These tests are disabled on Windows because they take too long.


### PR DESCRIPTION
`nolocale-test` does not compile with MSVC when `FMT_PEDANTIC` is on:

```
include\fmt\base.h(455): error C2338: static_assert failed:
  'Unicode support requires compiling with /utf-8'
```

The target is built from `../src/format.cc` directly (`test/CMakeLists.txt:132`), so it does not pick up the `/utf-8` that `CMakeLists.txt:255` adds to the `fmt` target. `unicode-test` already guards the same flag the same way at `test/CMakeLists.txt:73-75`, so this follows that.

It has not shown up in CI because the target only exists under `FMT_PEDANTIC`, and `windows.yml` does not set it, while `linux.yml:211-212` and `macos.yml:46` both do.

Checked at C++20 and C++23 with MSVC 19.44, since I wondered whether it was standard-specific. It is not, it fails at both. After the change the full build succeeds and `ctest` is 23/23 with `FMT_PEDANTIC=ON`.

---

Disclosure: written with AI assistance. The build output above is from my own machine.
