### PR TITLE
Correct locale support in size optimization docs

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -800,9 +800,9 @@ configuring CMake.
 
 - **`FMT_OPTIMIZE_SIZE`**: Controls binary size optimizations:
     - `0` - off (default)
-    - `1` - disables locale support and applies some optimizations
-    - `2` - disables some Unicode features, named arguments and applies more
-      aggressive optimizations
+    - `1` - applies some optimizations
+    - `2` - disables locale support by default, some Unicode features, and
+      named arguments, and applies more aggressive optimizations
 
 ### Binary Size Optimization
 


### PR DESCRIPTION
Fixes #4922.

Move locale disabling from the level 1 description to level 2, matching the default `FMT_USE_LOCALE` definition in `base.h` and the existing macro documentation. No runtime behavior changes.

Validation:

- MSVC compile-time probes for `FMT_OPTIMIZE_SIZE=0/1/2` confirm default `FMT_USE_LOCALE=1/1/0`.
- Built the patched MkDocs site with the pinned documentation requirements, Doxygen 1.18.0 and `PYTHONUTF8=1`; checked the rendered configuration table. One existing `chrono-format-specifications` anchor warning remains. Without Python UTF-8 mode, the existing C++ handler cannot read Doxygen's UTF-8 XML under Windows cp1252.
- `git diff --check` passes.
