### PR TITLE
Fix the chrono format specification link

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -474,7 +474,7 @@ Using `fmt::join`, you can separate tuple elements with a custom separator:
 - [`std::tm`](https://en.cppreference.com/w/cpp/chrono/c/tm)
 
 The format syntax is described in [Chrono Format Specifications](syntax.md#
-chrono-format-specifications).
+chrono-format-spec).
 
 **Example**:
 


### PR DESCRIPTION
Fixes #4926.

Point the chrono API reference to the existing explicit `chrono-format-spec`
anchor in `syntax.md`. The old plural fragment has no target.

Validation:

- Documentation build passes using the pinned docs environment and Doxygen
  1.18.0; the missing-anchor warning is gone.
- Generated `api/index.html` links to `../syntax/#chrono-format-spec`, and
  generated `syntax/index.html` contains that ID. The old fragment is absent.
- `git diff --check` passes.

One documentation line only; no API, syntax, dependency or CI change. On this
Windows host the build uses process-local UTF-8 mode; the separate default-codec
fix in #4925 is not included in this branch.
