### PR TITLE
Fix argument count in dynamic stores with named arguments

### DIFF
--- a/include/fmt/args.h
+++ b/include/fmt/args.h
@@ -131,7 +131,7 @@ FMT_EXPORT template <typename Context> class dynamic_format_arg_store {
   constexpr dynamic_format_arg_store() = default;
 
   operator basic_format_args<Context>() const {
-    return basic_format_args<Context>(data(), static_cast<int>(data_.size()),
+    return basic_format_args<Context>(data(), static_cast<int>(size()),
                                       !named_info_.empty());
   }
 
@@ -210,7 +210,9 @@ FMT_EXPORT template <typename Context> class dynamic_format_arg_store {
   }
 
   /// Returns the number of elements in the store.
-  auto size() const noexcept -> size_t { return data_.size(); }
+  auto size() const noexcept -> size_t {
+    return data_.size() - (named_info_.empty() ? 0 : 1);
+  }
 };
 
 FMT_END_NAMESPACE

--- a/test/args-test.cc
+++ b/test/args-test.cc
@@ -200,3 +200,38 @@ TEST(args_test, size) {
   store.clear();
   EXPECT_EQ(store.size(), 0);
 }
+
+TEST(args_test, named_arg_count) {
+  fmt::dynamic_format_arg_store<fmt::format_context> store;
+  EXPECT_EQ(store.size(), 0u);
+  EXPECT_THROW(fmt::vformat("{0}", store), fmt::format_error);
+
+  store.push_back(fmt::arg("a", 42));
+  EXPECT_EQ(store.size(), 1u);
+  EXPECT_EQ("42 42", fmt::vformat("{0} {a}", store));
+  EXPECT_THROW(fmt::vformat("{1}", store), fmt::format_error);
+
+  store.push_back(fmt::arg("b", 43));
+  EXPECT_EQ(store.size(), 2u);
+  EXPECT_EQ("42 43 43", fmt::vformat("{0} {1} {b}", store));
+  EXPECT_THROW(fmt::vformat("{2}", store), fmt::format_error);
+
+  store.push_back(44);
+  EXPECT_EQ(store.size(), 3u);
+  EXPECT_EQ("42 43 44", fmt::vformat("{a} {b} {2}", store));
+  EXPECT_THROW(fmt::vformat("{3}", store), fmt::format_error);
+
+  store.clear();
+  EXPECT_EQ(store.size(), 0u);
+  EXPECT_THROW(fmt::vformat("{0}", store), fmt::format_error);
+
+  store.push_back(45);
+  EXPECT_EQ(store.size(), 1u);
+  EXPECT_EQ("45", fmt::vformat("{0}", store));
+  EXPECT_THROW(fmt::vformat("{1}", store), fmt::format_error);
+
+  store.push_back(fmt::arg("c", 46));
+  EXPECT_EQ(store.size(), 2u);
+  EXPECT_EQ("45 46 46", fmt::vformat("{0} {1} {c}", store));
+  EXPECT_THROW(fmt::vformat("{2}", store), fmt::format_error);
+}


### PR DESCRIPTION
## Summary

Code counted formatting arguments incorrectly when named arguments were present. It took the internal metadata slot as a formatting argument. Change made the math correct with

```cpp
 return data_.size() - (named_info_.empty() ? 0 : 1);
```

i.e. subtracting 1 from the arguments vector count when named arguments are present which makes the counting correct. The corrected count is also used when constructing `basic_format_args`. Also regression tests were added.
