### PR TITLE
Fix unreachable code warning in range formatter

### DIFF
--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -515,10 +515,9 @@ struct formatter<
   using nonlocking = void;
 
   FMT_CONSTEXPR formatter() {
-    if FMT_CONSTEXPR20 (range_format_kind<R, Char>::value != range_format::set)
-      return;
-    range_formatter_.set_brackets(detail::string_literal<Char, '{'>{},
-                                  detail::string_literal<Char, '}'>{});
+    if FMT_CONSTEXPR20 (range_format_kind<R, Char>::value == range_format::set)
+      range_formatter_.set_brackets(detail::string_literal<Char, '{'>{},
+                                    detail::string_literal<Char, '}'>{});
   }
 
   FMT_CONSTEXPR auto parse(parse_context<Char>& ctx) -> const Char* {


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree to license your contribution(s)
under the terms outlined in LICENSE.rst and represent that you have the right
to do so.
-->

Fixes #4930.

The range formatter constructor returned from a compile-time branch for every
non-set range, leaving the bracket customization after the return. New MSVC
versions diagnose that statement as unreachable when sequence range formatters
are instantiated.

Invert the condition and only customize brackets for set ranges. This preserves
the behavior for both pre-C++20 and C++20 builds while allowing `if constexpr`
to discard the unused branch.

Testing:

- MSVC 19.44 `/W4`: the `ranges.h` C4702 warning reproduced before the change
  and is absent after it
- `ranges-test` passed
- full MSVC Release build passed
- full CTest: 20/22 passed; `chrono-test.locale` and
  `unicode-test.legacy_locale` fail under this machine's zh-CN locale